### PR TITLE
Bug fix for asset update of unkown asset types

### DIFF
--- a/manager/src/main/java/org/openremote/manager/asset/AssetResourceImpl.java
+++ b/manager/src/main/java/org/openremote/manager/asset/AssetResourceImpl.java
@@ -280,6 +280,7 @@ public class AssetResourceImpl extends ManagerWebResource implements AssetResour
         }
     }
 
+    // TODO: AssetResource update should not overwrite the existing asset
     @Override
     public Asset<?> update(RequestParams requestParams, String assetId, Asset<?> asset) {
 

--- a/manager/src/main/java/org/openremote/manager/asset/AssetStorageService.java
+++ b/manager/src/main/java/org/openremote/manager/asset/AssetStorageService.java
@@ -47,6 +47,7 @@ import org.openremote.model.asset.*;
 import org.openremote.model.asset.impl.GatewayAsset;
 import org.openremote.model.asset.impl.GroupAsset;
 import org.openremote.model.asset.impl.ThingAsset;
+import org.openremote.model.asset.impl.UnknownAsset;
 import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.attribute.AttributeMap;
@@ -787,7 +788,20 @@ public class AssetStorageService extends RouteBuilder implements ContainerServic
                 }
             }
 
-            T updatedAsset = em.merge(asset);
+            T updatedAsset;
+
+            if (existingAsset instanceof UnknownAsset && !(asset instanceof UnknownAsset)) {
+                // This occurs when an existing asset is merged but the type is unknown
+                // We'll copy updates into existing asset
+                existingAsset.setAttributes(asset.getAttributes());
+                existingAsset.setName(asset.getName());
+                existingAsset.setVersion(asset.getVersion());
+                existingAsset.setParentId(asset.getParentId());
+                existingAsset.setAccessPublicRead(asset.isAccessPublicRead());
+                updatedAsset = em.merge(existingAsset);
+            } else {
+                updatedAsset = em.merge(asset);
+            }
 
             if (LOG.isLoggable(FINE)) {
                 LOG.fine("Asset merge took: " + (System.currentTimeMillis() - startTime) + "ms");

--- a/model/src/main/java/org/openremote/model/asset/impl/UnknownAsset.java
+++ b/model/src/main/java/org/openremote/model/asset/impl/UnknownAsset.java
@@ -25,7 +25,7 @@ import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 
 /**
- * This is only needed so JPA can deserialise an Asset whose type doesn't match an entity otherwise it is un-used
+ * This is used for deserializing assets whose type is unknown to this instance
  */
 @Entity
 @DiscriminatorValue("not null")

--- a/model/src/main/java/org/openremote/model/jackson/AssetTypeIdResolver.java
+++ b/model/src/main/java/org/openremote/model/jackson/AssetTypeIdResolver.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
 import org.openremote.model.asset.Asset;
 import org.openremote.model.asset.AssetDescriptor;
 import org.openremote.model.asset.impl.ThingAsset;
+import org.openremote.model.asset.impl.UnknownAsset;
 import org.openremote.model.util.ValueUtil;
 
 import java.io.IOException;

--- a/test/src/test/groovy/org/openremote/test/model/AssetModelTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/model/AssetModelTest.groovy
@@ -53,6 +53,8 @@ class AssetModelTest extends Specification implements ManagerContainerTrait {
 
     @Shared
     static AssetModelResource assetModelResource
+    @Shared
+    static AssetStorageService assetStorageService
 
     static String CUSTOM_ASSET_TYPE = "CustomAsset"
     static ValueDescriptor[] dynamicValueDescriptors = [new ValueDescriptor("dynamicValue", null, ValueConstraint.constraints(new ValueConstraint.AllowedValues("value1", "value2")), null, null, null)]
@@ -75,6 +77,7 @@ class AssetModelTest extends Specification implements ManagerContainerTrait {
         container.getService(AssetModelService).initDynamicModel()
         ValueUtil.doInitialise()
         assetModelResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM).proxy(AssetModelResource.class)
+        assetStorageService = container.getService(AssetStorageService.class)
     }
 
     def "Check AttributeMap equality checking"() {
@@ -388,6 +391,14 @@ class AssetModelTest extends Specification implements ManagerContainerTrait {
         customAsset.getAttribute("attr1").get().type == ValueType.TIMESTAMP
         customAsset.getAttribute("attr2").get().type == ValueType.POSITIVE_INTEGER
         customAsset.getAttribute("attr2").get().value.orElse(0) == 3
+
+        when: "we make a change to the asset and merge it directly into the asset storage service (bypassing any cloning logic in AssetResource)"
+        customAsset.getAttribute("dynamic1").ifPresent {it.setValue("value2")}
+        customAsset = assetStorageService.merge(customAsset, false, null, null)
+
+        then: "it should succeed"
+        customAsset.getAttribute("dynamic1").flatMap {it.value}.orElse(null) == "value2"
+        customAsset.type == "CustomAsset"
     }
 
     def "Retrieving all asset model info"() {


### PR DESCRIPTION
Fixes #1786

This problem doesn't occur when using HTTP API because that overlays asset changes onto existing asset but it will occur with any other call to `AssetStorageService.merge()` (e.g. `GatewayConnector.saveAssetLocally()`).

The issue arises because `AssetTypeIdResolver` resolves unknown types as `ThingAsset` but JPA uses `UnknownAsset` and the following exception is thrown:
```
org.hibernate.NonUniqueObjectException: A different object with the same identifier value was already associated with the session : [org.openremote.model.asset.impl.ThingAsset]
```

I tried changing the `AssetTypeIdResolver` to use `UnkownAsset` but JPA will not allow instances of `UnknownAsset` to be created as it is using the `@DiscriminatorValue("not null")` annotation and the following exception is thrown:
```
org.hibernate.exception.ConstraintViolationException: could not execute statement [ERROR: null value in column "type" of relation "asset" violates not-null constraint
```

The solution implemented here works ok but code in `AssetResourceImpl.update()` should be unified.