### PR TITLE
Skip the mTLS test when test.mosquitto.org fails the signing request (with HTTP 502).

### DIFF
--- a/test/src/test/groovy/org/openremote/test/protocol/mqtt/MQTTClientProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/mqtt/MQTTClientProtocolTest.groovy
@@ -197,7 +197,7 @@ class MQTTClientProtocolTest extends Specification implements ManagerContainerTr
         HttpResponse<String> testResponse = testClient.send(testRequest, HttpResponse.BodyHandlers.ofString())
 
         then:
-        if(testResponse.statusCode() != 200) throw new TestAbortedException("Should be 200");
+        if(testResponse.statusCode() != 200) throw new TestAbortedException("Mosquitto server unavailable");
 
         and: "the container starts"
         def container = startContainer(defaultConfig(), defaultServices())

--- a/test/src/test/groovy/org/openremote/test/protocol/mqtt/MQTTClientProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/mqtt/MQTTClientProtocolTest.groovy
@@ -29,7 +29,6 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder
 import org.bouncycastle.util.io.pem.PemObject
 import org.bouncycastle.util.io.pem.PemWriter
-import org.junit.AssumptionViolatedException
 import org.openremote.agent.protocol.mqtt.MQTTAgent
 import org.openremote.agent.protocol.mqtt.MQTTAgentLink
 import org.openremote.agent.protocol.mqtt.MQTTProtocol
@@ -54,6 +53,7 @@ import org.openremote.model.util.UniqueIdentifierGenerator
 import org.openremote.setup.integration.KeycloakTestSetup
 import org.openremote.setup.integration.ManagerTestSetup
 import org.openremote.test.ManagerContainerTrait
+import org.opentest4j.TestAbortedException
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -185,13 +185,19 @@ class MQTTClientProtocolTest extends Specification implements ManagerContainerTr
         given: "expected conditions"
         def conditions = new PollingConditions(timeout: 100, delay: 0.2)
 
-        and: "External connectivity has been assured"
-        try {
-            assert new Socket("test.mosquitto.org", 8884) != null
-            assert new Socket("test.mosquitto.org", 443) != null
-        } catch (Exception e) {
-            throw new AssumptionViolatedException("No connectivity to external hosts, skip test");
-        }
+        when:
+        assert new Socket("test.mosquitto.org", 8884) != null
+        assert new Socket("test.mosquitto.org", 443) != null
+        HttpClient testClient = HttpClient.newHttpClient()
+        HttpRequest testRequest = HttpRequest.newBuilder()
+                .GET()
+                .uri(new URI("https://test.mosquitto.org/ssl/index.php"))
+                .build()
+
+        HttpResponse<String> testResponse = testClient.send(testRequest, HttpResponse.BodyHandlers.ofString())
+
+        then:
+        if(testResponse.statusCode() != 200) throw new TestAbortedException("Should be 200");
 
         and: "the container starts"
         def container = startContainer(defaultConfig(), defaultServices())
@@ -207,7 +213,7 @@ class MQTTClientProtocolTest extends Specification implements ManagerContainerTr
         def aliasName = "testalias"
         def keyAlias = Constants.MASTER_REALM + "." + aliasName
 
-
+        when:
         KeyStore clientKeystore = keyStoreService.getKeyStore()
         KeyStore clientTruststore = keyStoreService.getTrustStore()
 
@@ -244,7 +250,7 @@ class MQTTClientProtocolTest extends Specification implements ManagerContainerTr
         keyStoreService.storeKeyStore(clientKeystore)
         keyStoreService.storeTrustStore(clientTruststore)
 
-        when: "an MQTT client agent is created to connect to this tests manager"
+        and: "an MQTT client agent is created to connect to this tests manager"
         def clientId = UniqueIdentifierGenerator.generateId()
         def agent = new MQTTAgent("Test agent")
                 .setRealm(Constants.MASTER_REALM)

--- a/test/src/test/groovy/org/openremote/test/protocol/mqtt/MQTTClientProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/mqtt/MQTTClientProtocolTest.groovy
@@ -186,8 +186,8 @@ class MQTTClientProtocolTest extends Specification implements ManagerContainerTr
         def conditions = new PollingConditions(timeout: 100, delay: 0.2)
 
         when:
-        assert new Socket("test.mosquitto.org", 8884) != null
-        assert new Socket("test.mosquitto.org", 443) != null
+        Socket webSocket = new Socket("test.mosquitto.org", 443)
+        Socket mqttSocket = new Socket("test.mosquitto.org", 8884)
         HttpClient testClient = HttpClient.newHttpClient()
         HttpRequest testRequest = HttpRequest.newBuilder()
                 .GET()
@@ -197,7 +197,9 @@ class MQTTClientProtocolTest extends Specification implements ManagerContainerTr
         HttpResponse<String> testResponse = testClient.send(testRequest, HttpResponse.BodyHandlers.ofString())
 
         then:
-        if(testResponse.statusCode() != 200) throw new TestAbortedException("Mosquitto server unavailable");
+        if(webSocket == null) throw new TestAbortedException("Mosquitto web server unavailable");
+        if(mqttSocket == null) throw new TestAbortedException("Mosquitto MQTT broker unavailable");
+        if(testResponse.statusCode() != 200) throw new TestAbortedException("Mosquitto signing service unavailable");
 
         and: "the container starts"
         def container = startContainer(defaultConfig(), defaultServices())


### PR DESCRIPTION
To skip a test programmatically, make sure to throw `TestAbortedException` on the top level (https://github.com/spockframework/spock/issues/1185). The throw needs to happen in the top level of the test, couldn't get it to work using a Util function I made.