### PR TITLE
Update KeycloakIdentityProvider to use official healthcheck endpoint

### DIFF
--- a/container/src/main/java/org/openremote/container/security/keycloak/KeycloakIdentityProvider.java
+++ b/container/src/main/java/org/openremote/container/security/keycloak/KeycloakIdentityProvider.java
@@ -324,7 +324,7 @@ public abstract class KeycloakIdentityProvider implements IdentityProvider {
         Response response = null;
 
         try {
-            response = resource.getWelcomePage();
+            response = resource.getInstanceHealth();
             if (response != null &&
                 (response.getStatusInfo().getFamily() == SUCCESSFUL
                     || response.getStatusInfo().getFamily() == REDIRECTION)) {

--- a/container/src/main/java/org/openremote/container/security/keycloak/KeycloakResource.java
+++ b/container/src/main/java/org/openremote/container/security/keycloak/KeycloakResource.java
@@ -60,7 +60,7 @@ public interface KeycloakResource {
     AdapterConfig getAdapterConfig(@PathParam("realm") String realm, @PathParam("clientId") String clientId);
 
 	@GET
-	@Path("/")
+	@Path("health")
 	@Produces(TEXT_HTML)
 	Response getInstanceHealth();
 }

--- a/container/src/main/java/org/openremote/container/security/keycloak/KeycloakResource.java
+++ b/container/src/main/java/org/openremote/container/security/keycloak/KeycloakResource.java
@@ -59,4 +59,8 @@ public interface KeycloakResource {
     @Produces(APPLICATION_JSON)
     AdapterConfig getAdapterConfig(@PathParam("realm") String realm, @PathParam("clientId") String clientId);
 
+	@GET
+	@Path("/")
+	@Produces(TEXT_HTML)
+	Response getInstanceHealth();
 }


### PR DESCRIPTION
Solves #1277: 

Using the welcome page as a tester for if keycloak is running is not the best. Keycloak now has a healthcheck API: https://www.keycloak.org/server/health

Maybe use this to check if keycloak is healthy or not before performing any actions.

The healthcheck is already enabled in OpenRemote's Keycloak instance so no Keycloak configuration changes.