### PR TITLE
Added: Rules When-Then operator 'not updated for' 

### DIFF
--- a/manager/src/main/java/org/openremote/manager/rules/AssetQueryPredicate.java
+++ b/manager/src/main/java/org/openremote/manager/rules/AssetQueryPredicate.java
@@ -200,17 +200,17 @@ public class AssetQueryPredicate implements Predicate<AttributeInfo> {
             condition.getItems().stream()
                 .forEach(p -> {         
                     Predicate<AttributeInfo> wrappedPredicate = attributeInfo -> {
-                        Predicate<NameValueHolder<?>> basePredicates = asPredicate(currentMillisProducer, p);
-                        
-                        // Include older than timestamp check if timestampOlderThan is provided
+
+                        // Check timestamp not updated for condition
                         if (p.timestampOlderThan != null) {
                             long currentTime = currentMillisProducer.get();
                             long durationMillis = TimeUtil.parseTimeDuration(p.timestampOlderThan);
-                            if (!(attributeInfo.getTimestamp() < currentTime - durationMillis)) {
+                            if (attributeInfo.getTimestamp() > currentTime - durationMillis) {
                                 return false;
                             }
                         }
                         
+                        Predicate<NameValueHolder<?>> basePredicates = asPredicate(currentMillisProducer, p);
                         return basePredicates.test(attributeInfo);
                     };
                     attributePredicates.add(wrappedPredicate);

--- a/manager/src/main/java/org/openremote/manager/rules/AssetQueryPredicate.java
+++ b/manager/src/main/java/org/openremote/manager/rules/AssetQueryPredicate.java
@@ -201,13 +201,16 @@ public class AssetQueryPredicate implements Predicate<AttributeInfo> {
                 .forEach(p -> {         
                     AtomicReference<Predicate<AttributeInfo>> predicate = new AtomicReference<>();
                     
-                    // timestampOlderThan is set then we use this as a predicate
+                    // If timestampOlderThan is set then we use this as a predicate
                     if (p.timestampOlderThan != null) {
                         long durationMillis = TimeUtil.parseTimeDuration(p.timestampOlderThan);
-                        Predicate<AttributeInfo> timestampPredicate = assetState -> assetState.getTimestamp() < currentMillisProducer.get() - durationMillis;
+                        Predicate<AttributeInfo> timestampPredicate = assetState -> {
+                            long currentTime = currentMillisProducer.get();
+                            return assetState.getTimestamp() < currentTime - durationMillis;
+                        };
                         predicate.set(timestampPredicate);
                     } else {
-                        // otherwise we use the value predicate (regular predicate)
+                        // Otherwise we use the normal predicate
                         Predicate<AttributeInfo> attributePredicate = (Predicate<AttributeInfo>)(Predicate)asPredicate(currentMillisProducer, p);
                         predicate.set(attributePredicate);
                     }

--- a/model/src/main/java/org/openremote/model/query/filter/AttributePredicate.java
+++ b/model/src/main/java/org/openremote/model/query/filter/AttributePredicate.java
@@ -37,6 +37,9 @@ public class AttributePredicate extends NameValuePredicate {
     public NameValuePredicate[] meta;
     public ValuePredicate previousValue;
 
+    // ISO 8601 duration expression (e.g. PT5M)
+    public String timestampOlderThan;
+
     public AttributePredicate() {
     }
 

--- a/test/src/test/groovy/org/openremote/test/rules/residence/JsonRulesTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/residence/JsonRulesTest.groovy
@@ -693,6 +693,173 @@ class JsonRulesTest extends Specification implements ManagerContainerTrait {
         }
     }
 
+    def "Trigger actions when an attribute is not updated for a specified duration"() {
+
+        given: "the container environment is started"
+        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+        def container = startContainer(defaultConfig(), defaultServices())
+        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+        def rulesService = container.getService(RulesService.class)
+        def rulesetStorageService = container.getService(RulesetStorageService.class)
+        def timerService = container.getService(TimerService.class)
+        def assetStorageService = container.getService(AssetStorageService.class)
+        RulesEngine realmBuildingEngine
+
+        and: "the pseudo clock is stopped"
+        stopPseudoClock()
+
+        when: "a light asset is added to the building realm"
+        def lightId = UniqueIdentifierGenerator.generateId("LightTest")
+        def lightAsset = new LightAsset("LightTest")
+                .setId(lightId)
+                .setRealm(keycloakTestSetup.realmBuilding.name)
+                .setLocation(new GeoJSONPoint(0, 0))
+
+        def ruleState = new MetaItem<>(MetaItemType.RULE_STATE)
+        lightAsset.getAttributes().get("brightness").get().addMeta(ruleState)
+        lightAsset.getAttributes().get("onOff").get().addMeta(ruleState)
+        assetStorageService.merge(lightAsset)
+
+        then: "the light asset should be present"
+        conditions.eventually {
+            def light = assetStorageService.find(lightId)
+            assert light != null
+        }
+
+        // RuleSet: WHEN:
+        // Any light asset has its onOff attribute not updated for 3 minutes
+        // AND
+        // Any light asset has its brightness attribute greater than 50
+        // THEN:
+        // Set the notes of the light asset to "Matched"
+        when: "a ruleset with a notUpdatedFor attribute condition has been added"
+        def rulesStr = getClass().getResource("/org/openremote/test/rules/JsonNotUpdatedForRule.json").text
+        def rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
+        Ruleset ruleset = new RealmRuleset(
+                keycloakTestSetup.realmBuilding.name,
+                "Not Updated For Rule",
+                Ruleset.Lang.JSON,
+                rulesStr)
+        ruleset = rulesetStorageService.merge(ruleset)
+        def lastFireTimestamp = 0
+
+        then: "the rule engines to become available and be running with asset states inserted"
+        conditions.eventually {
+            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+            assert realmBuildingEngine != null
+            assert realmBuildingEngine.isRunning()
+            assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 2 // 2 additional rule states
+            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+        }
+
+        when: "the light asset is updated with onOff set to true and brightness set to 100"
+        lightAsset = assetStorageService.find(lightId)
+        lightAsset.getAttribute("onOff").get().setValue(true)
+        lightAsset.getAttribute("brightness").get().setValue(100)
+        assetStorageService.merge(lightAsset)
+
+        then: "the light asset should have its onOff attribute set to true and brightness set to 100"
+        conditions.eventually {
+            def light = assetStorageService.find(lightId)
+            assert light.getAttribute("onOff").get().getValue().orElse(false) == true
+            assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
+        }
+
+        when: "time advances for 6 seconds"
+        advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+        then: "the rule engine should have fired"
+        conditions.eventually {
+            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
+            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+        }
+
+        and: "the light asset note attribute should still be empty"
+        conditions.eventually {
+            def light = assetStorageService.find(lightId)
+            assert light.getAttribute("notes").get().getValue().orElse("") == ""
+        }
+
+        when: "time advances for 1 minute"
+        advancePseudoClock(1, TimeUnit.MINUTES, container)
+
+        then: "the rule engine should have fired"
+        conditions.eventually {
+            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
+            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+        }
+
+        and: "the light asset note attribute should still be empty"
+        conditions.eventually {
+            def light = assetStorageService.find(lightId)
+            assert light.getAttribute("notes").get().getValue().orElse("") == ""
+        }
+
+        when: "time advances for 2 minutes"
+        advancePseudoClock(2, TimeUnit.MINUTES, container)
+
+        then: "the rule engine should have fired"
+        conditions.eventually {
+            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
+            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+        }
+
+        and: "the light asset note attribute should be set to Matched" // because onOff was still unchanged for 3 minutes and brightness was above 50
+        conditions.eventually {
+            def light = assetStorageService.find(lightId)
+            assert light.getAttribute("notes").get().getValue().orElse("") == "Matched"
+        }
+
+        when: "brightness is updated to 0 and notes is updated to empty"
+        lightAsset = assetStorageService.find(lightId)
+        lightAsset.getAttribute("brightness").get().setValue(0)
+        lightAsset.getAttribute("notes").get().setValue("")
+        assetStorageService.merge(lightAsset)
+
+        then: "the light asset should have its brightness set to 0 and notes set to empty"
+        conditions.eventually {
+            def light = assetStorageService.find(lightId)
+            assert light.getAttribute("brightness").get().getValue().orElse(0) == 0
+            assert light.getAttribute("notes").get().getValue().orElse("") == ""
+        }
+
+        when: "time advances for 6 seconds"
+        advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+        then: "the rule engine should have fired"
+        conditions.eventually {
+            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
+            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+        }
+
+        when: "brightness is updated to 100"
+        lightAsset = assetStorageService.find(lightId)
+        lightAsset.getAttribute("brightness").get().setValue(100)
+        assetStorageService.merge(lightAsset)
+
+        then: "the light asset should have its brightness set to 100"
+        conditions.eventually {
+            def light = assetStorageService.find(lightId)
+            assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
+        }
+
+        when: "time advances for 6 seconds"
+        advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+        then: "the rule engine should have fired"
+        conditions.eventually {
+            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
+            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+        }
+
+        and: "the light asset note attribute should be set to Matched" // because onOff was still unchanged for 3 minutes and brightness was set to be above 50 again
+        conditions.eventually {
+            def light = assetStorageService.find(lightId)
+            assert light.getAttribute("notes").get().getValue().orElse("") == "Matched"
+        }
+    }
+
     def "Trigger actions when attribute conditions match for specified durations"() {
 
         given: "the container environment is started"

--- a/test/src/test/resources/org/openremote/test/rules/JsonNotUpdatedForRule.json
+++ b/test/src/test/resources/org/openremote/test/rules/JsonNotUpdatedForRule.json
@@ -1,0 +1,55 @@
+{
+    "rules": [
+        {
+            "recurrence": { "mins": 0 },
+            "when": {
+                "operator": "OR",
+                "groups": [
+                    {
+                        "operator": "AND",
+                        "items": [
+                            {
+                                "assets": {
+                                    "types": ["LightAsset"],
+                                    "attributes": {
+                                        "items": [
+                                            {
+                                                "name": {
+                                                    "predicateType": "string",
+                                                    "match": "EXACT",
+                                                    "value": "onOff"
+                                                },
+                                                "timestampOlderThan": "PT3M"
+                                            },
+                                            {
+                                                "name": {
+                                                    "predicateType": "string",
+                                                    "match": "EXACT",
+                                                    "value": "brightness"
+                                                },
+                                                "value": {
+                                                    "predicateType": "number",
+                                                    "operator": "GREATER_THAN",
+                                                    "value": 50
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "then": [
+                {
+                    "action": "write-attribute",
+                    "target": { "matchedAssets": { "types": ["LightAsset"] } },
+                    "value": "Matched",
+                    "attributeName": "notes"
+                }
+            ],
+            "name": "My Light: OnOff not updated for"
+        }
+    ]
+}

--- a/ui/app/shared/locales/de/or.json
+++ b/ui/app/shared/locales/de/or.json
@@ -58,6 +58,7 @@
   "notEndsWith": "Endet nicht mit",
   "containsKey": "Enthält Schlüssel",
   "notContainsKey": "Enthält nicht den Schlüssel",
+  "notUpdatedFor": "Nicht aktualisiert für",
   "true": "Wahr",
   "false": "Falsch",
   "radiusMin": "Radius (min. 100m)",

--- a/ui/app/shared/locales/en/or.json
+++ b/ui/app/shared/locales/en/or.json
@@ -61,6 +61,7 @@
   "notEndsWith": "Does not end with",
   "containsKey": "Contains key",
   "notContainsKey": "Does not contain key",
+  "notUpdatedFor": "Not updated for",
   "true": "Is true",
   "false": "Is false",
   "radiusMin": "Radius (min. 100m)",

--- a/ui/app/shared/locales/nl/or.json
+++ b/ui/app/shared/locales/nl/or.json
@@ -61,6 +61,7 @@
   "notEndsWith": "Eindigt niet met",
   "containsKey": "Bevat key",
   "notContainsKey": "Bevat geen keys",
+  "notUpdatedFor": "Niet bijgewerkt voor",
   "true": "Waar",
   "false": "Niet waar",
   "radiusMin": "Straal (min. 100m)",

--- a/ui/component/or-rules/src/index.ts
+++ b/ui/component/or-rules/src/index.ts
@@ -94,7 +94,8 @@ export enum AssetQueryOperator {
     WITHIN_RADIUS = "withinRadius",
     OUTSIDE_RADIUS = "outsideRadius",
     WITHIN_RECTANGLE = "withinRectangle",
-    OUTSIDE_RECTANGLE = "outsideRectangle"
+    OUTSIDE_RECTANGLE = "outsideRectangle",
+    NOT_UPDATED_FOR = "notUpdatedFor"
 }
 
 export interface AllowedActionTargetTypes {

--- a/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
@@ -311,6 +311,14 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
     }
 
     protected attributeDurationTemplate(durationMap: Map<number, string | undefined>, index: number, onAdd: (index: number) => void, onChange: (index: number, duration: string | undefined) => void) {
+        const attributePredicate = this.query.attributes?.items?.[index];
+        const operator = attributePredicate ? this.getOperator(attributePredicate) : undefined;
+        
+        // Don't show duration button if NOT_UPDATED_FOR is selected
+        if (operator === AssetQueryOperator.NOT_UPDATED_FOR) {
+            return html``;
+        }
+
         if(durationMap.has(index)) {
             const isoDuration = durationMap.get(index);
             const duration = isoDuration ? moment.duration(isoDuration) : undefined;
@@ -825,6 +833,10 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
                     match: AssetQueryMatch.CONTAINS
                 };
             }
+            // operator without value predicate - since timestamp is being used rather than attribute value
+            case AssetQueryOperator.NOT_UPDATED_FOR:
+                attributePredicate.timestampOlderThan = "PT0M";
+                break;
         }
 
         attributePredicate.value = predicate;

--- a/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
@@ -631,6 +631,20 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
         }
     }
 
+    protected updateDurationMap(index: number): void {
+        if (this.duration) {
+            // re-assign durations by filtering out the index and adjusting remaining indices
+            const newDurationEntries = Array.from(this.duration.entries())
+                .filter(([k, _]) => k !== index)
+                .map(([k, v]) => {
+                    const newIndex = k > index ? k - 1 : k;
+                    return [newIndex, v] as [number, string | undefined]; // adjust indices after the removed index
+                });
+
+            this.duration = new Map<number, string | undefined>(newDurationEntries);
+        }
+    }
+
     protected setOperator(assetDescriptor: AssetDescriptor, attribute: Attribute<any> | undefined, attributeName: string, attributePredicate: AttributePredicate, operator: string | undefined) {
 
         if (!this.query
@@ -839,6 +853,9 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
             // operator without value predicate - since timestamp is being used rather than attribute value
             case AssetQueryOperator.NOT_UPDATED_FOR:
                 attributePredicate.timestampOlderThan = "";
+
+                const index = this.query.attributes.items.indexOf(attributePredicate);
+                this.updateDurationMap(index);
                 break;
         }
 
@@ -869,18 +886,7 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
         const index = group.items!.indexOf(attributePredicate);
         if (index >= 0) {
             group.items!.splice(index, 1);
-
-            if (this.duration) {
-                // re-assign durations
-                const newDurationEntries = Array.from(this.duration.entries())
-                    .filter(([k, _]) => k !== index)  // filter out the index
-                    .map(([k, v]) => {
-                        const newIndex = k > index ? k - 1 : k;
-                        return [newIndex, v] as [number, string | undefined]; // adjust indices after the removed index
-                    })
-
-                this.duration = new Map<number, string | undefined>(newDurationEntries);
-            }
+            this.updateDurationMap(index);
         }
         this.dispatchEvent(new OrRulesJsonRuleChangedEvent());
         this.requestUpdate();

--- a/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
@@ -248,16 +248,17 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
 
         if (operator === AssetQueryOperator.NOT_UPDATED_FOR) {
             const duration = attributePredicate.timestampOlderThan ? 
-                moment.duration(attributePredicate.timestampOlderThan).asMinutes() : 0;
+                moment.duration(attributePredicate.timestampOlderThan) : undefined;
             return html`
                 <or-mwc-input type="${InputType.NUMBER}" 
                               min="0"
-                              .value="${duration}"
+                              .value="${duration?.asMinutes()}"
                               label="${i18next.t("minutes")}"
                               @or-mwc-input-changed="${(ev: OrInputChangedEvent) => {
                                   const minutes = ev.detail.value;
+                                  const newDuration = moment.duration(minutes, "minutes");
                                   attributePredicate.timestampOlderThan = minutes > 0 ? 
-                                      `PT${minutes}M` : undefined;
+                                      newDuration.toISOString() : undefined;
                                   this.dispatchEvent(new OrRulesJsonRuleChangedEvent());
                               }}">
                 </or-mwc-input>`;
@@ -655,6 +656,8 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
             this.requestUpdate();
             return;
         }
+
+        attributePredicate.timestampOlderThan = undefined;
 
         const valueDescriptor = descriptors[1];
         let predicate: ValuePredicateUnion | undefined;

--- a/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
@@ -838,7 +838,7 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
             }
             // operator without value predicate - since timestamp is being used rather than attribute value
             case AssetQueryOperator.NOT_UPDATED_FOR:
-                attributePredicate.timestampOlderThan = "PT0M";
+                attributePredicate.timestampOlderThan = "";
                 break;
         }
 

--- a/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
@@ -253,7 +253,7 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
                 <or-mwc-input type="${InputType.NUMBER}" 
                               min="0"
                               .value="${duration?.asMinutes()}"
-                              label="${i18next.t("minutes")}"
+                              label="${i18next.t("rulesEditorDuration")}"
                               @or-mwc-input-changed="${(ev: OrInputChangedEvent) => {
                                   const minutes = ev.detail.value;
                                   const newDuration = moment.duration(minutes, "minutes");

--- a/ui/component/or-rules/src/json-viewer/or-rule-json-viewer.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-json-viewer.ts
@@ -423,7 +423,7 @@ export class OrRuleJsonViewer extends translate(i18next)(LitElement) implements 
                 if (!attribute.name || !attribute.name.match || !attribute.name.value) {
                     return false;
                 }
-                if (!attribute.value || !this._validateValuePredicate(attribute.value)) {
+                if (!attribute.timestampOlderThan && (!attribute.value || !this._validateValuePredicate(attribute.value))) {
                     return false;
                 }
             }

--- a/ui/component/or-rules/src/or-rule-viewer.ts
+++ b/ui/component/or-rules/src/or-rule-viewer.ts
@@ -265,7 +265,6 @@ export class OrRuleViewer extends translate(i18next)(LitElement) {
     protected _onRuleChanged(e: OrRulesRuleChangedEvent) {
         this.modified = true;
         this._ruleValid = e.detail;
-        console.log("rule changed", e.detail);
     }
 
     protected _onSaveClicked() {

--- a/ui/component/or-rules/src/or-rule-viewer.ts
+++ b/ui/component/or-rules/src/or-rule-viewer.ts
@@ -265,6 +265,7 @@ export class OrRuleViewer extends translate(i18next)(LitElement) {
     protected _onRuleChanged(e: OrRulesRuleChangedEvent) {
         this.modified = true;
         this._ruleValid = e.detail;
+        console.log("rule changed", e.detail);
     }
 
     protected _onSaveClicked() {


### PR DESCRIPTION
Adds the 'Not updated for' operator for When-Then attribute conditions #1449 

Extended the AttributePredicate class with timestampOlderThan as specified here https://github.com/openremote/openremote/issues/1449#issuecomment-2504351582 and extended the asAttributeMatcher to take the timestampOlderThan field into account when its set for the given predicate