### PR TITLE
Adjust username pattern, fix user form validation

### DIFF
--- a/model/src/main/java/org/openremote/model/security/User.java
+++ b/model/src/main/java/org/openremote/model/security/User.java
@@ -120,7 +120,7 @@ public class User {
     }
 
     @Size(min = 3, max = 255, message = "{User.username.Size}")
-    @Pattern(regexp = "[A-Za-z0-9\\-_]+", message = "{User.username.Pattern}")
+    @Pattern(regexp = "[A-Za-z0-9\\-_@.]+", message = "{User.username.Pattern}")
     @JsonProperty
     public String getUsername() {
         return username == null ? null : username.replace(SERVICE_ACCOUNT_PREFIX, "");


### PR DESCRIPTION
- Fix pattern so that email as username users could be updated.
- Fix user page form validation. Before it was only checking inside the left column div. Now it checks all elements based on a class. Also changes to roles or userasset links can make the save button enabled.

- e-mail as username Keycloak option not covered in tests though..