### PR TITLE
Remove obsolete version property from Docker Compose files

### DIFF
--- a/balena/docker-compose.yml
+++ b/balena/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.4'
-
 volumes:
   proxy-data:
   postgresql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@
 #
 # It is configured to use the AWS logging driver.
 #
-version: '2.4'
-
 volumes:
   proxy-data:
   manager-data:

--- a/profile/basic-identity.yml
+++ b/profile/basic-identity.yml
@@ -9,8 +9,6 @@
 #
 # Please see deploy.yml for configuration details for each service.
 #
-version: '2.4'
-
 volumes:
   manager-data:
   postgresql-data:

--- a/profile/demo.yml
+++ b/profile/demo.yml
@@ -12,8 +12,6 @@
 #
 # Please see profile/deploy.yml for configuration details for each service.
 #
-version: '2.4'
-
 volumes:
   proxy-data:
   manager-data:

--- a/profile/deploy.yml
+++ b/profile/deploy.yml
@@ -19,8 +19,6 @@
 # OR_EMAIL_ADMIN
 # OR_IDENTITY_PROVIDER
 #
-version: '2.4'
-
 volumes:
 #  postgresql-data: # Needed if you want to persist postgres data outside of container
   manager-data: # A storage volume for file persistence in the manager (can be used by services and protocols)

--- a/profile/dev-map.yml
+++ b/profile/dev-map.yml
@@ -4,8 +4,6 @@
 #
 # Please see deploy.yml for configuration details for each service.
 #
-version: '2.4'
-
 services:
 
   map:

--- a/profile/dev-proxy.yml
+++ b/profile/dev-proxy.yml
@@ -10,8 +10,6 @@
 #
 # Please see deploy.yml for configuration details for each service.
 #
-version: '2.4'
-
 volumes:
   postgresql-data:
 

--- a/profile/dev-testing.yml
+++ b/profile/dev-testing.yml
@@ -4,7 +4,6 @@
 #
 # Please see profile/deploy.yml for configuration details for each service.
 #
-version: '2.4'
 volumes:
   postgresql-data:
 services:

--- a/profile/dev-ui.yml
+++ b/profile/dev-ui.yml
@@ -4,8 +4,6 @@
 #
 # Please see profile/deploy.yml for configuration details for each service.
 #
-version: '2.4'
-
 volumes:
   manager-data:
 

--- a/test/load1/deployment1/test-load1.yml
+++ b/test/load1/deployment1/test-load1.yml
@@ -12,8 +12,6 @@
 #
 # Please see profile/deploy.yml for configuration details for each service.
 #
-version: '2.4'
-
 volumes:
   proxy-data:
   manager-data:


### PR DESCRIPTION
The version property was used by Docker Compose CLI V1 which has been EOL since mid 2023.

If you use it with Docker Compose CLI V2 the following warnings are logged:

> the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

See: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete