### PR TITLE
Fix scroll issue for assets and rules

### DIFF
--- a/ui/component/or-app/src/index.ts
+++ b/ui/component/or-app/src/index.ts
@@ -120,7 +120,6 @@ export class OrApp<S extends AppStateKeyed> extends LitElement {
                 
             .main-content {
                 display: flex;
-                flex-direction: column;
                 flex: 1;
                 box-sizing: border-box;
                 background-color: var(--or-app-color2);


### PR DESCRIPTION
When the asset tree/rules list becomes too long, it made the whole page scroll instead of only the list. Same for the asset-viewer/rules viewer that makes the list scroll if too high.