### PR TITLE
Add MomentJS format for `ValueType.TIMESTAMP` ( Fix for #1023)

### DIFF
--- a/model/src/main/java/org/openremote/model/value/ValueType.java
+++ b/model/src/main/java/org/openremote/model/value/ValueType.java
@@ -112,7 +112,7 @@ public final class ValueType {
 
     public static final ValueDescriptor<String> TIMESTAMP_ISO8601 = new ValueDescriptor<>("timestampISO8601", String.class,
         new ValueConstraint.Pattern(Constants.ISO8601_DATETIME_REGEXP)
-    );
+    ).withFormat(new ValueFormat().setAsDate(true).setMomentJsFormat("DD-MMM-YYYY hh:mm A"));
 
     public static final ValueDescriptor<Date> DATE_AND_TIME = new ValueDescriptor<>("dateAndTime", Date.class);
 

--- a/model/src/main/java/org/openremote/model/value/ValueType.java
+++ b/model/src/main/java/org/openremote/model/value/ValueType.java
@@ -108,7 +108,7 @@ public final class ValueType {
 
     public static final ValueDescriptor<Long> TIMESTAMP = new ValueDescriptor<>("timestamp", Long.class,
         new ValueConstraint.Min(0)
-    );
+    ).withFormat(new ValueFormat().setAsDate(true).setMomentJsFormat("DD-MMM-YYYY hh:mm A"));
 
     public static final ValueDescriptor<String> TIMESTAMP_ISO8601 = new ValueDescriptor<>("timestampISO8601", String.class,
         new ValueConstraint.Pattern(Constants.ISO8601_DATETIME_REGEXP)


### PR DESCRIPTION
I applied the fix that Don recommended for `ValueType.TIMESTAMP` and `ValueType.TIMESTAMP_ISO8601`; Here are the results:

The `test1` attribute is just a Timestamp attribute added using the manager UI.

![image](https://github.com/user-attachments/assets/8cc67d1e-de93-43e2-b115-b62630eb2c7b)

@DonWillems @richturner not sure how much you would like this to be reworked in general, but it is a way to get all timestamp attribute types rendered properly in the sidebar. Let me know if you would like to see a general rework of the way we render Attributes in the UI.

fixes #1023 

