### PR TITLE
fix by checking on dragstart if we start with ctrl/shift key or not

### DIFF
--- a/ui/component/or-asset-tree/src/index.ts
+++ b/ui/component/or-asset-tree/src/index.ts
@@ -1814,6 +1814,9 @@ export class OrAssetTree extends subscribe(manager)(LitElement) {
         }
 
         if (selectedId && this.selectedIds && !this.selectedIds.includes(selectedId)) {
+            if (!ev.ctrlKey && !ev.shiftKey) {
+                this.selectedIds = [];
+            }
             this.selectedIds.push(selectedId);
         }
     }


### PR DESCRIPTION
Hi @richturner 

Here a small fix to avoid wrong asset selection on drag & drop (see issue related)

regards