### PR TITLE
Updated meta tags to not include 'demo'

### DIFF
--- a/ui/app/console_loader/index.html
+++ b/ui/app/console_loader/index.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes, viewport-fit=cover">
 
-    <title>OpenRemote Demo</title>
-    <meta name="application-name" content="OpenRemote Demo">
+    <title>OpenRemote</title>
+    <meta name="application-name" content="OpenRemote">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta name="apple-mobile-web-app-title" content="OpenRemote Demo">
+    <meta name="apple-mobile-web-app-title" content="OpenRemote">
 
     <meta name="msapplication-TileImage" content="images/Icon-144.png">
     <meta name="msapplication-TileColor" content="#ffffff">

--- a/ui/app/console_loader/src/index.ts
+++ b/ui/app/console_loader/src/index.ts
@@ -85,7 +85,7 @@ const appConfig: AppConfig<RootState> = {
     ],
     realms: {
         default: {
-            appTitle: "OpenRemote Demo",
+            appTitle: "OpenRemote",
             logo: require("../images/logo.png"),
             logoMobile: require("../images/logo-mobile.png")
         }

--- a/ui/app/insights/index.html
+++ b/ui/app/insights/index.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes, viewport-fit=cover">
 
-    <title>OpenRemote Demo</title>
-    <meta name="application-name" content="OpenRemote Demo">
+    <title>OpenRemote Insights</title>
+    <meta name="application-name" content="OpenRemote Insights">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta name="apple-mobile-web-app-title" content="OpenRemote Demo">
+    <meta name="apple-mobile-web-app-title" content="OpenRemote Insights">
 
     <meta name="msapplication-TileImage" content="images/Icon-144.png">
     <meta name="msapplication-TileColor" content="#ffffff">

--- a/ui/app/manager/index.html
+++ b/ui/app/manager/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
     <title></title>
-    <meta name="application-name" content="OpenRemote Demo">
+    <meta name="application-name" content="OpenRemote">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta name="apple-mobile-web-app-title" content="OpenRemote Demo">
+    <meta name="apple-mobile-web-app-title" content="OpenRemote">
 
     <meta name="msapplication-TileImage" content="images/Icon-144.png">
     <meta name="msapplication-TileColor" content="#ffffff">


### PR DESCRIPTION
## Description
We discovered an issue where embeds of links to the OpenRemote Manager UI, included the word 'demo' in it.
In this case it was a link to a custom project with branding, causing confusion of "the instance not being a demo".

This was because the default meta tags of the Manager app were not correct.
The change is quite straightforward.

## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Changes are manually tested by you and the reviewer
