### PR TITLE
Enhancement/gateway widget offline feedback

### DIFF
--- a/ui/app/shared/locales/en/or.json
+++ b/ui/app/shared/locales/en/or.json
@@ -358,7 +358,8 @@
     "createNew": "Add new Gateway tunnel",
     "selectAsset": "Select gateway asset",
     "closeSuccessful": "Closed tunnel successfully",
-    "closesAt": "Closes at"
+    "closesAt": "Closes at",
+    "offline": "Offline"
   },
   "tunnels": "tunnels",
   "tunnel": "tunnel",

--- a/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
@@ -170,7 +170,7 @@ export class GatewayWidget extends OrWidget {
                         } else {
                             return html`
                                 <div>
-                                <or-mwc-input .type="${InputType.BUTTON}" label="${i18next.t('gatewayTunnels.start')}" outlined .disabled="${disabled}"
+                                <or-mwc-input .type="${InputType.BUTTON}" label="${disabled ? i18next.t('gatewayTunnels.offline') : i18next.t('gatewayTunnels.start')}" outlined .disabled="${disabled}"
                                               @or-mwc-input-changed="${(ev: OrInputChangedEvent) => this._onStartTunnelClick(ev)}"
                                 ></or-mwc-input>
                                 </div>

--- a/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
@@ -117,6 +117,7 @@ export class GatewayWidget extends OrWidget {
     protected firstUpdated(changedProps: PropertyValues) {
         if(this.widgetConfig) {
 
+            const tunnelInfo = this._getTunnelInfoByConfig(this.widgetConfig);
             this._readyCheck(this.widgetConfig);
             // Apply a timeout of 500 millis, so the tunnel has time to close upon disconnectedCallback() of a different widget.
             setTimeout(() => {

--- a/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
@@ -62,7 +62,7 @@ export class GatewayWidget extends OrWidget {
     @state()
     protected _activeTunnel?: GatewayTunnelInfo;
 
-    protected _isOnline = false;
+    protected _isReady = false;
 
     protected _startedByUser = false;
 
@@ -138,8 +138,8 @@ export class GatewayWidget extends OrWidget {
 
     protected render(): TemplateResult {
         const tunnelInfo = this._getTunnelInfoByConfig(this.widgetConfig);
-        this._getGatewayOnline(tunnelInfo)
-        const disabled = this.getEditMode?.() || !this._isConfigComplete(this.widgetConfig) || !this._isOnline;
+        const disabled = this.getEditMode?.() || !this._isConfigComplete(this.widgetConfig) || !this._isReady;
+        this._getGatewayStatus(tunnelInfo)
         return html`
             <div id="gateway-widget-wrapper">
                 <div id="gateway-widget-container">
@@ -169,12 +169,9 @@ export class GatewayWidget extends OrWidget {
                             `;
                         } else {
                             return html`
-                                <div>
                                 <or-mwc-input .type="${InputType.BUTTON}" label="${disabled ? i18next.t('gatewayTunnels.offline') : i18next.t('gatewayTunnels.start')}" outlined .disabled="${disabled}"
                                               @or-mwc-input-changed="${(ev: OrInputChangedEvent) => this._onStartTunnelClick(ev)}"
                                 ></or-mwc-input>
-                                </div>
-                                <div><or-translate value="Gateway Status"></or-translate>: ${this._isOnline}</div>
                             `;
                         }
                     })}
@@ -331,16 +328,16 @@ export class GatewayWidget extends OrWidget {
     }
 
     /**
-     * Internal function that requests the Manager API for the gatewayStatus based on the gatewayId in {@link GatewayTunnelInfo}.
+     * Internal function that requests the Manager API for the gatewayStatus of the gatewayId asset in {@link GatewayTunnelInfo}.
      * Returns true only if 'CONNECTED', as this is the only valid connectionStatus to start a tunnel.
      */
-   protected async _getGatewayOnline(info: GatewayTunnelInfo): Promise<void> {
+   protected async _getGatewayStatus(info: GatewayTunnelInfo): Promise<void> {
         const response =  await manager.rest.api.AssetResource.get(info.gatewayId)
         if (response.status === 200 && response.data && response.data.attributes && response.data.attributes.gatewayStatus) {
-            const statusString = response.data.attributes.gatewayStatus.value!;
-            this._isOnline = (statusString == "CONNECTED")
+            this._isReady = (response.data.attributes.gatewayStatus.value == "CONNECTED");
         } else {
-            this._isOnline = false }
+            this._isReady = false;
+             }
     }
 
 


### PR DESCRIPTION
Fixes https://github.com/openremote/vdl-es/issues/88

With a widget, you could try to start a tunnel trough a gateway that is not online. This returned the generic snackbar error "An error has occured", providing no feedback why.

Added an http request to get the actual gatewayStatus and gray out the start button if returned status isn't "CONNECTED"

--> Must still be tested on a live master-gateway setup