### PR TITLE
Add var as a unit

### DIFF
--- a/manager/src/web/shared/locales/en/or.json
+++ b/manager/src/web/shared/locales/en/or.json
@@ -466,6 +466,7 @@
     "hertz": "Hz",
     "rpm": "rpm",
     "carbon": "CO2",
+    "var": "var",
     "meta": {},
     "attribute": {}
   },

--- a/manager/src/web/shared/locales/nl/or.json
+++ b/manager/src/web/shared/locales/nl/or.json
@@ -465,6 +465,7 @@
     "hertz": "Hz",
     "rpm": "rpm",
     "carbon": "CO2",
+    "var": "var",
     "meta": {},
     "attribute": {}
   },

--- a/model/src/main/java/org/openremote/model/Constants.java
+++ b/model/src/main/java/org/openremote/model/Constants.java
@@ -147,4 +147,5 @@ public interface Constants {
     String UNITS_RPM = "rpm";
     String UNITS_PART_PER_MILLION = "ppm";
     String UNITS_CARBON = "carbon";
+    String UNITS_VAR = "var";
 }


### PR DESCRIPTION
The unit "var" is commonly used in electronics & energy and is the unit for reactive power.
https://en.wikipedia.org/wiki/AC_power

I did all the same steps Don did to add the constant "hecto" to the repo in #1245 
https://github.com/openremote/openremote/commit/331fcba2bcf615b188edab38b5b918ec96726df6
