### PR TITLE
Fix relative manager URL

### DIFF
--- a/ui/component/core/src/index.ts
+++ b/ui/component/core/src/index.ts
@@ -92,7 +92,7 @@ export function normaliseConfig(config: ManagerConfig): ManagerConfig {
     if (!normalisedConfig.managerUrl || normalisedConfig.managerUrl === "") {
         // Assume manager is running on same host as this code
         normalisedConfig.managerUrl = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ":" + window.location.port : "")
-            + window.location.pathname.replace(/\/manager\/\S*/g, "");
+            + window.location.pathname.replace(/\/[^/]+\/?$/, '');
     } else {
         // Normalise by stripping any trailing slashes
         normalisedConfig.managerUrl = normalisedConfig.managerUrl.replace(/\/+$/, "");


### PR DESCRIPTION
## Description

Computes the manager URL by removing the last subpath instead of only /manager so APIs can also be found for custom apps.

Fixes #1706

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
