### PR TITLE
Publish test sources and JavaDoc artifacts

### DIFF
--- a/test/build.gradle
+++ b/test/build.gradle
@@ -90,6 +90,11 @@ javadoc {
     failOnError = false
 }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 publishing {
     publications {
         maven(MavenPublication) {


### PR DESCRIPTION
The openremote-test JAR created with the changes in https://github.com/openremote/openremote/pull/1723 is missing sources/JavaDocs. Because of this the Sources and JavaDoc validation fails when trying to publish it to Maven Central.