### PR TITLE
UI bugfix where dialog is not closed on window navigation 

### DIFF
--- a/ui/component/or-mwc-components/src/or-mwc-dialog.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-dialog.ts
@@ -277,8 +277,16 @@ export class OrMwcDialog extends LitElement {
         }
     }
 
+    connectedCallback() {
+        super.connectedCallback();
+        console.log("or-mwc-dialog connectedCallback()");
+        window.addEventListener("popstate", this._onBrowserNavigate);
+    }
+
     disconnectedCallback(): void {
         super.disconnectedCallback();
+        console.log("or-mwc-dialog disconnectedCallback()")
+        window.removeEventListener("popstate", this._onBrowserNavigate);
         if (this._mdcComponent) {
             this._mdcComponent.destroy();
             this._mdcComponent = undefined;
@@ -353,5 +361,9 @@ export class OrMwcDialog extends LitElement {
             this._mdcComponent = undefined;
         }
         this.dispatchEvent(new OrMwcDialogClosedEvent(action));
+    }
+
+    protected _onBrowserNavigate(ev: PopStateEvent) {
+        console.log(ev);
     }
 }

--- a/ui/component/or-mwc-components/src/or-mwc-dialog.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-dialog.ts
@@ -369,6 +369,6 @@ export class OrMwcDialog extends LitElement {
      * We attempt to close the dialog when this occurs.
      */
     protected _onBrowserNavigate(ev: PopStateEvent) {
-        this.close();
+        this.close("close");
     }
 }

--- a/ui/component/or-mwc-components/src/or-mwc-dialog.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-dialog.ts
@@ -221,6 +221,7 @@ export class OrMwcDialog extends LitElement {
     protected _mdcElem!: HTMLElement;
 
     protected _mdcComponent?: MDCDialog;
+    protected _popstateEventBind = (ev: PopStateEvent) => this._onBrowserNavigate(ev);
 
     public get isOpen() {
         return this._mdcComponent ? this._mdcComponent.isOpen : false;
@@ -279,14 +280,12 @@ export class OrMwcDialog extends LitElement {
 
     connectedCallback() {
         super.connectedCallback();
-        console.log("or-mwc-dialog connectedCallback()");
-        window.addEventListener("popstate", this._onBrowserNavigate);
+        window.addEventListener("popstate", this._popstateEventBind);
     }
 
     disconnectedCallback(): void {
         super.disconnectedCallback();
-        console.log("or-mwc-dialog disconnectedCallback()")
-        window.removeEventListener("popstate", this._onBrowserNavigate);
+        window.removeEventListener("popstate", this._popstateEventBind);
         if (this._mdcComponent) {
             this._mdcComponent.destroy();
             this._mdcComponent = undefined;
@@ -364,6 +363,6 @@ export class OrMwcDialog extends LitElement {
     }
 
     protected _onBrowserNavigate(ev: PopStateEvent) {
-        console.log(ev);
+        this.close();
     }
 }

--- a/ui/component/or-mwc-components/src/or-mwc-dialog.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-dialog.ts
@@ -221,6 +221,8 @@ export class OrMwcDialog extends LitElement {
     protected _mdcElem!: HTMLElement;
 
     protected _mdcComponent?: MDCDialog;
+
+    // Bind for the 'popstate' event that tracks changes in the browser history.
     protected _popstateEventBind = (ev: PopStateEvent) => this._onBrowserNavigate(ev);
 
     public get isOpen() {
@@ -362,6 +364,10 @@ export class OrMwcDialog extends LitElement {
         this.dispatchEvent(new OrMwcDialogClosedEvent(action));
     }
 
+    /**
+     * Function callback for when the browser window navigates to another place.
+     * We attempt to close the dialog when this occurs.
+     */
     protected _onBrowserNavigate(ev: PopStateEvent) {
         this.close();
     }


### PR DESCRIPTION
Added an `EventListener` on `window` that checks `popstate`;
https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event

When a change in the history state occurs (for example back/forward navigation), it closes the dialog.