### PR TITLE
UI fixes for the Manager Insights page

### DIFF
--- a/ui/app/manager/index.html
+++ b/ui/app/manager/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-    <title>OpenRemote Demo</title>
+    <title></title>
     <meta name="application-name" content="OpenRemote Demo">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="apple-mobile-web-app-title" content="OpenRemote Demo">

--- a/ui/component/or-dashboard-builder/src/index.ts
+++ b/ui/component/or-dashboard-builder/src/index.ts
@@ -457,12 +457,16 @@ export class OrDashboardBuilder extends LitElement {
 
     selectDashboard(dashboard: Dashboard | undefined) {
         if(this.dashboards != null) {
+
+            // If switching between dashboards, check if there were changes, and reset to 'initialDashboardJSON' if needed.
             if(this.selectedDashboard && this.initialDashboardJSON) {
-                const indexOf = this.dashboards.indexOf(this.selectedDashboard);
-                if(indexOf) {
-                    this.dashboards[indexOf] = JSON.parse(this.initialDashboardJSON) as Dashboard;
+                const index = this.dashboards.indexOf(this.selectedDashboard);
+                if(index && JSON.stringify(this.selectedDashboard) !== this.initialDashboardJSON) {
+                    this.dashboards[index] = JSON.parse(this.initialDashboardJSON) as Dashboard;
                 }
             }
+
+            // Update selected dashboard
             this.selectedDashboard = (dashboard ? this.dashboards.find((x) => { return x.id == dashboard.id; }) : undefined);
             this.initialDashboardJSON = JSON.stringify(this.selectedDashboard);
             this.initialTemplateJSON = JSON.stringify(this.selectedDashboard?.template);
@@ -608,8 +612,8 @@ export class OrDashboardBuilder extends LitElement {
                         <div id="fullscreen-header">
                             <div id="fullscreen-header-wrapper">
                                 <div id="fullscreen-header-title" style="display: flex; align-items: center;">
-                                    <or-icon class="showMobile" style="margin-right: 10px;" icon="chevron-left" @click="${() => { this.selectedDashboard = undefined; }}"></or-icon>
-                                    <or-icon class="hideMobile" style="margin-right: 10px;" icon="menu" @click="${() => { this.showDashboardTree = !this.showDashboardTree; }}"></or-icon>
+                                    <or-icon class="showMobile" style="margin-right: 10px; cursor: pointer;" icon="chevron-left" @click="${() => { this.selectedDashboard = undefined; }}"></or-icon>
+                                    <or-icon class="hideMobile" style="margin-right: 10px; cursor: pointer;" icon="menu" @click="${() => { this.showDashboardTree = !this.showDashboardTree; }}"></or-icon>
                                     <span>${this.selectedDashboard?.displayName}</span>
                                 </div>
                                 <div id="fullscreen-header-actions">

--- a/ui/component/or-dashboard-builder/src/or-dashboard-tree.ts
+++ b/ui/component/or-dashboard-builder/src/or-dashboard-tree.ts
@@ -21,6 +21,11 @@ const treeStyling = css`
         flex-direction: row;
         padding-right: 5px;
     }
+    
+    #content {
+        flex: 1;
+        overflow: hidden auto;
+    }
 
     .node-container {
         align-items: center;


### PR DESCRIPTION
Changelog:
- Fix for infinite loop that occurred after reopening dashboard tree
- `or-dashboard-tree` is now vertically scrollable
- HTML page now uses an empty window `title` until JavaScript is initialized, preventing the "OpenRemote Demo" flash.