### PR TITLE
UI updates: Removed 'autoclose' for tunnel widget

### DIFF
--- a/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
+++ b/ui/component/or-dashboard-builder/src/widgets/gateway-widget.ts
@@ -97,20 +97,9 @@ export class GatewayWidget extends OrWidget {
     }
 
     disconnectedCallback() {
-        if(this._activeTunnel) {
-            if(this._startedByUser) {
-                this._stopTunnel(this._activeTunnel).then(() => {
-                    console.warn("Stopped the active tunnel, as it was created through the widget.");
-                });
-            } else {
-                console.warn("Keeping the active tunnel open, as it is not started through the widget.");
-            }
-        }
-
         if (this._refreshTimer) {
             clearTimeout(this._refreshTimer);
         }
-
         super.disconnectedCallback();
     }
 


### PR DESCRIPTION
### Description
Now, tunnels do not automatically close after reloading or closing the gateway widget.

Fixes #1804 

### Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer