### PR TITLE
Add default response code to Swagger configuration in ManagerWebService

### DIFF
--- a/manager/src/main/java/org/openremote/manager/web/ManagerWebService.java
+++ b/manager/src/main/java/org/openremote/manager/web/ManagerWebService.java
@@ -253,8 +253,8 @@ public class ManagerWebService extends WebService {
         oas.info(info);
         SwaggerConfiguration oasConfig = new SwaggerConfiguration()
                 .resourcePackages(Set.of("org.openremote.model.*"))
-                .openAPI(oas);
-
+                .openAPI(oas)
+                .defaultResponseCode("200");
         OpenApiResource openApiResource = new OpenApiResource();
         openApiResource.openApiConfiguration(oasConfig);
         addApiSingleton(openApiResource);


### PR DESCRIPTION
## Description
This changes the default response codes from ``default`` to ``200`` in the swagger configuration, #1903

## Checklist


- [x] 1. Change the default response code from ``default`` to ``200``
- [x] 2. All tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

Thank you all in advance
