### PR TITLE
Bugfix/MQTT Wildcard subscription does not take into account the service user being a restricted user 

### DIFF
--- a/manager/src/main/java/org/openremote/manager/mqtt/DefaultMQTTHandler.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/DefaultMQTTHandler.java
@@ -295,12 +295,15 @@ public class DefaultMQTTHandler extends MQTTHandler {
             return;
         }
    
-        // If service user is restricted, then restrict subscription to only linked assets
+        // Add an additional filter for restricted service users so that events are additionally filtered to only include events for linked assets
         if (isRestricted) {
+            filter.setRestrictedEvents(true);
+
             List<String> userAssetIds = assetStorageService.findUserAssetLinks(authContext.getAuthenticatedRealmName(), authContext.getUserId(), null)
                 .stream()
                 .map(userAssetLink -> userAssetLink.getId().getAssetId())
                 .toList();
+
             filter.setUserAssetIds(userAssetIds);
         }
 

--- a/manager/src/main/java/org/openremote/manager/mqtt/DefaultMQTTHandler.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/DefaultMQTTHandler.java
@@ -295,10 +295,9 @@ public class DefaultMQTTHandler extends MQTTHandler {
             return;
         }
    
-        // Add an additional filter for restricted service users so that events are additionally filtered to only include events for linked assets
+        // Specify userAssetIds for restricted service users so that events are additionally filtered to only include events for these assets
         if (isRestricted) {
-            filter.setRestrictedEvents(true);
-
+            // filter.setRestrictedEvents(true); -- This restricts the events to only attributes with the restricted meta configuration
             List<String> userAssetIds = assetStorageService.findUserAssetLinks(authContext.getAuthenticatedRealmName(), authContext.getUserId(), null)
                 .stream()
                 .map(userAssetLink -> userAssetLink.getId().getAssetId())

--- a/manager/src/main/java/org/openremote/manager/mqtt/MQTTHandler.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/MQTTHandler.java
@@ -38,6 +38,7 @@ import org.openremote.container.security.AuthContext;
 import org.openremote.container.security.keycloak.AccessTokenAuthContext;
 import org.openremote.container.security.keycloak.KeycloakIdentityProvider;
 import org.openremote.container.timer.TimerService;
+import org.openremote.manager.asset.AssetStorageService;
 import org.openremote.manager.event.ClientEventService;
 import org.openremote.manager.security.ManagerIdentityService;
 import org.openremote.manager.security.ManagerKeycloakIdentityProvider;
@@ -70,6 +71,7 @@ public abstract class MQTTHandler {
     protected MQTTBrokerService mqttBrokerService;
     protected MessageBrokerService messageBrokerService;
     protected ManagerKeycloakIdentityProvider identityProvider;
+    protected AssetStorageService assetStorageService;
     protected ExecutorService executorService;
     protected TimerService timerService;
     protected boolean isKeycloak;
@@ -98,6 +100,7 @@ public abstract class MQTTHandler {
         mqttBrokerService = container.getService(MQTTBrokerService.class);
         clientEventService = container.getService(ClientEventService.class);
         messageBrokerService = container.getService(MessageBrokerService.class);
+        assetStorageService = container.getService(AssetStorageService.class);
         ManagerIdentityService identityService = container.getService(ManagerIdentityService.class);
         executorService = container.getExecutor();
         timerService = container.getService(TimerService.class);


### PR DESCRIPTION
Closes #1902 

***

This adds an additional step to the `onSubscribe` function and explictely updates the built AssetFilter with the `userAssetIds` based on the assets linked to the restricted service user.

This ensures the published events are filtered by the assets the service user is linked to (when restricted). See `AssetFilter.java`  https://github.com/openremote/openremote/blob/e9d3cba436cd23f7097d33c83ac0e7b4c98a0cc1/model/src/main/java/org/openremote/model/asset/AssetFilter.java#L212-L214