### PR TITLE
Bugfix: SyslogService is not purging syslog events

### DIFF
--- a/manager/src/main/java/org/openremote/manager/syslog/SyslogService.java
+++ b/manager/src/main/java/org/openremote/manager/syslog/SyslogService.java
@@ -132,8 +132,10 @@ public class SyslogService extends Handler implements ContainerService {
         try {
             persistenceService.doTransaction(em -> em.createQuery(
                 "delete from SyslogEvent e " +
-                    "where e.timestamp < now() - make_interval(0, 0, 0, 0, 0, :minutes, 0)"
-            ).setParameter("minutes", config.getStoredMaxAgeMinutes()).executeUpdate());
+                    "where e.timestamp <= :date")
+                    .setParameter("date",
+                            Date.from(Instant.now().minus(config.getStoredMaxAgeMinutes(), ChronoUnit.MINUTES)))
+                    .executeUpdate());
         } catch (Throwable e) {
             LOG.log(Level.WARNING, "Failed to purge syslog events", e);
         }


### PR DESCRIPTION
Hi,

Every night, I get the same stack trace attached to this message. The syslog events are not being purged in the database. The root cause is a "-" operator during comparison of timestamps that isn't supported in the current version of HQL.

I propose a fix based on the HQL query in the function _getEvents_ in the same file. Their timestamps are evaluated in a working manner.

Peter



```
java.lang.IllegalArgumentException: org.hibernate.query.SemanticException: Operand of - is of type 'java.lang.Object' which is not a numeric type (it is not an instance of 'java.lang.Number', 'java.time.Temporal', or 'java.time.TemporalAmount')
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:143)
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:167)
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:173)
	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:802)
	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:707)
	at org.hibernate.internal.SessionImpl.createQuery(SessionImpl.java:201)
	at org.openremote.manager.syslog.SyslogService.lambda$purgeSyslog$1(SyslogService.java:133)
	at org.openremote.container.persistence.PersistenceService.lambda$doTransaction$4(PersistenceService.java:416)
	at org.openremote.container.persistence.PersistenceService.doReturningTransaction(PersistenceService.java:426)
	at org.openremote.container.persistence.PersistenceService.doTransaction(PersistenceService.java:415)
	at org.openremote.manager.syslog.SyslogService.purgeSyslog(SyslogService.java:133)
	at io.micrometer.core.instrument.AbstractTimer.record(AbstractTimer.java:247)
	at io.micrometer.core.instrument.Timer.lambda$wrap$0(Timer.java:196)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: org.hibernate.query.SemanticException: Operand of - is of type 'java.lang.Object' which is not a numeric type (it is not an instance of 'java.lang.Number', 'java.time.Temporal', or 'java.time.TemporalAmount')
	at org.hibernate.query.sqm.internal.TypecheckUtil.assertOperable(TypecheckUtil.java:453)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitAdditionExpression(SemanticQueryBuilder.java:2918)
	at org.hibernate.grammars.hql.HqlParser$AdditionExpressionContext.accept(HqlParser.java:7003)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.createComparisonPredicate(SemanticQueryBuilder.java:2429)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitComparisonPredicate(SemanticQueryBuilder.java:2391)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitComparisonPredicate(SemanticQueryBuilder.java:268)
	at org.hibernate.grammars.hql.HqlParser$ComparisonPredicateContext.accept(HqlParser.java:6071)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitWhereClause(SemanticQueryBuilder.java:2243)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitDeleteStatement(SemanticQueryBuilder.java:635)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.visitStatement(SemanticQueryBuilder.java:412)
	at org.hibernate.query.hql.internal.SemanticQueryBuilder.buildSemanticModel(SemanticQueryBuilder.java:310)
	at org.hibernate.query.hql.internal.StandardHqlTranslator.translate(StandardHqlTranslator.java:71)
	at org.hibernate.query.internal.QueryInterpretationCacheStandardImpl.createHqlInterpretation(QueryInterpretationCacheStandardImpl.java:165)
	at org.hibernate.query.internal.QueryInterpretationCacheStandardImpl.resolveHqlInterpretation(QueryInterpretationCacheStandardImpl.java:147)
	at org.hibernate.internal.AbstractSharedSessionContract.interpretHql(AbstractSharedSessionContract.java:744)
	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:794)
	... 15 more
```