### PR TITLE
Bugfix for exception on the logs page

### DIFF
--- a/ui/component/or-log-viewer/src/index.ts
+++ b/ui/component/or-log-viewer/src/index.ts
@@ -486,7 +486,7 @@ export class OrLogViewer extends translate(i18next)(LitElement) {
         if (linkHeaders) {
             const links = linkParser.parse(linkHeaders);
             const lastLink = links.rel("last");
-            if (lastLink) {
+            if (lastLink && lastLink.uri) {
                 const url = new URL(lastLink.uri);
                 return Util.getQueryParameters(url.search)['page'] as number;
             }

--- a/ui/component/or-log-viewer/src/index.ts
+++ b/ui/component/or-log-viewer/src/index.ts
@@ -476,8 +476,8 @@ export class OrLogViewer extends translate(i18next)(LitElement) {
 
         if (response.status === 200) {
             // Get page count
-            this._pageCount = this._getPageCount(response);
             this._data = response.data;
+            this._pageCount = this._getPageCount(response);
         }
     }
 

--- a/ui/component/or-log-viewer/src/index.ts
+++ b/ui/component/or-log-viewer/src/index.ts
@@ -475,8 +475,8 @@ export class OrLogViewer extends translate(i18next)(LitElement) {
         this._loading = false;
 
         if (response.status === 200) {
-            // Get page count
             this._data = response.data;
+             // Get page count
             this._pageCount = this._getPageCount(response);
         }
     }


### PR DESCRIPTION
## Description
  This fixes #1637 
  
I've added an undefined check for the lastLink.uri property which fixes the issue and the exception that was occurring due to an undefined value.

Edit: I also changed the function order to make sure this._data is set before calling _getPageCount() because if the latter fails it would cause shouldUpdate() to be called again which would end up in a recursive call because this._data was still undefined.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

