### PR TITLE
Implementation of AssetStateDuration ValueType

### DIFF
--- a/model/src/main/java/org/openremote/model/asset/AssetStateDuration.java
+++ b/model/src/main/java/org/openremote/model/asset/AssetStateDuration.java
@@ -1,0 +1,69 @@
+package org.openremote.model.asset;
+
+import org.openremote.model.value.MetaItemType;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+
+/**
+ * <p>
+ * A {@link org.openremote.model.value.ValueType} that can store 2 and only 2 {@link java.time.LocalDateTime} values,
+ * that indicate the start-time and the end-time of a time-constrained {@link Asset} state.
+ * Its use is meant to assist in retrieving historical {@link org.openremote.model.datapoint.Datapoint}s between
+ * two different {@link java.time.Instant}s.
+ * <p>
+ * By utilizing a {@link AssetStateDuration} {@link org.openremote.model.attribute.Attribute}
+ * in conjunction with {@link MetaItemType#STORE_DATA_POINTS}, users can easily request the needed
+ * {@link AssetStateDuration}s, for any given time duration, e.g. 30 days, with
+ * which they can then request the specific periods for which an {@link Asset} was in a certain, user-defined, state.
+ * <p>
+ *     As an example, assume a Bike-share service, and each {@link Asset} is a single bike.
+ *     At the end of a fiscal quarter, we would like to analyze the usage of each bicycle, and the time and duration
+ *     at which it moved, to then gauge the profitability of the bike.
+ * <p>
+ *     Instead of manually retrieving every single datapoint from the asset and then analyzing it to retrieve the value
+ *     changes, we can have an {@link AssetStateDuration} {@link org.openremote.model.attribute.Attribute}, which at
+ *     the end of any given session, or trip, stores the start-time and the end-time of the bike.
+ * <p>
+ *     As the Attribute has {@link MetaItemType#STORE_DATA_POINTS}, we can retrieve the {@link AssetStateDuration}s
+ *     for the quarter that passed, and for each of the {@link AssetStateDuration}s, request the data-points between
+ *     the start and end Timestamps.
+ * <p>
+ *     In this way, we have access to every single Duration that the Asset was at any given state.
+ * <p>
+ *     <i>
+ *         We can then apply any sort of filtering on the set of {@link AssetStateDuration}s to retrieve our needed data.
+ *     </i>
+ * </p>
+ */
+public class AssetStateDuration implements Serializable {
+    private final Timestamp startTime;
+    private final Timestamp endTime;
+
+    public AssetStateDuration(Timestamp startTime, Timestamp endTime) {
+        if (startTime == null || endTime == null) {
+            throw new IllegalArgumentException("Start time and end time cannot be null");
+        }
+        if (startTime.after(endTime)) {
+            throw new IllegalArgumentException("Start time cannot be after end time");
+        }
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public Timestamp getStartTime() {
+        return startTime;
+    }
+
+    public Timestamp getEndTime() {
+        return endTime;
+    }
+
+    @Override
+    public String toString() {
+        return "AssetStateDuration{" +
+                "startTime=" + startTime +
+                ", endTime=" + endTime +
+                '}';
+    }
+}

--- a/model/src/main/java/org/openremote/model/value/ValueType.java
+++ b/model/src/main/java/org/openremote/model/value/ValueType.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BaseJsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.openremote.model.Constants;
+import org.openremote.model.asset.AssetStateDuration;
 import org.openremote.model.asset.agent.AgentLink;
 import org.openremote.model.asset.agent.ConnectionStatus;
 import org.openremote.model.attribute.AttributeExecuteStatus;
@@ -129,6 +130,8 @@ public final class ValueType {
     public static final ValueDescriptor<PeriodAndDuration> PERIOD_ISO8601 = new ValueDescriptor<>("timeAndPeriodDurationISO8601", PeriodAndDuration.class,
         new ValueConstraint.Pattern(Constants.ISO8601_DURATION_REGEXP)
     );
+
+    public static final ValueDescriptor<AssetStateDuration> ASSET_STATE_DURATION = new ValueDescriptor<>("AssetStateDuration", AssetStateDuration.class);
 
     public static final ValueDescriptor<String> EMAIL = new ValueDescriptor<>("email", String.class,
         new ValueConstraint.Pattern(Constants.EMAIL_REGEXP)


### PR DESCRIPTION
Whilst planning the implementation of the trip features for Fleet Management, me, @MartinaeyNL , and @pierrekil , started talking about how it would be best efficient and reusable to store the duration of any given asset's state. For example, in fleet management it would be when the vehicle is in movement, or when it is outside a geofenced area, when it is speeding, etc. After talking about it, we think that it is the best balance between generalization and ease of use. 

The data-type also has other use-cases, such as energy consumption thresholds, energy pricing, energy generation durations etc. 

Used together with STORE_DATA_POINTS, every time the attribute is updated, a new datapoint is created, and when exporting large sums of data, it is ultimately much easier to pull the AssetStateDuration datapoints, and then use the start and end times to pull the actual attribute data that are needed. It is also easier to track different states an asset may be in, like both overspeeding and moving, in the case of a vehicle. 

Some of the functionality is illustrated in feature/fleet-management, with or-map-asset-card-trip-section for retrieving data and TeltonikaMQTTHandler#assetChangedTripState for storing data.