### PR TITLE
Bug fix for slow loading on /assets page for many linked users

### DIFF
--- a/manager/src/main/java/org/openremote/manager/security/UserResourceImpl.java
+++ b/manager/src/main/java/org/openremote/manager/security/UserResourceImpl.java
@@ -246,17 +246,15 @@ public class UserResourceImpl extends ManagerWebResource implements org.openremo
 
     @Override
     public UserRoles[] getUsersRoles(RequestParams params, String realm, String clientId, String[] userIds) {
-
         boolean hasAdminReadRole = hasResourceRole(ClientRole.READ_ADMIN.getValue(), Constants.KEYCLOAK_CLIENT_ID);
         String me = getUserId();
 
-        // enforce “you can only fetch your own roles unless you're admin”
         for (String uId : userIds) {
             if (!hasAdminReadRole && !Objects.equals(me, uId)) {
                 throw new ForbiddenException("Can only retrieve own user roles unless you have role '" + ClientRole.READ_ADMIN + "'");
             }
         }
-        //location of try good?
+        
         List<UserRoles> result = new ArrayList<>();
         for (String uId : userIds) {
             try {

--- a/model/src/main/java/org/openremote/model/security/UserResource.java
+++ b/model/src/main/java/org/openremote/model/security/UserResource.java
@@ -28,6 +28,8 @@ import org.openremote.model.Constants;
 import org.openremote.model.http.RequestParams;
 import org.openremote.model.query.UserQuery;
 
+import java.util.List;
+
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 /**
@@ -127,6 +129,13 @@ public interface UserResource {
     @Produces(APPLICATION_JSON)
     @Operation(operationId = "getUserRealmRoles", summary = "Retrieve realm roles for a user in a realm")
     String[] getUserRealmRoles(@BeanParam RequestParams requestParams, @PathParam("realm") String realm, @PathParam("userId") String userId);
+
+    @POST
+    @Path("{realm}/userRoles/batch")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @Operation(operationId = "getUsersRoles", summary = "Retrieve client and realm roles for multiple users in a realm")
+    UserRoles[] getUsersRoles(@BeanParam RequestParams params, @PathParam("realm") String realm, @QueryParam("clientId") String clientId, String[] userIds);
 
     @GET
     @Path("userRoles/{clientId}")

--- a/model/src/main/java/org/openremote/model/security/UserRoles.java
+++ b/model/src/main/java/org/openremote/model/security/UserRoles.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017, OpenRemote Inc.
+ *
+ * See the CONTRIBUTORS.txt file in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.openremote.model.security;
+
+public class UserRoles {
+    private String userId;
+    private String[] clientRoles;
+    private String[] realmRoles;
+    private boolean restrictedUser;
+
+    public UserRoles() {}
+
+    public UserRoles(String userId, String[] clientRoles, String[] realmRoles, boolean restrictedUser) {
+        this.userId = userId;
+        this.clientRoles = clientRoles;
+        this.realmRoles = realmRoles;
+        this.restrictedUser = restrictedUser;
+    }
+
+    public String getUserId() { return userId; }
+    public void setUserId(String userId) { this.userId = userId; }
+
+    public String[] getClientRoles() { return clientRoles; }
+    public void setClientRoles(String[] clientRoles) { this.clientRoles = clientRoles; }
+
+    public String[] getRealmRoles() { return realmRoles; }
+    public void setRealmRoles(String[] realmRoles) { this.realmRoles = realmRoles; }
+
+    public boolean isRestrictedUser() { return restrictedUser; }
+    public void setRestrictedUser(boolean restrictedUser) { this.restrictedUser = restrictedUser; }
+}


### PR DESCRIPTION
## Description
<!--
-->
/assets page takes a long time to load when there are many linked users. Pagination, an improved endpoint, or a loading indicator could be used to address this. 

- Added new UserResource endpoint to retrieve batch user roles.
- Introduced UserRoles class to encapsulate role-related data in backend responses. 
- Refactored frontend logic to make use of the new batch endpoint when fetching user roles. 

This simplifies user role fetching by reducing multiple API calls to a single batch request, improving efficiency and addressing part of the performance concern.

While this improves the endpoint as suggested in the issue, it is a partial fix. Additional work (e.g. pagination, UI loading indicators) will be needed to fully resolve the problem.

#1803

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
