### PR TITLE
Improve asset tree loading by avoiding to compute to many times the c…

### DIFF
--- a/ui/component/or-asset-tree/src/index.ts
+++ b/ui/component/or-asset-tree/src/index.ts
@@ -1692,7 +1692,6 @@ export class OrAssetTree extends subscribe(manager)(LitElement) {
             this._nodes = [];
         } else {
             if (manager.isRestrictedUser()) {
-                console.log('isRestricted');
                 // Any assets whose parents aren't accessible need to be re-parented
                 assets.forEach(asset => {
                     if (!!asset.parentId && !!asset.path && assets.find(a => a.id === asset.parentId) === undefined) {


### PR DESCRIPTION
I avoid to compute too many times through the assets array the children for each node on the Build of the asset tree architecture.

On my local it improves the loading with an instance of 5000 assets : 

**Before :**
<img width="822" alt="Screenshot 2022-10-19 at 11 30 32" src="https://user-images.githubusercontent.com/10142800/196657505-f0c63016-6c13-4b08-b9fb-e030262231fa.png">

**After :**
<img width="822" alt="Screenshot 2022-10-19 at 11 34 55" src="https://user-images.githubusercontent.com/10142800/196657510-51b0084a-7744-4ceb-b46b-ae496fb0e310.png">
