### PR TITLE
Docker OpenRemote-wide logging to Manager Syslog port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ volumes:
   manager-data:
   postgresql-data:
 
+x-logging: &default-logging
+  driver: syslog
+  options:
+    syslog-address: "tcp://manager:1514"
+    syslog-facility: "daemon"
+
 services:
 
   proxy:

--- a/profile/dev-testing.yml
+++ b/profile/dev-testing.yml
@@ -6,6 +6,12 @@
 #
 version: '2.4'
 
+#x-logging: &default-logging
+#  driver: syslog
+#  options:
+#    syslog-address: "tcp://localhost:1514"
+
+
 services:
 
   keycloak:
@@ -25,6 +31,7 @@ services:
       KC_HOSTNAME_PORT: ${KC_HOSTNAME_PORT:-8080}
       # Prevent theme caching during dev
       KEYCLOAK_START_OPTS: --spi-theme-static-max-age=-1 --spi-theme-cache-themes=false --spi-theme-cache-templates=false
+#    logging: *default-logging
 
   postgresql:
     extends:
@@ -35,3 +42,4 @@ services:
     # Access directly if needed on localhost
     ports:
       - "5432:5432"
+#    logging: *default-logging


### PR DESCRIPTION
This PR introduces the feature of OpenRemote-wide logging from all containers into the manager's `SyslogService`. This would allow for users to have an easier logging experience and allow for easier debugging/monitoring of OpenRemote as a whole. If I get this to work, I would optimally have that port serve as a Syslog server itself, allowing for sending all those logs outside of the container (to some other monitoring server). 

@richturner I'm having an issue within `UDPStringServer` specifically from `AbstractTCPServer`, starting somewhere in line 83. When debugging, I send a message using `echo "test" | nc -u -w1 localhost 1514 -v`, and I can see that I am hitting that line using a breakpoint, but the message does not seem to propagate to my messageConsumer. I'd appreciate any pointers, but I assume it's still my mistake, since it's dealing with low-level stuff. Thanks!