### PR TITLE
Fix for or-chart where interval could not be overridden

### DIFF
--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -1073,7 +1073,7 @@ export class OrChart extends translate(i18next)(LitElement) {
                     console.error("Could not grab width of the Chart for estimating amount of datapoints. Using 10 points instead.")
                 }
                 query.amountOfPoints = (this._chartElem.clientWidth == 0) ? 100 : Math.round(this._chartElem.clientWidth / 10); // set amount of datapoints based on current chart width.
-            } else if(query.type == 'interval') {
+            } else if(query.type == 'interval' && query.interval == undefined) {
                 const diffInHours = (this.datapointQuery.toTimestamp! - this.datapointQuery.fromTimestamp!) / 1000 / 60 / 60;
                 const intervalArr = this._getInterval(diffInHours);
                 query.interval = (intervalArr[0].toString() + " " + intervalArr[1].toString()); // for example: "5 minute"


### PR DESCRIPTION
Interval is now not overridden anymore if already set by parent component.
So if someone uses the `or-chart` component, and wants to specify an datapoint interval manually,
it now correctly applies the value.