### PR TITLE
Bugfix for attribute history; data changes did not correctly update the UI.

### DIFF
--- a/ui/component/or-attribute-history/src/index.ts
+++ b/ui/component/or-attribute-history/src/index.ts
@@ -446,6 +446,7 @@ export class OrAttributeHistory extends translate(i18next)(LitElement) {
                 }
             }
         } else {
+            // Updating the table template before render, if necessary, to prevent additional update
             if (!this._tableTemplate || changedProperties.has("_data")) {
                 this._tableTemplate = this._getTableTemplate();
             }

--- a/ui/component/or-attribute-history/src/index.ts
+++ b/ui/component/or-attribute-history/src/index.ts
@@ -335,7 +335,7 @@ export class OrAttributeHistory extends translate(i18next)(LitElement) {
     }
 
     // Method that is executed during an update, to compute (additional) values before rendering.
-    // Used instead of updated() to prevent a second update.
+    // Used instead of updated() to prevent a second render when properties get changed.
     willUpdate(changedProperties: PropertyValues) {
         super.willUpdate(changedProperties);
 

--- a/ui/component/or-attribute-history/src/index.ts
+++ b/ui/component/or-attribute-history/src/index.ts
@@ -321,8 +321,7 @@ export class OrAttributeHistory extends translate(i18next)(LitElement) {
                     <div id="msg">
                         <or-translate value="invalidAttribute"></or-translate>
                     </div>
-                ` : isChart
-            ? html`
+                ` : isChart ? html`
                         <div id="chart-container">
                             <canvas id="chart"></canvas>
                         </div>
@@ -335,8 +334,10 @@ export class OrAttributeHistory extends translate(i18next)(LitElement) {
         `;
     }
 
-    updated(changedProperties: PropertyValues) {
-        super.updated(changedProperties);
+    // Method that is executed during an update, to compute (additional) values before rendering.
+    // Used instead of updated() to prevent a second update.
+    willUpdate(changedProperties: PropertyValues) {
+        super.willUpdate(changedProperties);
 
         if (!this._type || !this._data) {
             return;


### PR DESCRIPTION
Bugfix for #1030 .

## Breakdown of the issue
The `or-attribute-history` component was incorrectly updating / rendering the data.
I discovered the following behavior:

1. Data from the correct timestamps is fetched from the database.
2. The `_data` property gets updated, triggering a render.
3. Render takes place.
4. After render, during `updated()`, a new table is created with the new data using `this._getTableTemplate()`.
5. The `_tableTemplate` property gets updated.
6. LitElement tries to update, but we cancel it manually because of insufficient changes. (see snippet)

```typescript
 shouldUpdate(_changedProperties: PropertyValues): boolean {
        let reloadData = _changedProperties.has("period") || _changedProperties.has("toTimestamp") || _changedProperties.has("attribute");
        if (this._dataFirstLoaded && !_changedProperties.get('_loading') && !reloadData) {
            return false;
        }

// If only _tableTemplate is changed, it will return false, since nothing else is updated.
```

## Changes made
I could've included a check with `changedProperties.has('_tableTemplate')` within `shouldUpdate()`.
However, that would mean 2 updates are required for each data update.

So, I changed the `updated()` method to `willUpdate()`. See https://lit.dev/docs/components/lifecycle/#willupdate
Now the table changes **during** the same update, instead of having to trigger a 2nd render. (that initially was cancelled)


.