### PR TITLE
Don't allow recursive AssetQuery to retrieve `ACCESS_PUBLIC_READ` assets

### DIFF
--- a/manager/src/main/java/org/openremote/manager/asset/AssetStorageService.java
+++ b/manager/src/main/java/org/openremote/manager/asset/AssetStorageService.java
@@ -1674,7 +1674,7 @@ public class AssetStorageService extends RouteBuilder implements ContainerServic
                 binders.add((em, st) -> st.setParameter(pos, query.userIds));
             }
 
-            if (level == 1 && query.access == Access.PUBLIC) {
+            if (query.access == Access.PUBLIC) {
                 sb.append(" and A.ACCESS_PUBLIC_READ is true");
             }
 

--- a/test/src/test/groovy/org/openremote/test/assets/AssetPermissionsTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetPermissionsTest.groovy
@@ -823,8 +823,16 @@ class AssetPermissionsTest extends Specification implements ManagerContainerTrai
         and: "the asset resource"
         def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(AssetResource.class)
 
+        when: "the anonymous user tries to retrieve all assets"
+        def assets = assetResource.queryAssets(null, new AssetQuery().recursive(true))
+
+        then: "only public assets should be returned"
+        assets.size() == 2
+        assets.find {it.id == managerTestSetup.apartment1Id } != null
+        assets.find {it.id == managerTestSetup.apartment2LivingroomId } != null
+
         when: "the public assets are retrieved"
-        def assets = assetResource.queryAssets(null, new AssetQuery()
+        assets = assetResource.queryAssets(null, new AssetQuery()
                 .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name)))
 
         then: "the public assets should be retrieved"

--- a/test/src/test/groovy/org/openremote/test/console/ConsoleTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/console/ConsoleTest.groovy
@@ -128,7 +128,6 @@ class ConsoleTest extends Specification implements ManagerContainerTrait {
         def authenticatedAssetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
         def anonymousConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(ConsoleResource.class)
         def anonymousRulesResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(RulesResource.class)
-        def anonymousAssetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(AssetResource.class)
 
         when: "a console registers with an authenticated user"
         def consoleRegistration = new ConsoleRegistration(null,


### PR DESCRIPTION
fixes #1671 