### PR TITLE
Hotfix for users page not functioning

### DIFF
--- a/ui/app/manager/src/pages/page-account.ts
+++ b/ui/app/manager/src/pages/page-account.ts
@@ -152,10 +152,10 @@ export class PageAccount extends Page<AppStateKeyed>  {
     @state()
     protected _passwordPolicy: string[] = [];
 
-    @query("#password")
+    @query("#new-password")
     protected _passwordElem?: OrMwcInput;
 
-    @query("#repeatPassword")
+    @query("#new-repeatPassword")
     protected _repeatPasswordElem?: OrMwcInput;
 
     static get styles() {

--- a/ui/app/manager/src/pages/page-users.ts
+++ b/ui/app/manager/src/pages/page-users.ts
@@ -750,8 +750,8 @@ export class PageUsers extends Page<AppStateKeyed> {
     }
 
     protected _onPasswordChanged(user: UserModel, suffix: string) {
-        const passwordComponent = this.shadowRoot.getElementById("password-" + suffix) as OrMwcInput;
-        const repeatPasswordComponent = this.shadowRoot.getElementById("repeatPassword-" + suffix) as OrMwcInput;
+        const passwordComponent = this.shadowRoot.getElementById("new-password-" + suffix) as OrMwcInput;
+        const repeatPasswordComponent = this.shadowRoot.getElementById("new-repeatPassword-" + suffix) as OrMwcInput;
 
         if (repeatPasswordComponent.value !== passwordComponent.value) {
             const error = i18next.t("passwordMismatch");
@@ -857,7 +857,7 @@ export class PageUsers extends Page<AppStateKeyed> {
                                   .label="${i18next.t("username")}"
                                   .type="${InputType.TEXT}" minLength="3" maxLength="255" 
                                   ?required="${isServiceUser || !this._registrationEmailAsUsername}"
-                                  pattern="[A-Za-z0-9\-_+@.ßçʊ]+"
+                                  pattern="[A-Za-z0-9_+@.\-ßçʊÇʊ]+"
                                   .value="${user.username}" autocomplete="false"
                                   .validationMessage="${i18next.t("invalidUsername")}"
                                   @or-mwc-input-changed="${(e: OrInputChangedEvent) => {


### PR DESCRIPTION
Fixes #1636 

Changelog:
- Hotfix for repeat password verification not working (both user- and account page), causing the save button to break.
- Corrected the username input pattern, which was an invalid expression.
