### PR TITLE
feat: custom tile server and tile uploads

### DIFF
--- a/manager/src/main/java/org/openremote/manager/app/ConfigurationService.java
+++ b/manager/src/main/java/org/openremote/manager/app/ConfigurationService.java
@@ -58,6 +58,9 @@ public class ConfigurationService implements ContainerService {
     public static final String OR_MAP_TILES_PATH = "OR_MAP_TILES_PATH";
     public static final String OR_MAP_TILES_PATH_DEFAULT = "manager/src/map/mapdata.mbtiles";
 
+    public static final String OR_CUSTOM_MAP_TILES_PATH = "OR_CUSTOM_MAP_TILES_PATH";
+    public static final String OR_CUSTOM_MAP_TILES_PATH_DEFAULT = "manager/src/map/mapdata-custom.mbtiles";
+
     protected ManagerIdentityService identityService;
     protected PersistenceService persistenceService;
     protected Path pathPublicRoot;
@@ -65,6 +68,7 @@ public class ConfigurationService implements ContainerService {
     private static final Logger LOG = Logger.getLogger(ConfigurationService.class.getName());
 
     protected Path mapTilesPath;
+    protected Path customMapTilesPath;
     protected Path mapSettingsPath;
     protected Path managerConfigPath;
     protected AtomicReference<ManagerAppConfig> managerAppConfig;
@@ -96,6 +100,10 @@ public class ConfigurationService implements ContainerService {
                 .filter(Files::isRegularFile)
                 .findFirst().orElse(null);
 
+        customMapTilesPath = Stream.of(getString(container.getConfig(), OR_CUSTOM_MAP_TILES_PATH, OR_CUSTOM_MAP_TILES_PATH_DEFAULT), "/deployment/map/mapdata-custom.mbtiles", "/opt/map/mapdata-custom.mbtiles", OR_CUSTOM_MAP_TILES_PATH_DEFAULT)
+                .map(Path::of)
+                .map(Path::toAbsolutePath).findFirst().orElse(null);
+
         managerConfigPath = Stream.of(getPersistedManagerConfigPath(), pathPublicRoot.resolve("manager_config.json"))
                 .map(Path::toAbsolutePath)
                 .filter(Files::isRegularFile)
@@ -110,6 +118,7 @@ public class ConfigurationService implements ContainerService {
         LOG.info("\t- manager_config.json: " + managerConfigPath);
         LOG.info("\t- mapsettings.json: " + mapSettingsPath);
         LOG.info("\t- mapdata.mbtiles: " + mapTilesPath);
+        LOG.info("\t- mapdata-custom.mbtiles: " + customMapTilesPath);
     }
 
     @Override
@@ -125,6 +134,7 @@ public class ConfigurationService implements ContainerService {
     public String toString() {
         return "ConfigurationService{" +
                 "mapTilesPath=" + mapTilesPath +
+                ", customMapTilesPath=" + customMapTilesPath +
                 ", mapSettingsPath=" + mapSettingsPath +
                 ", managerConfigPath=" + managerConfigPath +
                 '}';
@@ -162,6 +172,10 @@ public class ConfigurationService implements ContainerService {
 
     public Path getMapTilesPath() {
         return mapTilesPath;
+    }
+
+    public Path getCustomMapTilesPath() {
+        return customMapTilesPath;
     }
 
     public ManagerAppConfig getManagerConfig() {

--- a/manager/src/main/java/org/openremote/manager/map/MapResourceImpl.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapResourceImpl.java
@@ -23,13 +23,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.openremote.container.web.WebResource;
 import org.openremote.manager.security.ManagerIdentityService;
 import org.openremote.model.http.RequestParams;
-import org.openremote.model.manager.MapRealmConfig;
+import org.openremote.model.manager.MapConfig;
 import org.openremote.model.map.MapResource;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
-
-import java.util.Map;
 
 public class MapResourceImpl extends WebResource implements MapResource {
 
@@ -42,7 +40,7 @@ public class MapResourceImpl extends WebResource implements MapResource {
     }
 
     @Override
-    public Object saveSettings(RequestParams requestParams, Map<String, MapRealmConfig> mapConfig) {
+    public Object saveSettings(RequestParams requestParams, MapConfig mapConfig) {
         return mapService.saveMapConfig(mapConfig);
     }
 

--- a/manager/src/main/java/org/openremote/manager/map/MapResourceImpl.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapResourceImpl.java
@@ -20,6 +20,12 @@
 package org.openremote.manager.map;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Context;
+
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.openremote.container.web.WebResource;
 import org.openremote.manager.security.ManagerIdentityService;
 import org.openremote.model.http.RequestParams;
@@ -68,5 +74,25 @@ public class MapResourceImpl extends WebResource implements MapResource {
         } else {
             throw new WebApplicationException(Response.Status.NO_CONTENT);
         }
+    }
+
+    @Override
+    public Response uploadMap(@Context HttpServletRequest request) {
+        try (InputStream stream = request.getInputStream()) {
+            boolean isSaved = mapService.saveUploadedFile(stream, "mapdata-custom.mbtiles");
+            if (isSaved) {
+                return Response.ok("File uploaded successfully").build();
+            } else {
+                return Response.serverError().entity("File upload failed").build();
+            }
+        } catch (IOException error) {
+            throw new WebApplicationException(Response.Status.BAD_REQUEST);
+        }
+    }
+
+    @Override
+    public Response removeMap(@Context HttpServletRequest request) {
+        mapService.removeUploadedFile("mapdata-custom.mbtiles");
+        return Response.noContent().build();
     }
 }

--- a/manager/src/main/java/org/openremote/manager/map/MapResourceImpl.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapResourceImpl.java
@@ -79,6 +79,10 @@ public class MapResourceImpl extends WebResource implements MapResource {
 
     @Override
     public Response uploadMap(@Context HttpServletRequest request) {
+        if (request.getContentLength() > mapService.customMapLimit) {
+            throw new WebApplicationException("{\"map-custom\": false}", Response.Status.REQUEST_ENTITY_TOO_LARGE);
+        }
+
         try (InputStream stream = request.getInputStream()) {
             boolean isSaved = mapService.saveUploadedFile(stream);
             ObjectNode response = ValueUtil.JSON
@@ -95,9 +99,10 @@ public class MapResourceImpl extends WebResource implements MapResource {
     }
 
     @Override
-    public Response isMapCustom() {
+    public Response customMapInfo() {
         ObjectNode response = ValueUtil.JSON
             .createObjectNode()
+            .put("custom-map-limit", mapService.customMapLimit)
             .put("map-custom", mapService.isCustomUploadedFile());
 
         return Response.ok().entity(response).build();

--- a/manager/src/main/java/org/openremote/manager/map/MapService.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapService.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.ResponseCodeHandler;
 import io.undertow.server.handlers.proxy.ProxyHandler;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import org.openremote.container.web.WebService;
 import org.openremote.manager.app.ConfigurationService;
@@ -32,7 +34,8 @@ import org.openremote.manager.security.ManagerIdentityService;
 import org.openremote.manager.web.ManagerWebService;
 import org.openremote.model.Container;
 import org.openremote.model.ContainerService;
-import org.openremote.model.manager.MapRealmConfig;
+import org.openremote.model.manager.MapConfig;
+import org.openremote.model.manager.MapSourceConfig;
 import org.openremote.model.util.TextUtil;
 import org.openremote.model.util.ValueUtil;
 
@@ -66,6 +69,7 @@ public class MapService implements ContainerService {
     public static final String OR_PATH_PREFIX = "OR_PATH_PREFIX";
     public static final String OR_PATH_PREFIX_DEFAULT = "";
     private static final Logger LOG = Logger.getLogger(MapService.class.getName());
+    private static final String DEFAULT_VECTOR_TILES_URL = "mbtiles://mapdata.mbtiles";
     private static ConfigurationService configurationService;
 
     // Shared SQL connection is fine concurrently in SQLite
@@ -76,13 +80,28 @@ public class MapService implements ContainerService {
     protected ConcurrentMap<String, ObjectNode> mapSettingsJs = new ConcurrentHashMap<>();
     protected String pathPrefix;
 
-    public ObjectNode saveMapConfig(Map<String, MapRealmConfig> mapConfiguration) throws RuntimeException {
+    public ObjectNode saveMapConfig(MapConfig mapConfiguration) throws RuntimeException {
         if (mapConfig == null) {
             mapConfig = ValueUtil.JSON.createObjectNode();
         }
-        mapConfig.putPOJO("options", mapConfiguration);
+
+        ObjectNode vector_tiles = ValueUtil.JSON.valueToTree(mapConfiguration.sources.get("vector_tiles"));
+        if (vector_tiles.hasNonNull("url")) {
+            if (!vector_tiles.get("url").textValue().contains("/{z}/{x}/{y}")) {
+                throw new WebApplicationException(Response.Status.BAD_REQUEST);
+            }
+        } else {
+            vector_tiles.put("url", DEFAULT_VECTOR_TILES_URL);
+            mapConfiguration.sources.put("vector_tiles", ValueUtil.JSON.convertValue(vector_tiles, MapSourceConfig.class));
+        }
+
+        mapConfig.putPOJO("options", mapConfiguration.options);
+        mapConfig.putPOJO("sources", mapConfiguration.sources);
+
         configurationService.saveMapConfig(mapConfig);
+        mapConfig = configurationService.getMapConfig();
         mapSettings.clear();
+
         return mapConfig;
     }
 
@@ -276,7 +295,7 @@ public class MapService implements ContainerService {
                 .filter(JsonNode::isObject)
                 .ifPresent(vectorTilesNode -> {
                     ObjectNode vectorTilesObj = (ObjectNode)vectorTilesNode;
-                    vectorTilesObj.remove("url");
+                    String url = vectorTilesObj.remove("url").textValue();
 
                     vectorTilesObj.put("attribution", metadata.attribution);
                     vectorTilesObj.put("maxzoom", metadata.maxZoom);
@@ -291,7 +310,14 @@ public class MapService implements ContainerService {
                             }));
 
                     ArrayNode tilesArray = mapConfig.arrayNode();
-                    String tileUrl = UriBuilder.fromUri(host).replacePath(pathPrefix + API_PATH).path(realm).path("map/tile").build().toString() + "/{z}/{x}/{y}";
+                    String tileUrl = !url.contentEquals(DEFAULT_VECTOR_TILES_URL)
+                        ? url
+                        : UriBuilder.fromUri(host)
+                            .replacePath(pathPrefix + API_PATH)
+                            .path(realm)
+                            .path("map/tile")
+                            .build()
+                            .toString() + "/{z}/{x}/{y}";
                     tilesArray.insert(0, tileUrl);
                     vectorTilesObj.replace("tiles", tilesArray);
                 });

--- a/manager/src/main/java/org/openremote/manager/map/MapService.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapService.java
@@ -39,9 +39,16 @@ import org.openremote.model.manager.MapSourceConfig;
 import org.openremote.model.util.TextUtil;
 import org.openremote.model.util.ValueUtil;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.*;
+import java.util.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -57,6 +64,7 @@ import static org.openremote.manager.web.ManagerWebService.API_PATH;
 
 public class MapService implements ContainerService {
 
+    public static final String OR_MAP_TILES_CUSTOM_PATH = "manager/src/map/mapdata-custom.mbtiles";
     public static final String MAP_SHARED_DATA_BASE_URI = "/shared";
     public static final String OR_MAP_TILESERVER_HOST = "OR_MAP_TILESERVER_HOST";
     public static final String OR_MAP_TILESERVER_HOST_DEFAULT = null;
@@ -215,6 +223,16 @@ public class MapService implements ContainerService {
         if (!mapTilesPath.toFile().exists()) {
             return;
         }
+        File parentDir = mapTilesPath.getParent().toFile();
+        if (parentDir.isDirectory()) {
+            String fileExtension = ".mbtiles";
+            File[] matchingFiles = parentDir.listFiles((dir, name) -> !Objects.equals(name, "mapdata.mbtiles") && name.endsWith(fileExtension));
+
+            if (matchingFiles != null && matchingFiles.length != 0) {
+                mapTilesPath = matchingFiles[0].toPath().toAbsolutePath();
+            }
+        }
+
         Class.forName(org.sqlite.JDBC.class.getName());
         connection = DriverManager.getConnection("jdbc:sqlite:" + mapTilesPath);
         metadata = getMetadata(connection);
@@ -401,6 +419,29 @@ public class MapService implements ContainerService {
         } finally {
             closeQuietly(query, result);
         }
+    }
+
+    public boolean saveUploadedFile(InputStream fileInputStream, String filename) {
+        // TODO: Specify target directory for uploaded file
+        Path destinationPath = Paths.get("manager/src/map/", filename);
+
+        try (OutputStream outputStream = Files.newOutputStream(destinationPath)) {
+            byte[] buffer = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = fileInputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, bytesRead);
+            }
+            LOG.info("File uploaded successfully to: " + destinationPath.toAbsolutePath());
+            return true;
+        } catch (IOException e) {
+            LOG.log(Level.SEVERE, "Failed to save uploaded file", e);
+            return false;
+        }
+    }
+
+    public boolean removeUploadedFile(String filename) {
+        // TODO: Specify target directory for deleted file
+        return new File("manager/src/map/", filename).delete();
     }
 
     protected static final class Metadata {

--- a/manager/src/main/java/org/openremote/manager/map/MapService.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapService.java
@@ -49,9 +49,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.*;
 import java.util.*;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
@@ -421,9 +418,9 @@ public class MapService implements ContainerService {
         }
     }
 
-    public boolean saveUploadedFile(InputStream fileInputStream, String filename) {
+    public boolean saveUploadedFile(InputStream fileInputStream) {
         // TODO: Specify target directory for uploaded file
-        Path destinationPath = Paths.get("manager/src/map/", filename);
+        Path destinationPath = Paths.get("manager/src/map/", "mapdata-custom.mbtiles");
 
         try (OutputStream outputStream = Files.newOutputStream(destinationPath)) {
             byte[] buffer = new byte[4096];
@@ -432,16 +429,29 @@ public class MapService implements ContainerService {
                 outputStream.write(buffer, 0, bytesRead);
             }
             LOG.info("File uploaded successfully to: " + destinationPath.toAbsolutePath());
+            this.setData();
             return true;
-        } catch (IOException e) {
+        } catch (IOException | SQLException | ClassNotFoundException e) {
             LOG.log(Level.SEVERE, "Failed to save uploaded file", e);
             return false;
         }
     }
 
-    public boolean removeUploadedFile(String filename) {
-        // TODO: Specify target directory for deleted file
-        return new File("manager/src/map/", filename).delete();
+    public boolean isCustomUploadedFile() {
+        Path destinationPath = Paths.get("manager/src/map/", "mapdata-custom.mbtiles");
+
+        return Files.exists(destinationPath);
+    }
+
+    public boolean deleteUploadedFile() {
+        Path destinationPath = Paths.get("manager/src/map/", "mapdata-custom.mbtiles");
+        boolean deleted = destinationPath.toFile().delete();
+        if (deleted) {
+            LOG.info("File deleted successfully");
+        } else {
+            LOG.severe("Failed to delete file");
+        }
+        return deleted;
     }
 
     protected static final class Metadata {

--- a/manager/src/main/java/org/openremote/manager/map/MapService.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapService.java
@@ -431,15 +431,17 @@ public class MapService implements ContainerService {
             LOG.info("File uploaded successfully to: " + destinationPath.toAbsolutePath());
             this.setData();
             return true;
-        } catch (IOException | SQLException | ClassNotFoundException e) {
+        } catch (IOException e) {
             LOG.log(Level.SEVERE, "Failed to save uploaded file", e);
+            return false;
+        } catch (SQLException | ClassNotFoundException e) {
+            LOG.log(Level.SEVERE, "Failed to load uploaded file", e);
             return false;
         }
     }
 
     public boolean isCustomUploadedFile() {
         Path destinationPath = Paths.get("manager/src/map/", "mapdata-custom.mbtiles");
-
         return Files.exists(destinationPath);
     }
 
@@ -450,6 +452,11 @@ public class MapService implements ContainerService {
             LOG.info("File deleted successfully");
         } else {
             LOG.severe("Failed to delete file");
+        }
+        try {
+            this.setData();
+        } catch (SQLException | ClassNotFoundException e) {
+            LOG.log(Level.SEVERE, "Failed to load default file", e);
         }
         return deleted;
     }

--- a/manager/src/main/java/org/openremote/manager/map/MapService.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapService.java
@@ -61,7 +61,6 @@ import static org.openremote.manager.web.ManagerWebService.API_PATH;
 
 public class MapService implements ContainerService {
 
-    public static final String OR_MAP_TILES_CUSTOM_PATH = "manager/src/map/mapdata-custom.mbtiles";
     public static final String MAP_SHARED_DATA_BASE_URI = "/shared";
     public static final String OR_MAP_TILESERVER_HOST = "OR_MAP_TILESERVER_HOST";
     public static final String OR_MAP_TILESERVER_HOST_DEFAULT = null;
@@ -419,8 +418,7 @@ public class MapService implements ContainerService {
     }
 
     public boolean saveUploadedFile(InputStream fileInputStream) {
-        // TODO: Specify target directory for uploaded file
-        Path destinationPath = Paths.get("manager/src/map/", "mapdata-custom.mbtiles");
+        Path destinationPath = configurationService.getCustomMapTilesPath();
 
         try (OutputStream outputStream = Files.newOutputStream(destinationPath)) {
             byte[] buffer = new byte[4096];
@@ -441,12 +439,15 @@ public class MapService implements ContainerService {
     }
 
     public boolean isCustomUploadedFile() {
-        Path destinationPath = Paths.get("manager/src/map/", "mapdata-custom.mbtiles");
+        Path destinationPath = configurationService.getCustomMapTilesPath();
+        if (destinationPath == null) {
+            return false;
+        }
         return Files.exists(destinationPath);
     }
 
     public boolean deleteUploadedFile() {
-        Path destinationPath = Paths.get("manager/src/map/", "mapdata-custom.mbtiles");
+        Path destinationPath = configurationService.getCustomMapTilesPath();
         boolean deleted = destinationPath.toFile().delete();
         if (deleted) {
             LOG.info("File deleted successfully");

--- a/manager/src/main/java/org/openremote/manager/map/MapService.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapService.java
@@ -90,14 +90,14 @@ public class MapService implements ContainerService {
             mapConfig = ValueUtil.JSON.createObjectNode();
         }
 
-        ObjectNode vector_tiles = ValueUtil.JSON.valueToTree(mapConfiguration.sources.get("vector_tiles"));
-        if (vector_tiles.hasNonNull("url")) {
-            if (!vector_tiles.get("url").textValue().contains("/{z}/{x}/{y}")) {
+        ObjectNode vectorTiles = ValueUtil.JSON.valueToTree(mapConfiguration.sources.get("vector_tiles"));
+        if (vectorTiles.hasNonNull("url")) {
+            if (!vectorTiles.get("url").textValue().contains("/{z}/{x}/{y}")) {
                 throw new WebApplicationException(Response.Status.BAD_REQUEST);
             }
         } else {
-            vector_tiles.put("url", DEFAULT_VECTOR_TILES_URL);
-            mapConfiguration.sources.put("vector_tiles", ValueUtil.JSON.convertValue(vector_tiles, MapSourceConfig.class));
+            vectorTiles.put("url", DEFAULT_VECTOR_TILES_URL);
+            mapConfiguration.sources.put("vector_tiles", ValueUtil.JSON.convertValue(vectorTiles, MapSourceConfig.class));
         }
 
         mapConfig.putPOJO("options", mapConfiguration.options);

--- a/manager/src/main/java/org/openremote/manager/map/MapService.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapService.java
@@ -66,6 +66,8 @@ public class MapService implements ContainerService {
     public static final String OR_MAP_TILESERVER_HOST_DEFAULT = null;
     public static final String OR_MAP_TILESERVER_PORT = "OR_MAP_TILESERVER_PORT";
     public static final int OR_MAP_TILESERVER_PORT_DEFAULT = 8082;
+    public static final String OR_CUSTOM_MAP_SIZE_LIMIT = "OR_CUSTOM_MAP_SIZE_LIMIT";
+    public static final int OR_CUSTOM_MAP_SIZE_LIMIT_DEFAULT = 1_000_000_000;
     public static final String RASTER_MAP_TILE_PATH = "/raster_map/tile";
     public static final String TILESERVER_TILE_PATH = "/styles/standard";
     public static final String OR_MAP_TILESERVER_REQUEST_TIMEOUT = "OR_MAP_TILESERVER_REQUEST_TIMEOUT";
@@ -83,6 +85,7 @@ public class MapService implements ContainerService {
     protected ConcurrentMap<String, ObjectNode> mapSettings = new ConcurrentHashMap<>();
     protected ConcurrentMap<String, ObjectNode> mapSettingsJs = new ConcurrentHashMap<>();
     protected String pathPrefix;
+    protected int customMapLimit = OR_CUSTOM_MAP_SIZE_LIMIT_DEFAULT;
 
     public ObjectNode saveMapConfig(MapConfig mapConfiguration) throws RuntimeException {
         if (mapConfig == null) {
@@ -174,6 +177,7 @@ public class MapService implements ContainerService {
         String tileServerHost = getString(container.getConfig(), OR_MAP_TILESERVER_HOST, OR_MAP_TILESERVER_HOST_DEFAULT);
         int tileServerPort = getInteger(container.getConfig(), OR_MAP_TILESERVER_PORT, OR_MAP_TILESERVER_PORT_DEFAULT);
         pathPrefix = getString(container.getConfig(), OR_PATH_PREFIX, OR_PATH_PREFIX_DEFAULT);
+        customMapLimit = getInteger(container.getConfig(), OR_CUSTOM_MAP_SIZE_LIMIT, OR_CUSTOM_MAP_SIZE_LIMIT_DEFAULT);
 
         if (!TextUtil.isNullOrEmpty(tileServerHost)) {
 

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -11,7 +11,9 @@ dependencies {
     api "org.hibernate.orm:hibernate-core:$hibernateVersion"
     api "org.hibernate.validator:hibernate-validator:$hibernateValidatorVersion"
     api "jakarta.el:jakarta.el-api:$javaxELAPIVersion"
-
+    api ("org.jboss.resteasy:resteasy-undertow:$resteasyVersion") {
+        exclude group: "io.undertow",  module: "undertow-servlet-jakarta"
+    }
     api "jakarta.annotation:jakarta.annotation-api:$javaxAnnotationsVersion"
     api "jakarta.ws.rs:jakarta.ws.rs-api:$jaxrsSpecVersion"
 

--- a/model/src/main/java/org/openremote/model/manager/MapConfig.java
+++ b/model/src/main/java/org/openremote/model/manager/MapConfig.java
@@ -22,5 +22,6 @@ package org.openremote.model.manager;
 import java.util.Map;
 
 public class MapConfig {
-    protected Map<String, MapRealmConfig> options;
+    public Map<String, MapRealmConfig> options;
+    public Map<String, MapSourceConfig> sources;
 }

--- a/model/src/main/java/org/openremote/model/manager/MapSourceConfig.java
+++ b/model/src/main/java/org/openremote/model/manager/MapSourceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, OpenRemote Inc.
+ * Copyright 2025, OpenRemote Inc.
  *
  * See the CONTRIBUTORS.txt file in the distribution for a
  * full listing of individual contributors.
@@ -77,6 +77,4 @@ public class MapSourceConfig {
 	 * @implSpec Optional string.
 	 */
 	protected String attribution;
-	// protected String promoteId;
-	// protected boolean volatile;
 }

--- a/model/src/main/java/org/openremote/model/manager/MapSourceConfig.java
+++ b/model/src/main/java/org/openremote/model/manager/MapSourceConfig.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022, OpenRemote Inc.
+ *
+ * See the CONTRIBUTORS.txt file in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.openremote.model.manager;
+
+/**
+ * Implements MapLibre style spec sources property.
+ * 
+ * @see https://maplibre.org/maplibre-style-spec/sources
+ */
+public class MapSourceConfig {
+	/**
+	 * The type of the source.
+	 * 
+	 * @implSpec Required enum. Possible values: <code>vector</code>.
+	 */
+	protected String type;
+	/**
+	 * A URL to a TileJSON resource.
+	 * 
+	 * @implSpec Optional string. Supported protocols are <code>http:</code> and <code>https:</code>.
+	 */
+	protected String url;
+	/**
+	 * An array of one or more tile source URLs, as in the TileJSON spec.
+	 * 
+	 * @implSpec Optional array. Possible values: vector.
+	 */
+	protected String[] tiles;
+	/**
+	 * An array containing the longitude and latitude of the southwest and northeast corners of the source's bounding box in the following order: <code>[sw.lng, sw.lat, ne.lng, ne.lat]</code>. When this property is included in a source, no tiles outside of the given bounds are requested by MapLibre.
+	 * 
+	 * @implSpec Optional array. Possible values: vector.
+	 */
+	protected float[] bounds;
+	/**
+	 * Influences the y direction of the tile coordinates. The global-mercator (aka Spherical Mercator) profile is assumed.
+   * <p><ul>
+	 * <li><code>xyz</code>: Slippy map tilenames scheme.</li>
+   * <li><code>tms</code>: OSGeo spec scheme.</li>
+	 * </ul></p>
+	 * 
+	 * @implSpec Optional enum. Possible values: <code>xyz</code>, <code>tms</code>. Defaults to <code>xyz</code>.
+	 */
+	protected String scheme;
+	/**
+   * Minimum zoom level for which tiles are available, as in the TileJSON spec.
+	 * 
+	 * @implSpec Optional number. Defaults to <code>0</code>.
+	 */
+	protected Integer minzoom;
+	/**
+	 * Maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles at the maxzoom are used when displaying the map at higher zoom levels.
+	 * 
+	 * @implSpec Optional number. Defaults to <code>22</code>.
+	 */
+	protected Integer maxzoom;
+	/**
+	 * Contains an attribution to be displayed when the map is shown to a user.
+	 * 
+	 * @implSpec Optional string.
+	 */
+	protected String attribution;
+	// protected String promoteId;
+	// protected boolean volatile;
+}

--- a/model/src/main/java/org/openremote/model/map/MapResource.java
+++ b/model/src/main/java/org/openremote/model/map/MapResource.java
@@ -23,12 +23,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.openremote.model.http.RequestParams;
-import org.openremote.model.manager.MapRealmConfig;
+import org.openremote.model.manager.MapConfig;
 
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
-
-import java.util.Map;
 
 @Tag(name = "Map", description = "Operations on maps")
 @Path("map")
@@ -41,7 +39,7 @@ public interface MapResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "saveSettings", summary = "Update map settings")
-    Object saveSettings(@BeanParam RequestParams requestParams, Map<String, MapRealmConfig> mapConfig);
+    Object saveSettings(@BeanParam RequestParams requestParams, MapConfig mapConfig);
 
     /**
      * Returns style used to initialise Mapbox GL

--- a/model/src/main/java/org/openremote/model/map/MapResource.java
+++ b/model/src/main/java/org/openremote/model/map/MapResource.java
@@ -22,6 +22,9 @@ package org.openremote.model.map;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
 import org.openremote.model.http.RequestParams;
 import org.openremote.model.manager.MapConfig;
 
@@ -68,4 +71,23 @@ public interface MapResource {
     @Path("tile/{zoom}/{column}/{row}")
     @Operation(operationId = "getTile", summary = "Retrieve the vector tile data for Mapbox GL")
     byte[] getTile(@PathParam("zoom")int zoom, @PathParam("column")int column, @PathParam("row")int row);
+
+    /**
+     * Saves mbtiles file
+     */
+    @POST
+    @Path("upload")
+    @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+    @Produces("text/plain")
+    @Operation(operationId = "uploadMap", summary = "Saves mbtiles file")
+    Response uploadMap(@Context HttpServletRequest request);
+
+    /**
+     * Removes mbtiles file
+     */
+    @POST
+    @Path("upload")
+    @Produces("text/plain")
+    @Operation(operationId = "removeMap", summary = "Removes mbtiles file")
+    Response removeMap(@Context HttpServletRequest request);
 }

--- a/model/src/main/java/org/openremote/model/map/MapResource.java
+++ b/model/src/main/java/org/openremote/model/map/MapResource.java
@@ -78,16 +78,19 @@ public interface MapResource {
     @POST
     @Path("upload")
     @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-    @Produces("text/plain")
     @Operation(operationId = "uploadMap", summary = "Saves mbtiles file")
     Response uploadMap(@Context HttpServletRequest request);
+
+    @GET
+    @Path("isMapCustom")
+    Response isMapCustom();
 
     /**
      * Removes mbtiles file
      */
     @POST
-    @Path("upload")
+    @Path("deleteMap")
     @Produces("text/plain")
-    @Operation(operationId = "removeMap", summary = "Removes mbtiles file")
-    Response removeMap(@Context HttpServletRequest request);
+    @Operation(operationId = "deleteMap", summary = "Removes mbtiles file")
+    Response deleteMap(@Context HttpServletRequest request);
 }

--- a/model/src/main/java/org/openremote/model/map/MapResource.java
+++ b/model/src/main/java/org/openremote/model/map/MapResource.java
@@ -82,8 +82,8 @@ public interface MapResource {
     Response uploadMap(@Context HttpServletRequest request);
 
     @GET
-    @Path("isMapCustom")
-    Response isMapCustom();
+    @Path("customMapInfo")
+    Response customMapInfo();
 
     /**
      * Removes mbtiles file

--- a/profile/deploy.yml
+++ b/profile/deploy.yml
@@ -271,6 +271,9 @@ services:
       # manager's map, as well as other style details and colours.
       OR_MAP_SETTINGS_PATH: ${OR_MAP_SETTINGS_PATH:-/deployment/map/mapsettings.json}
 
+      # Override the maximum allowed custom map tiles database file size in bytes.
+      OR_CUSTOM_MAP_SIZE_LIMIT: ${OR_CUSTOM_MAP_SIZE_LIMIT:-1000000000}
+
       # Set the tileserver host name and port; the manager will reverse proxy to this server
       # to provide raster map tiles to frontend apps
       OR_MAP_TILESERVER_HOST:

--- a/ui/app/manager/src/components/configuration/or-conf-panel.ts
+++ b/ui/app/manager/src/components/configuration/or-conf-panel.ts
@@ -2,7 +2,7 @@ import {html, LitElement, TemplateResult} from "lit";
 import {InputType, OrInputChangedEvent} from "@openremote/or-mwc-components/or-mwc-input";
 import {customElement, property} from "lit/decorators.js";
 import {when} from 'lit/directives/when.js';
-import {ManagerAppConfig} from "@openremote/model";
+import {ManagerAppConfig, MapConfig} from "@openremote/model";
 import {DialogAction, OrMwcDialog, showDialog} from "@openremote/or-mwc-components/or-mwc-dialog";
 import {i18next} from "@openremote/or-translate";
 import "@openremote/or-components/or-loading-indicator";
@@ -15,7 +15,7 @@ import {OrConfMapCard} from "./or-conf-map/or-conf-map-card";
 export class OrConfPanel extends LitElement {
 
     @property()
-    public config?: {[id: string]: any} | ManagerAppConfig = {};
+    public config?: MapConfig | ManagerAppConfig = {};
 
     @property()
     public realmOptions: { name: string, displayName: string, canDelete: boolean }[] = [];
@@ -34,23 +34,26 @@ export class OrConfPanel extends LitElement {
         if(this.isManagerConfig(config)) {
             return config.realms;
         } else if(this.isMapConfig(config)) {
-            return config;
+            return config.options;
         }
         return undefined;
     }
 
-    protected isMapConfig(object: unknown): boolean {
-        const keys = Object.keys(object);
-        // Instead of looking for the exact same entries, ensure that at least one of them can be mapped.
-        // This also shows realm configs that don't have parent realms, but are still existing in the mapsettings.json
-        return this.realmOptions.filter((o) => keys.includes(o.name)).length > 0;
+    protected isMapConfig(object: unknown): object is MapConfig {
+        if (typeof object == 'object' && 'options' in object) {
+            const keys = Object.keys(object.options);
+            // Instead of looking for the exact same entries, ensure that at least one of them can be mapped.
+            // This also shows realm configs that don't have parent realms, but are still existing in the mapsettings.json
+            return this.realmOptions.filter((o) => keys.includes(o.name)).length > 0;
+        }
+        return false;
     }
 
     protected isManagerConfig(object: any): object is ManagerAppConfig {
         return 'realms' in object;
     }
 
-    protected notifyConfigChange(config: {[id: string]: any} | ManagerAppConfig) {
+    protected notifyConfigChange(config: MapConfig | ManagerAppConfig) {
         this.dispatchEvent(new CustomEvent("change", { detail: config }));
     }
 
@@ -118,7 +121,7 @@ export class OrConfPanel extends LitElement {
 
     // Filter the list of realms that are not present in the config.
     // Most used for the "add realm" dialog, to hide the realms that are already present.
-    protected getAvailableRealms(config?: ManagerAppConfig | {[id: string]: any}, realmOptions?: { name: string, displayName: string, canDelete: boolean }[]): { name: string, displayName: string, canDelete: boolean }[] {
+    protected getAvailableRealms(config?: ManagerAppConfig | MapConfig, realmOptions?: { name: string, displayName: string, canDelete: boolean }[]): { name: string, displayName: string, canDelete: boolean }[] {
         const realms = this.getRealmsProperty(config);
         if(realms) {
             return realmOptions.filter((r) => {

--- a/ui/app/manager/src/components/configuration/or-conf-panel.ts
+++ b/ui/app/manager/src/components/configuration/or-conf-panel.ts
@@ -40,7 +40,7 @@ export class OrConfPanel extends LitElement {
     }
 
     protected isMapConfig(object: unknown): object is MapConfig {
-        if (typeof object == 'object' && 'options' in object) {
+        if (typeof object === 'object' && 'options' in object) {
             const keys = Object.keys(object.options);
             // Instead of looking for the exact same entries, ensure that at least one of them can be mapped.
             // This also shows realm configs that don't have parent realms, but are still existing in the mapsettings.json

--- a/ui/app/manager/src/pages/page-configuration.ts
+++ b/ui/app/manager/src/pages/page-configuration.ts
@@ -216,10 +216,11 @@ export class PageConfiguration extends Page<AppStateKeyed> {
     @state()
     protected isMapCustom: boolean = false;
 
+    @state()
+    protected tilesForUpload: File;
+
     @query("#managerConfig-panel")
     protected realmConfigPanel?: OrConfPanel;
-
-    protected tilesForUpload: File;
 
     private readonly urlPrefix: string = (CONFIG_URL_PREFIX || "")
 
@@ -286,13 +287,18 @@ export class PageConfiguration extends Page<AppStateKeyed> {
             `, () => {
                 const realmHeading = html`
                     <div id="heading" style="justify-content: space-between;">
-                        <span style="margin: 0;">${i18next.t("configuration.realmStyling").toUpperCase()}</span>
+                        <span style="margin: 0;"><or-translate style="text-transform: uppercase;" value="configuration.realmStyling"></or-translate></span>
                         <or-conf-json .managerConfig="${this.managerConfiguration}" class="hide-mobile"
                                       @saveLocalManagerConfig="${(ev: CustomEvent) => {
                                           this.managerConfiguration = ev.detail.value as ManagerAppConfig;
                                           this.managerConfigurationChanged = true;
                                       }}"
                         ></or-conf-json>
+                    </div>
+                `;
+                const mapHeading = html`
+                    <div id="heading" style="justify-content: space-between;">
+                        <span style="margin: 0;"><or-translate style="text-transform: uppercase;" value="configuration.mapSettings"></or-translate></span>
                     </div>
                 `;
                 const realmOptions = this.realms?.map((r) => ({name: r.name, displayName: r.displayName, canDelete: true}));
@@ -302,7 +308,7 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                         <div id="header-wrapper">
                             <div id="header-title">
                                 <or-icon icon="palette-outline"></or-icon>
-                                ${i18next.t("appearance")}
+                                <or-translate value="appearance"></or-translate>
                             </div>
                             <div id="header-actions">
                                 <or-mwc-input id="save-btn" .disabled="${!this.managerConfigurationChanged && !this.mapConfigChanged}" raised type="button" label="save"
@@ -317,7 +323,7 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                                 ></or-conf-panel>
                             `, () => html`
                                 <div class="notFound-container">
-                                    <span>${i18next.t('configuration.managerConfigNotFound')}</span>
+                                    <span><or-translate value="configuration.managerConfigNotFound"></or-translate></span>
                                     <or-mwc-input type="${InputType.BUTTON}" label="configuration.tryAgain"
                                                   @or-mwc-input-changed="${() => this.getManagerConfig().then(val => {
                                                       this.managerConfiguration = val;
@@ -326,12 +332,12 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                                 </div>
                             `)}
                         </or-panel>
-                        <or-panel .heading="${i18next.t("configuration.mapSettings").toUpperCase()}">
+                        <or-panel .heading="${mapHeading}">
                             ${when(this.mapConfig, () => html`
                                 <div class="global-settings-container">
                                     <div class="custom-server-group">
-                                        <div class="subheader">${i18next.t("configuration.global.tileServer")}</div>
-                                        <span>${i18next.t("configuration.global.tileServerDescription")}</span>
+                                        <div class="subheader"><or-translate value="configuration.global.tileServer"></or-translate></div>
+                                        <span><or-translate value="configuration.global.tileServerDescription"></or-translate></span>
                                         <or-mwc-input class="input" outlined
                                             .value="${this.mapConfig.sources?.['vector_tiles']?.tiles?.[0] || this.mapConfig.sources?.['vector_tiles']?.url}" 
                                             .type="${InputType.URL}"
@@ -342,15 +348,14 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                                                         type: "vector",
                                                         url: e.detail.value || null
                                                     }
-                                                    this.requestUpdate("mapConfig");
                                                     this.mapConfigChanged = true;
                                                 }}"
                                         ></or-mwc-input>
                                     </div>
 
                                     <div class="custom-tile-group">
-                                        <div class="subheader">${i18next.t("configuration.global.mapTiles")}</div>
-                                        <span>${i18next.t("configuration.global.uploadMapTiles")}</span>
+                                        <div class="subheader"><or-translate value="configuration.global.mapTiles"></or-translate></div>
+                                        <span><or-translate value="configuration.global.uploadMapTiles"></or-translate></span>
                                         <div class="input d-inline-flex">
                                             <or-file-uploader 
                                                 .label=${i18next.t("configuration.global.uploadMapTiles")}"
@@ -371,7 +376,7 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                                 ></or-conf-panel>
                             `, () => html`
                                 <div class="notFound-container">
-                                    <span>${i18next.t('configuration.mapSettingsNotFound')}</span>
+                                    <span><or-translate value="configuration.mapSettingsNotFound"></or-translate></span>
                                     <or-mwc-input type="${InputType.BUTTON}" label="configuration.tryAgain"
                                                   @or-mwc-input-changed="${() => this.getMapConfig().then(val => {
                                                       this.mapConfig = val;
@@ -397,7 +402,6 @@ export class PageConfiguration extends Page<AppStateKeyed> {
     protected async uploadCustomMap(e: CustomEvent) {
         const file = e.detail.value[0] as File;
         this.tilesForUpload = file;
-        this.requestUpdate()
         this.mapConfigChanged = true;
     }
 

--- a/ui/app/manager/src/pages/page-configuration.ts
+++ b/ui/app/manager/src/pages/page-configuration.ts
@@ -325,7 +325,7 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                                         <div class="subheader">${i18next.t("configuration.global.tileServer")}</div>
                                         <span>${i18next.t("configuration.global.tileServerDescription")}</span>
                                         <or-mwc-input class="input" outlined
-                                            .value="${this.mapConfig.sources?.['vector_tiles']?.tiles?.[0]}" 
+                                            .value="${this.mapConfig.sources?.['vector_tiles']?.tiles?.[0] || this.mapConfig.sources?.['vector_tiles']?.url}" 
                                             .type="${InputType.URL}"
                                             .label="${i18next.t("configuration.global.tileServerPlaceholder")}"
                                             placeholder="https://api.example.com/tileset/{z}/{x}/{y}"

--- a/ui/app/manager/src/pages/page-configuration.ts
+++ b/ui/app/manager/src/pages/page-configuration.ts
@@ -184,6 +184,10 @@ export class PageConfiguration extends Page<AppStateKeyed> {
             .input or-mwc-input:not([icon]) {
                 width: 80%;
             }
+
+            .d-inline-flex {
+                display: inline-flex;
+            }
         `;
     }
 
@@ -211,6 +215,8 @@ export class PageConfiguration extends Page<AppStateKeyed> {
 
     @query("#managerConfig-panel")
     protected realmConfigPanel?: OrConfPanel;
+
+    protected tilesForUpload: File;
 
     private readonly urlPrefix: string = (CONFIG_URL_PREFIX || "")
 
@@ -335,7 +341,24 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                                     </div>
 
                                     <div class="custom-tile-group">
-                                        <!-- TODO: Add file input -->
+                                        <div class="subheader">${i18next.t("configuration.global.mapTiles")}</div>
+                                        <span>${i18next.t("configuration.global.uploadMapTiles")}</span>
+                                        <div class="input d-inline-flex">
+                                            <or-file-uploader 
+                                                .label=${i18next.t("configuration.global.uploadMapTiles")}"
+                                                .accept="application/vnd.sqlite3"
+                                                @change="${(e: CustomEvent) => {
+                                                    const file = e.detail.value[0] as File;
+                                                    this.tilesForUpload = file;
+                                                    this.requestUpdate()
+                                                    this.mapConfigChanged = true;;
+                                                }}"></or-file-uploader>
+                                            <or-mwc-input type="${InputType.BUTTON}" iconColor="black" icon="delete" 
+                                                @or-mwc-input-changed="${async () => {
+                                                    await manager.rest.api.MapResource.removeMap()
+                                                }}" 
+                                            />
+                                        </div>
                                     </div>
                                 </div>
                                 <hr style="border: none; border-top: 1px solid #bbb; margin: 0; margin-bottom: 10px">
@@ -396,13 +419,13 @@ export class PageConfiguration extends Page<AppStateKeyed> {
 
         // Save the images to the server that have been uploaded by the user.
         // TODO: Optimize code so it only saves images that have been changed.
-        const imagePromises = [];
+        const filePromises = [];
         if(this.realmConfigPanel !== undefined) {
             const elems = this.realmConfigPanel.getCardElements() as OrConfRealmCard[];
             elems.forEach((elem, index) => {
                 const files = elem?.getFiles();
                 Object.entries(files).forEach(async ([x, y]) => {
-                    imagePromises.push(
+                    filePromises.push(
                         manager.rest.api.ConfigurationResource.fileUpload(y, {path: (y as any).path}).then(file =>{
                             config.realms[elem.name][x] = file.data;
                         })
@@ -423,11 +446,15 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                 });
         }
 
+        filePromises.push(manager.rest.api.MapResource.uploadMap({
+            data: this.tilesForUpload,
+            headers: {'Content-Type': 'application/octet-stream'}
+        }));
 
-        // We first wait for the imagePromises to finish, so that
+        // We first wait for the filePromises to finish, so that
         // we can use the path returned from the backend to store to the
         // manager_config.
-        Promise.all(imagePromises).then((arr:string[]) => {
+        Promise.all(filePromises).then((arr:string[]) => {
             // Wait for all requests to complete, then finish loading.
             const promises = [
                 this.managerConfigurationChanged ? manager.rest.api.ConfigurationResource.update(config) : null,

--- a/ui/app/manager/src/pages/page-configuration.ts
+++ b/ui/app/manager/src/pages/page-configuration.ts
@@ -467,10 +467,12 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                 });
         }
 
-        filePromises.push(manager.rest.api.MapResource.uploadMap({
-            data: this.tilesForUpload,
-            headers: {'Content-Type': 'application/octet-stream'}
-        }));
+        if (this.tilesForUpload) {
+            filePromises.push(manager.rest.api.MapResource.uploadMap({
+                data: this.tilesForUpload,
+                headers: {'Content-Type': 'application/octet-stream'}
+            }));
+        }
 
         // We first wait for the filePromises to finish, so that
         // we can use the path returned from the backend to store to the

--- a/ui/app/manager/src/pages/page-configuration.ts
+++ b/ui/app/manager/src/pages/page-configuration.ts
@@ -217,6 +217,9 @@ export class PageConfiguration extends Page<AppStateKeyed> {
     protected isMapCustom: boolean = false;
 
     @state()
+    protected customMapLimit: number = 1e+9;
+
+    @state()
     protected tilesForUpload: File;
 
     @query("#managerConfig-panel")
@@ -231,8 +234,15 @@ export class PageConfiguration extends Page<AppStateKeyed> {
     }
 
     public async firstUpdated() {
-        const response = await manager.rest.api.MapResource.isMapCustom();
+        const response = await manager.rest.api.MapResource.customMapInfo();
+        this.customMapLimit = response.data["custom-map-limit"]
         this.isMapCustom = response.data["map-custom"]
+    }
+
+    public humanReadableBytes(bytes: number) {
+        const unit = ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'];
+        const exponent = Math.floor(Math.log(bytes) / Math.log(1000));
+        return (bytes / Math.pow(1000, exponent)).toFixed(2) + " " + unit[exponent];
     }
 
     // On every update..
@@ -355,10 +365,14 @@ export class PageConfiguration extends Page<AppStateKeyed> {
 
                                     <div class="custom-tile-group">
                                         <div class="subheader"><or-translate value="configuration.global.mapTiles"></or-translate></div>
-                                        <span><or-translate value="configuration.global.uploadMapTiles"></or-translate></span>
+                                        <span><or-translate value="configuration.global.uploadMapTiles" .options=${{
+                                            customMapLimit: this.humanReadableBytes(this.customMapLimit)
+                                        }}></or-translate></span>
                                         <div class="input d-inline-flex">
                                             <or-file-uploader 
-                                                .label=${i18next.t("configuration.global.uploadMapTiles")}"
+                                                .label=${i18next.t("configuration.global.uploadMapTiles", {
+                                                    customMapLimit: this.humanReadableBytes(this.customMapLimit)
+                                                })}"
                                                 .accept=${".mbtiles"}
                                                 @change="${(e) => this.uploadCustomMap(e)}"></or-file-uploader>
                                             ${when(this.isMapCustom, () => html`

--- a/ui/app/manager/src/pages/page-configuration.ts
+++ b/ui/app/manager/src/pages/page-configuration.ts
@@ -29,12 +29,12 @@ import "@openremote/or-components/or-collapsible-panel";
 import "@openremote/or-mwc-components/or-mwc-input";
 import "../components/configuration/or-conf-json";
 import "../components/configuration/or-conf-panel";
-import {ManagerAppConfig, MapRealmConfig, Realm} from "@openremote/model";
+import {ManagerAppConfig, MapConfig, Realm} from "@openremote/model";
 import {i18next} from "@openremote/or-translate";
 import "@openremote/or-components/or-loading-indicator";
 import {OrConfRealmCard} from "../components/configuration/or-conf-realm/or-conf-realm-card";
 import {OrConfPanel} from "../components/configuration/or-conf-panel";
-import { InputType } from "@openremote/or-mwc-components/or-mwc-input";
+import { InputType, OrInputChangedEvent } from "@openremote/or-mwc-components/or-mwc-input";
 import {DefaultHeaderMainMenu, DefaultHeaderSecondaryMenu, DefaultRealmConfig} from "../index";
 
 declare const CONFIG_URL_PREFIX: string;
@@ -144,6 +144,46 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                     display: none;
                 }
             }
+
+            /* Global map settings */
+
+            .subheader {
+                padding: 10px 0 4px;
+                font-weight: bolder;
+            }
+
+            .global-settings-container {
+                display: flex;
+            }
+
+            .custom-server-group {
+                width: 50%;
+            }
+
+            .custom-tile-group {
+                width: 50%;
+                padding-left: 12px;
+            }
+
+            @media screen and (max-width: 768px) {
+                .custom-tile-group, .custom-server-group {
+                    width: 100%;
+                    padding: unset;
+                }
+                .global-settings-container {
+                    display: block;
+                }
+            }
+
+            .input {
+                width: 100%;
+                max-width: 800px;
+                padding: 10px 0;
+            }
+
+            .input or-mwc-input:not([icon]) {
+                width: 80%;
+            }
         `;
     }
 
@@ -155,7 +195,7 @@ export class PageConfiguration extends Page<AppStateKeyed> {
     public managerConfiguration?: ManagerAppConfig;
 
     @state()
-    public mapConfig?: {[id: string]: any};
+    public mapConfig?: MapConfig;
 
     @state()
     protected realms?: Realm[];
@@ -274,6 +314,32 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                         </or-panel>
                         <or-panel .heading="${i18next.t("configuration.mapSettings").toUpperCase()}">
                             ${when(this.mapConfig, () => html`
+                                <div class="global-settings-container">
+                                    <div class="custom-server-group">
+                                        <div class="subheader">${i18next.t("configuration.global.tileServer")}</div>
+                                        <span>${i18next.t("configuration.global.tileServerDescription")}</span>
+                                        <or-mwc-input class="input" outlined
+                                            .value="${this.mapConfig.sources?.['vector_tiles']?.tiles?.[0]}" 
+                                            .type="${InputType.URL}"
+                                            .label="${i18next.t("configuration.global.tileServerPlaceholder")}"
+                                            placeholder="https://api.example.com/tileset/{z}/{x}/{y}"
+                                            @or-mwc-input-changed="${(e: OrInputChangedEvent) => {
+                                                    this.mapConfig.sources["vector_tiles"] = {
+                                                        type: "vector",
+                                                        url: e.detail.value || null
+                                                    }
+                                                    this.requestUpdate("mapConfig");
+                                                    this.mapConfigChanged = true;
+                                                }}"
+                                        ></or-mwc-input>
+                                    </div>
+
+                                    <div class="custom-tile-group">
+                                        <!-- TODO: Add file input -->
+                                    </div>
+                                </div>
+                                <hr style="border: none; border-top: 1px solid #bbb; margin: 0; margin-bottom: 10px">
+                                
                                 <or-conf-panel id="mapConfig-panel" .config="${this.mapConfig}" .realmOptions="${realmOptions}"
                                                @change="${() => { this.mapConfigChanged = true; }}"
                                 ></or-conf-panel>
@@ -314,16 +380,17 @@ export class PageConfiguration extends Page<AppStateKeyed> {
         };
     }
 
-    protected async getMapConfig(): Promise<{[id: string]: any}> {
+    protected async getMapConfig(): Promise<MapConfig> {
         const response = await manager.rest.api.MapResource.getSettings();
-        return (response.data.options as {[id: string]: any});
+        const { options, sources } = response.data as MapConfig;
+        return { options, sources };
     }
 
     protected async getAccessibleRealms(): Promise<Realm[]> {
         return (await manager.rest.api.RealmResource.getAccessible()).data;
     }
 
-    protected saveAllConfigs(config: ManagerAppConfig, mapConfig: {[p: string]: MapRealmConfig}) {
+    protected saveAllConfigs(config: ManagerAppConfig, mapConfig: MapConfig) {
         this.loading = true;
         let managerPromise;
 

--- a/ui/app/manager/src/pages/page-configuration.ts
+++ b/ui/app/manager/src/pages/page-configuration.ts
@@ -213,6 +213,9 @@ export class PageConfiguration extends Page<AppStateKeyed> {
     @state()
     protected mapConfigChanged = false;
 
+    @state()
+    protected isMapCustom: boolean = false;
+
     @query("#managerConfig-panel")
     protected realmConfigPanel?: OrConfPanel;
 
@@ -224,6 +227,11 @@ export class PageConfiguration extends Page<AppStateKeyed> {
     /* ------------------------------------------ */
 
     public stateChanged(state: AppStateKeyed) {
+    }
+
+    public async firstUpdated() {
+        const response = await manager.rest.api.MapResource.isMapCustom();
+        this.isMapCustom = response.data["map-custom"]
     }
 
     // On every update..
@@ -347,17 +355,12 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                                             <or-file-uploader 
                                                 .label=${i18next.t("configuration.global.uploadMapTiles")}"
                                                 .accept="application/vnd.sqlite3"
-                                                @change="${(e: CustomEvent) => {
-                                                    const file = e.detail.value[0] as File;
-                                                    this.tilesForUpload = file;
-                                                    this.requestUpdate()
-                                                    this.mapConfigChanged = true;;
-                                                }}"></or-file-uploader>
-                                            <or-mwc-input type="${InputType.BUTTON}" iconColor="black" icon="delete" 
-                                                @or-mwc-input-changed="${async () => {
-                                                    await manager.rest.api.MapResource.removeMap()
-                                                }}" 
-                                            />
+                                                @change="${(e) => this.uploadCustomMap(e)}"></or-file-uploader>
+                                            ${when(this.isMapCustom, () => html`
+                                                    <or-mwc-input type="${InputType.BUTTON}" iconColor="black" icon="delete" 
+                                                        @or-mwc-input-changed="${async () => await this.deleteCustomMap()}" 
+                                                    />
+                                            `)}
                                         </div>
                                     </div>
                                 </div>
@@ -391,7 +394,25 @@ export class PageConfiguration extends Page<AppStateKeyed> {
 
     // FETCH METHODS
 
-    protected async getManagerConfig(): Promise<ManagerAppConfig> {
+    protected async uploadCustomMap(e: CustomEvent) {
+        const file = e.detail.value[0] as File;
+        this.tilesForUpload = file;
+        this.requestUpdate()
+        this.mapConfigChanged = true;
+    }
+
+    protected async deleteCustomMap() {
+        const response = await manager.rest.api.MapResource.deleteMap();
+
+        if (response.status !== 204) {
+            console.error("Map delete failed")
+            return
+        }
+
+        window.location.reload();
+    }
+
+    protected async getManagerConfig(): Promise<ManagerAppConfig | undefined> {
         const response = await manager.rest.api.ConfigurationResource.getManagerConfig();
         return response.status === 200 ? response.data as ManagerAppConfig : {
             realms: {

--- a/ui/app/manager/src/pages/page-configuration.ts
+++ b/ui/app/manager/src/pages/page-configuration.ts
@@ -359,7 +359,7 @@ export class PageConfiguration extends Page<AppStateKeyed> {
                                         <div class="input d-inline-flex">
                                             <or-file-uploader 
                                                 .label=${i18next.t("configuration.global.uploadMapTiles")}"
-                                                .accept="application/vnd.sqlite3"
+                                                .accept=${".mbtiles"}
                                                 @change="${(e) => this.uploadCustomMap(e)}"></or-file-uploader>
                                             ${when(this.isMapCustom, () => html`
                                                     <or-mwc-input type="${InputType.BUTTON}" iconColor="black" icon="delete" 
@@ -475,6 +475,8 @@ export class PageConfiguration extends Page<AppStateKeyed> {
             filePromises.push(manager.rest.api.MapResource.uploadMap({
                 data: this.tilesForUpload,
                 headers: {'Content-Type': 'application/octet-stream'}
+            }).catch((reason) => {
+                console.error(reason);
             }));
         }
 

--- a/ui/app/shared/locales/en/or.json
+++ b/ui/app/shared/locales/en/or.json
@@ -809,7 +809,7 @@
       "tileServerDescription": "Configure a tile server. The URL must specify the tile coordinates using the /{z}/{x}/{y} scheme.",
       "tileServerPlaceholder": "Map Server URL",
       "mapTiles": "Custom Map Tiles",
-      "uploadMapTiles": "Upload custom map tiles."
+      "uploadMapTiles": "Upload custom map tiles. The maximum allowed file size is {{customMapLimit}}."
     }
   },
   "mqttSessions": "MQTT sessions",

--- a/ui/app/shared/locales/en/or.json
+++ b/ui/app/shared/locales/en/or.json
@@ -803,7 +803,12 @@
     "geoJsonDescription": "Customize the GeoJSON; add points, lines and polygons to be drawn on the map.",
     "deleteMapCustomization": "Delete map settings",
     "deleteMapCustomizationConfirm":"Are you sure you want to delete this Map customization?",
-    "addMapCustomization" : "Add map settings"
+    "addMapCustomization" : "Add map settings",
+    "global": {
+      "tileServer": "Custom Tile Server",
+      "tileServerDescription": "Configure a tile server. The URL must specify the tile coordinates using the /{z}/{x}/{y} scheme.",
+      "tileServerPlaceholder": "Map Server URL"
+    }
   },
   "mqttSessions": "MQTT sessions",
   "address": "Address",

--- a/ui/app/shared/locales/en/or.json
+++ b/ui/app/shared/locales/en/or.json
@@ -807,7 +807,9 @@
     "global": {
       "tileServer": "Custom Tile Server",
       "tileServerDescription": "Configure a tile server. The URL must specify the tile coordinates using the /{z}/{x}/{y} scheme.",
-      "tileServerPlaceholder": "Map Server URL"
+      "tileServerPlaceholder": "Map Server URL",
+      "mapTiles": "Custom Map Tiles",
+      "uploadMapTiles": "Upload custom map tiles."
     }
   },
   "mqttSessions": "MQTT sessions",

--- a/ui/app/shared/locales/nl/or.json
+++ b/ui/app/shared/locales/nl/or.json
@@ -800,7 +800,14 @@
     "geoJsonDescription": "Bewerk de GeoJSON; voeg punten, lijnen, en andere vormen toe aan de kaart.",
     "deleteMapCustomization": "Kaartinstelling verwijderen",
     "deleteMapCustomizationConfirm":"Weet je zeker dat je deze kaart wilt verwijderen",
-    "addMapCustomization" : "Voeg een Kaartinstelling toe"
+    "addMapCustomization" : "Voeg een Kaartinstelling toe",
+    "global": {
+      "tileServer": "Eigen Tegel Server",
+      "tileServerDescription": "Configureer een Tegel server. De URL moet de tegelcoördinaten specificeren met behulp van het /{z}/{x}/{y} schema.",
+      "tileServerPlaceholder": "Kaartserver URL",
+      "mapTiles": "Eigen Kaarttegels",
+      "uploadMapTiles": "Upload aangepaste kaarttegels."
+    }
   },
   "realmRole": {
     "admin": "Super admin"

--- a/ui/app/shared/locales/nl/or.json
+++ b/ui/app/shared/locales/nl/or.json
@@ -806,7 +806,7 @@
       "tileServerDescription": "Configureer een Tegel server. De URL moet de tegelcoördinaten specificeren met behulp van het /{z}/{x}/{y} schema.",
       "tileServerPlaceholder": "Kaartserver URL",
       "mapTiles": "Eigen Kaarttegels",
-      "uploadMapTiles": "Upload aangepaste kaarttegels."
+      "uploadMapTiles": "Upload aangepaste kaarttegels. De maximaal toegestane bestandsgrootte is {{customMapLimit}}."
     }
   },
   "realmRole": {

--- a/ui/component/or-map/src/mapwidget.ts
+++ b/ui/component/or-map/src/mapwidget.ts
@@ -313,8 +313,11 @@ export class MapWidget {
                 container: this._mapContainer,
                 style: settings as StyleSpecification,
                 transformRequest: (url, resourceType) => {
+                    // Cross-domain tile servers usually have the following headers specified "access-control-allow-methods	GET", "access-control-allow-origin *", "allow GET,HEAD". The "Access-Control-Request-Headers: Authorization" may not be set e.g. with Mapbox tile servers. The CORS preflight request (OPTION) will in this case fail if the "authorization" header is being requested cross-domain. The only headers allowed are so called "simple request" headers, see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests.
+                    const headers = new URL(window.origin).hostname === new URL(url).hostname 
+                        ? {Authorization: manager.getAuthorizationHeader()} : {}
                     return {
-                        headers: {Authorization: manager.getAuthorizationHeader()},
+                        headers,
                         url
                     };
                 }


### PR DESCRIPTION
## Description

Adds the ability to configure a custom tile server and upload custom vector tiles.

Tile Server
- Only accepts tile servers that support `/{z}/{x}/{y}` scheme.
- Takes precedence over custom tile uploads.

Tile Upload
- By default only accepts 1GB tile uploads and expects `*.mbtiles`.
- Validates the tile database file is a valid SQLite database.
- Allows overwriting tile upload limit with `OR_CUSTOM_MAP_SIZE_LIMIT` environment variable.

original pr: https://github.com/openremote/openremote/pull/1494

## Checklist

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

