### PR TITLE
Remove trailing space from or-mwc-input

### DIFF
--- a/ui/component/or-asset-tree/src/index.ts
+++ b/ui/component/or-asset-tree/src/index.ts
@@ -439,8 +439,7 @@ export class OrAssetTree extends subscribe(manager)(LitElement) {
                               @or-mwc-input-changed="${ (e: OrInputChangedEvent) => {
                                   // Means field has lost focus so do filter immediately
                                   this._onFilterInput((e.detail.value as string) || undefined, true);
-                              }}"
-                              trailingSpace="true">
+                              }}">
                               </or-mwc-input>
                 <or-icon id="filterSettingsIcon" icon="tune" @click="${() => {
                     if ( this._filterSetting.classList.contains("visible") ) {

--- a/ui/component/or-asset-tree/src/style.ts
+++ b/ui/component/or-asset-tree/src/style.ts
@@ -226,7 +226,7 @@ export const style = css`
     }
     
     #filterInput {
-        padding: 7px 10px;
+        padding: 7px 12px 7px 7px;
     }
     
     #clearIconContainer {
@@ -256,7 +256,7 @@ export const style = css`
     
     #filterSettingsIcon {
         cursor: pointer;
-        margin-right: 5px;
+        margin-right: 12px;
     }
     
     #asset-tree-filter-setting {

--- a/ui/component/or-mwc-components/src/or-mwc-input.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-input.ts
@@ -596,10 +596,6 @@ const style = css`
     .or-label-with-icon {
         left: 42px !important;
     }
-    
-    .or-trailing-space {
-        width: 78%;
-    }
 `;
 
 @customElement("or-mwc-input")
@@ -768,9 +764,6 @@ export class OrMwcInput extends LitElement {
 
     @property({type: Boolean})
     public resizeVertical: boolean = false;
-
-    @property({type: Boolean})
-    public trailingSpace: boolean = false;
 
     public get nativeValue(): any {
         if (this._mdcComponent) {
@@ -1315,7 +1308,7 @@ export class OrMwcInput extends LitElement {
                                 @change="${(e: Event) => this.onValueChange((e.target as HTMLTextAreaElement), (e.target as HTMLTextAreaElement).value)}">${valMinMax[0] ? valMinMax[0] : ""}</textarea>`
                             : html`
                             <input type="${type}" id="elem" aria-labelledby="${ifDefined(label ? "label" : undefined)}"
-                            class="mdc-text-field__input ${this.trailingSpace ? "or-trailing-space" : ""}" ?required="${this.required}" ?readonly="${this.readonly}"
+                            class="mdc-text-field__input" ?required="${this.required}" ?readonly="${this.readonly}"
                             ?disabled="${this.disabled}" min="${ifDefined(valMinMax[1])}" max="${ifDefined(valMinMax[2])}"
                             step="${this.step ? this.step : "any"}" minlength="${ifDefined(this.minLength)}" pattern="${ifDefined(this.pattern)}"
                             maxlength="${ifDefined(this.maxLength)}" placeholder="${ifDefined(this.placeHolder)}"


### PR DESCRIPTION
- Remove trailing space from asset tree filter. Not needed anymore since icon and clear button were removed.
- Small styling changes to make icon of filter options line up with asset tree bar above