### PR TITLE
Clear console web history after login

### DIFF
--- a/ui/component/core/src/console.ts
+++ b/ui/component/core/src/console.ts
@@ -400,7 +400,6 @@ export class Console {
      */
     public _doSendGenericMessage(type: string, msg: any) {
         const payload = { type: type, data: msg };
-        console.log("Sending generic message to console; ", payload); // TODO: Remove this (added temporarily for testing)
         if (this.isMobile) {
             this._postNativeShellMessage(payload);
         } else {

--- a/ui/component/core/src/console.ts
+++ b/ui/component/core/src/console.ts
@@ -380,13 +380,17 @@ export class Console {
     }
 
     protected _postNativeShellMessage(jsonMessage: any) {
-        if (this.shellAndroid) {
-            // @ts-ignore
-            return window.MobileInterface.postMessage(JSON.stringify(jsonMessage));
-        }
-        if (this.shellApple) {
-            // @ts-ignore
-            return window.webkit.messageHandlers.int.postMessage(jsonMessage);
+        try {
+            if (this.shellAndroid) {
+                // @ts-ignore
+                return window.MobileInterface.postMessage(JSON.stringify(jsonMessage));
+            }
+            if (this.shellApple) {
+                // @ts-ignore
+                return window.webkit.messageHandlers.int.postMessage(jsonMessage);
+            }
+        } catch (e) {
+            console.error("Failed to send shell message towards console", e);
         }
     }
 
@@ -395,11 +399,12 @@ export class Console {
      * TODO: Will be improved in the future, see this GitHub issue; https://github.com/openremote/openremote/issues/1318
      */
     public _doSendGenericMessage(type: string, msg: any) {
-        console.log(`Sending generic message of type (${type}), with msg (${msg})`); // TODO: Remove this (added temporarily for testing)
+        const payload = { type: type, data: msg };
+        console.log("Sending generic message to console; ", payload); // TODO: Remove this (added temporarily for testing)
         if (this.isMobile) {
-            this._postNativeShellMessage({type: type, data: msg });
+            this._postNativeShellMessage(payload);
         } else {
-            console.warn("Failed to send generic message to console.")
+            console.warn("Failed to send generic message to console.", payload)
         }
     }
 

--- a/ui/component/core/src/console.ts
+++ b/ui/component/core/src/console.ts
@@ -390,6 +390,19 @@ export class Console {
         }
     }
 
+    /**
+     * Function that allows sending of custom types and messages towards the console.
+     * TODO: Will be improved in the future, see this GitHub issue; https://github.com/openremote/openremote/issues/1318
+     */
+    public _doSendGenericMessage(type: string, msg: any) {
+        console.log(`Sending generic message of type (${type}), with msg (${msg})`); // TODO: Remove this (added temporarily for testing)
+        if (this.isMobile) {
+            this._postNativeShellMessage({type: type, data: msg });
+        } else {
+            console.warn("Failed to send generic message to console.")
+        }
+    }
+
     public _doSendProviderMessage(msg: any) {
         if (this.isMobile) {
             this._postNativeShellMessage({type: "provider", data: msg});

--- a/ui/component/core/src/index.ts
+++ b/ui/component/core/src/index.ts
@@ -374,6 +374,7 @@ export class Manager implements EventProviderFactory {
 
         // Don't let console registration error prevent loading
         const consoleSuccess = await this.doConsoleInit();
+        console.log(`Done with console initialisation. Result is ${consoleSuccess}`); // TODO: Remove this (added temporarily for testing)
         if(consoleSuccess) {
             // Send the console a message to clear the web history, so no pages outside the app can be accessed.
             // For example, this prevents navigating back to an authentication screen.

--- a/ui/component/core/src/index.ts
+++ b/ui/component/core/src/index.ts
@@ -985,6 +985,16 @@ export class Manager implements EventProviderFactory {
                 this.login();
             }
         }
+
+        // Send the console a message to clear the login page that was visited earlier.
+        // This prevents navigating back to an authentication screen.
+        this._clearWebHistory();
+    }
+
+    /** Function that clears the `WebView` history of a console. It will not delete the history on regular browsers. */
+    protected _clearWebHistory(): void {
+        console.log("Clearing web history..."); // TODO: Remove this (added temporarily for testing)
+        this.console?._doSendGenericMessage("CLEAR_WEB_HISTORY", undefined);
     }
 
     // NOTE: The below works with Keycloak 2.x JS API - They made breaking changes in newer versions

--- a/ui/component/core/src/index.ts
+++ b/ui/component/core/src/index.ts
@@ -373,7 +373,13 @@ export class Manager implements EventProviderFactory {
         }
 
         // Don't let console registration error prevent loading
-        await this.doConsoleInit();
+        const consoleSuccess = await this.doConsoleInit();
+        if(consoleSuccess) {
+            // Send the console a message to clear the web history, so no pages outside the app can be accessed.
+            // For example, this prevents navigating back to an authentication screen.
+            this._clearWebHistory();
+        }
+
         success = await this.doTranslateInit() && success;
 
         if (success) {
@@ -985,16 +991,6 @@ export class Manager implements EventProviderFactory {
                 this.login();
             }
         }
-
-        // Send the console a message to clear the login page that was visited earlier.
-        // This prevents navigating back to an authentication screen.
-        this._clearWebHistory();
-    }
-
-    /** Function that clears the `WebView` history of a console. It will not delete the history on regular browsers. */
-    protected _clearWebHistory(): void {
-        console.log("Clearing web history..."); // TODO: Remove this (added temporarily for testing)
-        this.console?._doSendGenericMessage("CLEAR_WEB_HISTORY", undefined);
     }
 
     // NOTE: The below works with Keycloak 2.x JS API - They made breaking changes in newer versions
@@ -1169,6 +1165,13 @@ export class Manager implements EventProviderFactory {
             }
         }
     }
+
+    /** Function that clears the `WebView` history of a console. It will not delete the history on regular browsers. */
+    protected _clearWebHistory(): void {
+        console.log("Clearing web history..."); // TODO: Remove this (added temporarily for testing)
+        this.console?._doSendGenericMessage("CLEAR_WEB_HISTORY", undefined);
+    }
+
 }
 
 export const manager = new Manager(); // Needed for webpack bundling

--- a/ui/component/core/src/index.ts
+++ b/ui/component/core/src/index.ts
@@ -374,7 +374,6 @@ export class Manager implements EventProviderFactory {
 
         // Don't let console registration error prevent loading
         const consoleSuccess = await this.doConsoleInit();
-        console.log(`Done with console initialisation. Result is ${consoleSuccess}`); // TODO: Remove this (added temporarily for testing)
         if(consoleSuccess) {
             // Send the console a message to clear the web history, so no pages outside the app can be accessed.
             // For example, this prevents navigating back to an authentication screen.
@@ -1169,7 +1168,6 @@ export class Manager implements EventProviderFactory {
 
     /** Function that clears the `WebView` history of a console. It will not delete the history on regular browsers. */
     protected _clearWebHistory(): void {
-        console.log("Clearing web history..."); // TODO: Remove this (added temporarily for testing)
         this.console?._doSendGenericMessage("CLEAR_WEB_HISTORY", undefined);
     }
 


### PR DESCRIPTION
I finished the frontend code for the new console functionality of clearing the browser history.

### Changelog:
- After console initialization in `core`, it will attempt to send a `CLEAR_WEB_HISTORY` message to the consoles, to trigger the clearing of the `WebView` history. 
- Added temporary `_doSendGenericMessage()` function that allows sending any message type towards consoles.
- Surrounded the internal "send message to console" function with a try-catch.

### Important notes:
Initially, the idea was to only clear "browser history" after logging in.
However, since authentication is done before initializing the console connection, I decided to handle it this way.
