### PR TITLE
Fix CustomX509TrustManagerFactorySpi constructor deprecation

### DIFF
--- a/agent/src/main/java/org/openremote/agent/protocol/mqtt/CustomX509TrustManagerFactorySpi.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/mqtt/CustomX509TrustManagerFactorySpi.java
@@ -133,7 +133,7 @@ public class CustomX509TrustManagerFactorySpi extends TrustManagerFactorySpi {
 	// Register the provider
 	public static class CustomProvider extends Provider {
 		public CustomProvider() {
-			super("CustomX509TrustManagerFactory", 1.0, "Custom X509 TrustManager Factory");
+			super("CustomX509TrustManagerFactory", "1.0", "Custom X509 TrustManager Factory");
 			put("TrustManagerFactory.CustomX509TrustManagerFactory", this.getClass().getName());
 		}
 	}


### PR DESCRIPTION
Fixes the following warnings:

```
Task :agent:compileJava
/home/runner/work/openremote/openremote/agent/src/main/java/org/openremote/agent/protocol/mqtt/CustomX509TrustManagerFactorySpi.java:136: warning: [deprecation] Provider(String,double,String) in Provider has been deprecated
   super("CustomX509TrustManagerFactory", 1.0, "Custom X509 TrustManager Factory");
   ^
```