### PR TITLE
UI Bugfix; Insights navigation causing the browser tab to hang

### DIFF
--- a/ui/component/core/src/util.ts
+++ b/ui/component/core/src/util.ts
@@ -29,7 +29,7 @@ import Qs from "qs";
 import {AssetModelUtil} from "@openremote/model";
 import moment from "moment";
 import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
-import {isEqual, transform} from "lodash";
+import {transform} from "lodash";
 
 export class Deferred<T> {
 
@@ -284,7 +284,7 @@ export function objectsEqual(obj1?: any, obj2?: any, deep: boolean = true): bool
 export function difference(object?: any, base?: any): any {
     function changes(object?: any, base?: any) {
         return transform(object, function(result: any, value, key: string | number | symbol) {
-            if (!isEqual(value, base?.[key])) {
+            if (!objectsEqual(value, base?.[key])) {
                 result[key] = (isObject(value) && isObject(base?.[key])) ? changes(value, base?.[key]) : value;
             }
         });

--- a/ui/component/core/src/util.ts
+++ b/ui/component/core/src/util.ts
@@ -29,6 +29,7 @@ import Qs from "qs";
 import {AssetModelUtil} from "@openremote/model";
 import moment from "moment";
 import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
+import {isEqual, transform} from "lodash";
 
 export class Deferred<T> {
 
@@ -273,6 +274,22 @@ export function objectsEqual(obj1?: any, obj2?: any, deep: boolean = true): bool
     }
 
     return false;
+}
+/**
+ * Deep diff between two object, using lodash
+ * @param  {Object} object Object compared
+ * @param  {Object} base   Object to compare with
+ * @return {Object}        Return a new object who represent the diff
+ */
+export function difference(object?: any, base?: any): any {
+    function changes(object?: any, base?: any) {
+        return transform(object, function(result: any, value, key: string | number | symbol) {
+            if (!isEqual(value, base?.[key])) {
+                result[key] = (isObject(value) && isObject(base?.[key])) ? changes(value, base?.[key]) : value;
+            }
+        });
+    }
+    return changes(object, base);
 }
 
 export function arrayRemove<T>(arr: T[], item: T) {

--- a/ui/component/core/src/util.ts
+++ b/ui/component/core/src/util.ts
@@ -282,13 +282,11 @@ export function objectsEqual(obj1?: any, obj2?: any, deep: boolean = true): bool
  * @return {Object}        Return a new object who represent the diff
  */
 export function difference(object?: any, base?: any): any {
-    function changes(object?: any, base?: any) {
-        return transform(object, function(result: any, value, key: string | number | symbol) {
-            if (!objectsEqual(value, base?.[key])) {
-                result[key] = (isObject(value) && isObject(base?.[key])) ? changes(value, base?.[key]) : value;
-            }
-        });
-    }
+    const changes = (object: any, base: any) => transform(object, function(result: any, value, key: string | number | symbol) {
+        if (!objectsEqual(value, base?.[key])) {
+            result[key] = (isObject(value) && isObject(base?.[key])) ? changes(value, base?.[key]) : value;
+        }
+    });
     return changes(object, base);
 }
 

--- a/ui/component/or-dashboard-builder/src/index.ts
+++ b/ui/component/or-dashboard-builder/src/index.ts
@@ -332,21 +332,19 @@ export class OrDashboardBuilder extends LitElement {
 
             // Check for dashboard changes
             const initialDashboard = this.initialDashboardJSON ? JSON.parse(this.initialDashboardJSON) : undefined;
-            const dashboardEqual = Util.objectsEqual(this.selectedDashboard, initialDashboard);
-            if(!dashboardEqual) {
+            const dashboardDiff = Util.difference(this.selectedDashboard, initialDashboard);
+            if(Object.keys(dashboardDiff).length > 0) {
                 this.hasChanged = true;
-                const diff = Util.difference(this.selectedDashboard, initialDashboard);
-                console.debug("Dashboard has detected changes! Diff:", diff);
+                console.debug("Dashboard has detected changes! Diff:", dashboardDiff);
             }
 
             // Check for template changes
             else {
                 const initialTemplate = this.initialTemplateJSON ? JSON.parse(this.initialTemplateJSON) : undefined;
-                const templateEqual = Util.objectsEqual(this.currentTemplate, initialTemplate);
-                if(!templateEqual) {
+                const templateDiff = Util.difference(this.currentTemplate, initialTemplate);
+                if(Object.keys(templateDiff).length > 0) {
                     this.hasChanged = true;
-                    const diff = Util.difference(this.currentTemplate, initialTemplate);
-                    console.debug("Template has detected changes! Diff:", diff);
+                    console.debug("Template has detected changes! Diff:", templateDiff);
                 } else {
 
                     // If no changes detected between dashboard nor template

--- a/ui/component/or-dashboard-builder/src/index.ts
+++ b/ui/component/or-dashboard-builder/src/index.ts
@@ -329,9 +329,30 @@ export class OrDashboardBuilder extends LitElement {
 
         // On any update (except widget selection), check whether hasChanged should be updated.
         if(!(changedProps.size === 1 && changedProps.has('selectedWidget'))) {
-            const dashboardEqual = Util.objectsEqual(this.selectedDashboard, this.initialDashboardJSON ? JSON.parse(this.initialDashboardJSON) : undefined);
-            const templateEqual = Util.objectsEqual(this.currentTemplate, this.initialTemplateJSON ? JSON.parse(this.initialTemplateJSON) : undefined);
-            this.hasChanged = (!dashboardEqual || !templateEqual);
+
+            // Check for dashboard changes
+            const initialDashboard = this.initialDashboardJSON ? JSON.parse(this.initialDashboardJSON) : undefined;
+            const dashboardEqual = Util.objectsEqual(this.selectedDashboard, initialDashboard);
+            if(!dashboardEqual) {
+                this.hasChanged = true;
+                const diff = Util.difference(this.selectedDashboard, initialDashboard);
+                console.debug("Dashboard has detected changes! Diff:", diff);
+            }
+
+            // Check for template changes
+            else {
+                const initialTemplate = this.initialTemplateJSON ? JSON.parse(this.initialTemplateJSON) : undefined;
+                const templateEqual = Util.objectsEqual(this.currentTemplate, initialTemplate);
+                if(!templateEqual) {
+                    this.hasChanged = true;
+                    const diff = Util.difference(this.currentTemplate, initialTemplate);
+                    console.debug("Template has detected changes! Diff:", diff);
+                } else {
+
+                    // If no changes detected between dashboard nor template
+                    this.hasChanged = false;
+                }
+            }
         }
 
         // Support for realm switching

--- a/ui/component/or-dashboard-builder/src/or-dashboard-widgetcontainer.ts
+++ b/ui/component/or-dashboard-builder/src/or-dashboard-widgetcontainer.ts
@@ -7,6 +7,7 @@ import {DashboardWidget} from "@openremote/model";
 import {OrWidget, WidgetManifest} from "./util/or-widget";
 import {WidgetService} from "./service/widget-service";
 import {WidgetConfig} from "./util/widget-config";
+import {Util} from "@openremote/core";
 
 /* ------------------------------------ */
 
@@ -73,7 +74,7 @@ export class OrDashboardWidgetContainer extends LitElement {
             const oldVal = changedProps.get('widget') as DashboardWidget | undefined;
             const idChanged = oldVal?.id !== this.widget?.id;
             const nameChanged = oldVal?.displayName !== this.widget?.displayName;
-            const configChanged = JSON.stringify(oldVal?.widgetConfig) !== JSON.stringify(this.getWidgetConfig());
+            const configChanged = !Util.objectsEqual(oldVal?.widgetConfig, this.getWidgetConfig());
             if (!(idChanged || nameChanged || configChanged)) {
                 changed.delete('widget');
             }

--- a/ui/component/or-dashboard-builder/src/or-dashboard-widgetcontainer.ts
+++ b/ui/component/or-dashboard-builder/src/or-dashboard-widgetcontainer.ts
@@ -1,4 +1,3 @@
-import {i18next} from "@openremote/or-translate";
 import {html, LitElement, PropertyValues} from "lit";
 import {customElement, property, query, state} from "lit/decorators.js";
 import {when} from "lit/directives/when.js";
@@ -20,6 +19,9 @@ export class OrDashboardWidgetContainer extends LitElement {
 
     @property()
     protected readonly widget!: DashboardWidget;
+
+    @property() // Optional property, that overrides widget.widgetConfig. Useful for view-only mode.
+    protected widgetConfig?: WidgetConfig;
 
     @property()
     protected readonly editMode!: boolean;
@@ -49,7 +51,7 @@ export class OrDashboardWidgetContainer extends LitElement {
         this.resizeObserver?.disconnect();
     }
 
-    shouldUpdate(changedProps: Map<PropertyKey, unknown>): boolean {
+    shouldUpdate(changedProps: PropertyValues): boolean {
         const changed = changedProps;
 
         // Update config if some values in the spec are not set.
@@ -57,7 +59,11 @@ export class OrDashboardWidgetContainer extends LitElement {
         if (this.widget) {
             const manifest = WidgetService.getManifest(this.widget.widgetTypeId!);
             if (manifest) {
-                this.widget.widgetConfig = WidgetService.correctToConfigSpec(manifest, this.widget.widgetConfig);
+                if(this.editMode) {
+                    this.widget.widgetConfig = WidgetService.correctToConfigSpec(manifest, this.widget.widgetConfig);
+                } else {
+                    this.widgetConfig = WidgetService.correctToConfigSpec(manifest, this.widget.widgetConfig);
+                }
             }
         }
 
@@ -67,7 +73,7 @@ export class OrDashboardWidgetContainer extends LitElement {
             const oldVal = changedProps.get('widget') as DashboardWidget | undefined;
             const idChanged = oldVal?.id !== this.widget?.id;
             const nameChanged = oldVal?.displayName !== this.widget?.displayName;
-            const configChanged = JSON.stringify(oldVal?.widgetConfig) !== JSON.stringify(this.widget?.widgetConfig);
+            const configChanged = JSON.stringify(oldVal?.widgetConfig) !== JSON.stringify(this.getWidgetConfig());
             if (!(idChanged || nameChanged || configChanged)) {
                 changed.delete('widget');
             }
@@ -76,7 +82,7 @@ export class OrDashboardWidgetContainer extends LitElement {
         return (changed.size === 0 ? false : super.shouldUpdate(changedProps));
     }
 
-    willUpdate(changedProps: Map<string, any>) {
+    willUpdate(changedProps: PropertyValues) {
         super.willUpdate(changedProps);
 
         if (!this.manifest && this.widget) {
@@ -85,7 +91,7 @@ export class OrDashboardWidgetContainer extends LitElement {
 
         // Create widget
         if (changedProps.has("widget") && this.widget) {
-            this.initializeWidgetElem(this.manifest!, this.widget.widgetConfig);
+            this.initializeWidgetElem(this.manifest!, this.getWidgetConfig()!);
         }
     }
 
@@ -151,5 +157,9 @@ export class OrDashboardWidgetContainer extends LitElement {
 
     public refreshContent(force: boolean) {
         this.orWidget?.refreshContent(force);
+    }
+
+    public getWidgetConfig(): WidgetConfig | undefined {
+        return this.widgetConfig || this.widget?.widgetConfig;
     }
 }

--- a/ui/component/or-dashboard-builder/src/service/widget-service.ts
+++ b/ui/component/or-dashboard-builder/src/service/widget-service.ts
@@ -42,7 +42,13 @@ export class WidgetService {
 
     // Method used to correct the OrWidgetConfig specification
     // So, if certain fields are removed or invalid, it will be corrected by merging the object with the default OrWidgetConfig.
+    // Will only return a different object if it actually changes. This prevents child objects being returned in a different order.
     public static correctToConfigSpec(manifest: WidgetManifest, widgetConfig: WidgetConfig) {
-        return Util.mergeObjects(manifest.getDefaultConfig(), widgetConfig, false) as WidgetConfig;
+        const newConfig = Util.mergeObjects(manifest.getDefaultConfig(), widgetConfig, false) as WidgetConfig;
+        if(Util.objectsEqual(newConfig, widgetConfig)) {
+            return widgetConfig;
+        } else {
+            return newConfig;
+        }
     }
 }

--- a/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
@@ -111,6 +111,8 @@ export class GatewayWidget extends OrWidget {
                         console.log("Existing tunnel found!", info);
                         this._setActiveTunnel(info, true)
                     }
+                }).catch(e => {
+                    console.error(e);
                 }).finally(() => {
                     this._loading = false;
                 });


### PR DESCRIPTION
Fix for browser crashes we were seeing on the Insights page, when navigating between dashboards.
It was very tricky to discover the cause of this, as it only occurred in production mode,
and the Insights overall is a very complex and intuitive piece of JS code.

I decreased the amount/occurrence of `widgetConfig` corrections, as that seems to be the cause.
Along with that, I've improved logging for the dashboard 'hasChanged' diff checks.

Changelog;
- While in view mode, the 'widget config correction' is now only applied within the preview,
and not exposed to a higher layer. As there is no need to 'save the changes that have been made' for example.
- Updated 'widget config correction' function, to only return a different JS object when changes have been made.
Originally it was returning the same object, but the fields were in a different order; causing unnecessary UI updates.
- Improved logging for `hasChanged` functionality, with the difference between dashboard objects being shared in the console.
- Added new util function using lodash; `difference(obj1, obj2)`
- Added `catch` clause for getting the initial tunnel connection in the `tunnel-widget`.