### PR TITLE
Fix manager not starting due to NPE when using `OR_IDENTITY_PROVIDER=basic`

### DIFF
--- a/manager/src/main/java/org/openremote/manager/system/StatusResourceImpl.java
+++ b/manager/src/main/java/org/openremote/manager/system/StatusResourceImpl.java
@@ -45,7 +45,7 @@ public class StatusResourceImpl implements StatusResource {
         String authServerUrl = "";
 
         ManagerIdentityService identityService = container.getService(ManagerIdentityService.class);
-        if (identityService != null) {
+        if (identityService != null && identityService.getIdentityProvider().getFrontendURI() != null) {
             authServerUrl = identityService.getIdentityProvider().getFrontendURI();
         }
 


### PR DESCRIPTION
Fixes the following NPE when using `OR_IDENTITY_PROVIDER=basic`:

```
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:209)
	at java.base/java.util.ImmutableCollections$MapN.<init>(ImmutableCollections.java:1186)
	at java.base/java.util.Map.of(Map.java:1373)
	at org.openremote.manager.system.StatusResourceImpl.<init>(StatusResourceImpl.java:60)
	at org.openremote.manager.system.HealthService.init(HealthService.java:79)
	at org.openremote.container.Container.start(Container.java:172)
	at org.openremote.container.Container.startBackground(Container.java:228)
	at org.openremote.manager.Main.main(Main.java:31)
```

The issue is that `Map.of` requires non-null values while `ManagerBasicIdentityProvider.getFrontendURI()` returns `null`.