### PR TITLE
Fix custom project deployment

### DIFF
--- a/.ci_cd/deploy.sh
+++ b/.ci_cd/deploy.sh
@@ -51,7 +51,7 @@ HOST="$OR_HOSTNAME"
 
 # Copy CI/CD files into temp dir
 echo "Copying CI/CD files into temp dir"
-if [ "$IS_CUSTOM_PROJECT" == 'true' ]; then
+if [ "$IS_MAIN_REPO" == 'false' ]; then
   cp -r openremote/.ci_cd/host_init temp/
   cp -r openremote/.ci_cd/aws temp/
 fi

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -935,6 +935,7 @@ jobs:
             os.system("echo 'One or more deployments failed'")
             sys.exit(1)
         env:
+          IS_CUSTOM_PROJECT: ${{ steps.is_main_repo.outputs.value == 'false' }}
           IS_MAIN_REPO: ${{ steps.is_main_repo.outputs.value }}
           DEPLOYMENTS: ${{ steps.deployments.outputs.value }}
           MANAGER_DOCKER_BUILD_PATH: ${{ steps.manager-docker-command.outputs.buildPath }}


### PR DESCRIPTION
Deployment fails because the `IS_CUSTOM_PROJECT` environmenet variable was replaced in #1554. I added a computed value temporarily back to the deploy step so we can test this change before creating a new release.