### PR TITLE
Fix release deployment

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -459,7 +459,7 @@ jobs:
         run: |
           deployments=$DEPLOYMENTS
 
-          if [ "$GITHUB_EVENT_NAME" == 'workflow_dispatch' ]; then
+          if [ "$GITHUB_EVENT_NAME" == 'workflow_dispatch' ] && [ "$GITHUB_REF_TYPE" != 'tag' ]; then
             tag="$INPUT_MANAGER_TAG"
             if [ -z "$INPUT_MANAGER_TAG" ]; then
               tag='#ref'


### PR DESCRIPTION
Makes sure GHA deploys to the specified release environment instead of the input environment.

See: https://github.com/openremote/openremote/actions/runs/12434215894/job/34717400640#step:46:175

> Executing deploy script for deployment: managerTag=#ref deploymentTag=886a303 environment=