### PR TITLE
Hotfix for dashboard ID being specified when duplicating it in the UI.

### DIFF
--- a/ui/component/or-dashboard-builder/src/service/dashboard-service.ts
+++ b/ui/component/or-dashboard-builder/src/service/dashboard-service.ts
@@ -23,7 +23,7 @@ export class DashboardService {
                 }
             } as Dashboard;
         } else {
-            dashboard.id = randomId();
+            dashboard.id = undefined;
             if(dashboard.template) {
                 dashboard.template.id = randomId();
                 dashboard.template.widgets?.forEach(w => w.id = randomId());


### PR DESCRIPTION
## Description
This is a hotfix for duplicating dashboards in the Insights UI.
Due to the Hibernate upgrade in the backend, the frontend cannot provide IDs anymore for entity creation.
Currently, in the frontend, it was generating a random ID.

This PR removes this random ID generation, and replaces it with undefined.


## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
