### PR TITLE
Added example dashboards to demo setup

### DIFF
--- a/manager/src/main/java/org/openremote/manager/dashboard/DashboardStorageService.java
+++ b/manager/src/main/java/org/openremote/manager/dashboard/DashboardStorageService.java
@@ -64,7 +64,7 @@ public class DashboardStorageService extends RouteBuilder implements ContainerSe
     // Querying dashboards from the database
     // userId is required for checking dashboard ownership. If userId is NULL, we assume the user is not logged in.
     // editable can be used to only return dashboards where the user has edit access.
-    protected Dashboard[] query(List<String> dashboardIds, String realm, String userId, Boolean publicOnly, Boolean editable) {
+    public Dashboard[] query(List<String> dashboardIds, String realm, String userId, Boolean publicOnly, Boolean editable) {
         if(realm == null) {
             throw new IllegalArgumentException("No realm is specified.");
         }
@@ -115,7 +115,7 @@ public class DashboardStorageService extends RouteBuilder implements ContainerSe
 
     // Method to check if a dashboardId actually exists in the database
     // Useful for when query() does not return any accessible dashboard for that user, and check if it does however exist.
-    protected boolean exists(String dashboardId, String realm) {
+    public boolean exists(String dashboardId, String realm) {
         if(dashboardId == null) {
             throw new IllegalArgumentException("No dashboardId is specified.");
         }
@@ -135,7 +135,7 @@ public class DashboardStorageService extends RouteBuilder implements ContainerSe
 
 
     // Creation of initial dashboard (so no updating!)
-    protected Dashboard createNew(Dashboard dashboard) {
+    public Dashboard createNew(Dashboard dashboard) {
         if(dashboard == null) {
             throw new IllegalArgumentException("No dashboard is specified.");
         }
@@ -151,7 +151,7 @@ public class DashboardStorageService extends RouteBuilder implements ContainerSe
     }
 
     // Update of an existing dashboard
-    protected Dashboard update(Dashboard dashboard, String realm, String userId) throws IllegalArgumentException {
+    public Dashboard update(Dashboard dashboard, String realm, String userId) throws IllegalArgumentException {
         if(dashboard == null) {
             throw new IllegalArgumentException("No dashboard is specified.");
         }
@@ -173,7 +173,7 @@ public class DashboardStorageService extends RouteBuilder implements ContainerSe
         }
     }
 
-    protected boolean delete(String dashboardId, String realm, String userId) throws IllegalArgumentException {
+    public boolean delete(String dashboardId, String realm, String userId) throws IllegalArgumentException {
         if(dashboardId == null) {
             throw new IllegalArgumentException("No dashboardId is specified.");
         }

--- a/setup/src/demo/java/org/openremote/setup/demo/DemoSetupTasks.java
+++ b/setup/src/demo/java/org/openremote/setup/demo/DemoSetupTasks.java
@@ -41,7 +41,8 @@ public class DemoSetupTasks implements SetupTasks {
                 new KeycloakDemoSetup(container),
                 new ManagerDemoSetup(container),
                 new RulesDemoSetup(container),
-                new ManagerDemoAgentSetup(container)
+                new ManagerDemoAgentSetup(container),
+                new ManagerDemoDashboardSetup(container)
             );
         }
 

--- a/setup/src/demo/java/org/openremote/setup/demo/ManagerDemoDashboardSetup.java
+++ b/setup/src/demo/java/org/openremote/setup/demo/ManagerDemoDashboardSetup.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024, OpenRemote Inc.
+ *
+ * See the CONTRIBUTORS.txt file in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.openremote.setup.demo;
+
+import org.openremote.manager.dashboard.DashboardStorageService;
+import org.openremote.manager.setup.ManagerSetup;
+import org.openremote.model.Container;
+import org.openremote.model.dashboard.Dashboard;
+import org.openremote.model.util.ValueUtil;
+
+import java.io.InputStream;
+
+public class ManagerDemoDashboardSetup extends ManagerSetup {
+
+    protected final DashboardStorageService dashboardStorageService;
+
+    public ManagerDemoDashboardSetup(Container container) {
+        super(container);
+        this.dashboardStorageService = container.getService(DashboardStorageService.class);
+    }
+
+    @Override
+    public void onStart() throws Exception {
+        super.onStart();
+
+        // SmartCity
+        try (InputStream inputStream = ManagerDemoDashboardSetup.class.getResourceAsStream("/demo/dashboards/smartcity/parking.json")) {
+            Dashboard dashboard = ValueUtil.JSON.readValue(inputStream, Dashboard.class);
+            dashboardStorageService.createNew(dashboard);
+        }
+
+        // Manufacturer
+        try (InputStream inputStream = ManagerDemoDashboardSetup.class.getResourceAsStream("/demo/dashboards/manufacturer/harvesting.json")) {
+            Dashboard dashboard = ValueUtil.JSON.readValue(inputStream, Dashboard.class);
+            dashboardStorageService.createNew(dashboard);
+        }
+
+    }
+}

--- a/setup/src/demo/resources/demo/dashboards/manufacturer/harvesting.json
+++ b/setup/src/demo/resources/demo/dashboards/manufacturer/harvesting.json
@@ -1,0 +1,429 @@
+{
+  "id": "3k0JH2gePMKy3BnLoRqLp5",
+  "createdOn": 1711029945937,
+  "realm": "manufacturer",
+  "version": 11,
+  "ownerId": "e5ca8a39-5193-478d-ba86-57e7095679cf",
+  "viewAccess": "SHARED",
+  "editAccess": "SHARED",
+  "displayName": "Harvesting dashboard",
+  "template": {
+    "id": "vmkw9nr0i4",
+    "columns": 12,
+    "maxScreenWidth": 4000,
+    "refreshInterval": "OFF",
+    "screenPresets": [
+      {
+        "id": "mobile",
+        "displayName": "dashboard.size.mobile",
+        "breakpoint": 640,
+        "scalingPreset": "WRAP_TO_SINGLE_COLUMN"
+      }
+    ],
+    "widgets": [
+      {
+        "id": "slipo02jjs",
+        "displayName": "Total flow",
+        "gridItem": {
+          "id": "slipo02jjs",
+          "x": 0,
+          "y": 0,
+          "w": 6,
+          "h": 3,
+          "minH": 2,
+          "minW": 2,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "linechart",
+        "widgetConfig": {
+          "showLegend": true,
+          "chartOptions": {
+            "options": {
+              "scales": {
+                "y": {},
+                "y1": {}
+              }
+            }
+          },
+          "attributeRefs": [
+            {
+              "id": "72f37OCsEYkVPdzgcKDlRL",
+              "name": "flowTotal"
+            },
+            {
+              "id": "7jSsUaNvM3ZQGfRqBTsOpJ",
+              "name": "flowTotal"
+            },
+            {
+              "id": "7atRfYJf83HuiHB6ZdM3ko",
+              "name": "flowTotal"
+            }
+          ],
+          "datapointQuery": {
+            "type": "lttb",
+            "toTimestamp": 1711029955635,
+            "fromTimestamp": 1710943555635,
+            "amountOfPoints": 100
+          },
+          "rightAxisAttributes": [],
+          "defaultTimePresetKey": "last24Hours",
+          "showTimestampControls": false
+        }
+      },
+      {
+        "id": "4vsnq4odw8",
+        "displayName": "Harvest Robot 1 - speed",
+        "gridItem": {
+          "id": "4vsnq4odw8",
+          "x": 6,
+          "y": 0,
+          "w": 3,
+          "h": 3,
+          "minH": 1,
+          "minW": 1,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "gauge",
+        "widgetConfig": {
+          "max": 100,
+          "min": 0,
+          "decimals": 0,
+          "valueType": "number",
+          "thresholds": [
+            [
+              0,
+              "#4caf50"
+            ],
+            [
+              75,
+              "#ff9800"
+            ],
+            [
+              90,
+              "#ef5350"
+            ]
+          ],
+          "attributeRefs": [
+            {
+              "id": "6ZQkcWjwZjL8d04t9mvVvW",
+              "name": "speed"
+            }
+          ]
+        }
+      },
+      {
+        "id": "0z3bfyv8fw",
+        "displayName": "Harvest Robot 1 - harvested Session",
+        "gridItem": {
+          "id": "0z3bfyv8fw",
+          "x": 9,
+          "y": 0,
+          "w": 3,
+          "h": 3,
+          "minH": 1,
+          "minW": 1,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "kpi",
+        "widgetConfig": {
+          "period": "hour",
+          "decimals": 0,
+          "deltaFormat": "absolute",
+          "attributeRefs": [
+            {
+              "id": "6ZQkcWjwZjL8d04t9mvVvW",
+              "name": "harvestedSession"
+            }
+          ],
+          "showTimestampControls": true
+        }
+      },
+      {
+        "id": "r0w96d6mi1l",
+        "displayName": "Harvest and irrigation - summary",
+        "gridItem": {
+          "id": "r0w96d6mi1l",
+          "x": 0,
+          "y": 3,
+          "w": 4,
+          "h": 3,
+          "minH": 1,
+          "minW": 1,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "image",
+        "widgetConfig": {
+          "markers": [
+            {
+              "coordinates": [
+                45,
+                80
+              ],
+              "attributeRef": {
+                "id": "6ZQkcWjwZjL8d04t9mvVvW",
+                "name": "harvestedSession"
+              }
+            },
+            {
+              "coordinates": [
+                75,
+                80
+              ],
+              "attributeRef": {
+                "id": "2XOXVoMmDkOyLjY1JEnuoF",
+                "name": "soilTensionMeasured"
+              }
+            },
+            {
+              "coordinates": [
+                12,
+                80
+              ],
+              "attributeRef": {
+                "id": "2XOXVoMmDkOyLjY1JEnuoF",
+                "name": "temperature"
+              }
+            }
+          ],
+          "imagePath": "https://openremote.io/wp-content/uploads/2024/03/organifarms2.jpeg",
+          "attributeRefs": [
+            {
+              "id": "6ZQkcWjwZjL8d04t9mvVvW",
+              "name": "harvestedSession"
+            },
+            {
+              "id": "2XOXVoMmDkOyLjY1JEnuoF",
+              "name": "soilTensionMeasured"
+            },
+            {
+              "id": "2XOXVoMmDkOyLjY1JEnuoF",
+              "name": "temperature"
+            }
+          ],
+          "showTimestampControls": false
+        }
+      },
+      {
+        "id": "l2a718n1xp",
+        "displayName": "Harvest Robot 1",
+        "gridItem": {
+          "id": "l2a718n1xp",
+          "x": 4,
+          "y": 3,
+          "w": 2,
+          "h": 1,
+          "minH": 0,
+          "minW": 0,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "attributeinput",
+        "widgetConfig": {
+          "readonly": false,
+          "attributeRefs": [
+            {
+              "id": "6ZQkcWjwZjL8d04t9mvVvW",
+              "name": "operationMode"
+            }
+          ],
+          "showHelperText": false
+        }
+      },
+      {
+        "id": "7cnhy57jkd",
+        "displayName": "Harvest Robot 1",
+        "gridItem": {
+          "id": "7cnhy57jkd",
+          "x": 4,
+          "y": 4,
+          "w": 2,
+          "h": 1,
+          "minH": 0,
+          "minW": 0,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "attributeinput",
+        "widgetConfig": {
+          "readonly": true,
+          "attributeRefs": [
+            {
+              "id": "6ZQkcWjwZjL8d04t9mvVvW",
+              "name": "speed"
+            }
+          ],
+          "showHelperText": false
+        }
+      },
+      {
+        "id": "ovhykndppih",
+        "displayName": "Irrigation 1",
+        "gridItem": {
+          "id": "ovhykndppih",
+          "x": 4,
+          "y": 5,
+          "w": 2,
+          "h": 1,
+          "minH": 0,
+          "minW": 0,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "attributeinput",
+        "widgetConfig": {
+          "readonly": false,
+          "attributeRefs": [
+            {
+              "id": "72f37OCsEYkVPdzgcKDlRL",
+              "name": "flowNutrients"
+            }
+          ],
+          "showHelperText": false
+        }
+      },
+      {
+        "id": "wd1oa93jrw",
+        "displayName": "Irrigation assets",
+        "gridItem": {
+          "id": "wd1oa93jrw",
+          "x": 6,
+          "y": 3,
+          "w": 6,
+          "h": 3,
+          "minH": 2,
+          "minW": 2,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "map",
+        "widgetConfig": {
+          "zoom": 12,
+          "center": {
+            "lat": 51.97,
+            "lng": 4.295
+          },
+          "assetIds": [
+            "5xl65BMWEKtRiEchVBkANS",
+            "6PH7Ti0yKO9iQG8xeRMtSZ",
+            "3cCtcUEyVRs9V1X1JZdpPy",
+            "7R2GiUXxqKquYpsSERhDA5",
+            "4yYoOPOlnUrOVlE8Ym50Pw",
+            "72f37OCsEYkVPdzgcKDlRL",
+            "7jSsUaNvM3ZQGfRqBTsOpJ",
+            "7atRfYJf83HuiHB6ZdM3ko",
+            "4zpw0K9DYH4ejSXqBKetJJ",
+            "7XusRNMIB1z2R77Uyr5sfP",
+            "7jEekZEXNaX15k6lvwas13"
+          ],
+          "assetType": "IrrigationAsset",
+          "showUnits": true,
+          "valueType": "positiveNumber",
+          "assetTypes": [],
+          "attributes": [],
+          "boolColors": {
+            "true": "#4caf50",
+            "type": "boolean",
+            "false": "#ef5350"
+          },
+          "showLabels": true,
+          "textColors": [
+            [
+              "example",
+              "#4caf50"
+            ],
+            [
+              "example2",
+              "#ff9800"
+            ]
+          ],
+          "thresholds": [
+            [
+              90,
+              "#ef5350"
+            ],
+            [
+              75,
+              "#ff9800"
+            ],
+            [
+              0,
+              "#4caf50"
+            ]
+          ],
+          "showGeoJson": true,
+          "attributeName": "flowTotal",
+          "attributeRefs": []
+        }
+      },
+      {
+        "id": "ku2zv5v9hj",
+        "displayName": "Summary harvest robots",
+        "gridItem": {
+          "id": "ku2zv5v9hj",
+          "x": 0,
+          "y": 6,
+          "w": 12,
+          "h": 4,
+          "minH": 0,
+          "minW": 0,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "table",
+        "widgetConfig": {
+          "assetIds": [
+            "6ZQkcWjwZjL8d04t9mvVvW",
+            "3mha9bCluTsqybsGXt5vPb",
+            "4shhSXQ69KQZY3kJEK9uOH",
+            "6LDbUPVtOVzI961EMJNnpD",
+            "5EQdLwkCfhJdWtYyVqvuOI"
+          ],
+          "assetType": "HarvestRobotAsset",
+          "tableSize": 10,
+          "tableOptions": [
+            10,
+            25,
+            100
+          ],
+          "attributeNames": [
+            "harvestedTotal",
+            "vegetableType",
+            "speed",
+            "harvestedSession"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/setup/src/demo/resources/demo/dashboards/smartcity/parking.json
+++ b/setup/src/demo/resources/demo/dashboards/smartcity/parking.json
@@ -1,0 +1,278 @@
+{
+  "id": "5o0KL29L50Q7hSoVyvAI2y",
+  "createdOn": 1711029229921,
+  "realm": "smartcity",
+  "version": 8,
+  "ownerId": "e5ca8a39-5193-478d-ba86-57e7095679cf",
+  "viewAccess": "SHARED",
+  "editAccess": "SHARED",
+  "displayName": "Parking dashboard",
+  "template": {
+    "id": "szpfxnrzpg",
+    "columns": 12,
+    "maxScreenWidth": 4000,
+    "refreshInterval": "OFF",
+    "screenPresets": [
+      {
+        "id": "mobile",
+        "displayName": "dashboard.size.mobile",
+        "breakpoint": 640,
+        "scalingPreset": "WRAP_TO_SINGLE_COLUMN"
+      }
+    ],
+    "widgets": [
+      {
+        "id": "b4qzd9haajg",
+        "displayName": "Spaces occupied",
+        "gridItem": {
+          "id": "b4qzd9haajg",
+          "x": 0,
+          "y": 0,
+          "w": 8,
+          "h": 4,
+          "minH": 2,
+          "minW": 2,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "linechart",
+        "widgetConfig": {
+          "showLegend": true,
+          "chartOptions": {
+            "options": {
+              "scales": {
+                "y": {},
+                "y1": {}
+              }
+            }
+          },
+          "attributeRefs": [
+            {
+              "id": "2tLAEBGjmRCu1KrdJn9T2Z",
+              "name": "spacesOccupied"
+            },
+            {
+              "id": "3D49AxXerrIycM8gNd0zlK",
+              "name": "spacesOccupied"
+            },
+            {
+              "id": "1yuaW634x1LqumPTwGxvyg",
+              "name": "spacesOccupied"
+            }
+          ],
+          "datapointQuery": {
+            "type": "lttb",
+            "toTimestamp": 1711029263421,
+            "fromTimestamp": 1710942863421,
+            "amountOfPoints": 100
+          },
+          "rightAxisAttributes": [],
+          "defaultTimePresetKey": "last24Hours",
+          "showTimestampControls": false
+        }
+      },
+      {
+        "id": "he1n3khghci",
+        "displayName": "Parking space occupation",
+        "gridItem": {
+          "id": "he1n3khghci",
+          "x": 8,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "minH": 2,
+          "minW": 2,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "map",
+        "widgetConfig": {
+          "zoom": 14,
+          "assetIds": [
+            "1yuaW634x1LqumPTwGxvyg",
+            "3D49AxXerrIycM8gNd0zlK",
+            "2tLAEBGjmRCu1KrdJn9T2Z"
+          ],
+          "assetType": "ParkingAsset",
+          "showUnits": false,
+          "valueType": "positiveInteger",
+          "assetTypes": [],
+          "attributes": [],
+          "boolColors": {
+            "true": "#4caf50",
+            "type": "boolean",
+            "false": "#ef5350"
+          },
+          "showLabels": true,
+          "textColors": [
+            [
+              "example",
+              "#4caf50"
+            ],
+            [
+              "example2",
+              "#ff9800"
+            ]
+          ],
+          "thresholds": [
+            [
+              450,
+              "#ef5350"
+            ],
+            [
+              250,
+              "#ff9800"
+            ],
+            [
+              0,
+              "#4caf50"
+            ]
+          ],
+          "showGeoJson": true,
+          "attributeName": "spacesOccupied",
+          "attributeRefs": []
+        }
+      },
+      {
+        "id": "atxb3vf2zc",
+        "displayName": "Parking total Occupancy (%)",
+        "gridItem": {
+          "id": "atxb3vf2zc",
+          "x": 0,
+          "y": 4,
+          "w": 3,
+          "h": 3,
+          "minH": 1,
+          "minW": 1,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "gauge",
+        "widgetConfig": {
+          "max": 100,
+          "min": 0,
+          "decimals": 0,
+          "valueType": "number",
+          "thresholds": [
+            [
+              0,
+              "#4caf50"
+            ],
+            [
+              75,
+              "#ff9800"
+            ],
+            [
+              90,
+              "#ef5350"
+            ]
+          ],
+          "attributeRefs": [
+            {
+              "id": "7UUzmvnTuLdjVpTb8MnjSX",
+              "name": "totalOccupancy"
+            }
+          ]
+        }
+      },
+      {
+        "id": "va9swrnq9ig",
+        "displayName": "Boompjes parking",
+        "gridItem": {
+          "id": "va9swrnq9ig",
+          "x": 3,
+          "y": 4,
+          "w": 4,
+          "h": 3,
+          "minH": 1,
+          "minW": 1,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "image",
+        "widgetConfig": {
+          "markers": [
+            {
+              "coordinates": [
+                10,
+                50
+              ],
+              "attributeRef": {
+                "id": "52kOB7c1Rs7WUxgfoCKf5B",
+                "name": "onOff"
+              }
+            },
+            {
+              "coordinates": [
+                9,
+                10
+              ],
+              "attributeRef": {
+                "id": "52kOB7c1Rs7WUxgfoCKf5B",
+                "name": "colourRGB"
+              }
+            }
+          ],
+          "imagePath": "https://openremote.io/wp-content/uploads/2024/03/Parking-boompjes.png",
+          "attributeRefs": [
+            {
+              "id": "52kOB7c1Rs7WUxgfoCKf5B",
+              "name": "colourRGB"
+            }
+          ],
+          "showTimestampControls": false
+        }
+      },
+      {
+        "id": "c2jlie8wj8",
+        "displayName": "Parking",
+        "gridItem": {
+          "id": "c2jlie8wj8",
+          "x": 7,
+          "y": 4,
+          "w": 5,
+          "h": 3,
+          "minH": 0,
+          "minW": 0,
+          "minPixelH": 0,
+          "minPixelW": 0,
+          "noResize": false,
+          "noMove": false,
+          "locked": false
+        },
+        "widgetTypeId": "table",
+        "widgetConfig": {
+          "assetIds": [
+            "2tLAEBGjmRCu1KrdJn9T2Z",
+            "3D49AxXerrIycM8gNd0zlK",
+            "1yuaW634x1LqumPTwGxvyg"
+          ],
+          "assetType": "ParkingAsset",
+          "tableSize": 10,
+          "tableOptions": [
+            10,
+            25,
+            100
+          ],
+          "attributeNames": [
+            "spacesOccupied",
+            "spacesOpen",
+            "spacesTotal"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/ui/component/or-attribute-card/src/index.ts
+++ b/ui/component/or-attribute-card/src/index.ts
@@ -777,7 +777,7 @@ export class OrAttributeCard extends LitElement {
         }
 
         const attr = this.assetAttributes[0][1];
-        const roundedVal = +value.toFixed(this.mainValueDecimals); // + operator prevents str return
+        const roundedVal = +value?.toFixed(this.mainValueDecimals); // + operator prevents str return
         const attributeDescriptor = AssetModelUtil.getAttributeDescriptor(attr.name!, this.assets[0].type!);
         const units = Util.resolveUnits(Util.getAttributeUnits(attr, attributeDescriptor, this.assets[0].type));
         this.setLabelSizeByLength(roundedVal.toString());


### PR DESCRIPTION
Fixes issue #842;

Added example dashboards to the demo setup that were built by @pierrekil.
Also includes a hotfix for null values in `or-attribute-card`.

Smartcity / "Parking dashboard";
<img src='https://github.com/openremote/openremote/assets/27913110/bc17768a-5ffa-4558-9d9e-ea1e99707f11' width='400'>

Manufacturer / "Harvesting dashboard"
<img src='https://github.com/openremote/openremote/assets/27913110/cb2ae28b-f5c6-41b7-9b6b-be4699902453' width='400'>
