### PR TITLE
Minor Insights & Charting fixes

### DIFF
--- a/ui/component/or-attribute-card/src/index.ts
+++ b/ui/component/or-attribute-card/src/index.ts
@@ -359,7 +359,6 @@ export class OrAttributeCard extends LitElement {
                                 <or-mwc-input class="button" .type="${InputType.BUTTON}" label="${i18next.t("selectAttribute")}" icon="plus" @or-mwc-input-changed="${() => this._openDialog("editAttribute")}"></or-mwc-input>
                             ` : html`
                                 <span>${i18next.t('noAttributesConnected')}</span>
-                                <or-mwc-input class="button" .type="${InputType.BUTTON}" icon="reload" @or-mwc-input-changed="${() => { this.requestUpdate(); }}"></or-mwc-input>
                             `}
                         </div>
                     </div>
@@ -375,9 +374,7 @@ export class OrAttributeCard extends LitElement {
                             <span>${i18next.t("couldNotRetrieveAttribute")}</span>
                             ${this.shouldShowControls() ? html`
                                 <or-mwc-input class="button" .type="${InputType.BUTTON}" label="${i18next.t("selectAttribute")}" icon="plus" @or-mwc-input-changed="${() => this._openDialog("editAttribute")}"></or-mwc-input>
-                            ` : html`
-                                <or-mwc-input class="button" .type="${InputType.BUTTON}" icon="reload" @or-mwc-input-changed="${() => { this.requestUpdate(); }}"></or-mwc-input>
-                            `}
+                            ` : undefined}
                         </div>
                     </div>
                 </div>

--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -38,7 +38,7 @@ import {
     Title,
     Tooltip
 } from "chart.js";
-import {InputType, OrInputChangedEvent} from "@openremote/or-mwc-components/or-mwc-input";
+import {InputType} from "@openremote/or-mwc-components/or-mwc-input";
 import moment from "moment";
 import {OrAssetTreeSelectionEvent} from "@openremote/or-asset-tree";
 import {getAssetDescriptorIconTemplate} from "@openremote/or-icon";
@@ -48,8 +48,8 @@ import {GenericAxiosResponse} from "@openremote/rest";
 import {OrAttributePicker, OrAttributePickerPickedEvent} from "@openremote/or-attribute-picker";
 import {showDialog} from "@openremote/or-mwc-components/or-mwc-dialog";
 import {cache} from "lit/directives/cache.js";
-import {debounce, throttle} from "lodash";
-import { getContentWithMenuTemplate } from "@openremote/or-mwc-components/or-mwc-menu";
+import {throttle} from "lodash";
+import {getContentWithMenuTemplate} from "@openremote/or-mwc-components/or-mwc-menu";
 import {ListItem} from "@openremote/or-mwc-components/or-mwc-list";
 
 Chart.register(LineController, ScatterController, LineElement, PointElement, LinearScale, TimeScale, Title, Filler, Legend, Tooltip, ChartAnnotation);
@@ -538,8 +538,8 @@ export class OrChart extends translate(i18next)(LitElement) {
                                     millisecond: 'HH:mm:ss.SSS',
                                     second: 'HH:mm:ss',
                                     minute: "HH:mm",
-                                    hour: "HH:mm",
-                                    day: "MMM D",
+                                    hour: (this._endOfPeriod && this._startOfPeriod && this._endOfPeriod - this._startOfPeriod > 86400000) ? "MMM DD, HH:mm" : "HH:mm",
+                                    day: "MMM DD",
                                     week: "w"
                                 },
                                 unit: this._timeUnits,
@@ -977,9 +977,11 @@ export class OrChart extends translate(i18next)(LitElement) {
             return [30, DatapointInterval.MINUTE];
         } else if(diffInHours <= 24) { // one day
             return [1, DatapointInterval.HOUR];
-        } else if(diffInHours <= 168) { // one week
-            return [6, DatapointInterval.HOUR];
-        } else if(diffInHours <= 720) { // one month
+        } else if(diffInHours <= 48) { // two days
+            return [3, DatapointInterval.HOUR];
+        } else if(diffInHours <= 96) {
+            return [12, DatapointInterval.HOUR];
+        } else if(diffInHours <= 744) { // one month
             return [1, DatapointInterval.DAY];
         } else {
             return [1, DatapointInterval.MONTH];

--- a/ui/component/or-dashboard-builder/src/or-dashboard-settingspanel.ts
+++ b/ui/component/or-dashboard-builder/src/or-dashboard-settingspanel.ts
@@ -258,8 +258,6 @@ export class OrDashboardSettingsPanel extends LitElement {
                 showSnackbar(undefined, i18next.t('errorOccurred'));
             });
             return assets;
-        } else {
-            console.error("Error: attributeRefs are not present in widget config!");
         }
     }
 

--- a/ui/component/or-dashboard-builder/src/widgets/or-chart-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/or-chart-widget.ts
@@ -123,13 +123,23 @@ export class OrChartWidgetContent extends LitElement {
 
     render() {
         return html`
-            <or-chart .assets="${this.assets}" .assetAttributes="${this.assetAttributes}" .realm="${this.realm}"
-                      .showLegend="${(this.widget?.widgetConfig?.showLegend != null) ? this.widget?.widgetConfig?.showLegend : true}"
-                      .attributeControls="${false}" .timestampControls="${!this.editMode && this.widget?.widgetConfig?.showTimestampControls}" .algorithm="${this.widget?.widgetConfig?.algorithm}"
-                      .timePresetOptions="${timePresetOptions}" .timePresetKey="${this.widget?.widgetConfig?.defaultTimePresetKey}"
-                      .datapointQuery="${this.widget?.widgetConfig?.datapointQuery}" .chartOptions="${this.widget?.widgetConfig?.chartOptions}"
-                      style="height: 100%"
-            ></or-chart>
+            ${when(this.assets && this.assetAttributes && this.assets.length > 0 && this.assetAttributes.length > 0, () => {
+                return html`
+                    <or-chart .assets="${this.assets}" .assetAttributes="${this.assetAttributes}" .realm="${this.realm}" 
+                              .showLegend="${(this.widget?.widgetConfig?.showLegend != null) ? this.widget?.widgetConfig?.showLegend : true}" 
+                              .attributeControls="${false}" .timestampControls="${!this.editMode && this.widget?.widgetConfig?.showTimestampControls}" .algorithm="${this.widget?.widgetConfig?.algorithm}" 
+                              .timePresetOptions="${timePresetOptions}" .timePresetKey="${this.widget?.widgetConfig?.defaultTimePresetKey}" 
+                              .datapointQuery="${this.widget?.widgetConfig?.datapointQuery}" .chartOptions="${this.widget?.widgetConfig?.chartOptions}" 
+                              style="height: 100%"
+                    ></or-chart>
+                `;
+            }, () => {
+                return html`
+                    <div style="height: 100%; display: flex; justify-content: center; align-items: center;">
+                        <span>${i18next.t('noAttributesConnected')}</span>
+                    </div>
+                `
+            })}
         `
     }
 

--- a/ui/component/or-dashboard-builder/src/widgets/or-chart-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/or-chart-widget.ts
@@ -381,7 +381,7 @@ class OrChartWidgetSettings extends LitElement {
                 ${this.generateExpandableHeader(i18next.t('algorithm'))}
             </div>
             <div>
-                ${this.expandedPanels.includes('algorithm') ? html`
+                ${this.expandedPanels.includes(i18next.t('algorithm')) ? html`
                     ${when(config.datapointQuery, () => {
                         const typeOptions = new Map<string, string>([["Default", 'lttb'], ["With interval", 'interval']]);
                         const typeValue = Array.from(typeOptions.entries()).find((entry => entry[1] == config.datapointQuery.type))![0]

--- a/ui/component/or-dashboard-builder/src/widgets/or-chart-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/or-chart-widget.ts
@@ -193,8 +193,6 @@ export class OrChartWidgetContent extends LitElement {
                 showSnackbar(undefined, i18next.t('errorOccurred'));
             });
             return assets;
-        } else if(!config.attributeRefs) {
-            console.error("Error: attributeRefs are not present in widget config!");
         }
     }
 

--- a/ui/component/or-dashboard-builder/src/widgets/or-gauge-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/or-gauge-widget.ts
@@ -86,7 +86,9 @@ export class OrGaugeWidgetContent extends LitElement {
                 `;
             }, () => {
                 return html`
-                    <span>No attributes selected.</span>
+                    <div style="height: 100%; display: flex; justify-content: center; align-items: center;">
+                        <span>${i18next.t('noAttributesConnected')}</span>
+                    </div>
                 `
             })}
             <!--<or-gauge .attrRef="${this.widget?.widgetConfig.attributeRefs[0]}"></or-gauge>-->

--- a/ui/component/or-dashboard-builder/src/widgets/or-gauge-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/or-gauge-widget.ts
@@ -125,8 +125,6 @@ export class OrGaugeWidgetContent extends LitElement {
                 showSnackbar(undefined, i18next.t('errorOccurred'));
             });
             return assets;
-        } else {
-            console.error("Error: attributeRefs are not present in widget config!");
         }
     }
 }

--- a/ui/component/or-dashboard-builder/src/widgets/or-kpi-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/or-kpi-widget.ts
@@ -112,8 +112,6 @@ export class OrKpiWidgetContent extends LitElement {
                 showSnackbar(undefined, i18next.t('errorOccurred'));
             });
             return assets;
-        } else {
-            console.error("Error: attributeRefs are not present in widget config!");
         }
     }
 }

--- a/ui/component/or-dashboard-builder/src/widgets/or-kpi-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/or-kpi-widget.ts
@@ -8,7 +8,6 @@ import {OrWidgetConfig, OrWidgetEntity} from "./or-base-widget";
 import {style} from "../style";
 import {SettingsPanelType, widgetSettingsStyling} from "../or-dashboard-settingspanel";
 import {InputType, OrInputChangedEvent } from "@openremote/or-mwc-components/or-mwc-input";
-import { when } from "lit/directives/when.js";
 
 export interface KpiWidgetConfig extends OrWidgetConfig {
     displayName: string;

--- a/ui/component/or-dashboard-builder/src/widgets/or-kpi-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/or-kpi-widget.ts
@@ -8,6 +8,7 @@ import {OrWidgetConfig, OrWidgetEntity} from "./or-base-widget";
 import {style} from "../style";
 import {SettingsPanelType, widgetSettingsStyling} from "../or-dashboard-settingspanel";
 import {InputType, OrInputChangedEvent } from "@openremote/or-mwc-components/or-mwc-input";
+import { when } from "lit/directives/when.js";
 
 export interface KpiWidgetConfig extends OrWidgetConfig {
     displayName: string;


### PR DESCRIPTION
Minor but important fixes for the Insights page.
Only frontend-related changes.

Changelog:
- Hotfix for algorithm options not showing in chart widget settings.
- Ticks on the x-axis on `or-chart` have been improved, to display more ticks on certain timeframes.
- "No attributes connected" text is now translated correctly, and centered with within the widget.
- Removed unused reload button on `or-attribute-card` 