### PR TITLE
Frontend Hotfix: Realm color not working on appearance page.

### DIFF
--- a/ui/app/manager/src/components/configuration/or-conf-realm/or-conf-realm-card.ts
+++ b/ui/app/manager/src/components/configuration/or-conf-realm/or-conf-realm-card.ts
@@ -183,7 +183,8 @@ export class OrConfRealmCard extends LitElement {
         Object.entries(colors).forEach(([key, value]) => {
             css += key +":" +value + ";"
         })
-        this.realm.styles = css
+        css += "}";
+        this.realm.styles = css;
         this.notifyConfigChange(this.realm);
     }
 


### PR DESCRIPTION
Fixes #1249

Hotfix for the `styles` object not correctly being saved on the appearance page.
The final parenthesis was not added, causing the custom realm colors to not be applied.