### PR TITLE
Added new or-mwc-tabs component

### DIFF
--- a/ui/component/or-mwc-components/package.json
+++ b/ui/component/or-mwc-components/package.json
@@ -40,6 +40,7 @@
     "@material/slider": "^9.0.0",
     "@material/snackbar": "^9.0.0",
     "@material/switch": "^9.0.0",
+    "@material/tab-bar": "^9.0.0",
     "@material/textfield": "^9.0.0",
     "@openremote/core": "workspace:*",
     "@openremote/or-icon": "^1.0.4",

--- a/ui/component/or-mwc-components/src/or-mwc-tabs.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-tabs.ts
@@ -1,0 +1,171 @@
+import { MDCTabBar } from "@material/tab-bar";
+import {css, CSSResult, html, LitElement, TemplateResult, unsafeCSS } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import {DefaultColor4, DefaultColor8} from "@openremote/core";
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+
+// Material Styling import
+const tabStyle = require("@material/tab/dist/mdc.tab.css");
+const tabBarStyle = require("@material/tab-bar/dist/mdc.tab-bar.css");
+const tabIndicatorStyle = require("@material/tab-indicator/dist/mdc.tab-indicator.css");
+const tabScrollerStyle = require("@material/tab-scroller/dist/mdc.tab-scroller.css");
+
+export interface OrMwcTabItem {
+    name?: string,
+    icon?: string,
+    content?: TemplateResult | string
+}
+
+//language=css
+const tabStyling = css`
+    .mdc-tab {
+        background: ${unsafeCSS(DefaultColor4)};
+    }
+    .mdc-tab .mdc-tab__text-label {
+        color: ${unsafeCSS(DefaultColor8)};
+    }
+    .mdc-tab .mdc-tab__icon {
+        color: ${unsafeCSS(DefaultColor8)};
+    }
+    .mdc-tab-indicator .mdc-tab-indicator__content--underline {
+        border-color: ${unsafeCSS(DefaultColor8)};
+    }
+    .mdc-tab__ripple::before, .mdc-tab__ripple::after {
+        background-color: var(--ripplecolor, ${unsafeCSS(DefaultColor8)});
+    }
+    .mdc-tab-vertical {
+        height: 72px !important; /* 72px is original Material spec */
+    }
+    .mdc-tab-vertical__content {
+        flex-direction: column;
+        gap: 6px; /* 6px is original Material spec */
+    }
+    .mdc-tab-vertical__text-label {
+        padding-left: 0 !important;
+    }
+`
+
+/* ----------------- */
+
+@customElement("or-mwc-tabs")
+export class OrMwcTabs extends LitElement {
+
+    static get styles() {
+        return [unsafeCSS(tabStyle), unsafeCSS(tabBarStyle), unsafeCSS(tabIndicatorStyle), unsafeCSS(tabScrollerStyle), tabStyling];
+    }
+
+    @property({type: Number}) // Selected tab index from the items array
+    protected index?: number;
+
+    @property({type: Array})
+    protected items?: OrMwcTabItem[];
+
+    @property({type: String})
+    protected iconPosition?: "left" | "top";
+
+    @property({type: String})
+    protected bgColor?: string;
+
+    @property({type: String})
+    protected color?: string;
+
+    @property() // Custom styling that gets injected in render()
+    protected styles?: CSSResult | string;
+
+    @state()
+    private mdcTabBar: MDCTabBar | undefined;
+
+
+    constructor() {
+        super();
+
+        // default values
+        if (this.index == null) { this.index = 0; }
+        if (this.items == null) { this.items = []; }
+        if (this.iconPosition == null) { this.iconPosition = "left"; }
+
+        this.updateComplete.then(() => {
+            const tabBarElement = this.shadowRoot?.querySelector('.mdc-tab-bar');
+            if(tabBarElement != null) {
+                this.mdcTabBar = new MDCTabBar(tabBarElement); // init of material component
+                this.mdcTabBar.listen("MDCTabBar:activated", (event: CustomEvent) => {
+                    this.index = event.detail.index;
+                });
+            }
+
+            if(tabBarElement != null) {
+
+                // Adding classes for Icon top position or not.
+                if(this.iconPosition === "top") {
+                    if(this.items?.find((item) => { return (item.name != null && item.icon != null); }) != undefined) {
+                        tabBarElement.querySelectorAll('.mdc-tab').forEach((value: Element) => { value.classList.add('mdc-tab-vertical'); });
+                        tabBarElement.querySelectorAll('.mdc-tab__content').forEach((value: Element) => { value.classList.add('mdc-tab-vertical__content')});
+                        tabBarElement.querySelectorAll('.mdc-tab__text-label').forEach((value: Element) => { value.classList.add('mdc-tab-vertical__text-label')});
+                    }
+                }
+
+                // Apply colors if set differently
+                if(this.bgColor != null) {
+                    tabBarElement.querySelectorAll('.mdc-tab').forEach((value: Element) => {
+                        (value as HTMLElement).style.background = this.bgColor as string;
+                    });
+                }
+                if(this.color != null) {
+                    tabBarElement.querySelectorAll('.mdc-tab__text-label').forEach((value: Element) => { (value as HTMLElement).style.color = this.color as string; });
+                    tabBarElement.querySelectorAll('.mdc-tab__icon').forEach((value: Element) => { (value as HTMLElement).style.color = this.color as string; })
+                    tabBarElement.querySelectorAll('.mdc-tab-indicator__content--underline').forEach((value: Element) => { (value as HTMLElement).style.borderColor = this.color as string; });
+                    tabBarElement.querySelectorAll('.mdc-tab__ripple').forEach((value: Element) => { (value as HTMLElement).style.setProperty('--ripplecolor', this.color as string); })
+                }
+            }
+        })
+    }
+
+    // If an update happens on either the Index or mdcTabBar object.
+    protected updated(changedProperties: Map<string, any>) {
+        if(changedProperties.has('index') || changedProperties.has('mdcTabBar')) {
+            if(this.mdcTabBar != null && this.index != null) {
+                this.mdcTabBar.activateTab(this.index);
+                this.dispatchEvent(new CustomEvent("activated", { detail: { index: this.index }}))
+            }
+        }
+    }
+
+
+    protected render() {
+        let selectedItem: OrMwcTabItem | undefined;
+        if(this.items != null && this.index != null) {
+            selectedItem = this.items[this.index];
+        }
+        return html`
+            ${typeof(this.styles) === "string" ? html`<style>${this.styles}</style>` : this.styles || ``}
+            <div>
+                <div class="mdc-tab-bar" role="tablist" id="tab-bar">
+                    <div class="mdc-tab-scroller">
+                        <div class="mdc-tab-scroller__scroll-area">
+                            <div class="mdc-tab-scroller__scroll-content">
+                                ${this.items?.map((menuItem => { return html`
+                                    <button class="mdc-tab" role="tab" aria-selected="false" tabindex="${this.items?.indexOf(menuItem)}">
+                                    <span class="mdc-tab__content">
+                                        ${menuItem.icon != null ? html`<or-icon icon="${menuItem.icon}" class="mdc-tab__icon"></or-icon>` : null}
+                                        ${menuItem.name != null ? html`<span class="mdc-tab__text-label">${menuItem.name}</span>` : null}
+                                    </span>
+                                        <span class="mdc-tab-indicator">
+                                        <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
+                                    </span>
+                                        <span class="mdc-tab__ripple"></span>
+                                    </button>
+                                `}))}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div>
+                    <div>
+                        <!-- Content of menu Item. Using either unsafeHTML or HTML depending on input type -->
+                        ${(selectedItem != null && selectedItem.content != null) ? (typeof selectedItem.content == "string" ? unsafeHTML(selectedItem.content as string) : html`${selectedItem.content}`) : undefined}
+                    </div>
+                </div>
+            </div>
+        `
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,6 +2718,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material/tab-bar@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@material/tab-bar@npm:9.0.0"
+  dependencies:
+    "@material/animation": ^9.0.0
+    "@material/base": ^9.0.0
+    "@material/density": ^9.0.0
+    "@material/feature-targeting": ^9.0.0
+    "@material/tab": ^9.0.0
+    "@material/tab-scroller": ^9.0.0
+    tslib: ^1.9.3
+  checksum: 8b7b3dd20143ab30196c001c5e855a0d20796b64a0854454cc3e4683c6e183848936ed5444f061c536777d15510284d5e81149ff384d5d2f23aeae5377c04811
+  languageName: node
+  linkType: hard
+
+"@material/tab-indicator@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@material/tab-indicator@npm:9.0.0"
+  dependencies:
+    "@material/animation": ^9.0.0
+    "@material/base": ^9.0.0
+    "@material/feature-targeting": ^9.0.0
+    "@material/theme": ^9.0.0
+    tslib: ^1.9.3
+  checksum: b34d32da55f8f3eee71bf3bde6f821ec5190a8b820ee0d91e4aade2e1818617b873e48a44ffb3c9975946d675bb47c0f0fc08910684d34db829b9e834f7b045d
+  languageName: node
+  linkType: hard
+
+"@material/tab-scroller@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@material/tab-scroller@npm:9.0.0"
+  dependencies:
+    "@material/animation": ^9.0.0
+    "@material/base": ^9.0.0
+    "@material/dom": ^9.0.0
+    "@material/feature-targeting": ^9.0.0
+    "@material/tab": ^9.0.0
+    tslib: ^1.9.3
+  checksum: e93c2d97f6a5f01c74c37ae70f7be3abf2e2c3a243de744d0c06fcb787bad02293bc975d1b5583049deb6278e07c184041015a9a5ebb6690db27ab3b7a1bad8a
+  languageName: node
+  linkType: hard
+
+"@material/tab@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@material/tab@npm:9.0.0"
+  dependencies:
+    "@material/base": ^9.0.0
+    "@material/feature-targeting": ^9.0.0
+    "@material/ripple": ^9.0.0
+    "@material/rtl": ^9.0.0
+    "@material/tab-indicator": ^9.0.0
+    "@material/theme": ^9.0.0
+    "@material/typography": ^9.0.0
+    tslib: ^1.9.3
+  checksum: 1d2a7d858a96fb4f2d4743cb4018af71cf5a92f833cfea8d86ccb731399ee503bb9eb64a1f02520170a43e6417a1dbbfbaf136538b1611369f73b34e57ca142f
+  languageName: node
+  linkType: hard
+
 "@material/textfield@npm:^9.0.0":
   version: 9.0.0
   resolution: "@material/textfield@npm:9.0.0"
@@ -3414,6 +3472,7 @@ __metadata:
     "@material/slider": ^9.0.0
     "@material/snackbar": ^9.0.0
     "@material/switch": ^9.0.0
+    "@material/tab-bar": ^9.0.0
     "@material/textfield": ^9.0.0
     "@openremote/core": "workspace:*"
     "@openremote/or-icon": ^1.0.4


### PR DESCRIPTION
Implementation of a new mwc component as referenced in #662 
Uses the material spec for switching TemplateResult which can be put in using a property, or handled outside of the component with the "activated"-event. Any feedback or improvement is welcome, since it is my first pull request here 😄 