### PR TITLE
Use or-translate for mwc button component

### DIFF
--- a/ui/component/or-app/src/index.ts
+++ b/ui/component/or-app/src/index.ts
@@ -123,6 +123,10 @@ export class OrApp<S extends AppStateKeyed> extends LitElement {
                 overflow: auto;
             }
             
+            .no-scroll {
+                overflow: hidden;
+            }
+
             main > * {
                 display: flex;
                 flex: 1;

--- a/ui/component/or-mwc-components/src/or-mwc-input.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-input.ts
@@ -1197,7 +1197,7 @@ export class OrMwcInput extends LitElement {
                             @mousedown="${(ev: MouseEvent) => onMouseDown(ev)}" @mouseup="${(ev: MouseEvent) => onMouseUp(ev)}">
                             ${!isIconButton ? html`<div class="mdc-button__ripple"></div>` : ``}
                             ${this.icon ? html`<or-icon class="${isIconButton ? "" : this.action ? "mdc-fab__icon" : "mdc-button__icon"}" aria-hidden="true" icon="${this.icon}"></or-icon>` : ``}
-                            ${this.label ? html`<span class="${this.action ? "mdc-fab__label" : "mdc-button__label"}">${this.label}</span>` : ``}
+                            ${this.label ? html`<span class="${this.action ? "mdc-fab__label" : "mdc-button__label"}"><or-translate .value="${this.label}"></or-translate></span>` : ``}
                             ${!isIconButton && this.iconTrailing ? html`<or-icon class="${this.action ? "mdc-fab__icon" : "mdc-button__icon"}" aria-hidden="true" icon="${this.iconTrailing}"></or-icon>` : ``}
                         </button>
                     `;


### PR DESCRIPTION
- Use or-translate for mwc button component
- Add no-scroll class which can be used in app's to prevent overflowing of content