### PR TITLE
Bugfix for hidden semicolon on `or-mwc-snackbar`

### DIFF
--- a/ui/component/or-mwc-components/src/or-mwc-snackbar.ts
+++ b/ui/component/or-mwc-components/src/or-mwc-snackbar.ts
@@ -127,7 +127,7 @@ export class OrMwcSnackbar extends LitElement {
                             <or-mwc-input type="button" class="mdc-button mdc-snackbar__action" label="${this.buttonText}">                                
                             </or-mwc-input>
                         </div>
-                    `};
+                    `}
                 </div>
             </div>
         `;


### PR DESCRIPTION
I was browsing the manager UI with a dark mode reader enabled, and after trying to move an asset, I saw this snackbar:

<img width="366" alt="image" src="https://github.com/user-attachments/assets/c0aab2db-c5ac-40e7-90dd-c162155d3542" />

Everything looks good, other than the questionmark that's on the right side. Testing it without the dark mode reader, it's barely visible, so it makes sense that it wasn't noticed:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/8f027a93-15fc-4591-98b9-8cdd81fd4369" />

So this PR fixes that. Very small PR, but I saw it and I needed to fix it. 😆😆😆