### PR TITLE
Hotfix for SQL migration failing when migrating from 1.2.4 to 1.3.0

### DIFF
--- a/manager/src/main/resources/org/openremote/manager/setup/database/V20250217_01__KeepExistingWidgetConfig.sql
+++ b/manager/src/main/resources/org/openremote/manager/setup/database/V20250217_01__KeepExistingWidgetConfig.sql
@@ -6,23 +6,26 @@ WITH json_data AS (
     SELECT
         id,
         template,
-        jsonb_set(
-            template,
-            '{widgets}',
-            (
-                SELECT jsonb_agg(
-                    jsonb_set(
-                        widget,
-                        '{widgetConfig,allOfType}',
-                        CASE
-                            WHEN (widget ->> 'widgetTypeId') = 'map' THEN 'true'::jsonb
-                            WHEN (widget ->> 'widgetTypeId') = 'table' THEN 'false'::jsonb
-                            ELSE widget -> 'widgetConfig' -> 'allOfType'
-                        END
-                    )
-                )
-                FROM jsonb_array_elements(template -> 'widgets') AS widget
-            )
+        COALESCE(
+                jsonb_set(
+                        template,
+                        '{widgets}',
+                        (
+                            SELECT jsonb_agg(
+                                           jsonb_set(
+                                                   widget,
+                                                   '{widgetConfig,allOfType}',
+                                                   CASE
+                                                       WHEN (widget ->> 'widgetTypeId') = 'map' THEN 'true'::jsonb
+                                                       WHEN (widget ->> 'widgetTypeId') = 'table' THEN 'false'::jsonb
+                                                       ELSE widget -> 'widgetConfig' -> 'allOfType'
+                                                       END
+                                           )
+                                   )
+                            FROM jsonb_array_elements(template -> 'widgets') AS widget
+                        )
+                ),
+                template
         ) AS updated_json
     FROM dashboard
 )

--- a/manager/src/main/resources/org/openremote/manager/setup/database/V20250217_01__KeepExistingWidgetConfig.sql
+++ b/manager/src/main/resources/org/openremote/manager/setup/database/V20250217_01__KeepExistingWidgetConfig.sql
@@ -1,35 +1,19 @@
-/*
-* Set existing widgets configs to match their pre-update behavior.
-*/
-
-WITH json_data AS (
-    SELECT
-        id,
-        template,
-        COALESCE(
-            jsonb_set(
-                template,
-                '{widgets}',
-                (
-                    SELECT jsonb_agg(
-                        jsonb_set(
-                            widget,
-                            '{widgetConfig,allOfType}',
-                            CASE
-                                WHEN (widget ->> 'widgetTypeId') = 'map' THEN 'true'::jsonb
-                                WHEN (widget ->> 'widgetTypeId') = 'table' THEN 'false'::jsonb
-                                ELSE widget -> 'widgetConfig' -> 'allOfType'
-                            END
-                        )
-                    )
-                    FROM jsonb_array_elements(template -> 'widgets') AS widget
-                )
-            ),
-            template
-        ) AS updated_json
-    FROM dashboard
-)
 UPDATE dashboard
-SET template = json_data.updated_json
-FROM json_data
-WHERE dashboard.id = json_data.id;
+SET template = jsonb_set(
+        template,
+        '{widgets}',
+        (
+            SELECT jsonb_agg(
+                           CASE
+                               WHEN widget->>'widgetTypeId' = 'map' THEN
+                                   jsonb_set(widget, '{widgetConfig,allOfType}', 'true'::jsonb)
+                               WHEN widget->>'widgetTypeId' = 'table' THEN
+                                   jsonb_set(widget, '{widgetConfig,allOfType}', 'false'::jsonb)
+                               ELSE
+                                   widget  -- Leave non-map/table widgets unchanged
+                               END
+                   )
+            FROM jsonb_array_elements(template->'widgets') widget
+        )
+)
+WHERE template->'widgets' IS NOT NULL;

--- a/manager/src/main/resources/org/openremote/manager/setup/database/V20250217_01__KeepExistingWidgetConfig.sql
+++ b/manager/src/main/resources/org/openremote/manager/setup/database/V20250217_01__KeepExistingWidgetConfig.sql
@@ -7,25 +7,25 @@ WITH json_data AS (
         id,
         template,
         COALESCE(
-                jsonb_set(
-                        template,
-                        '{widgets}',
-                        (
-                            SELECT jsonb_agg(
-                                           jsonb_set(
-                                                   widget,
-                                                   '{widgetConfig,allOfType}',
-                                                   CASE
-                                                       WHEN (widget ->> 'widgetTypeId') = 'map' THEN 'true'::jsonb
-                                                       WHEN (widget ->> 'widgetTypeId') = 'table' THEN 'false'::jsonb
-                                                       ELSE widget -> 'widgetConfig' -> 'allOfType'
-                                                       END
-                                           )
-                                   )
-                            FROM jsonb_array_elements(template -> 'widgets') AS widget
+            jsonb_set(
+                template,
+                '{widgets}',
+                (
+                    SELECT jsonb_agg(
+                        jsonb_set(
+                            widget,
+                            '{widgetConfig,allOfType}',
+                            CASE
+                                WHEN (widget ->> 'widgetTypeId') = 'map' THEN 'true'::jsonb
+                                WHEN (widget ->> 'widgetTypeId') = 'table' THEN 'false'::jsonb
+                                ELSE widget -> 'widgetConfig' -> 'allOfType'
+                            END
                         )
-                ),
-                template
+                    )
+                    FROM jsonb_array_elements(template -> 'widgets') AS widget
+                )
+            ),
+            template
         ) AS updated_json
     FROM dashboard
 )


### PR DESCRIPTION
There was an issue reproducible in regards to the SQL migration.
Steps:
1. Run a new OpenRemote instance with version 1.2.4.
2. Create a new dashboard in the Manager UI without editing anything.
3. Shut down the 1.2.4 instance.
4. Pull the latest version of 1.3.0.
5. Make sure `OR_SETUP_RUN_ON_RESTART` is set to false, so it will keep the data from 1.2.4.
6. Start the instance with version 1.3.0.