### PR TITLE
Fix order of path in parent input

### DIFF
--- a/ui/component/or-asset-viewer/src/or-edit-asset-panel.ts
+++ b/ui/component/or-asset-viewer/src/or-edit-asset-panel.ts
@@ -583,7 +583,7 @@ export class OrEditAssetPanel extends LitElement {
             const path = [this.asset.id!];
             let parentNode = assetTree.selectedNodes[0];
             while (parentNode !== undefined) {
-                path.push(parentNode.asset!.id!);
+                path.unshift(parentNode.asset!.id!);
                 parentNode = parentNode.parent;
             }
             this.asset.path = path;


### PR DESCRIPTION
When using the parent select dialog the resulting path that is shown in the parent input was incorrect. Fixed by building the path the other way round.