### PR TITLE
Prevent tag deserialization errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ scmVersion {
     }
     tag {
         prefix.set('')
+        // This deserializer prevents errors when tags exist that cannot be deserialized
+        deserializer({config, position, tagName -> tagName ==~ /^[0-9]+\.[0-9]+\.[0-9]+$/ ? tagName : "1.1.0" })
         initialVersion({config, position -> '1.2.0'})
     }
 }


### PR DESCRIPTION
Prevents build errors whenever the Git repository contains historic tags that cannot be deserialized:

> Failed to parse version: test-1.2.3 that matched configured prefix: . There can be no tags that match the prefix but contain non-SemVer string after the prefix. Detailed message: Unexpected character 'LETTER(t)' at position '0', expecting '[DIGIT]'