### PR TITLE
Manager_config: do not overwrite image paths if the image is not actually copied, other bugfixes

### DIFF
--- a/manager/src/main/java/org/openremote/manager/app/ConfigurationService.java
+++ b/manager/src/main/java/org/openremote/manager/app/ConfigurationService.java
@@ -309,7 +309,7 @@ public class ConfigurationService implements ContainerService {
                 } else {
                     LOG.warning("manager_config.json image reference doesn't exist: " + imagePath);
                 }
-            }else{
+            } else {
                 return originalString;
             }
         }

--- a/manager/src/main/java/org/openremote/manager/app/ConfigurationService.java
+++ b/manager/src/main/java/org/openremote/manager/app/ConfigurationService.java
@@ -276,10 +276,10 @@ public class ConfigurationService implements ContainerService {
                     managerAppRealmConfig.setLogo(fixImageRef(managerAppRealmConfig.getLogo()));
                 }
                 if (!TextUtil.isNullOrEmpty(managerAppRealmConfig.getLogoMobile())) {
-                    managerAppRealmConfig.setLogo(fixImageRef(managerAppRealmConfig.getLogoMobile()));
+                    managerAppRealmConfig.setLogoMobile(fixImageRef(managerAppRealmConfig.getLogoMobile()));
                 }
                 if (!TextUtil.isNullOrEmpty(managerAppRealmConfig.getFavicon())) {
-                    managerAppRealmConfig.setLogo(fixImageRef(managerAppRealmConfig.getFavicon()));
+                    managerAppRealmConfig.setFavicon(fixImageRef(managerAppRealmConfig.getFavicon()));
                 }
             });
         }
@@ -287,6 +287,7 @@ public class ConfigurationService implements ContainerService {
     }
 
     protected String fixImageRef(String image) {
+        String originalString = image;
         if (!image.isBlank()) {
             image = image.replace("/api/master/configuration/manager/image/", "");
             image = image.replace("images/", "");
@@ -308,6 +309,8 @@ public class ConfigurationService implements ContainerService {
                 } else {
                     LOG.warning("manager_config.json image reference doesn't exist: " + imagePath);
                 }
+            }else{
+                return originalString;
             }
         }
         return image;

--- a/manager/src/main/java/org/openremote/manager/app/ConfigurationService.java
+++ b/manager/src/main/java/org/openremote/manager/app/ConfigurationService.java
@@ -304,7 +304,7 @@ public class ConfigurationService implements ContainerService {
                         // Change the reference in the config to the typical API-like reference:
                         image = "/api/master/configuration/manager/image/" + imagePath;
                     } catch (Exception e) {
-                        LOG.warning("Error occurred whilst copying manager config image to persisted path: " + imagePath);
+                        LOG.warning("Error occurred whilst copying manager config image to persisted path: " + persistedImagePath);
                     }
                 } else {
                     LOG.warning("manager_config.json image reference doesn't exist: " + imagePath);


### PR DESCRIPTION


Now does not replace the original image path reference if the file isn't actually copied over to the persistence directory.

## Description
Bugfix for #1624 

Also spotted some bugs for `logoMobile` and `favicon` fixed those as well. 

closes #1624

## Checklist


- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer