### PR TITLE
Add org.jdom version, fix for build error

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation "dev.failsafe:failsafe:$failsafeVersion"
 
     implementation "org.eclipse.angus:angus-mail:$jakartaMailVersion"
+
+    implementation "org.jdom:jdom:$jdomVersion"
 }
 
 jar {

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     implementation "org.eclipse.angus:angus-mail:$jakartaMailVersion"
 
-    implementation "org.jdom:jdom:$jdomVersion"
+    implementation "org.jdom:jdom2:$jdomVersion"
 }
 
 jar {

--- a/agent/src/main/java/org/openremote/agent/protocol/bluetooth/mesh/SequenceNumberPersistencyManager.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/bluetooth/mesh/SequenceNumberPersistencyManager.java
@@ -19,12 +19,12 @@
  */
 package org.openremote.agent.protocol.bluetooth.mesh;
 
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.input.SAXBuilder;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.openremote.agent.protocol.bluetooth.mesh.utils.MeshParserUtils;
 import org.openremote.model.syslog.SyslogCategory;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,3 +60,4 @@ jbossLoggingManagerVersion=2.1.19.Final
 greenmailVersion=2.0.0
 prometheusVersion=0.16.0
 micrometerVersion=1.11.0
+jdomVersion=1.1.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,4 +60,4 @@ jbossLoggingManagerVersion=2.1.19.Final
 greenmailVersion=2.0.0
 prometheusVersion=0.16.0
 micrometerVersion=1.11.0
-jdomVersion=1.1.3
+jdomVersion=2.0.6.1


### PR DESCRIPTION
Some people experience build errors due to lack of jdom package.

The forum post: https://forum.openremote.io/t/issue-with-building-the-main-branch/2327

Please be aware for org.jdom the following CVE issue is still open. Consider migrating to org.jdom2

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33813