### PR TITLE
Allow identity provider to set email as username

### DIFF
--- a/manager/src/main/java/org/openremote/manager/security/ManagerKeycloakIdentityProvider.java
+++ b/manager/src/main/java/org/openremote/manager/security/ManagerKeycloakIdentityProvider.java
@@ -262,13 +262,12 @@ public class ManagerKeycloakIdentityProvider extends KeycloakIdentityProvider im
     @Override
     public User createUpdateUser(String realm, final User user, String passwordSecret, boolean allowUpdate) throws WebApplicationException {
         return getRealms(realmsResource -> {
-
-            if (user.getUsername() == null) {
+            if (getRealm(realm).getRegistrationEmailAsUsername() && !user.isServiceAccount() ? user.getEmail() == null : user.getUsername() == null) {
                 throw new BadRequestException("Attempt to create/update user but no username provided: User=" + user);
             }
 
             // Force lowercase username
-            user.setUsername(user.getUsername().toLowerCase(Locale.ROOT));
+            if (!getRealm(realm).getRegistrationEmailAsUsername()) user.setUsername(user.getUsername().toLowerCase(Locale.ROOT));
 
             boolean isUpdate = false;
             User existingUser = user.getId() != null ? getUser(user.getId()) : getUserByUsername(realm, user.getUsername());

--- a/manager/src/main/java/org/openremote/manager/security/ManagerKeycloakIdentityProvider.java
+++ b/manager/src/main/java/org/openremote/manager/security/ManagerKeycloakIdentityProvider.java
@@ -262,12 +262,17 @@ public class ManagerKeycloakIdentityProvider extends KeycloakIdentityProvider im
     @Override
     public User createUpdateUser(String realm, final User user, String passwordSecret, boolean allowUpdate) throws WebApplicationException {
         return getRealms(realmsResource -> {
-            if (getRealm(realm).getRegistrationEmailAsUsername() && !user.isServiceAccount() ? user.getEmail() == null : user.getUsername() == null) {
-                throw new BadRequestException("Attempt to create/update user but no username provided: User=" + user);
-            }
 
             // Force lowercase username
-            if (!getRealm(realm).getRegistrationEmailAsUsername()) user.setUsername(user.getUsername().toLowerCase(Locale.ROOT));
+            if (user.getUsername() != null) {
+                user.setUsername(user.getUsername().toLowerCase(Locale.ROOT));
+            }
+
+            if (!user.isServiceAccount() && allowUpdate) {
+                if (getRealm(realm).getRegistrationEmailAsUsername() ? user.getEmail() == null : user.getUsername() == null) {
+                    throw new BadRequestException("Attempt to create/update user but no username or email provided: User=" + user);
+                }
+            }
 
             boolean isUpdate = false;
             User existingUser = user.getId() != null ? getUser(user.getId()) : getUserByUsername(realm, user.getUsername());

--- a/manager/src/web/shared/locales/en/or.json
+++ b/manager/src/web/shared/locales/en/or.json
@@ -545,6 +545,8 @@
     }
   },
   "rowsPerPage": "Rows per page",
+  "noEmailSet": "Create user failed, no email set.",
+  "noUsernameSet": "Create user failed, no username set",
   "createUserFailed": "Create user failed",
   "saveUserFailed": "Save user failed",
   "saveUserSucceeded": "Saved user successfully!",

--- a/manager/src/web/shared/locales/nl/or.json
+++ b/manager/src/web/shared/locales/nl/or.json
@@ -545,6 +545,8 @@
     }
   },
   "rowsPerPage": "Rijen per pagina",
+  "noEmailSet": "Gebruiker aanmaken mislukt, geen email ingevuld.",
+  "noUsernameSet": "Gebruiker aanmaken mislukt, geen gebruikersnaam ingevuld.",
   "createUserFailed": "Aanmaken gebruiker mislukt",
   "saveUserFailed": "Opslaan gebruiker mislukt",
   "saveUserSucceeded": "Gebruiker succesvol opgeslagen!",

--- a/model/src/main/java/org/openremote/model/security/User.java
+++ b/model/src/main/java/org/openremote/model/security/User.java
@@ -119,12 +119,11 @@ public class User {
         return this;
     }
 
-    @NotNull(message = "{User.username.NotNull}")
     @Size(min = 3, max = 255, message = "{User.username.Size}")
-    @Pattern(regexp = "[a-zA-Z0-9-_]+", message = "{User.username.Pattern}")
+    @Pattern(regexp = "[A-Za-z0-9\\-_]+", message = "{User.username.Pattern}")
     @JsonProperty
     public String getUsername() {
-        return username.replace(SERVICE_ACCOUNT_PREFIX, "");
+        return username == null ? null : username.replace(SERVICE_ACCOUNT_PREFIX, "");
     }
 
     @JsonSetter("username")

--- a/ui/app/manager/src/pages/page-users.ts
+++ b/ui/app/manager/src/pages/page-users.ts
@@ -207,6 +207,8 @@ export class PageUsers extends Page<AppStateKeyed> {
     protected _roles: Role[] = [];
     @state()
     protected _realmRoles: Role[] = [];
+    @state()
+    protected _registrationEmailAsUsername: boolean = false;
 
     @state()
     protected _compositeRoles: Role[] = [];
@@ -314,6 +316,7 @@ export class PageUsers extends Page<AppStateKeyed> {
 
         this._compositeRoles = roleResponse.data.filter(role => role.composite).sort(Util.sortByString(role => role.name));
         this._roles = roleResponse.data.filter(role => !role.composite).sort(Util.sortByString(role => role.name));
+        this._registrationEmailAsUsername = realmResponse.data.registrationEmailAsUsername;
         this._realmRoles = (realmResponse.data.realmRoles || []).sort(Util.sortByString(role => role.name));
         this._users = usersResponse.data.filter(user => !user.serviceAccount).sort(Util.sortByString(u => u.username));
         this._serviceUsers = usersResponse.data.filter(user => user.serviceAccount).sort(Util.sortByString(u => u.username));
@@ -321,13 +324,14 @@ export class PageUsers extends Page<AppStateKeyed> {
     }
 
     private async _createUpdateUser(user: UserModel, action: 'update' | 'create') {
-        if (!user.username) {
-            return;
+        if ((this._registrationEmailAsUsername && !user.serviceAccount) ? !user.email : !user.username) {
+            showSnackbar(undefined, i18next.t((this._registrationEmailAsUsername && !user.serviceAccount) ? "noEmailSet" : "noUsernameSet"), i18next.t("dismiss"));
+            return false;
         }
 
         if (user.password === "") {
             // Means a validation failure shouldn't get here
-            return;
+            return false;
         }
 
         const isUpdate = !!user.id;
@@ -362,6 +366,7 @@ export class PageUsers extends Page<AppStateKeyed> {
 
         } finally {
             await this.loadUsers();
+            return true;
         }
     }
 
@@ -786,21 +791,26 @@ export class PageUsers extends Page<AppStateKeyed> {
                 <div class="column">
                     <h5>${i18next.t("details")}</h5>
                     <!-- user details -->
-                    <or-mwc-input id="username-${suffix}" ?readonly="${!!user.id || readonly}" .disabled="${!!user.id}"
+                    <or-mwc-input id="username-${suffix}" ?readonly="${!!user.id || readonly}" .disabled="${!!user.id || (!isServiceUser && this._registrationEmailAsUsername)}"
                                   .label="${i18next.t("username")}"
-                                  .type="${InputType.TEXT}" minLength="3" maxLength="255" required
-                                  pattern="[a-zA-Z0-9-_]+"
+                                  .type="${InputType.TEXT}" minLength="3" maxLength="255" 
+                                  ?required="${isServiceUser || !this._registrationEmailAsUsername}"
+                                  pattern="[A-Za-z0-9\\-_]+"
                                   .value="${user.username}"
                                   .validationMessage="${i18next.t("invalidUsername")}"
                                   @or-mwc-input-changed="${(e: OrInputChangedEvent) => {
                                       user.username = e.detail.value;
                                       this.onUserChanged(e, suffix)
                                   }}"></or-mwc-input>
-                    <or-mwc-input ?readonly="${readonly}"
+                    <!-- if identity provider is set to use email as username, make it required -->
+                    <or-mwc-input ?readonly="${(!!user.id && this._registrationEmailAsUsername) || readonly}"
+                                  .disabled="${!!user.id && this._registrationEmailAsUsername}"
                                   class="${isServiceUser ? "hidden" : ""}"
                                   .label="${i18next.t("email")}"
                                   .type="${InputType.EMAIL}"
                                   .value="${user.email}"
+                                  ?required="${!isServiceUser && this._registrationEmailAsUsername}"
+                                  pattern="^[\\w\\.\\-]+@([\\w\\-]+\\.)+[\\w]{2,4}$"
                                   .validationMessage="${i18next.t("invalidEmail")}"
                                   @or-mwc-input-changed="${(e: OrInputChangedEvent) => {
                                       user.email = e.detail.value;
@@ -951,14 +961,17 @@ export class PageUsers extends Page<AppStateKeyed> {
                         ></or-mwc-input>
                     `)}
                     <div style="display: flex; align-items: center; gap: 16px; margin: 0 0 0 auto;">
-                        <or-mwc-input id="savebtn-${suffix}" style="margin: 0;" raised ?disabled="${readonly}"
+                        <!-- Button disabled until an input has input, and by that a valid check is done -->
+                        <or-mwc-input id="savebtn-${suffix}" style="margin: 0;" raised disabled
                                       .label="${i18next.t(user.id ? "save" : "create")}"
                                       .type="${InputType.BUTTON}"
                                       @or-mwc-input-changed="${(e: OrInputChangedEvent) => {
                                           let error: { status?: number, text: string };
-                                          this._saveUserPromise = this._createUpdateUser(user, user.id ? 'update' : 'create').then(() => {
-                                              showSnackbar(undefined, i18next.t("saveUserSucceeded"));
-                                              this.reset();
+                                          this._saveUserPromise = this._createUpdateUser(user, user.id ? 'update' : 'create').then((result) => {
+                                              if (result) {                                              
+                                                  showSnackbar(undefined, i18next.t("saveUserSucceeded"));
+                                                  this.reset();
+                                              }
                                           }).catch((ex) => {
                                               if (isAxiosError(ex)) {
                                                   error = {

--- a/ui/app/manager/src/pages/page-users.ts
+++ b/ui/app/manager/src/pages/page-users.ts
@@ -323,7 +323,7 @@ export class PageUsers extends Page<AppStateKeyed> {
         this._loading = false;
     }
 
-    private async _createUpdateUser(user: UserModel, action: 'update' | 'create') {
+    private async _createUpdateUser(user: UserModel, action: 'update' | 'create'): Promise<boolean> {
         if ((this._registrationEmailAsUsername && !user.serviceAccount) ? !user.email : !user.username) {
             showSnackbar(undefined, i18next.t((this._registrationEmailAsUsername && !user.serviceAccount) ? "noEmailSet" : "noUsernameSet"), i18next.t("dismiss"));
             return false;
@@ -968,6 +968,7 @@ export class PageUsers extends Page<AppStateKeyed> {
                                       @or-mwc-input-changed="${(e: OrInputChangedEvent) => {
                                           let error: { status?: number, text: string };
                                           this._saveUserPromise = this._createUpdateUser(user, user.id ? 'update' : 'create').then((result) => {
+                                              // Return to the users page on successful user create/update
                                               if (result) {                                              
                                                   showSnackbar(undefined, i18next.t("saveUserSucceeded"));
                                                   this.reset();


### PR DESCRIPTION
Enhancement of users page to handle email as username when set by identity providers.
Exception made for service users, as they won't have an email address.