### PR TITLE
Fix for deselecting asset when expanding/collapsing in or-asset-tree

### DIFF
--- a/ui/app/manager/src/pages/page-assets.ts
+++ b/ui/app/manager/src/pages/page-assets.ts
@@ -209,7 +209,6 @@ export class PageAssets extends Page<AssetsStateKeyed>  {
     // State is only utilised for initial loading, and for changes within the store.
     // On the assets page, we shouldn't change editMode nor assetIds if the URL/state hasn't changed.
     stateChanged(state: AppStateKeyed) {
-        // State is only utilised for initial loading
         this.getRealmState(state); // Order is important here!
         this._editMode = !!(state.app.params && state.app.params.editMode === "true");
         if(!this._assetIds || this._assetIds.length === 0 && this._assetIds[0] === state.app.params.id) {

--- a/ui/app/manager/src/pages/page-assets.ts
+++ b/ui/app/manager/src/pages/page-assets.ts
@@ -211,7 +211,7 @@ export class PageAssets extends Page<AssetsStateKeyed>  {
     stateChanged(state: AppStateKeyed) {
         this.getRealmState(state); // Order is important here!
         this._editMode = !!(state.app.params && state.app.params.editMode === "true");
-        if(!this._assetIds || this._assetIds.length === 0 && this._assetIds[0] === state.app.params.id) {
+        if(!this._assetIds || (this._assetIds.length === 0 && this._assetIds[0] === state.app.params.id)) {
             this._assetIds = state.app.params && state.app.params.id ? [state.app.params.id as string] : undefined;
         }
     }

--- a/ui/app/manager/src/pages/page-assets.ts
+++ b/ui/app/manager/src/pages/page-assets.ts
@@ -162,6 +162,7 @@ export class PageAssets extends Page<AssetsStateKeyed>  {
     protected _viewer!: OrAssetViewer;
 
     protected _addedAssetId?: string;
+    protected _currentStateJsonString?: string;
     protected _realmSelector = (state: AppStateKeyed) => state.app.realm || manager.displayRealm;
 
     get name(): string {
@@ -206,11 +207,16 @@ export class PageAssets extends Page<AssetsStateKeyed>  {
         `;
     }
 
+    // State is only utilised for initial loading, and for changes within the store.
+    // On the assets page, we shouldn't change editMode nor assetIds if the URL/state hasn't changed.
     stateChanged(state: AppStateKeyed) {
-        // State is only utilised for initial loading
-        this.getRealmState(state); // Order is important here!
-        this._editMode = !!(state.app.params && state.app.params.editMode === "true");
-        this._assetIds = state.app.params && state.app.params.id ? [state.app.params.id as string] : undefined;
+        const newStateJsonString: string = JSON.stringify(state.app);
+        if(this._currentStateJsonString != newStateJsonString) {
+            this.getRealmState(state); // Order is important here!
+            this._editMode = !!(state.app.params && state.app.params.editMode === "true");
+            this._assetIds = state.app.params && state.app.params.id ? [state.app.params.id as string] : undefined;
+        }
+        this._currentStateJsonString = newStateJsonString;
     }
 
     protected _onAssetSelectionRequested(event: OrAssetTreeRequestSelectionEvent) {
@@ -301,7 +307,7 @@ export class PageAssets extends Page<AssetsStateKeyed>  {
         }
     }
 
-    protected async  _onAssetParentChange(newParentId: any) {
+    protected async _onAssetParentChange(newParentId: any) {
         let parentId: string | undefined = newParentId.parentId;
         let assetsIds: string[] = newParentId.assetsIds;
 

--- a/ui/app/manager/src/pages/page-assets.ts
+++ b/ui/app/manager/src/pages/page-assets.ts
@@ -162,7 +162,6 @@ export class PageAssets extends Page<AssetsStateKeyed>  {
     protected _viewer!: OrAssetViewer;
 
     protected _addedAssetId?: string;
-    protected _currentStateJsonString?: string;
     protected _realmSelector = (state: AppStateKeyed) => state.app.realm || manager.displayRealm;
 
     get name(): string {
@@ -210,13 +209,12 @@ export class PageAssets extends Page<AssetsStateKeyed>  {
     // State is only utilised for initial loading, and for changes within the store.
     // On the assets page, we shouldn't change editMode nor assetIds if the URL/state hasn't changed.
     stateChanged(state: AppStateKeyed) {
-        const newStateJsonString: string = JSON.stringify(state.app);
-        if(this._currentStateJsonString != newStateJsonString) {
-            this.getRealmState(state); // Order is important here!
-            this._editMode = !!(state.app.params && state.app.params.editMode === "true");
+        // State is only utilised for initial loading
+        this.getRealmState(state); // Order is important here!
+        this._editMode = !!(state.app.params && state.app.params.editMode === "true");
+        if(!this._assetIds || this._assetIds.length === 0 && this._assetIds[0] === state.app.params.id) {
             this._assetIds = state.app.params && state.app.params.id ? [state.app.params.id as string] : undefined;
         }
-        this._currentStateJsonString = newStateJsonString;
     }
 
     protected _onAssetSelectionRequested(event: OrAssetTreeRequestSelectionEvent) {


### PR DESCRIPTION
Fixes #976 

Previously the asset was deselected when expanding/collapsing assets in the `or-asset-tree` sidebar.
This was caused by `stateChanged()` being triggered by the changes in the `_store` we make for caching the expanded assets.
I now included a check whether the `AppState` has changed (such as URL and parameters), since we don't need to update
the `editMode` nor `assetIds` in other cases.