### PR TITLE
Prevent URL update to /insights/false on navigation without context

### DIFF
--- a/ui/app/manager/src/pages/page-insights.ts
+++ b/ui/app/manager/src/pages/page-insights.ts
@@ -127,9 +127,13 @@ export class PageInsights extends Page<AppStateKeyed>  {
     }
 
     protected _updateRoute(silent: boolean = true) {
-        router.navigate(getInsightsRoute(this._editMode, this._dashboardId), {
-            callHooks: !silent,
-            callHandler: !silent
-        });
+        // This if condition prevents updating the URL to /insights/false when no edit mode or dashboard is selected.
+        // This avoids polluting the browser history and ensures users don't get redirected to Insights on refresh.
+        if (this._editMode || this._dashboardId) {
+            router.navigate(getInsightsRoute(this._editMode, this._dashboardId), {
+                callHooks: !silent,
+                callHandler: !silent
+            });
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixes #1884

Prevents the URL from being updated to /insights/false when no dashboard or edit mode is selected. This avoids redirecting back to Insights on page refresh and keeps the user on the intended view.

## Checklist

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer