### PR TITLE
Frontend bugfix: Chart only displaying 100 points

### DIFF
--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -1144,7 +1144,7 @@ export class OrChart extends translate(i18next)(LitElement) {
 
             if(query.type == 'lttb' && !query.amountOfPoints) {
                 if(this._chartElem.clientWidth == 0) {
-                    console.error("Could not grab width of the Chart for estimating amount of datapoints. Using 10 points instead.")
+                    console.error("Could not grab width of the Chart for estimating amount of datapoints. Using 100 points instead.")
                 }
                 query.amountOfPoints = (this._chartElem.clientWidth == 0) ? 100 : Math.round(this._chartElem.clientWidth / 5); // set amount of datapoints based on current chart width.
             } else if(query.type == 'interval' && !query.interval) {

--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -1142,12 +1142,18 @@ export class OrChart extends translate(i18next)(LitElement) {
             query.fromTimestamp = this._startOfPeriod;
             query.toTimestamp = this._endOfPeriod;
 
-            if(query.type == 'lttb' && !query.amountOfPoints) {
-                if(this._chartElem.clientWidth == 0) {
-                    console.error("Could not grab width of the Chart for estimating amount of datapoints. Using 100 points instead.")
+            if(query.type == 'lttb') {
+                if(this._chartElem.clientWidth === 0) console.warn("Could not grab width of the Chart for estimating amount of data points. Using 100 points instead.")
+
+                // If amount of data points is set, only allow a maximum of 1 points per pixel in width
+                // Otherwise, dynamically set amount of data points based on chart width (1000px = 200 data points)
+                if(query.amountOfPoints) {
+                    query.amountOfPoints = Math.min(query.amountOfPoints, this._chartElem.clientWidth)
+                } else {
+                    query.amountOfPoints = (this._chartElem.clientWidth ? Math.round(this._chartElem.clientWidth / 5) : 100)
                 }
-                query.amountOfPoints = (this._chartElem.clientWidth == 0) ? 100 : Math.round(this._chartElem.clientWidth / 5); // set amount of datapoints based on current chart width.
-            } else if(query.type == 'interval' && !query.interval) {
+
+            } else if(query.type === 'interval' && !query.interval) {
                 const diffInHours = (this.datapointQuery.toTimestamp! - this.datapointQuery.fromTimestamp!) / 1000 / 60 / 60;
                 const intervalArr = this._getInterval(diffInHours);
                 query.interval = (intervalArr[0].toString() + " " + intervalArr[1].toString()); // for example: "5 minute"

--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -1146,7 +1146,7 @@ export class OrChart extends translate(i18next)(LitElement) {
                 if(this._chartElem.clientWidth == 0) {
                     console.error("Could not grab width of the Chart for estimating amount of datapoints. Using 10 points instead.")
                 }
-                query.amountOfPoints = (this._chartElem.clientWidth == 0) ? 100 : Math.round(this._chartElem.clientWidth / 10); // set amount of datapoints based on current chart width.
+                query.amountOfPoints = (this._chartElem.clientWidth == 0) ? 100 : Math.round(this._chartElem.clientWidth / 5); // set amount of datapoints based on current chart width.
             } else if(query.type == 'interval' && !query.interval) {
                 const diffInHours = (this.datapointQuery.toTimestamp! - this.datapointQuery.fromTimestamp!) / 1000 / 60 / 60;
                 const intervalArr = this._getInterval(diffInHours);

--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -1143,14 +1143,20 @@ export class OrChart extends translate(i18next)(LitElement) {
             query.toTimestamp = this._endOfPeriod;
 
             if(query.type == 'lttb') {
-                if(this._chartElem.clientWidth === 0) console.warn("Could not grab width of the Chart for estimating amount of data points. Using 100 points instead.")
 
                 // If amount of data points is set, only allow a maximum of 1 points per pixel in width
                 // Otherwise, dynamically set amount of data points based on chart width (1000px = 200 data points)
                 if(query.amountOfPoints) {
-                    query.amountOfPoints = Math.min(query.amountOfPoints, this._chartElem.clientWidth)
+                    if(this._chartElem?.clientWidth > 0) {
+                        query.amountOfPoints = Math.min(query.amountOfPoints, this._chartElem?.clientWidth)
+                    }
                 } else {
-                    query.amountOfPoints = (this._chartElem.clientWidth ? Math.round(this._chartElem.clientWidth / 5) : 100)
+                    if(this._chartElem?.clientWidth > 0) {
+                        query.amountOfPoints = Math.round(this._chartElem.clientWidth / 5)
+                    } else {
+                        console.warn("Could not grab width of the Chart for estimating amount of data points. Using 100 points instead.")
+                        query.amountOfPoints = 100;
+                    }
                 }
 
             } else if(query.type === 'interval' && !query.interval) {

--- a/ui/component/or-dashboard-builder/src/or-dashboard-preview.ts
+++ b/ui/component/or-dashboard-builder/src/or-dashboard-preview.ts
@@ -338,7 +338,7 @@ export class OrDashboardPreview extends LitElement {
     // Main setup Grid method (often used)
     async setupGrid(recreate: boolean, force: boolean = false) {
         this.isLoading = true;
-        await this.waitUntil((_: any) => this.shadowRoot?.getElementById("gridElement") != null)
+        await this.updateComplete;
         let gridElement = this.shadowRoot?.getElementById("gridElement");
         if(gridElement != null) {
             if(recreate && this.grid != null) {

--- a/ui/component/or-dashboard-builder/src/widgets/chart-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/chart-widget.ts
@@ -57,8 +57,7 @@ function getDefaultWidgetConfig(): ChartWidgetConfig {
         datapointQuery: {
             type: "lttb",
             fromTimestamp: dates[0].getTime(),
-            toTimestamp: dates[1].getTime(),
-            amountOfPoints: 100
+            toTimestamp: dates[1].getTime()
         },
         chartOptions: {
             options: {
@@ -198,8 +197,7 @@ export class ChartWidget extends OrAssetWidget {
         return {
             type: "lttb",
             fromTimestamp: moment().set('minute', -60).toDate().getTime(),
-            toTimestamp: moment().set('minute', 60).toDate().getTime(),
-            amountOfPoints: 100
+            toTimestamp: moment().set('minute', 60).toDate().getTime()
         }
     }
 }


### PR DESCRIPTION
Changelog;
- Fix for issue #1254, where only 100 datapoints were displayed on a chart.
I fixed this by resolving grid rendering issues and removing the default amountOfPoints value.
- Multiplied the amount of datapoints shown by 2, so now a chart of 1000px wide will give 200 datapoints.