### PR TITLE
Use parallel Gradle builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xms256m -Xmx1024m
+org.gradle.parallel=true
 
 jaxrsSpecVersion = 3.1.0
 javaxAnnotationsVersion = 2.1.1


### PR DESCRIPTION
I gave [parallel Gradle executution](https://docs.gradle.org/current/userguide/performance.html#parallel_execution) a test and it seems to work fine so far.
It puts my abundance of CPU cores to use making builds 45% faster (45s instead of 1m 17s).

The gain comes mostly from running the NPM tasks in parallel.

Sequential execution:

![Screenshot from 2024-09-04 10-39-32](https://github.com/user-attachments/assets/320a3aa3-77b5-4b95-84f7-6fa51a54df05)

Parallel execution:

![Screenshot from 2024-09-04 10-39-21](https://github.com/user-attachments/assets/b19539d2-dc2f-4280-a0d2-dd5223f8bb8d)
