### PR TITLE
Close the drawn rectangle on the map

### DIFF
--- a/ui/component/or-map/src/mapwidget.ts
+++ b/ui/component/or-map/src/mapwidget.ts
@@ -625,6 +625,7 @@ export class MapWidget {
                     [boundsArray[2], boundsArray[3]],
                     [boundsArray[2], boundsArray[1]],
                     [boundsArray[0], boundsArray[1]],
+                    [boundsArray[0], boundsArray[3]]
                 ]
             ]
             this._mapGl.fitBounds([


### PR DESCRIPTION
On the appearance page map settings a rectangle is drawn to show the set bounds. The last line of the square was never properly drawn making it look awkward sometimes.