### PR TITLE
Increased default number of decimals from 3 to the maximum of 20.

### DIFF
--- a/ui/component/or-mwc-components/src/or-mwc-input.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-input.ts
@@ -1345,6 +1345,9 @@ export class OrMwcInput extends LitElement {
                                     format.asDate = true;
                                     format.momentJsFormat = "YYYY-MM-DDTHH:mm";
                                     break;
+                                case InputType.NUMBER:
+                                    format.maximumFractionDigits = 20; // default according to Web documentation
+                                    break;
                             }
 
                             // Numbers/dates must be in english locale without commas etc.


### PR DESCRIPTION
Fixes #1187.

Numbers in or-mwc-input don't default to 3 decimals anymore.
Default is now the maximum of 20 instead.