### PR TITLE
UI updates: Fix manager config bug when no config exists on the backend

### DIFF
--- a/model-util/src/main/java/CustomTypeProcessor.java
+++ b/model-util/src/main/java/CustomTypeProcessor.java
@@ -69,7 +69,12 @@ public class CustomTypeProcessor implements TypeProcessor {
 
         rawClass = Utils.getRawClassOrNull(javaType);
 
-        if (javaType instanceof ParameterizedType) {
+        if (javaType instanceof ParameterizedType parameterizedType) {
+
+            // Map<String, Object> -> {[id: string]: unknown} to prevent arrays matching
+            if (rawClass == Map.class && Utils.getRawClassOrNull(parameterizedType.getActualTypeArguments()[0]) == String.class && Utils.getRawClassOrNull(parameterizedType.getActualTypeArguments()[1]) == Object.class) {
+                return new Result(new TsType.IndexedArrayType(TsType.String, TsType.Unknown));
+            }
 
             // Exclude type params
             TsIgnoreTypeParams ignoreTypeParams = rawClass.getAnnotation(TsIgnoreTypeParams.class);
@@ -82,7 +87,6 @@ public class CustomTypeProcessor implements TypeProcessor {
                 }
 
                 // Ignore specified
-                final ParameterizedType parameterizedType = (ParameterizedType) javaType;
                 List<Integer> removeIndexes = Arrays.stream(ignoreTypeParams.paramIndexes()).boxed().toList();
 
                 if (parameterizedType.getRawType() instanceof final Class<?> javaClass) {

--- a/model/src/main/java/org/openremote/model/manager/ManagerAppConfig.java
+++ b/model/src/main/java/org/openremote/model/manager/ManagerAppConfig.java
@@ -19,11 +19,9 @@
  */
 package org.openremote.model.manager;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.io.Serializable;
 import java.util.Map;
-@JsonInclude(JsonInclude.Include.NON_NULL)
+
 public class ManagerAppConfig implements Serializable {
     protected boolean loadLocales;
     protected Map<String, String> languages;

--- a/model/src/main/java/org/openremote/model/rules/json/RuleCondition.java
+++ b/model/src/main/java/org/openremote/model/rules/json/RuleCondition.java
@@ -19,6 +19,7 @@
  */
 package org.openremote.model.rules.json;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.openremote.model.query.AssetQuery;
 import org.openremote.model.rules.SunPositionTrigger;
 
@@ -46,7 +47,7 @@ public class RuleCondition {
     /**
      * Map of attribute and ISO8601 duration expression (e.g. PT1H)
      */
-    public Map<Integer, String> duration;
+    public Map<Integer, @Nullable String> duration;
 
     /**
      * CRON expression in UTC (e.g. *&#47;5 * * * *)

--- a/project.gradle
+++ b/project.gradle
@@ -233,7 +233,7 @@ def createTSGeneratorConfigForModel(String outputFileName, Project...customProje
                         "JsonSerializeExtension"
                 ]
                 customTypeMappings = [
-                        "com.fasterxml.jackson.databind.node.ObjectNode:{ [id: string]: any }",
+                        "com.fasterxml.jackson.databind.node.ObjectNode:{ [id: string]: unknown }",
                         "java.lang.Class<T>:string",
                         "org.openremote.model.attribute.MetaItem<T>:any"
                 ]
@@ -252,7 +252,7 @@ def createTSGeneratorConfigForClient(String outputFileName, File modelInfoJson, 
                         "cz.habarta.typescript.generator.ext.AxiosClientExtension"
                 ]
                 customTypeMappings = [
-                        "com.fasterxml.jackson.databind.node.ObjectNode:{ [id: string]: any }",
+                        "com.fasterxml.jackson.databind.node.ObjectNode:{ [id: string]: unknown }",
                         "java.lang.Class<T>:string",
                         "org.openremote.model.attribute.MetaItem<T>:any",
                         "org.openremote.model.asset.Asset<T>:Model.Asset",
@@ -302,12 +302,14 @@ def createTSGeneratorConfig(boolean outputAPIClient, String outputFileName, Proj
                 (outputAPIClient ? "org.openremote.model.**Resource" : "org.openremote.model.**")
         ] + classPatternGlobs
         customTypeNamingFunction = "function(name, simpleName) { if (name.indexOf(\"\$\") > 0) return name.substr(name.lastIndexOf(\".\")+1).replace(\"\$\",\"\"); }"
+        nullabilityDefinition = cz.habarta.typescript.generator.NullabilityDefinition.nullAndUndefinedInlineUnion
+        nullableAnnotations = ["org.checkerframework.checker.nullness.qual.Nullable"]
         excludeClassPatterns = [
                 "org.openremote.model.event.shared.*Filter**",
                 "org.openremote.model.util.**",
                 "org.openremote.model.flow.**",
                 "java.io.**",
-                "java.lang.**",
+                //"java.lang.**",
                 "org.hibernate.**",
                 "jakarta.**"
         ]

--- a/ui/app/manager/src/components/configuration/or-conf-realm/or-conf-realm-card.ts
+++ b/ui/app/manager/src/components/configuration/or-conf-realm/or-conf-realm-card.ts
@@ -37,6 +37,7 @@ import { FileInfo, ManagerAppRealmConfig } from "@openremote/model";
 import { DialogAction, OrMwcDialog, showDialog } from "@openremote/or-mwc-components/or-mwc-dialog";
 import {when} from 'lit/directives/when.js';
 import ISO6391 from 'iso-639-1';
+import {DefaultHeaderMainMenu, DefaultHeaderSecondaryMenu} from "../../../index";
 
 declare const MANAGER_URL: string
 
@@ -131,30 +132,8 @@ export class OrConfRealmCard extends LitElement {
     protected logo:string = this.realm.logo;
     protected logoMobile:string = this.realm.logoMobile;
     protected favicon:string = this.realm.favicon;
-
-    protected headerListPrimary: string[] = [
-        "map",
-        "assets",
-        "rules",
-        "insights",
-    ];
-
-
-    protected headerListSecondary: string[] = [
-        "gatewayHeaderItem",
-        "export",
-        "logs",
-        "realms",
-
-        "users",
-        "roles",
-
-        "account",
-        "language",
-        "appearance",
-        "logout"
-
-    ];
+    protected headerListPrimary: string[] = Object.keys(DefaultHeaderMainMenu);
+    protected headerListSecondary: string[] = Object.keys(DefaultHeaderSecondaryMenu);
 
     protected commonLanguages: string[] = Object.entries(DEFAULT_LANGUAGES).map(entry => ISO6391.getName(entry[0]));
     protected _languages: string[][] = [];

--- a/ui/app/manager/src/headers.ts
+++ b/ui/app/manager/src/headers.ts
@@ -52,7 +52,7 @@ export function headerItemGatewayTunnel<S extends AppStateKeyed, A extends AnyAc
         icon: "lan-connect",
         value: "gateway-tunnel",
         href: "gateway-tunnel",
-        text: "gatewayTunnels.",
+        text: "gatewayTunnel",
         roles: ["write:admin", "read:admin"]
     }
 }

--- a/ui/app/manager/src/index.ts
+++ b/ui/app/manager/src/index.ts
@@ -90,7 +90,7 @@ export const DefaultHeaderMainMenu: {[name: string]: HeaderItem} = {
 };
 
 export const DefaultHeaderSecondaryMenu: {[name: string]: HeaderItem} = {
-    gateway: headerItemGatewayConnection(orApp),
+    gatewayConnection: headerItemGatewayConnection(orApp),
     gatewayTunnel: headerItemGatewayTunnel(orApp),
     language: headerItemLanguage(orApp),
     logs: headerItemLogs(orApp),
@@ -100,7 +100,7 @@ export const DefaultHeaderSecondaryMenu: {[name: string]: HeaderItem} = {
     realms: headerItemRealms(orApp),
     export: headerItemExport(orApp),
     provisioning: headerItemProvisioning(orApp),
-    configuration: headerItemConfiguration(orApp),
+    appearance: headerItemConfiguration(orApp),
     logout: headerItemLogout(orApp)
 };
 
@@ -114,30 +114,17 @@ export const DefaultRealmConfig: RealmAppConfig = {
     header: DefaultHeaderConfig
 };
 
-export const DefaultAppConfig: AppConfig<RootState> = {
-    pages: DefaultPagesConfig,
-    superUserHeader: DefaultHeaderConfig,
-    realms: {
-        default: DefaultRealmConfig
-    }
-};
-
 // Try and load the app config from JSON and if anything is found amalgamate it with default
 const configURL =  (MANAGER_URL ?? "") + "/api/master/configuration/manager";
 
-fetch(configURL).then(async (result) => {
-    if (!result.ok || result.status === 204) {
-        return DefaultAppConfig;
+fetch(configURL).then<ManagerAppConfig>(async (result) => {
+    let appConfig: ManagerAppConfig;
+
+    if (result.status === 200) {
+        appConfig = await result.json() as ManagerAppConfig;
     }
 
-    const appConfig = await result.json() as ManagerAppConfig;
-
-    if (appConfig === null) {
-        return DefaultAppConfig;
-    }
-
-    return appConfig;
-
+    return {...appConfig};
 }).then((appConfig: ManagerAppConfig) => {
 
     // Set locales and load path

--- a/ui/app/manager/src/pages/page-configuration.ts
+++ b/ui/app/manager/src/pages/page-configuration.ts
@@ -34,9 +34,8 @@ import {i18next} from "@openremote/or-translate";
 import "@openremote/or-components/or-loading-indicator";
 import {OrConfRealmCard} from "../components/configuration/or-conf-realm/or-conf-realm-card";
 import {OrConfPanel} from "../components/configuration/or-conf-panel";
-import {Input} from "@openremote/or-rules/lib/flow-viewer/services/input";
 import { InputType } from "@openremote/or-mwc-components/or-mwc-input";
-import {DefaultAppConfig} from "../index";
+import {DefaultHeaderMainMenu, DefaultHeaderSecondaryMenu, DefaultRealmConfig} from "../index";
 
 declare const CONFIG_URL_PREFIX: string;
 declare const MANAGER_URL: string | undefined;
@@ -299,9 +298,16 @@ export class PageConfiguration extends Page<AppStateKeyed> {
 
     // FETCH METHODS
 
-    protected async getManagerConfig(): Promise<ManagerAppConfig | undefined> {
+    protected async getManagerConfig(): Promise<ManagerAppConfig> {
         const response = await manager.rest.api.ConfigurationResource.getManagerConfig();
-        return response.status === 200 ? response.data as ManagerAppConfig : DefaultAppConfig;
+        return response.status === 200 ? response.data as ManagerAppConfig : {
+            realms: {
+                default: {
+                    appTitle: DefaultRealmConfig.appTitle,
+                    headers: [...Object.keys(DefaultHeaderMainMenu),...Object.keys(DefaultHeaderSecondaryMenu)]
+                }
+            }
+        };
     }
 
     protected async getMapConfig(): Promise<{[id: string]: any}> {

--- a/ui/app/manager/src/pages/page-gateway-tunnel.ts
+++ b/ui/app/manager/src/pages/page-gateway-tunnel.ts
@@ -124,7 +124,7 @@ export class PageGatewayTunnel extends Page<AppStateKeyed> {
             <div id="wrapper">
                 <div id="title">
                     <or-icon icon="lan-connect"></or-icon>
-                    ${i18next.t("gatewayTunnels.")}
+                    ${i18next.t("gatewayTunnel")}
                 </div>
                 <div class="panel">
                     <div class="panel-title" style="justify-content: space-between;">

--- a/ui/app/manager/src/pages/page-users.ts
+++ b/ui/app/manager/src/pages/page-users.ts
@@ -1068,7 +1068,7 @@ export class PageUsers extends Page<AppStateKeyed> {
                                               if (error) {
                                                   this.updateComplete.then(() => {
                                                       showSnackbar(undefined, error.text);
-                                                      if (error.status == 403) {
+                                                      if (error.status === 403) {
                                                           const elem = this.shadowRoot.getElementById('username-' + suffix) as OrMwcInput;
                                                           elem.setCustomValidity(error.text);
                                                           (elem.shadowRoot.getElementById("elem") as HTMLInputElement).reportValidity(); // manually reporting was required since we're not editing the username at all.

--- a/ui/app/shared/locales/en/or.json
+++ b/ui/app/shared/locales/en/or.json
@@ -346,7 +346,6 @@
     "JAVASCRIPT": "JavaScript"
   },
   "gatewayConnection": "Manager interconnect",
-  "gatewayHeaderItem": "Manager interconnect",
   "gateway": {
     "": "Manager interconnect",
     "limit_sharing_is_custom_error": "An advanced data limiting configuration is set. To modify click the JSON button. Clear it to use the fields below.",
@@ -355,9 +354,8 @@
     "limit_sharing_rate": "Limit the rate of how often attribute value updates are shared",
     "limit_sharing_rate_suffix": "minutes interval"
   },
-  "gatewayTunnel": "Gateway tunnel",
+  "gatewayTunnel": "Gateway tunnels",
   "gatewayTunnels": {
-    "": "Gateway tunnels",
     "settings": "Gateway settings",
     "start": "Start",
     "open": "Open",

--- a/ui/app/shared/locales/nl/or.json
+++ b/ui/app/shared/locales/nl/or.json
@@ -345,7 +345,6 @@
     "JAVASCRIPT": "JavaScript"
   },
   "gatewayConnection": "Manager interconnect",
-  "gatewayHeaderItem": "Manager interconnect",
   "gateway": {
     "": "Manager interconnect",
     "limit_sharing_is_custom_error": "Een aangepaste configuratie is ingesteld. Klik op JSON om deze aan te passen. Maak de configuratie leeg om de velden hieronder te gebruiken.",
@@ -354,9 +353,8 @@
     "limit_sharing_rate": "Begrens hoevaak attribuut waarden worden bijgewerkt",
     "limit_sharing_rate_suffix": "minuten interval"
   },
-  "gatewayTunnel": "Gateway tunnel",
+  "gatewayTunnel": "Gateway tunnels",
   "gatewayTunnels": {
-    "": "Gateway tunnels",
     "start": "Start",
     "open": "Open",
     "stop": "Stop",

--- a/ui/component/core/src/index.ts
+++ b/ui/component/core/src/index.ts
@@ -921,8 +921,8 @@ export class Manager implements EventProviderFactory {
         try {
             // Initialise keycloak
             this._keycloak = new Keycloak({
-                clientId: this._config.clientId,
-                realm: this._config.realm,
+                clientId: this._config.clientId!,
+                realm: this._config.realm!,
                 url: this._config.keycloakUrl
             });
 

--- a/ui/component/or-attribute-picker/src/asset-attribute-picker.ts
+++ b/ui/component/or-attribute-picker/src/asset-attribute-picker.ts
@@ -100,7 +100,7 @@ export class OrAssetAttributePicker extends AttributePicker {
                 </div>
                 <div class="col" style="flex: 1 1 auto;width: 260px;overflow: auto;">
                     ${when(this._assetAttributes && this._assetAttributes.length > 0, () => {
-            const selectedNames = this.selectedAttributes.filter(attrRef => attrRef.id === this._asset?.id).map(attrRef => attrRef.name);
+            const selectedNames = this.selectedAttributes.filter(attrRef => attrRef.id === this._asset?.id).map(attrRef => attrRef.name!);
             return html`
                             <div class="attributes-header">
                                 <or-translate value="attribute_plural"></or-translate>

--- a/ui/component/or-attribute-picker/src/assettype-attribute-picker.ts
+++ b/ui/component/or-attribute-picker/src/assettype-attribute-picker.ts
@@ -130,9 +130,9 @@ export class AssetTypeAttributePicker extends AttributePicker {
 
         const assetTypes = this._loadedAssetTypes || this._loadAssetTypes();
         const selectedTypeNames = this.selectedAttributes ? Array.from(this.selectedAttributes.keys()) : undefined;
-        const assetTypeItems = this._getAssetTypeDescriptors(assetTypes, assetTypes.filter(type => !selectedTypeNames || selectedTypeNames.includes(type.name)));
+        const assetTypeItems = this._getAssetTypeDescriptors(assetTypes, assetTypes.filter(type => !selectedTypeNames || selectedTypeNames.includes(type.name!)));
         const assetDescriptor = this._getAssetDescriptorByName(this._selectedAssetType);
-        const attributeTypes = (this._loadedAttributeTypes || (assetDescriptor ? this._loadAttributeTypes(assetDescriptor) : undefined))?.sort(Util.sortByString(item => item.name));
+        const attributeTypes = (this._loadedAttributeTypes || (assetDescriptor ? this._loadAttributeTypes(assetDescriptor) : undefined))?.sort(Util.sortByString(item => item.name!));
 
         this.content = () => html`
             <div class="row" style="display: flex;height: 600px;width: 800px;border-top: 1px solid ${unsafeCSS(DefaultColor5)};">
@@ -144,7 +144,7 @@ export class AssetTypeAttributePicker extends AttributePicker {
                 </div>
                 <div class="col" style="flex: 1 1 auto;width: 320px;overflow: auto;">
                     ${when(attributeTypes && attributeTypes.length > 0, () => {
-                        const selectedAttrNames = this._selectedAssetType ? this.selectedAttributes.get(this._selectedAssetType)?.map(desc => desc.name) : undefined;
+                        const selectedAttrNames = this._selectedAssetType ? this.selectedAttributes.get(this._selectedAssetType)?.map(desc => desc.name!) : undefined;
                         return html`
                             <div class="attributes-header">
                                 <or-translate value="attribute_plural"></or-translate>
@@ -213,7 +213,7 @@ export class AssetTypeAttributePicker extends AttributePicker {
             console.warn("Could not select attribute, since the attribute list seems to be empty?");
             return;
         }
-        this.selectedAttributes.set(this._selectedAssetType, this._loadedAttributeTypes?.filter(desc => attrNames.includes(desc.name)));
+        this.selectedAttributes.set(this._selectedAssetType, this._loadedAttributeTypes?.filter(desc => attrNames.includes(desc.name!)));
     }
 
 

--- a/ui/component/or-dashboard-builder/src/or-dashboard-tree.ts
+++ b/ui/component/or-dashboard-builder/src/or-dashboard-tree.ts
@@ -223,14 +223,14 @@ export class OrDashboardTree extends LitElement {
                 });
                 if (myDashboards.length > 0) {
                     const items: ListItem[] = [];
-                    myDashboards.sort((a, b) => a.displayName ? a.displayName.localeCompare(b.displayName) : 0).forEach(d => {
+                    myDashboards.sort((a, b) => a.displayName ? a.displayName.localeCompare(b.displayName!) : 0).forEach(d => {
                         items.push({icon: 'view-dashboard', text: d.displayName, value: d.id});
                     });
                     dashboardItems.push(items);
                 }
                 if (otherDashboards.length > 0) {
                     const items: ListItem[] = [];
-                    otherDashboards.sort((a, b) => a.displayName ? a.displayName.localeCompare(b.displayName) : 0).forEach(d => {
+                    otherDashboards.sort((a, b) => a.displayName ? a.displayName.localeCompare(b.displayName!) : 0).forEach(d => {
                         items.push({icon: 'view-dashboard', text: d.displayName, value: d.id});
                     });
                     dashboardItems.push(items);

--- a/ui/component/or-dashboard-builder/src/settings/gateway-settings.ts
+++ b/ui/component/or-dashboard-builder/src/settings/gateway-settings.ts
@@ -35,7 +35,7 @@ export class GatewaySettings extends WidgetSettings {
                                     ></or-mwc-input>
                                 `,
                                 complete: (gatewayAssets) => {
-                                    const options: [string, string][] = gatewayAssets.map(a => [a.id, a.name]);
+                                    const options: [string, string][] = gatewayAssets.map(a => [a.id!, a.name!]);
                                     const selected = gatewayAssets.find(a => a.id === this.widgetConfig.gatewayId);
                                     const value = selected ? [selected.id, selected.name] as [string, string] : undefined;
                                     return html`

--- a/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
@@ -334,7 +334,7 @@ export class GatewayWidget extends OrWidget {
      * Returns undefined if there is misalignment in the linked asset id or unexpected http code.
      */
    protected async _getGatewayStatus(info: GatewayTunnelInfo): Promise<string | undefined> {
-        const response =  await manager.rest.api.AssetResource.get(info.gatewayId)
+        const response =  await manager.rest.api.AssetResource.get(info.gatewayId!)
         if (response.status === 200 && response.data && response.data.attributes && response.data.attributes.gatewayStatus) {
             return response.data.attributes.gatewayStatus.value
         } else {

--- a/ui/component/or-dashboard-builder/src/widgets/table-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/table-widget.ts
@@ -84,7 +84,7 @@ export class TableWidget extends OrAssetWidget {
     protected loadAssets() {
         if(this.widgetConfig.allOfType) {
             this.queryAssets({
-                types: [this.widgetConfig.assetType],
+                types: [this.widgetConfig.assetType!],
                 select: {
                     attributes: this.widgetConfig.attributeNames
                 }

--- a/ui/component/or-rules/src/flow-viewer/services/project.ts
+++ b/ui/component/or-rules/src/flow-viewer/services/project.ts
@@ -228,8 +228,8 @@ export class Project extends EventEmitter {
 
     private enrichConnection(c: NodeConnection): NodeConnection {
         return {
-            from: NodeUtilities.getSocketFromID(c.from, this.nodes),
-            to: NodeUtilities.getSocketFromID(c.to, this.nodes)
+            from: NodeUtilities.getSocketFromID(c.from!, this.nodes)?.id,
+            to: NodeUtilities.getSocketFromID(c.to!, this.nodes)?.id
         }
     }
 }

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-alarm.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-alarm.ts
@@ -50,10 +50,10 @@ export class OrRuleFormAlarm extends LitElement {
 
     protected render() {
         const alarm: Alarm | undefined = this.action.alarm as Alarm;
-        const options: {value: string | undefined | null, label: string | undefined}[] = this.users.filter((u) => u.username != 'manager-keycloak').map((u) => {
+        const options: {value: string | undefined, label: string | undefined}[] = this.users.filter((u) => u.username !== 'manager-keycloak').map((u) => {
             return { value: u.id, label: u.username };
         });
-        options.unshift({value: null, label: i18next.t("none")})
+        options.unshift({value: undefined, label: i18next.t("none")})
         
         return html`
             <form style="display:grid">

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-notification.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-notification.ts
@@ -96,7 +96,7 @@ export class OrRuleActionNotification extends LitElement {
         if(this.action.notification) {
             const message = this.action.notification.message;
             if(message?.type === "localized") {
-                const locale = this.config?.notifications?.[manager.displayRealm]?.defaultLanguage || this.config?.notifications?.["default"]?.defaultLanguage || manager.config.defaultLanguage;
+                const locale = this.config?.notifications?.[manager.displayRealm]?.defaultLanguage || this.config?.notifications?.default?.defaultLanguage || manager.config.defaultLanguage!;
                 const msg = message.languages?.[locale]; // if localized, we use the default language
                 if(msg?.type === "push") {
                     this.action.notification.name = msg.title;

--- a/ui/component/or-rules/src/or-rule-viewer.ts
+++ b/ui/component/or-rules/src/or-rule-viewer.ts
@@ -193,7 +193,7 @@ export class OrRuleViewer extends translate(i18next)(LitElement) {
             case "EXECUTION_ERROR":
                 statusIcon = "alert-octagon";
                 statusClass = "iconfill-red";
-                statusText = this.ruleset.error;
+                statusText = this.ruleset.error!;
                 break;
             case "DISABLED":
                 statusIcon = "minus-circle";


### PR DESCRIPTION
Fixes #1676 

During investigation I discovered the typescript model had mostly `any` types and also `Map<String,Object>` is by default mapped to `{[id:string]: any}` which is a very loose type that even array objects match (which is why this issue wasn't picked up by typescript type checking).

I have now improved the typescript model generation and types are now stricter, I have fixed the code where needed to cope with these updates.

I have also fixed the `ManagerAppConfig` that was constructed in the frontend in the wrong structure. 