### PR TITLE
Fix for asset link failing on new user creation.

### DIFF
--- a/ui/app/manager/src/pages/page-users.ts
+++ b/ui/app/manager/src/pages/page-users.ts
@@ -560,6 +560,7 @@ export class PageUsers extends Page<AppStateKeyed> {
         return {
             enabled: true,
             password: undefined,
+            realm: manager.displayRealm,
             roles: [],
             previousRoles: [],
             realmRoles: [],


### PR DESCRIPTION
Fixes #934 .

When creating a new user, and adding linked assets during the creation, it failed to link the assets by throwing a 500.
Apparently the realm was not specified in the user model, causing the asset link to use an `undefined` realm.

See here:
```typescript
const onAssetSelectionChanged = (e: OrAssetTreeSelectionEvent) => {
    user.userAssetLinks = e.detail.newNodes.map(node => {
        const userAssetLink: UserAssetLink = {
            id: {
                userId: user.id,
                realm: user.realm, // was undefined when creating a new user, causing 500
                assetId: node.asset.id
            }
        };
        return userAssetLink;
    })
};
```

Now including `manager.displayRealm` within `getNewUserModel()`.