### PR TITLE
Fix attribute input enum bug

### DIFF
--- a/ui/component/or-mwc-components/src/or-mwc-input.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-input.ts
@@ -346,7 +346,7 @@ export const getValueHolderInputTemplateProvider: ValueInputProviderGenerator = 
         pattern = ".+";
     }
     if (allowedValuesConstraint && allowedValuesConstraint.allowedValues) {
-        const allowedLabels = allowedValuesConstraint.allowedValues;
+        const allowedLabels = allowedValuesConstraint.allowedValues[0];
         selectOptions = allowedValuesConstraint.allowedValues.map((v, i) => {
             let label = allowedLabels ? allowedLabels[i] : "" + v;
             label = Util.getAllowedValueLabel(label)!;


### PR DESCRIPTION
Enum attribute input fields are not displayed on the Assets page.

This fixes it, but I'm not entirely sure its the correct fix...