### PR TITLE
Improve container trait ruleset re-synchronisation

### DIFF
--- a/test/src/main/groovy/org/openremote/test/ContainerTrait.groovy
+++ b/test/src/main/groovy/org/openremote/test/ContainerTrait.groovy
@@ -281,9 +281,21 @@ trait ContainerTrait {
             }
 
             // Track rules (very basic)
-            TestFixture.globalRulesets = getRulesets(GlobalRuleset.class)
-            TestFixture.realmRulesets = getRulesets(RealmRuleset.class)
-            TestFixture.assetRulesets = getRulesets(AssetRuleset.class)
+            TestFixture.globalRulesets = getRulesets(GlobalRuleset.class).forEach {
+                // Clear IDs and versions
+                it.id = null
+                it.version = 0
+            }
+            TestFixture.realmRulesets = getRulesets(RealmRuleset.class).forEach {
+                // Clear IDs and versions
+                it.id = null
+                it.version = 0
+            }
+            TestFixture.assetRulesets = getRulesets(AssetRuleset.class).forEach {
+                // Clear IDs and versions
+                it.id = null
+                it.version = 0
+            }
 
             // Track assets
             TestFixture.assets = getAssets()


### PR DESCRIPTION
`ContainerTrait.startContainer()` tries to speed up tests by reusing the container and restoring the initial state between tests, part of that logic captures the rulesets after first startup and then on next startContainer call purges all rulesets and re-inserts the captured ones, for this to work post recent hibernate/JPA updates we need to clear the version and ID fields.