### PR TITLE
Fixed predicted data related rules synchronization

### DIFF
--- a/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
+++ b/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
@@ -554,7 +554,9 @@ public class RulesEngine<T extends Ruleset> {
     }
 
     protected void fireAllDeploymentsWithPredictedData() {
-        fireDeployments(deployments.values().stream().filter(RulesetDeployment::isTriggerOnPredictedData).collect(Collectors.toList()));
+        withLock(toString() + "::fireAllDeploymentsWithPredictedData", () -> {
+            fireDeployments(deployments.values().stream().filter(RulesetDeployment::isTriggerOnPredictedData).collect(Collectors.toList()));
+        });
     }
 
     protected void notifyAssetStatesChanged(AssetStateChangeEvent event) {


### PR DESCRIPTION
Missing synchronization caused ConcurrentModificationException and as a result rules were stopped.