### PR TITLE
Further restrictions on auto created gateway service users (See #1502)

### DIFF
--- a/manager/src/main/java/org/openremote/manager/event/ClientEventService.java
+++ b/manager/src/main/java/org/openremote/manager/event/ClientEventService.java
@@ -119,7 +119,7 @@ public class ClientEventService extends RouteBuilder implements ContainerService
     protected ManagerIdentityService identityService;
     protected GatewayService gatewayService;
     protected boolean started;
-    protected Consumer<Exchange> websocketInterceptor;
+    protected Consumer<Exchange> gatewayInterceptor;
 
     public static String getSessionKey(Exchange exchange) {
         return exchange.getIn().getHeader(UndertowConstants.CONNECTION_KEY, String.class);
@@ -249,8 +249,8 @@ public class ClientEventService extends RouteBuilder implements ContainerService
                 }
 
                 // Pass to gateway
-                if (websocketInterceptor != null) {
-                    websocketInterceptor.accept(exchange);
+                if (gatewayInterceptor != null) {
+                    gatewayInterceptor.accept(exchange);
                 }
             })
             .stop()
@@ -281,8 +281,8 @@ public class ClientEventService extends RouteBuilder implements ContainerService
                 }
 
                 // Pass to gateway
-                if (websocketInterceptor != null) {
-                    websocketInterceptor.accept(exchange);
+                if (gatewayInterceptor != null) {
+                    gatewayInterceptor.accept(exchange);
                 }
             })
             .process(exchange -> {
@@ -485,8 +485,12 @@ public class ClientEventService extends RouteBuilder implements ContainerService
             .asyncSend();
     }
 
-    public void setWebsocketInterceptor(Consumer<Exchange> consumer) {
-        this.websocketInterceptor = consumer;
+    /**
+     * This allows gateway connectors to intercept exchanges from gateway clients; it by-passes the standard processing
+     * including authorization so the interceptor provides its own authorization checks.
+     */
+    public void setGatewayInterceptor(Consumer<Exchange> consumer) {
+        this.gatewayInterceptor = consumer;
     }
 
     protected void onWebsocketSubscriptionTriggered(String sessionKey, EventSubscription<?> subscription, SharedEvent event) {

--- a/manager/src/main/java/org/openremote/manager/gateway/GatewayService.java
+++ b/manager/src/main/java/org/openremote/manager/gateway/GatewayService.java
@@ -35,7 +35,6 @@ import org.openremote.manager.rules.RulesetStorageService;
 import org.openremote.manager.security.ManagerIdentityService;
 import org.openremote.manager.security.ManagerKeycloakIdentityProvider;
 import org.openremote.manager.web.ManagerWebService;
-import org.openremote.model.Constants;
 import org.openremote.model.Container;
 import org.openremote.model.ContainerService;
 import org.openremote.model.PersistenceEvent;
@@ -49,7 +48,6 @@ import org.openremote.model.gateway.GatewayDisconnectEvent;
 import org.openremote.model.gateway.GatewayTunnelInfo;
 import org.openremote.model.query.AssetQuery;
 import org.openremote.model.rules.Ruleset;
-import org.openremote.model.security.ClientRole;
 import org.openremote.model.security.Realm;
 import org.openremote.model.security.User;
 import org.openremote.model.syslog.SyslogCategory;
@@ -201,20 +199,7 @@ public class GatewayService extends RouteBuilder implements ContainerService {
             active = true;
             identityProvider = (ManagerKeycloakIdentityProvider) identityService.getIdentityProvider();
             container.getService(MessageBrokerService.class).getContext().addRoutes(this);
-            clientEventService.setWebsocketInterceptor(this::onMessageIntercept);
-
-            // Gateways can send AssetsEvents into this central manager so we need to authorize those
-            clientEventService.addEventAuthorizer((requestRealm, authContext, event) -> {
-
-                if (authContext == null) {
-                    return false;
-                }
-
-                String clientId = authContext.getClientId();
-
-                // TODO: Introduce gateway realm role
-                return isGatewayClientId(clientId);
-            });
+            clientEventService.setGatewayInterceptor(this::onGatewayMessageIntercept);
 
             assetProcessingService.addEventInterceptor(new AttributeEventInterceptor() {
                 @Override
@@ -341,7 +326,11 @@ public class GatewayService extends RouteBuilder implements ContainerService {
         }
     }
 
-    protected void onMessageIntercept(Exchange exchange) {
+    /**
+     * This method by-passes the standard client event authorization so all consumers within the GatewayConnector
+     * must handle authorization and/or ensure operations can only be conducted on gateway descendants.
+     */
+    protected void onGatewayMessageIntercept(Exchange exchange) {
         String clientId = ClientEventService.getClientId(exchange);
 
         if (!isGatewayClientId(clientId)) {
@@ -818,14 +807,13 @@ public class GatewayService extends RouteBuilder implements ContainerService {
             }
 
             if (!userExists && gatewayUser != null) {
-                // Configure roles for this gateway user
-                identityProvider.updateUserRoles(
-                    gateway.getRealm(),
-                    gatewayUser.getId(),
-                    Constants.KEYCLOAK_CLIENT_ID,
-                    ClientRole.READ_ASSETS.getValue(),
-                    ClientRole.WRITE_ASSETS.getValue(),
-                    ClientRole.WRITE_ATTRIBUTES.getValue());
+                // Make the user restricted with no permissions
+                // Gateway events are handled directly by the GatewayConnector
+                identityProvider.updateUserRealmRoles(
+                        gateway.getRealm(),
+                        gatewayUser.getId(),
+                        identityProvider
+                            .addRealmRoles(gateway.getRealm(), gatewayUser.getId(), RESTRICTED_USER_REALM_ROLE));
             }
 
             if (!clientId.equals(gateway.getClientId().orElse(null)) || !secret.equals(gateway.getClientSecret().orElse(null))) {


### PR DESCRIPTION
Gateway events aren't processed the same way as other events so it is possible to remove all roles and make the user restricted without linking to assets.