### PR TITLE
bugfix/missing map metadata

### DIFF
--- a/manager/src/main/java/org/openremote/manager/map/MapService.java
+++ b/manager/src/main/java/org/openremote/manager/map/MapService.java
@@ -146,6 +146,9 @@ public class MapService implements ContainerService {
 
             if (!TextUtil.isNullOrEmpty(attribution) && vectorLayer != null && !vectorLayer.isEmpty() && maxZoom > 0) {
                 metadata = new Metadata(attribution, vectorLayer, bounds, center, maxZoom, minZoom);
+            } else {
+                metadata = new Metadata();
+                LOG.log(Level.SEVERE, "Required metadata missing in mbtiles DB");
             }
         } catch (Exception ex) {
             metadata = new Metadata();


### PR DESCRIPTION
## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Fixes the `getMetadata` method to always set metadata.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
