### PR TITLE
bugfix: attribute in history card becomes unclickable after select.

### DIFF
--- a/ui/component/or-asset-viewer/src/index.ts
+++ b/ui/component/or-asset-viewer/src/index.ts
@@ -600,6 +600,7 @@ function getPanelContent(id: string, assetInfo: AssetInfo, hostElement: LitEleme
                    flex: 0;
                    margin: 0 0 10px 0;
                    position: unset;
+                   z-index: 1;
                }
                
                #attribute-picker > or-mwc-input {


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/openremote/openremote/pull/1413 , where changing the or-attribute-history position style property made the attribute-picker become unclickable, because the elements overlap and or-attribute-history was now in front.
Raised the z-index of the attribute-picker.