### PR TITLE
Fix or-map-asset-card to break at a bigger width, to accomodate wider mobile devices

### DIFF
--- a/ui/app/manager/src/pages/page-map.ts
+++ b/ui/app/manager/src/pages/page-map.ts
@@ -147,7 +147,7 @@ export class PageMap extends Page<MapStateKeyed> {
                 width: 100%;
             }
         
-            @media only screen and (min-width: 415px){
+            @media only screen and (min-width: 40em){
                 or-map-asset-card {
                     position: absolute;
                     top: 10px;

--- a/ui/component/or-map/src/style.ts
+++ b/ui/component/or-map/src/style.ts
@@ -228,7 +228,7 @@ export const mapAssetCardStyle = css`
                 padding: 5px 12px;
             }
             
-            @media only screen and (min-width: 415px){
+            @media only screen and (min-width: 40em){
                 #card-container {
                     height: 400px; /* fallback for IE */
                     height: max-content;


### PR DESCRIPTION
The break now happens at 40em, which is approximately 560px with the default font-size. This is to accomodate ever-widening mobile screens (such as on newer iPhones), and also makes viewing on portrait-orientation tablets nicer. Especially with assets with lots of attributes (like on my fleet integration), the card basically covers the entire map on my iPhone 14 Plus.