### PR TITLE
Upgrade anchore/scan-action to v6.2.0

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -734,7 +734,7 @@ jobs:
 
       - name: Scan manager docker image
         if: steps.manager-docker-command.outputs.pushRequired == 'true'
-        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a # v3
+        uses: anchore/scan-action@2c901ab7378897c01b8efaa2d0c9bf519cc64b9e # v6.2.0
         id: manager-anchore-scan
         with:
           image: ${{ steps.manager-docker-command.outputs.managerDockerImage }}


### PR DESCRIPTION
Looks like the database of this old version is no longer updated causing the build to fail:

```
grype output...
  Executing: grype -o sarif --fail-on critical openremote/manager:develop
  1 error occurred:
  	* db could not be loaded: the vulnerability database was built 6 days ago (max allowed age is 5 days)
```