### PR TITLE
Bugfix for dashboard deletion while superuser

### DIFF
--- a/manager/src/main/java/org/openremote/manager/dashboard/DashboardResourceImpl.java
+++ b/manager/src/main/java/org/openremote/manager/dashboard/DashboardResourceImpl.java
@@ -53,9 +53,8 @@ public class DashboardResourceImpl extends ManagerWebResource implements Dashboa
     }
 
     @Override
-    public Dashboard get(RequestParams requestParams, String dashboardId) {
+    public Dashboard get(RequestParams requestParams, String realm, String dashboardId) {
         boolean publicOnly = true;
-        String realm = getRequestRealmName();
         if(realm == null) {
             throw new WebApplicationException(BAD_REQUEST);
         }
@@ -126,8 +125,7 @@ public class DashboardResourceImpl extends ManagerWebResource implements Dashboa
     }
 
     @Override
-    public void delete(RequestParams requestParams, String dashboardId) {
-        String realm = getRequestRealmName();
+    public void delete(RequestParams requestParams, String realm, String dashboardId) {
         if(realm == null) {
             throw new WebApplicationException(BAD_REQUEST);
         }

--- a/model/src/main/java/org/openremote/model/dashboard/DashboardResource.java
+++ b/model/src/main/java/org/openremote/model/dashboard/DashboardResource.java
@@ -22,9 +22,9 @@ public interface DashboardResource {
     Dashboard[] getAllRealmDashboards(@BeanParam RequestParams requestParams, @PathParam("realm") String realm);
 
     @GET
-    @Path("{dashboardId}")
+    @Path("{realm}/{dashboardId}")
     @Produces(APPLICATION_JSON)
-    Dashboard get(@BeanParam RequestParams requestParams, @PathParam("dashboardId") String dashboardId);
+    Dashboard get(@BeanParam RequestParams requestParams, @PathParam("realm") String realm, @PathParam("dashboardId") String dashboardId);
 
     @POST
     @Consumes(APPLICATION_JSON)
@@ -39,8 +39,8 @@ public interface DashboardResource {
     Dashboard update(@BeanParam RequestParams requestParams, @Valid Dashboard dashboard);
 
     @DELETE
-    @Path("{dashboardId}")
+    @Path("{realm}/{dashboardId}")
     @Produces(APPLICATION_JSON)
     @RolesAllowed({Constants.WRITE_INSIGHTS_ROLE})
-    void delete(@BeanParam RequestParams requestParams, @PathParam("dashboardId") String dashboardId);
+    void delete(@BeanParam RequestParams requestParams, @PathParam("realm") String realm, @PathParam("dashboardId") String dashboardId);
 }

--- a/test/src/test/groovy/org/openremote/test/dashboard/DashboardTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/dashboard/DashboardTest.groovy
@@ -89,7 +89,7 @@ class DashboardTest extends Specification implements ManagerContainerTrait {
         // Test to verify "DELETE" logic
 
         when: "admin user tries to delete a dashboard he doesn't own"
-        adminUserDashboardResource.delete(null, privateUser1Dashboard.id)
+        adminUserDashboardResource.delete(null, MASTER_REALM, privateUser1Dashboard.id)
 
         then: "it should throw exception"
         thrown NotFoundException
@@ -123,7 +123,7 @@ class DashboardTest extends Specification implements ManagerContainerTrait {
         // Test to verify private dashboards cannot be fetched by public/unauthenticated users, even if ID is specified
 
         when: "when a public user specifically fetches a private dashboard"
-        publicUserDashboardResource.get(null, adminDashboard.id);
+        publicUserDashboardResource.get(null, MASTER_REALM, adminDashboard.id);
 
         then: "it should throw exception"
         thrown ForbiddenException

--- a/ui/app/insights/src/pages/page-view.ts
+++ b/ui/app/insights/src/pages/page-view.ts
@@ -186,7 +186,7 @@ export class PageView extends Page<AppStateKeyed> {
     protected async fetchDashboard(id: string, loginRedirect: boolean = true): Promise<Dashboard | undefined> {
         let promise = this.getPromise('dashboard/' + id);
         if(promise == undefined) {
-            promise = this.registerPromise(('dashboard/' + id), manager.rest.api.DashboardResource.get(id), true, false);
+            promise = this.registerPromise(('dashboard/' + id), manager.rest.api.DashboardResource.get(this._realm, id), true, false);
         }
         try {
             const response = await promise;
@@ -259,7 +259,7 @@ export class PageView extends Page<AppStateKeyed> {
         } else if(!this.viewDashboardOnly) {
             return (translate ? i18next.t('noDashboardSelected-mobile') : 'noDashboardSelected-mobile')
         }
-        return (translate ? i18next.t('errorOccured') : 'errorOccured')
+        return (translate ? i18next.t('errorOccurred') : 'errorOccurred')
     }
 
     selectDashboard(id: string, closeDrawer: boolean = true) {

--- a/ui/component/or-dashboard-builder/src/or-dashboard-boardsettings.ts
+++ b/ui/component/or-dashboard-builder/src/or-dashboard-boardsettings.ts
@@ -193,7 +193,7 @@ export class OrDashboardBoardsettings extends LitElement {
         } else {
             return html`
                 <div style="padding: 24px;">
-                    <span>${i18next.t('errorOccured')}</span><br/>
+                    <span>${i18next.t('errorOccurred')}</span><br/>
                     <span>${i18next.t('noDashboardFound')}</span>
                 </div>
             `

--- a/ui/component/or-dashboard-builder/src/or-dashboard-preview.ts
+++ b/ui/component/or-dashboard-builder/src/or-dashboard-preview.ts
@@ -279,7 +279,7 @@ export class OrDashboardPreview extends LitElement {
 
         // Setup template (list of widgets and properties)
         if(!this.template && this.dashboardId) {
-            manager.rest.api.DashboardResource.get(this.dashboardId)
+            manager.rest.api.DashboardResource.get(this.realm, this.dashboardId)
                 .then((response) => { this.template = response.data.template!; })
                 .catch((reason) => { console.error(reason); showSnackbar(undefined, i18next.t('errorOccurred')); });
         } else if(this.template == null && this.dashboardId == null) {

--- a/ui/component/or-dashboard-builder/src/or-dashboard-tree.ts
+++ b/ui/component/or-dashboard-builder/src/or-dashboard-tree.ts
@@ -142,7 +142,7 @@ export class OrDashboardTree extends LitElement {
 
     private deleteDashboard(dashboard: Dashboard) {
         if(dashboard.id != null) {
-            manager.rest.api.DashboardResource.delete(dashboard.id)
+            manager.rest.api.DashboardResource.delete(this.realm, dashboard.id)
                 .then((response) => {
                     if(response.status == 204) {
                         this.getAllDashboards();


### PR DESCRIPTION
Bugfix for dashboard deletion while superuser, since request is sent with 'master' realm instead of a custom one.
Instead of adding a superuser check, or checking for permission after the query, I just added a `realm` parameter to the URL.

So be aware of the minor API change:
`GET /dashboard/{id}` -> `GET /dashboard/{realm}/{id}`
`DELETE /dashboard/{id}` -> `DELETE /dashboard/{realm}/{id}`

Also added small translation fix.