### PR TITLE
Bumped version of NPM packages to 1.7.0-snapshot

### DIFF
--- a/ui/app/console_loader/package.json
+++ b/ui/app/console_loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "console_loader",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Console App Loader",
   "author": "OpenRemote",
   "license": "AGPL-3.0-or-later",

--- a/ui/app/insights/package.json
+++ b/ui/app/insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/insights",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote Insights App",
   "author": "OpenRemote",
   "license": "AGPL-3.0-or-later",

--- a/ui/app/manager/package.json
+++ b/ui/app/manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/manager",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote Manager",
   "author": "OpenRemote",
   "license": "AGPL-3.0-or-later",

--- a/ui/component/core/package.json
+++ b/ui/component/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/core",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote 3.x Core",
   "main": "dist/umd/index.bundle.js",
   "module": "lib/index.js",

--- a/ui/component/model/package.json
+++ b/ui/component/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/model",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote 3.x Model Types",
   "main": "dist/umd/index.bundle.js",
   "module": "lib/index.js",

--- a/ui/component/or-app/package.json
+++ b/ui/component/or-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-app",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote app template",
   "author": "OpenRemote",
   "license": "AGPL-3.0-or-later",

--- a/ui/component/or-asset-tree/package.json
+++ b/ui/component/or-asset-tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-asset-tree",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote Asset Tree",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-asset-viewer/package.json
+++ b/ui/component/or-asset-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-asset-viewer",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote Asset Viewer",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-attribute-card/package.json
+++ b/ui/component/or-attribute-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-attribute-card",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote attribute card",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-attribute-history/package.json
+++ b/ui/component/or-attribute-history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-attribute-history",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote attribute history",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-attribute-input/package.json
+++ b/ui/component/or-attribute-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-attribute-input",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote attribute input",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-attribute-picker/package.json
+++ b/ui/component/or-attribute-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-attribute-picker",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote attribute picker dialog",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-bottom-navigation/package.json
+++ b/ui/component/or-bottom-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-bottom-navigation",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Temporary bottom navigation component",
   "main": "dist/or-bottom-navigation.js",
   "module": "lib/or-bottom-navigation.js",

--- a/ui/component/or-chart/package.json
+++ b/ui/component/or-chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-chart",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote chart",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-components/package.json
+++ b/ui/component/or-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-components",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote basic UI components",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-dashboard-builder/package.json
+++ b/ui/component/or-dashboard-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-dashboard-builder",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote Dashboard Builder",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-data-viewer/package.json
+++ b/ui/component/or-data-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-data-viewer",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote data Viewer",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-gauge/package.json
+++ b/ui/component/or-gauge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-gauge",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote gauge",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-icon/package.json
+++ b/ui/component/or-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-icon",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Icon component for displaying an icon from an icon set",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-json-forms/package.json
+++ b/ui/component/or-json-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-json-forms",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Renders a JSON schema and provides instance editing",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-log-viewer/package.json
+++ b/ui/component/or-log-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-log-viewer",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote syslog viewer",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-map/package.json
+++ b/ui/component/or-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-map",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Displays s vector or raster map",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-mwc-components/package.json
+++ b/ui/component/or-mwc-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-mwc-components",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Material Design Components packaged as web components (The official components are hardcoded to use Material Design font which has limited icons)",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-rules/package.json
+++ b/ui/component/or-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-rules",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote rules related UI components",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-smart-notify/package.json
+++ b/ui/component/or-smart-notify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-smart-notify",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote Smarty Notify element",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-survey-results/package.json
+++ b/ui/component/or-survey-results/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-survey-results",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Displays survey results",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-survey/package.json
+++ b/ui/component/or-survey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-survey",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Displays survey",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-thermostat/package.json
+++ b/ui/component/or-thermostat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-thermostat",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "A thermostat component for viewing current temperature and setting target temperature",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-timeline/package.json
+++ b/ui/component/or-timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-timeline",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote Timeline",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-translate/package.json
+++ b/ui/component/or-translate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-translate",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Provides a web component for translations using i18next",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/or-tree-menu/package.json
+++ b/ui/component/or-tree-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/or-tree-menu",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Web Component for displaying a tree menu of items with a predefined hierarchy",
   "customElements": "custom-elements.json",
   "main": "dist/umd/index.bundle.js",

--- a/ui/component/rest/package.json
+++ b/ui/component/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/rest",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "OpenRemote 3.x REST API",
   "main": "dist/umd/index.bundle.js",
   "module": "lib/index.js",

--- a/ui/demo/demo-core/package.json
+++ b/ui/demo/demo-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/demo-core",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Demo",
   "private": true,
   "scripts": {

--- a/ui/demo/demo-or-asset-tree/package.json
+++ b/ui/demo/demo-or-asset-tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/demo-or-asset-tree",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Component Demo",
   "private": true,
   "scripts": {

--- a/ui/demo/demo-or-map/package.json
+++ b/ui/demo/demo-or-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/demo-or-map",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Component Demo",
   "private": true,
   "scripts": {

--- a/ui/demo/demo-or-thermostat/package.json
+++ b/ui/demo/demo-or-thermostat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/demo-or-thermostat",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Component Demo",
   "private": true,
   "scripts": {

--- a/ui/demo/demo-rest/package.json
+++ b/ui/demo/demo-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/demo-rest",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Demo",
   "private": true,
   "scripts": {

--- a/ui/util/package.json
+++ b/ui/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openremote/util",
-  "version": "1.3.3",
+  "version": "1.7.0-snapshot",
   "description": "Build Util",
   "author": "OpenRemote",
   "main": "webpack.util.js",


### PR DESCRIPTION
## Description
Updated the NPM packages to `1.7.0-snapshot`, as it was stuck on `1.3.3` before.

Currently, this is automatically incremented in the CI/CD, so it's not applied to the code repository.
We'll need to look into an automated version bump in the future.

## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
