### PR TITLE
Add DuplicatesStrategy to fix gradle build command

### DIFF
--- a/manager/build.gradle
+++ b/manager/build.gradle
@@ -74,6 +74,14 @@ tasks.withType(Sync).configureEach {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
+tasks.withType(Tar){
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.withType(Zip) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 distributions {
     main {
         contents {


### PR DESCRIPTION
This allows for also running the very common `gradle build` command without any errors.