### PR TITLE
UI update: Fix link header parsing for log viewer

### DIFF
--- a/ui/component/or-log-viewer/src/index.ts
+++ b/ui/component/or-log-viewer/src/index.ts
@@ -485,10 +485,13 @@ export class OrLogViewer extends translate(i18next)(LitElement) {
         const linkHeaders = response.headers["link"] as any;
         if (linkHeaders) {
             const links = linkParser.parse(linkHeaders);
-            const lastLink = links.rel("last");
+            let lastLink = links.rel("last");
+            if (Array.isArray(lastLink) && lastLink.length > 0) {
+                lastLink = lastLink[0];
+            }
             if (lastLink && lastLink.uri) {
                 const url = new URL(lastLink.uri);
-                return Util.getQueryParameters(url.search)['page'] as number;
+                return parseInt(Util.getQueryParameters(url.search)['page']);
             }
         }
     }


### PR DESCRIPTION
## Description
The link header is incorrectly parsed by the log viewer so the page count is not retrieved.
