### PR TITLE
Chart: Bugfix for undefined unit text on predicted datapoints

### DIFF
--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -1126,6 +1126,7 @@ export class OrChart extends translate(i18next)(LitElement) {
                     data.push(dataset);
 
                     dataset = await this._loadAttributeData(this.assets[assetIndex], attribute, this.colors[colourIndex], predictedFromTimestamp, this._endOfPeriod!, true, asset.name + " " + label + " " + i18next.t("predicted"), options);
+                    (dataset as any).unit = unit;
                     data.push(dataset);
                 });
             }


### PR DESCRIPTION
Minor fox for the `undefined` text that is currently shown when hovering over any predicted datapoints in the or-chart

**Before**
![afbeelding](https://github.com/user-attachments/assets/9ee115e1-a9b5-4b6b-b81c-faa451f91b84)

**After**
![afbeelding](https://github.com/user-attachments/assets/89168819-f5a8-4c6f-b187-ebcb0e0d6db8)