### PR TITLE
UI fix for initial app language, respecting device preferencesas it doesn't respect device …

### DIFF
--- a/ui/app/manager/src/index.ts
+++ b/ui/app/manager/src/index.ts
@@ -241,27 +241,6 @@ fetch(configURL).then<ManagerAppConfig>(async (result) => {
                 .concat(pages.filter(pageProvider => !headerPaths.includes(pageProvider.name)));
         }
 
-        // If the user does not have a preferred language configured (in Keycloak),
-        // we need to update it with their preferred language from other sources. (consoles, realm configuration etc.)
-        // Check local storage for set language, otherwise use language set in config
-        manager.getUserPreferredLanguage().then((userLang: string | undefined) => {
-            if(!userLang) {
-                manager.getConsolePreferredLanguage().then((consoleLang: string | undefined) => {
-                    if (consoleLang) {
-                        manager.language = consoleLang;
-                    } else if (orAppConfig.realms[manager.displayRealm]) {
-                        manager.language = orAppConfig.realms[manager.displayRealm].language
-                    } else if (orAppConfig.realms['default']) {
-                        manager.language = orAppConfig.realms['default'].language
-                    } else {
-                        manager.language = 'en'
-                    }
-                }).catch(reason => {
-                    console.error("Failed to initialise app: " + reason);
-                })
-            }
-        })
-
         return orAppConfig;
     };
 

--- a/ui/component/core/src/index.ts
+++ b/ui/component/core/src/index.ts
@@ -488,8 +488,8 @@ export class Manager implements EventProviderFactory {
 
         // Look for language preference in local storage
         const initOptions: InitOptions = {
-            lng: await this.getConsolePreferredLanguage() || await this.getUserPreferredLanguage() || this.config.defaultLanguage || "en",
-            fallbackLng: "en",
+            lng: await this.getConsolePreferredLanguage() || await this.getUserPreferredLanguage() || this.config?.defaultLanguage || "en",
+            fallbackLng: this.config?.defaultLanguage || "en",
             defaultNS: "app",
             fallbackNS: "or",
             ns: this.config.loadTranslations,

--- a/ui/component/core/src/util.ts
+++ b/ui/component/core/src/util.ts
@@ -63,8 +63,8 @@ export interface GeoNotification {
     notification?: PushNotificationMessage;
 }
 
-export function getBrowserLanguage(): string {
-    return navigator.language.split("-")[0] || "en";
+export function getBrowserLanguage(): string | undefined {
+    return navigator?.language?.split("-")?.[0] || undefined;
 }
 
 export function getQueryParameters(queryStr: string): any {


### PR DESCRIPTION
## Description

**This pull request is work in progress. Still discovering the best fix**

It seems that the device / browser language currently is not respected by the Manager app.
Currently it falls back to "English" no matter the realm configuration, device preference, etc.

The last 12 months we made several improvements to retrieve the personalized language from different sources.
We check console storage -> keycloak storage -> browser language -> manager_config -> English.
However, the Manager UI code still overrides this behavior, causing it to fail on initial load.

Again, still work in progress.

## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
