### PR TITLE
Fix rules triggering on startup

### DIFF
--- a/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
+++ b/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
@@ -513,9 +513,9 @@ public class RulesEngine<T extends Ruleset> {
                 // Reset facts after this firing (loop detection etc.)
                 facts.reset();
                 lastFireTimestamp = timerService.getCurrentTimeMillis();
-                previouslyFired = true;
             }
         }
+        previouslyFired = true;
     }
 
     protected String getEngineId() {


### PR DESCRIPTION
The fix in #1433 did not work when the engine has multiple rules because `previouslyFired` was set after firing the first rule.