### PR TITLE
Fix out of memory crashes during UI development

### DIFF
--- a/ui/util/webpack.util.js
+++ b/ui/util/webpack.util.js
@@ -67,7 +67,7 @@ function getAppConfig(mode, isDevServer, dirname, managerUrl, keycloakUrl, port)
         output: {
             path: dirname + "/dist",
             publicPath: "/" + dirname.split(path.sep).slice(-1)[0] + "/",
-            filename: "[name].[contenthash].js"
+            filename: production ? "[name].[contenthash].js" : "[name].js"
         },
         module: {...getStandardModuleRules()},
         // optimization: {


### PR DESCRIPTION
When developing the Manager UI the webpack development server runs out of memory after recompiling the UI code ~50 times:

```
<--- Last few GCs --->
start of marking, biggest step 5.7 ms, walltime since start of marking 284 ms) (average mu = 0.319, current mu = [453384:0x64591a0]  1634005 ms: Mark-Compact (reduce) 8980.2 (9045.3) -> 8979.3 (9045.3) MB, 16.17 / 0.00 ms  (+ 240.7 ms in 4845 steps since start of marking, biggest step 5.8 ms, walltime since start of marking 270 ms) (average mu = 0.303, current mu = [453384:0x64591a0]  1634015 ms: Scavenge 8980.1 (9045.3) -> 8979.3 (9048.3) MB, 1.68 / 0.00 ms  (average mu = 0.303, current mu = 0.285) task;

<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0xb86ecf node::OOMErrorHandler(char const*, v8::OOMDetails const&) [webpack]
 2: 0xef74d0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [webpack]
 3: 0xef77b7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [webpack]
 4: 0x1109355  [webpack]
 5: 0x11098e4 v8::internal::Heap::RecomputeLimits(v8::internal::GarbageCollector) [webpack]
 6: 0x11207d4 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::internal::GarbageCollectionReason, char const*) [webpack]
 7: 0x1120fec v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [webpack]
 8: 0x1121d0a v8::internal::Heap::FinalizeIncrementalMarkingIfComplete(v8::internal::GarbageCollectionReason) [webpack]
 9: 0x112369a v8::internal::IncrementalMarkingJob::Task::RunInternal() [webpack]
10: 0xd3f5a6  [webpack]
11: 0xd42b4f node::PerIsolatePlatformData::FlushForegroundTasksInternal() [webpack]
12: 0x18b8913  [webpack]
13: 0x18cd38b  [webpack]
14: 0x18b9637 uv_run [webpack]
15: 0xbcdbe6 node::SpinEventLoopInternal(node::Environment*) [webpack]
16: 0xd13054  [webpack]
17: 0xd13aed node::NodeMainInstance::Run() [webpack]
18: 0xc77dbf node::Start(int, char**) [webpack]
19: 0x7398c3e29d90  [/lib/x86_64-linux-gnu/libc.so.6]
20: 0x7398c3e29e40 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
21: 0xbcae3e _start [webpack]
```

The root cause is that it generates new files continuously because the file names are hash based, see:

https://github.com/webpack/webpack/issues/10796

Without this fix the memory usage increases by ~100MB everytime the UI is recompiled:

![before](https://github.com/user-attachments/assets/85a8fb09-5b8b-4bac-bba2-7b482de458f7)

The memory usage remains the same with the fix:

![after](https://github.com/user-attachments/assets/101121a3-b156-4f4d-bd57-67e85f80ff17)



