### PR TITLE
Bugfix solar forecast service

### DIFF
--- a/manager/src/main/java/org/openremote/manager/energy/ForecastSolarService.java
+++ b/manager/src/main/java/org/openremote/manager/energy/ForecastSolarService.java
@@ -256,8 +256,12 @@ public class ForecastSolarService extends RouteBuilder implements ContainerServi
 
     protected void processAssetChange(PersistenceEvent<ElectricityProducerSolarAsset> persistenceEvent) {
         LOG.fine("Processing producer solar asset change: " + persistenceEvent);
-        // Remove asset from solar forecast map on asset deletion
-        if (persistenceEvent.getCause() == PersistenceEvent.Cause.DELETE) {
+
+        if (persistenceEvent.getCause() == PersistenceEvent.Cause.CREATE && persistenceEvent.getEntity().isIncludeForecastSolarService().orElse(false)) {
+            electricityProducerSolarAssetMap.put(persistenceEvent.getEntity().getId(), persistenceEvent.getEntity());
+            getSolarForecast(persistenceEvent.getEntity());
+            updateSolarForecastAttribute(persistenceEvent.getEntity());
+        } else if (persistenceEvent.getCause() == PersistenceEvent.Cause.DELETE) {
             electricityProducerSolarAssetMap.remove(persistenceEvent.getEntity().getId());
         }
     }

--- a/model/src/main/java/org/openremote/model/asset/impl/ElectricityProducerSolarAsset.java
+++ b/model/src/main/java/org/openremote/model/asset/impl/ElectricityProducerSolarAsset.java
@@ -52,7 +52,7 @@ public class ElectricityProducerSolarAsset extends ElectricityProducerAsset {
 
     public static final AttributeDescriptor<Boolean> INCLUDE_FORECAST_SOLAR_SERVICE = new AttributeDescriptor<>("includeForecastSolarService", BOOLEAN);
 
-    public static final AttributeDescriptor<Boolean> SET_ACTUAL_SOLAR_VALUE_WITH_FORECAST = new AttributeDescriptor<>("setActualSolarPowerValueWithForecast", BOOLEAN);
+    public static final AttributeDescriptor<Boolean> SET_ACTUAL_SOLAR_VALUE_WITH_FORECAST = new AttributeDescriptor<>("setActualSolarValueWithForecast", BOOLEAN);
 
     public static final AssetDescriptor<ElectricityProducerSolarAsset> DESCRIPTOR = new AssetDescriptor<>("white-balance-sunny", "EABB4D", ElectricityProducerSolarAsset.class);
 


### PR DESCRIPTION
- Fixed bug where solar forecast service was not started automatically when an asset was created programmatically with the 'isIncludeForecastSolarService' attribute set to 'true'
- Reverted accidental change of attribute  name  'setActualSolarPowerValueWithForecast' back to its original name 'setActualSolarValueWithForecast'