### PR TITLE
Bug fix for or-util when used from a custom project

### DIFF
--- a/ui/util/cli.js
+++ b/ui/util/cli.js
@@ -6,18 +6,21 @@ const { spawn } = require("child_process");
 
 /* THIS IS JUST A WRAPPER THAT LAUNCHES GRADLE TASKS  */
 
-/* Try and get the openremote project dir or custom project dir */
-function getWorkingDirectory() {
-    let dirs = __dirname.split(path.sep);
-    dirs.pop();
-
-    // get CWD as the openremote repo root
+/* Try and find the gradle wrapper in a parent dir */
+function getGradleDirectory() {
+    let dirs = process.cwd().split(path.sep);
     let cwd = dirs.join(path.sep);
-    cwd = path.join(cwd, "..");
 
-    if (fs.existsSync(path.join(cwd, "..", ".gitmodules"))) {
-        // Assume we're in a custom project
-        cwd = path.join(cwd, "..");
+    while (dirs.length > 0 && !fs.existsSync(path.join(cwd, "gradlew"))) {
+        dirs.pop();
+        cwd = dirs.join(path.sep);
+    }
+
+    if (!fs.existsSync(path.join(cwd, "gradlew"))) {
+        console.log("Failed to locate gradlew in a parent directory of: " + process.cwd());
+        process.exit(1);
+    } else {
+        console.log("Located gradlew in parent directory: " + cwd);
     }
 
     return cwd;
@@ -44,7 +47,7 @@ if (process.argv.length >= 3 && process.argv[2] =="watch") {
 } else {
 
     // Do build
-    let cwd = getWorkingDirectory();
+    let cwd = getGradleDirectory();
     console.log("Running gradlew modelBuild task in " + cwd + " ...");
     const gradleModelWatch = spawnSync((process.platform === "win32" ? "gradlew" : "./gradlew"), ["modelWatch"], {
         cwd: cwd,


### PR DESCRIPTION
This PR fixes an issue with trying to run or-util in a custom project when it is located in `node_modules`, it couldn't find the gradle wrapper directory so I have changed the logic to use the `process.cwd()` as a starting point and work up from there.