### PR TITLE
UI Fix: Insights can now be opened without authentication again

### DIFF
--- a/ui/app/insights/src/pages/page-view.ts
+++ b/ui/app/insights/src/pages/page-view.ts
@@ -79,7 +79,6 @@ export class PageView extends Page<AppStateKeyed> {
         super(props);
 
         // Register user
-        console.debug("Loading view dashboard page.. Login state:", manager.authenticated);
         if(manager.authenticated) {
             const userPromise = manager.rest.api.UserResource.getCurrent().then((response: any) => { this._userId = response.data.id; });
             this.registerPromise('user', userPromise, true, true);

--- a/ui/app/insights/src/pages/page-view.ts
+++ b/ui/app/insights/src/pages/page-view.ts
@@ -79,8 +79,11 @@ export class PageView extends Page<AppStateKeyed> {
         super(props);
 
         // Register user
-        const userPromise = manager.rest.api.UserResource.getCurrent().then((response: any) => { this._userId = response.data.id; });
-        this.registerPromise('user', userPromise, true, true);
+        console.debug("Loading view dashboard page.. Login state:", manager.authenticated);
+        if(manager.authenticated) {
+            const userPromise = manager.rest.api.UserResource.getCurrent().then((response: any) => { this._userId = response.data.id; });
+            this.registerPromise('user', userPromise, true, true);
+        }
 
         // Load available realms
         const realmPromise = manager.rest.api.RealmResource.getAccessible().then((response: any) => { this._loadedRealms = response.data; });

--- a/ui/component/core/src/index.ts
+++ b/ui/component/core/src/index.ts
@@ -687,7 +687,6 @@ export class Manager implements EventProviderFactory {
      * Checks the keycloak access token to gather the preferred language of a user.
      */
     public async getUserPreferredLanguage(keycloak = this._keycloak): Promise<string | undefined> {
-        console.debug("Getting user preferred language... Are they logged in?", keycloak?.authenticated);
 
         if(keycloak && keycloak.authenticated) {
             const profile: Keycloak.KeycloakProfile | undefined = keycloak?.profile || await keycloak?.loadUserProfile();


### PR DESCRIPTION
### Description
Fixes #1770

This PR includes a fix for the standalone Insights web app, where unauthenticated access was throwing exceptions.
The Insights app is accessible without a user login, since dashboards can be distributed publicly.
Due to recent changes with the localization (updating user language in Keycloak), the Insights app produced 403 errors
because they were not logged in.

Now, the "keycloak user language" related logic is skipped when not logged in.

### Changelog
- Now skipping GET `/user/user` in Insights custom app when unauthenticated.
- Fix for `core` attempting to update user language (in Keycloak) when not being logged in. Now skipping this step.
- Fix for `core` requesting user language (from Keycloak) when not being logged in. Now skipping this step.

### Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Reproduction steps in the linked issue are tested and verified. (both locally, and on a deployment)
- [ ] 3. Changes are manually tested by you and the reviewer
