### PR TITLE
UI fixes: Attribute input not responding to language change

### DIFF
--- a/manager/src/web/shared/locales/nl/or.json
+++ b/manager/src/web/shared/locales/nl/or.json
@@ -460,7 +460,14 @@
       "ElectricityProducerWindAsset": "Windturbine asset"
     },
     "meta": {},
-    "attribute": {},
+    "attribute": {
+      "LightAsset": {
+        "brightness": "Helderheid",
+        "colourRGB": "Kleur RGB",
+        "colourTemperature": "Kleur temperatuur",
+        "groupNumber": "Groep nummer"
+      }
+    },
     "value": {
       "unknown": "Onbekend"
     }

--- a/manager/src/web/shared/locales/nl/or.json
+++ b/manager/src/web/shared/locales/nl/or.json
@@ -460,14 +460,7 @@
       "ElectricityProducerWindAsset": "Windturbine asset"
     },
     "meta": {},
-    "attribute": {
-      "LightAsset": {
-        "brightness": "Helderheid",
-        "colourRGB": "Kleur RGB",
-        "colourTemperature": "Kleur temperatuur",
-        "groupNumber": "Groep nummer"
-      }
-    },
+    "attribute": {},
     "value": {
       "unknown": "Onbekend"
     }

--- a/ui/component/or-asset-viewer/src/index.ts
+++ b/ui/component/or-asset-viewer/src/index.ts
@@ -1147,6 +1147,17 @@ export class OrAssetViewer extends subscribe(manager)(translate(i18next)(LitElem
         return !!this.editMode && this._assetInfo && this._assetInfo.modified;
     }
 
+    /**
+     * When language is changed, we clear the cached templates,
+     * so can be rendered differently according to the selected language.
+     */
+    langChangedCallback = () => {
+        if(this._assetInfo) {
+            this._assetInfo.attributeTemplateMap = {};
+            this.requestUpdate("_assetInfo");
+        }
+    }
+
     shouldUpdate(changedProperties: PropertyValues): boolean {
 
         if (this._isReadonly()) {

--- a/ui/component/or-attribute-input/src/index.ts
+++ b/ui/component/or-attribute-input/src/index.ts
@@ -610,6 +610,7 @@ export class OrAttributeInput extends subscribe(manager)(translate(i18next)(LitE
             const descriptors = AssetModelUtil.getAttributeAndValueDescriptors(this.assetType, this.attribute ? this.attribute!.name : undefined, this._attributeDescriptor);
             label = Util.getAttributeLabel(this.attribute, descriptors[0], this.assetType, true);
         }
+
         return label;
     }
 

--- a/ui/component/or-attribute-input/src/index.ts
+++ b/ui/component/or-attribute-input/src/index.ts
@@ -602,16 +602,10 @@ export class OrAttributeInput extends subscribe(manager)(translate(i18next)(LitE
     }
 
     public getLabel(): string | undefined {
-        let label;
-
-        if (this.label) {
-            label = this.label;
-        } else if (this.label !== "" && this.label !== null) {
+        if (this.label !== "" && this.label !== null) {
             const descriptors = AssetModelUtil.getAttributeAndValueDescriptors(this.assetType, this.attribute ? this.attribute!.name : undefined, this._attributeDescriptor);
-            label = Util.getAttributeLabel(this.attribute, descriptors[0], this.assetType, true);
+            return Util.getAttributeLabel(this.attribute, descriptors[0], this.assetType, true);
         }
-
-        return label;
     }
 
     public isReadonly(): boolean {

--- a/ui/component/or-attribute-input/src/index.ts
+++ b/ui/component/or-attribute-input/src/index.ts
@@ -441,6 +441,11 @@ export class OrAttributeInput extends subscribe(manager)(translate(i18next)(LitE
         this._clearWriteTimeout();
     }
 
+    langChangedCallback = () => {
+        this._updateTemplate();
+        this.requestUpdate();
+    }
+
     public shouldUpdate(_changedProperties: PropertyValues): boolean {
         const shouldUpdate = super.shouldUpdate(_changedProperties);
 

--- a/ui/component/or-attribute-input/src/index.ts
+++ b/ui/component/or-attribute-input/src/index.ts
@@ -441,6 +441,13 @@ export class OrAttributeInput extends subscribe(manager)(translate(i18next)(LitE
         this._clearWriteTimeout();
     }
 
+    langChangedCallback = () => {
+        this.updateComplete.finally(() => {
+            this.label = this.getLabel(true);
+            this.requestUpdate();
+        })
+    }
+
     public shouldUpdate(_changedProperties: PropertyValues): boolean {
         const shouldUpdate = super.shouldUpdate(_changedProperties);
 
@@ -601,11 +608,17 @@ export class OrAttributeInput extends subscribe(manager)(translate(i18next)(LitE
         }
     }
 
-    public getLabel(): string | undefined {
-        if (this.label !== "" && this.label !== null) {
+    public getLabel(force = false): string | undefined {
+        let label;
+
+        if (this.label && !force) {
+            label = this.label;
+        } else if (force || (this.label !== "" && this.label !== null)) {
             const descriptors = AssetModelUtil.getAttributeAndValueDescriptors(this.assetType, this.attribute ? this.attribute!.name : undefined, this._attributeDescriptor);
-            return Util.getAttributeLabel(this.attribute, descriptors[0], this.assetType, true);
+            label = Util.getAttributeLabel(this.attribute, descriptors[0], this.assetType, true);
         }
+
+        return label;
     }
 
     public isReadonly(): boolean {

--- a/ui/component/or-attribute-input/src/index.ts
+++ b/ui/component/or-attribute-input/src/index.ts
@@ -441,13 +441,6 @@ export class OrAttributeInput extends subscribe(manager)(translate(i18next)(LitE
         this._clearWriteTimeout();
     }
 
-    langChangedCallback = () => {
-        this.updateComplete.finally(() => {
-            this.label = this.getLabel(true);
-            this.requestUpdate();
-        })
-    }
-
     public shouldUpdate(_changedProperties: PropertyValues): boolean {
         const shouldUpdate = super.shouldUpdate(_changedProperties);
 
@@ -608,16 +601,15 @@ export class OrAttributeInput extends subscribe(manager)(translate(i18next)(LitE
         }
     }
 
-    public getLabel(force = false): string | undefined {
+    public getLabel(): string | undefined {
         let label;
 
-        if (this.label && !force) {
+        if (this.label) {
             label = this.label;
-        } else if (force || (this.label !== "" && this.label !== null)) {
+        } else if (this.label !== "" && this.label !== null) {
             const descriptors = AssetModelUtil.getAttributeAndValueDescriptors(this.assetType, this.attribute ? this.attribute!.name : undefined, this._attributeDescriptor);
             label = Util.getAttributeLabel(this.attribute, descriptors[0], this.assetType, true);
         }
-
         return label;
     }
 

--- a/ui/component/or-mwc-components/src/or-mwc-input.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-input.ts
@@ -1660,6 +1660,10 @@ export class OrMwcInput extends LitElement {
             }
         }
 
+        if(_changedProperties.has("label")) {
+            (this._mdcComponent as any)?.layout?.(); // Adjusts the dimensions and positions for all sub-elements.
+        }
+
         if (this.autoValidate) {
             this.reportValidity();
         }


### PR DESCRIPTION
Fixed an issue where the label in `or-attribute-input` did not update when a user changes the manager language.
Made a change in the `getLabel()` function, so it does not simply return if a label already exists anymore,
as a parent component might want to update the label. Don't think this change will have a performance impact.

Fixes #1301.