### PR TITLE
Asset lock enhancements

### DIFF
--- a/container/src/main/java/org/openremote/container/message/MessageBrokerService.java
+++ b/container/src/main/java/org/openremote/container/message/MessageBrokerService.java
@@ -30,6 +30,7 @@ import org.apache.camel.impl.health.ConsumersHealthCheckRepository;
 import org.apache.camel.impl.health.ContextHealthCheck;
 import org.apache.camel.impl.health.DefaultHealthCheckRegistry;
 import org.apache.camel.impl.health.RoutesHealthCheckRepository;
+import org.apache.camel.model.RedeliveryPolicyDefinition;
 import org.apache.camel.spi.ExecutorServiceManager;
 import org.apache.camel.spi.StreamCachingStrategy;
 import org.apache.camel.spi.ThreadPoolFactory;
@@ -122,8 +123,11 @@ public class MessageBrokerService implements ContainerService {
         StreamCachingStrategy streamCachingStrategy = new DefaultStreamCachingStrategy();
         streamCachingStrategy.setSpoolThreshold(524288); // Half megabyte
         context.setStreamCachingStrategy(streamCachingStrategy);
-
-        context.getCamelContextExtension().setErrorHandlerFactory(new DefaultErrorHandlerBuilder());
+        RedeliveryPolicyDefinition redeliveryPolicy = new RedeliveryPolicyDefinition();
+        redeliveryPolicy.setAsyncDelayedRedelivery("false");
+        DefaultErrorHandlerBuilder errorHandler = new DefaultErrorHandlerBuilder();
+        errorHandler.setRedeliveryPolicy(redeliveryPolicy);
+        context.getCamelContextExtension().setErrorHandlerFactory(errorHandler);
 
         if (container.isDevMode()) {
             context.setMessageHistory(true);

--- a/manager/src/main/java/org/openremote/manager/asset/AssetProcessingService.java
+++ b/manager/src/main/java/org/openremote/manager/asset/AssetProcessingService.java
@@ -54,6 +54,8 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.openremote.model.attribute.AttributeWriteFailure.*;
 
@@ -67,7 +69,7 @@ import static org.openremote.model.attribute.AttributeWriteFailure.*;
  * <p>
  * <h2>Rules Service processing logic</h2>
  * <p>
- * Checks if attribute has {@link MetaItemType#RULE_STATE} and/or {@link MetaItemType#RULE_EVENT} {@link MetaItem}s,
+ * Checks if attribute has {@link MetaItemType#RULE_STATE} {@link MetaItem},
  * and if so the message is passed through the rule engines that are in scope for the asset.
  * <p>
  * <h2>Asset Storage Service processing logic</h2>
@@ -289,9 +291,24 @@ public class AssetProcessingService extends RouteBuilder implements ContainerSer
                     counter.increment();
                 }
 
-                boolean processed = eventTimer != null ?
-                    eventTimer.record(() -> processAttributeEvent(event)) :
-                    processAttributeEvent(event);
+                boolean processed;
+
+                if (eventTimer != null) {
+                    AtomicReference<TimeoutException> ex = new AtomicReference<>();
+                    processed = eventTimer.record(() -> {
+                        try {
+                            return processAttributeEvent(event);
+                        } catch (TimeoutException e) {
+                            ex.set(e);
+                        }
+                        return false;
+                    });
+                    if (ex.get() != null) {
+                        throw ex.get();
+                    }
+                } else {
+                    processed = processAttributeEvent(event);
+                }
 
                 exchange.getIn().setBody(processed);
             });
@@ -338,7 +355,7 @@ public class AssetProcessingService extends RouteBuilder implements ContainerSer
      * The {@link AttributeEvent} is passed to each registered {@link AttributeEventInterceptor} and if no interceptor
      * handles the event then the {@link Attribute} value is updated in the DB with the new event value and timestamp.
      */
-    protected boolean processAttributeEvent(AttributeEvent event) throws AssetProcessingException {
+    protected boolean processAttributeEvent(AttributeEvent event) throws AssetProcessingException, TimeoutException {
 
         return assetStorageService.withAssetLock(event.getId(),() -> {
 

--- a/manager/src/main/resources/logging-dev.properties
+++ b/manager/src/main/resources/logging-dev.properties
@@ -69,3 +69,4 @@ com.icegreen.greenmail.util.LineLoggingBuffer.level=INFO
 
 # Set to SEVERE to log invalid access tokens
 org.keycloak.adapters.BearerTokenRequestAuthenticator.level=OFF
+org.openremote.model.util.LockByKey.level=ALL


### PR DESCRIPTION
## Description
This PR is here to capture necessary additional improvements to the asset lock where issues were initially identified in #1812, some additional goals:

- Try to revert to ReentrantLock instead of Semaphore due to these objects being instantiated frequently and the former being more lightweight 
- Memory leak protection on edge cases
- Timeout on locks

Before being able to switch back to ReentrantLock then the cause of the threading issue in #1812 needs to be identified and addressed so that `unlock()` is always called by the same thread that called `lock()`. The stacktrace in the mentioned issue suggested that camel route processing was the cause of the thread context switch between the try and finally statements but I am not so sure about that and have been trying to recreate the exception (without success) using this simple test in a branch of the old `LockByKey`:

https://github.com/openremote/openremote/blob/asset_lock_investigation/test/src/test/groovy/org/openremote/test/benchmark/AttributeEventBenchmarkTest.groovy#L192

I think we need to get to the bottom of how these `IllegalMonitorStateException` errors are occurring to be able to correctly address this issue going forward, the error can be seen in many production environments by running the following command in an SSH session:
```
docker logs or-manager-1 2>&1 | grep 'IllegalMonitorStateException'
```

Whenever this exception occurs then it is likely that no changes can be made or attribute events processed for the assetID that currently owns the lock and due to there being no timeout on lock requests all Container executor threads can become blocked.