### PR TITLE
Corrected README of or-attribute-picker, so it references the correct component

### DIFF
--- a/ui/component/or-attribute-picker/README.md
+++ b/ui/component/or-attribute-picker/README.md
@@ -1,14 +1,14 @@
-# @openremote/or-attribute-input  \<or-attribute-input\>
+# @openremote/or-attribute-picker  \<or-attribute-picker\>
 [![NPM Version][npm-image]][npm-url]
 [![Linux Build][travis-image]][travis-url]
 [![Test Coverage][coveralls-image]][coveralls-url]
 
-Web Component for displaying an input control.
+Web Component for displaying a dialog to select an attribute.
 
 ## Install
 ```bash
-npm i @openremote/or-attribute-input
-yarn add @openremote/or-attribute-input
+npm i @openremote/or-attribute-picker
+yarn add @openremote/or-attribute-picker
 ```
 
 ## Usage
@@ -24,7 +24,7 @@ Internet Explorer 11 is also supported.
 [GNU AGPL](https://www.gnu.org/licenses/agpl-3.0.en.html)
 
 [npm-image]: https://img.shields.io/npm/v/live-xxx.svg
-[npm-url]: https://npmjs.org/package/@openremote/or-attribute-input
+[npm-url]: https://npmjs.org/package/@openremote/or-attribute-picker
 [travis-image]: https://img.shields.io/travis/live-js/live-xxx/master.svg
 [travis-url]: https://travis-ci.org/live-js/live-xxx
 [coveralls-image]: https://img.shields.io/coveralls/live-js/live-xxx/master.svg


### PR DESCRIPTION
Fix for `or-attribute-picker` README markdown file, as it was referring to a different component.