### PR TITLE
Hotfix for or-mwc-input select; ripple not behaving to Material Design spec

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Backend files changed
         id: backend-files-changed
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v34
         with:
           files_ignore: |
             .ci_cd/**
@@ -189,7 +189,7 @@ jobs:
       - name: UI files changed
         id: ui-files-changed
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v34
         with:
           files: |
             ui/app/manager/**

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -166,7 +166,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           # This will only be available when run by workflow_dispatch otherwise will checkout branch/commit that triggered the workflow
-          ref: ${{ steps.inputs-and-secrets.outputs.COMMIT }}
+          ref: ${{ steps.inputs-and-secrets.outputs.COMMIT || github.event.pull_request.head.sha }}
           submodules: recursive
 
       # Check which files have changed to only run appropriate tests and checks

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -166,7 +166,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           # This will only be available when run by workflow_dispatch otherwise will checkout branch/commit that triggered the workflow
-          ref: ${{ steps.inputs-and-secrets.outputs.COMMIT || github.event.pull_request.head.sha }}
+          ref: ${{ steps.inputs-and-secrets.outputs.COMMIT }}
           submodules: recursive
 
       # Check which files have changed to only run appropriate tests and checks

--- a/ui/component/or-mwc-components/src/or-mwc-input.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-input.ts
@@ -1007,7 +1007,7 @@ export class OrMwcInput extends LitElement {
                                      aria-expanded="false"
                                      aria-disabled="${""+(this.disabled || this.readonly)}"
                                      aria-labelledby="label selected-text">
-                                    <span class="mdc-select__ripple"></span>
+                                    ${!outlined ? html`<span class="mdc-select__ripple"></span>` : undefined}
                                     ${outlined ? this.renderOutlined(labelTemplate) : labelTemplate}
                                     <span class="mdc-select__selected-text-container">
                                       <span id="selected-text" class="mdc-select__selected-text"></span>


### PR DESCRIPTION
Includes a hotfix for `or-mwc-input` SELECT type when `outlined` property was enabled.
The ripple had unusual behavior, and it is now behaving to the Material Design specifications.