### PR TITLE
Bugfix for Rules: When-Then: text attribute with operator contains or does not contain does not show correct field for value

### DIFF
--- a/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
@@ -849,6 +849,7 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
                     negate: value === AssetQueryOperator.NOT_CONTAINS,
                     match: AssetQueryMatch.CONTAINS
                 };
+                break;
             }
             // operator without value predicate - since timestamp is being used rather than attribute value
             case AssetQueryOperator.NOT_UPDATED_FOR:

--- a/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
@@ -849,8 +849,8 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
                     negate: value === AssetQueryOperator.NOT_CONTAINS,
                     match: AssetQueryMatch.CONTAINS
                 };
-                break;
             }
+            break;
             // operator without value predicate - since timestamp is being used rather than attribute value
             case AssetQueryOperator.NOT_UPDATED_FOR:
                 attributePredicate.timestampOlderThan = "";

--- a/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
@@ -850,7 +850,7 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
                     match: AssetQueryMatch.CONTAINS
                 };
             }
-            break;
+                break;
             // operator without value predicate - since timestamp is being used rather than attribute value
             case AssetQueryOperator.NOT_UPDATED_FOR:
                 attributePredicate.timestampOlderThan = "";

--- a/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-asset-query.ts
@@ -844,12 +844,12 @@ export class OrRuleAssetQuery extends translate(i18next)(LitElement) {
                         negated: value === AssetQueryOperator.NOT_CONTAINS
                     };
                 } else if (valueDescriptor.jsonType === "string") {
-                predicate = {
-                    predicateType: "string",
-                    negate: value === AssetQueryOperator.NOT_CONTAINS,
-                    match: AssetQueryMatch.CONTAINS
-                };
-            }
+                    predicate = {
+                        predicateType: "string",
+                        negate: value === AssetQueryOperator.NOT_CONTAINS,
+                        match: AssetQueryMatch.CONTAINS
+                    };
+                }
                 break;
             // operator without value predicate - since timestamp is being used rather than attribute value
             case AssetQueryOperator.NOT_UPDATED_FOR:


### PR DESCRIPTION
## Description
Fixes #1707 

The break statement was missing from the switch case so when contains/not contains is selected it would proceed to the next case which is Not Updated For.

And adjustment for odd indentation

## Checklist


- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

