### PR TITLE
UI fix: Resolved or-attribute-picker export issues

### DIFF
--- a/ui/app/manager/src/pages/page-gateway.ts
+++ b/ui/app/manager/src/pages/page-gateway.ts
@@ -11,7 +11,7 @@ import manager, {DefaultColor1, DefaultColor3} from "@openremote/core";
 import {InputType, OrInputChangedEvent} from "@openremote/or-mwc-components/or-mwc-input";
 import {AppStateKeyed, Page, PageProvider} from "@openremote/or-app";
 import {Store} from "@reduxjs/toolkit";
-import {OrAssetTypeAttributePicker, OrAssetTypeAttributePickerPickedEvent} from "@openremote/or-attribute-picker";
+import {OrAssetTypeAttributePicker, AssetTypeAttributePickerPickedEvent} from "@openremote/or-attribute-picker";
 import "@openremote/or-components/or-ace-editor";
 import moment from "moment";
 import {OrAceEditor} from "@openremote/or-components/or-ace-editor";
@@ -431,7 +431,7 @@ export class PageGateway extends Page<AppStateKeyed>  {
     protected _onLimitAttributesButtonClick(_ev: OrInputChangedEvent) {
         const selectedAttrs = this._getAttrDescriptorMapFromFilters(this._connection.attributeFilters);
         const dialog = showDialog(new OrAssetTypeAttributePicker().setSelectedAttributes(selectedAttrs).setMultiSelect(true));
-        dialog.addEventListener(OrAssetTypeAttributePickerPickedEvent.NAME, (ev) => {
+        dialog.addEventListener(AssetTypeAttributePickerPickedEvent.NAME, (ev) => {
 
             const duration = this._intervalMin ? moment.duration(this._intervalMin, "minutes") : undefined;
             const assetTypeMap = ev.detail as Map<string, AttributeDescriptor[]>;

--- a/ui/component/or-attribute-picker/src/assettype-attribute-picker.ts
+++ b/ui/component/or-attribute-picker/src/assettype-attribute-picker.ts
@@ -1,4 +1,4 @@
-import {property, state} from "lit/decorators.js";
+import {customElement, property, state} from "lit/decorators.js";
 import {AttributePicker, AttributePickerPickedEvent} from "./attribute-picker";
 import {PropertyValues, html, unsafeCSS} from "lit";
 import {DefaultColor5, Util} from "@openremote/core";
@@ -37,10 +37,9 @@ declare global {
  *
  * @attribute {object} assetTypeFilter -Callback method for consumers to filter the asset type list shown. Returning true will make the asset type visible, returning false hides it.
  * @attribute {object} attributeFilter - Callback method for consumers to filter the attribute list shown. Returning true will make the attribute visible, returning false hides it.
- *
- * @remarks TODO: In the future this should be a separate component named "or-assettype-attribute-picker"
  */
-export class AssetTypeAttributePicker extends AttributePicker {
+@customElement("or-assettype-attribute-picker")
+export class OrAssetTypeAttributePicker extends AttributePicker {
 
     @property()
     public assetTypeFilter?: (descriptor: AssetDescriptor) => boolean;

--- a/ui/component/or-attribute-picker/src/index.ts
+++ b/ui/component/or-attribute-picker/src/index.ts
@@ -1,10 +1,9 @@
 import {customElement} from "lit/decorators.js";
 import {OrAssetAttributePicker, OrAssetAttributePickerPickedEvent} from "./asset-attribute-picker";
-import {AssetTypeAttributePickerPickedEvent, AssetTypeAttributePicker} from "./assettype-attribute-picker";
 
 /**
  * {@link CustomEvent} that triggers once attributes have been selected, and the user closes the dialog.
- * @deprecated Replaced this class with an abstract {@link OrAssetAttributePickerPickedEvent}, that is inherited by other classes like {@link OrAssetAttributePicker} and {@link AssetTypeAttributePicker}.
+ * @deprecated Replaced this class with an abstract {@link OrAssetAttributePickerPickedEvent}, that is inherited by other classes like {@link OrAssetAttributePicker} and {@link OrAssetTypeAttributePicker}.
  */
 export class OrAttributePickerPickedEvent extends OrAssetAttributePickerPickedEvent {
 
@@ -18,17 +17,5 @@ export class OrAttributePickerPickedEvent extends OrAssetAttributePickerPickedEv
 export class OrAttributePicker extends OrAssetAttributePicker {
 }
 
-/**
- * TODO: Remove this, and export the ./assettype-attribute-picker file
- */
-export class OrAssetTypeAttributePickerPickedEvent extends AssetTypeAttributePickerPickedEvent {
-
-}
-
-/**
- * TODO: Remove this, and export the ./assettype-attribute-picker file
- */
-@customElement("or-assettype-attribute-picker")
-export class OrAssetTypeAttributePicker extends AssetTypeAttributePicker {
-
-}
+export * from "./asset-attribute-picker";
+export * from "./assettype-attribute-picker";

--- a/ui/component/or-rules/src/flow-viewer/components/internal-picker.ts
+++ b/ui/component/or-rules/src/flow-viewer/components/internal-picker.ts
@@ -11,7 +11,7 @@ import { NodeUtilities } from "../node-structure";
 import { translate, i18next } from "@openremote/or-translate";
 import { PickerStyle } from "../styles/picker-styles";
 import { Util } from "@openremote/core";
-import { OrAttributePicker, OrAttributePickerPickedEvent } from "@openremote/or-attribute-picker";
+import {OrAssetAttributePicker, OrAssetAttributePickerPickedEvent} from "@openremote/or-attribute-picker";
 import { showDialog } from "@openremote/or-mwc-components/or-mwc-dialog";
 import {getAssetDescriptorIconTemplate} from "@openremote/or-icon";
 import {ifDefined} from "lit/directives/if-defined.js";
@@ -174,14 +174,14 @@ export class InternalPicker extends translate(i18next)(LitElement) {
                 _selectedAssets = [ this.selectedAsset.id ];
             }
 
-            const dialog = showDialog(new OrAttributePicker()
+            const dialog = showDialog(new OrAssetAttributePicker()
                 .setShowOnlyRuleStateAttrs(true)
                 .setShowOnlyDatapointAttrs(false)
                 .setMultiSelect(false)
                 .setSelectedAttributes(_selectedAttributes))
                 .setSelectedAssets(_selectedAssets);
 
-            dialog.addEventListener(OrAttributePickerPickedEvent.NAME, async (ev: OrAttributePickerPickedEvent) => {
+            dialog.addEventListener(OrAssetAttributePickerPickedEvent.NAME, async (ev: OrAssetAttributePickerPickedEvent) => {
                 const value: AttributeInternalValue = {
                     assetId: ev.detail[0].id,
                     attributeName: ev.detail[0].name


### PR DESCRIPTION
## Description
Some TypeScript compilers had issues with the `OrAttributePicker` class, and importing it.
Because the `index.ts` didn't specifically export the class (and its fields), it caused issues.
I now improved the package export handling, and applied more consistency for the components inside that package.

## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
