### PR TITLE
Add typed call for getOldValue consisent to getValue in AssetState class

### DIFF
--- a/model/src/main/java/org/openremote/model/rules/AssetState.java
+++ b/model/src/main/java/org/openremote/model/rules/AssetState.java
@@ -130,6 +130,10 @@ public class AssetState<T> implements Comparable<AssetState<?>>, NameValueHolder
         return Optional.ofNullable(oldValue);
     }
 
+    public <U> Optional<U> getOldValue(Class<U> valueType) {
+        return ValueUtil.getValueCoerced(oldValue, valueType);
+    }
+
     public long getOldValueTimestamp() {
         return oldValueTimestamp;
     }


### PR DESCRIPTION
In the AssetState class the next call is there
`public <U> Optional<U> getValue(Class<U> valueType)`

The equivalent call for the oldValue is not available. I added it
`public <U> Optional<U> getOldValue(Class<U> valueType)`

It increases the consistency in writing groovy scripts.