### PR TITLE
UI Fix: Flow Rules wiring not removed anymore during user changes

### DIFF
--- a/ui/component/or-rules/src/flow-viewer/services/project.ts
+++ b/ui/component/or-rules/src/flow-viewer/services/project.ts
@@ -221,7 +221,7 @@ export class Project extends EventEmitter {
     }
 
     public removeInvalidConnections() {
-        for (const c of this.connections.map(c => this.enrichConnection(c)).filter(async (j) => !(this.isValidConnection(j)))) {
+        for (const c of this.connections.map(c => this.enrichConnection(c)).filter(j => !this.isValidConnection(j))) {
             this.removeConnection(c);
         }
     }


### PR DESCRIPTION
### Description
Fixes #1827

The changes made in #1525 introduced a bug where every wire was removed in Flow Rules, after **any** change was made.
Turned out that an asynchronous `.filter()` function was used, which is impossible without an `await` keyword.
The `isValidConnection()` function does not return a `Promise<>`, so we can simply remove the asynchronous behavior here.

### Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Reproduction steps in the linked issue are tested and verified. (both locally, and on a deployment)
- [ ] 3. Changes are manually tested by you and the reviewer
