### PR TITLE
Enable direct rule navigation via rule ID in URL

### DIFF
--- a/ui/app/manager/src/pages/page-rules.ts
+++ b/ui/app/manager/src/pages/page-rules.ts
@@ -142,6 +142,9 @@ export class PageRules extends Page<AppStateKeyed>  {
                 this._ruleId = newRuleId;
                 this._updateRoute(newRuleId.toString());
             }
+        } else {
+            this._ruleId = undefined;
+            this._updateRoute();
         }
     }
 

--- a/ui/app/manager/src/pages/page-rules.ts
+++ b/ui/app/manager/src/pages/page-rules.ts
@@ -1,10 +1,10 @@
 import {css, html} from "lit";
 import {customElement, property, query} from "lit/decorators.js";
 import "@openremote/or-rules";
-import {OrRules, RulesConfig} from "@openremote/or-rules";
+import {OrRules, OrRulesSelectionEvent, RulesConfig, RulesetNode} from "@openremote/or-rules";
 import {NotificationTargetType, RulesetLang, WellknownAssets} from "@openremote/model";
 import {Store} from "@reduxjs/toolkit";
-import {Page, PageProvider} from "@openremote/or-app";
+import {Page, PageProvider, router} from "@openremote/or-app";
 import {AppStateKeyed} from "@openremote/or-app";
 import manager from "@openremote/core";
 import {createSelector} from "reselect";
@@ -80,6 +80,9 @@ export class PageRules extends Page<AppStateKeyed>  {
     @property()
     public config?: PageRulesConfig;
 
+    @property()
+    protected _ruleId?: number;
+
     @query("#rules")
     protected _orRules!: OrRules;
 
@@ -100,15 +103,58 @@ export class PageRules extends Page<AppStateKeyed>  {
 
     constructor(store: Store<AppStateKeyed>) {
         super(store);
+        // Listening to the rule selection event to update internal state
+        this.addEventListener(OrRulesSelectionEvent.NAME, this._onRuleSelection.bind(this));
     }
 
     protected render() {
         return html`
-            <or-rules id="rules" .config="${this.config && this.config.rules ? this.config.rules : PAGE_RULES_CONFIG_DEFAULT.rules}"></or-rules>
+            <or-rules id="rules"
+                      .config="${this.config && this.config.rules ? this.config.rules : PAGE_RULES_CONFIG_DEFAULT.rules}"
+                      .selectedRuleId="${this._ruleId}"
+            ></or-rules>
         `;
     }
 
     public stateChanged(state: AppStateKeyed) {
         this.getRealmState(state);
+
+        // Extracting the id from state and saving internally
+        this._ruleId = parseInt(state.app.params?.id);
+    }
+
+    /**
+     * Handles the selection event from the rule tree.
+     *
+     * If exactly one node is selected and it is of type 'rule', updates the internal `_ruleId`
+     * and updates the route to reflect the newly selected rule.
+     *
+     * @param event - The custom event containing the newly selected nodes.
+     */
+    protected _onRuleSelection(event: OrRulesSelectionEvent) {
+        const selectedNodes = event.detail.newNodes;
+        let newRuleId: number | undefined = undefined;
+        if (selectedNodes.length === 1 && selectedNodes[0].type === 'rule') {
+            const ruleNode = selectedNodes[0] as RulesetNode;
+            newRuleId = ruleNode.ruleset.id;
+
+            if (this._ruleId !== newRuleId) {
+                this._ruleId = newRuleId;
+                this._updateRoute(newRuleId.toString());
+            }
+        }
+    }
+
+    /**
+     * Updates the browser route to reflect the currently selected rule.
+     *
+     * Navigates to either `rules/<ruleId>` or `rules` if no rule ID is provided.
+     * Navigation is performed without triggering route hooks or handlers.
+     *
+     * @param ruleId - Optional string ID of the selected rule.
+     */
+    protected _updateRoute(ruleId?: string) {
+        const path = ruleId ? `rules/${ruleId}` : 'rules';
+        router.navigate(path, { callHooks: false, callHandler: false });
     }
 }

--- a/ui/component/or-rules/src/index.ts
+++ b/ui/component/or-rules/src/index.ts
@@ -853,6 +853,9 @@ export class OrRules extends translate(i18next)(LitElement) {
     @state()
     protected _selectedGroup?: string;
 
+    @property({ type: Number})
+        public selectedRuleId?: number;
+
     @query("#rule-tree")
     private _rulesTree?: OrRuleTree;
 
@@ -880,6 +883,71 @@ export class OrRules extends translate(i18next)(LitElement) {
                 <or-rule-viewer id="rule-viewer" .config="${this.config}" .readonly="${this._isReadonly()}"></or-rule-viewer>
             `)}
         `;
+    }
+
+    protected updated(changedProperties: PropertyValues): void {
+        super.updated(changedProperties);
+
+        if (changedProperties.has('selectedRuleId') && this.selectedRuleId) {
+            // If the parent changes the selected rule id, the new ruleset with that id
+            // is fetched and updated in the view
+            this._fetchRuleset(this.selectedRuleId!).then((ruleset) => {
+                const rulesetNode = {type: "rule", ruleset: ruleset, selected: true} as RulesetNode;
+                this._onNodeSelectionChanged({
+                    oldNodes: [],
+                    newNodes: [rulesetNode]
+                });
+            });
+        }
+    }
+
+    /**
+     * Attempts to fetch a ruleset by its ID without prior knowledge of its type (realm or global).
+     * Tries multiple endpoints sequentially until a match is found or all options fail.
+     * Handles 404 errors gracefully to continue searching, and rethrows other errors.
+     *
+     * @param rulesetId - The numeric ID of the ruleset to fetch.
+     * @returns The found RulesetUnion object or logs an error if none found.
+     */
+    protected async _fetchRuleset(rulesetId: number) {
+
+        let ruleset = undefined;
+
+        const id = rulesetId;
+        let foundRule: RulesetUnion | undefined;
+
+        // This pattern of trying endpoints is not ideal, but is one way to resolve
+        // an ID to a ruleset without knowing its type (realm, or global) beforehand.
+        const fetchers = [
+            () => manager.rest.api.RulesResource.getRealmRuleset(id),
+            () => manager.rest.api.RulesResource.getGlobalRuleset(id)
+        ];
+
+        try {
+            for (const fetcher of fetchers) {
+                try {
+                    const response = await fetcher();
+                    if (response.data) {
+                        foundRule = response.data;
+                        break; // Rule found, exit the loop
+                    }
+                } catch (e: any) {
+                    // A 404 status means the rule wasn't of this type, so we can safely continue.
+                    // Any other error should be surfaced.
+                    if (e.response?.status !== 404) {
+                        throw e;
+                    }
+                }
+            }
+
+            if (foundRule) {
+                return foundRule;
+            } else {
+                throw new Error(`Rule with ID ${id} not found in any context.`);
+            }
+        } catch (e) {
+            console.error(`Failed to fetch ruleset with id ${id}`, e);
+        }
     }
 
     public refresh() {
@@ -967,8 +1035,8 @@ export class OrRules extends translate(i18next)(LitElement) {
         } else {
             const groupNodes = selectedNodes.filter(n => n.type === "group") as RulesetGroupNode[]; // list of selected group nodes
             const rulesetNodes = selectedNodes.filter(n => n.type === "rule") as RulesetNode[]; // list of selected rule nodes
-            const selectedIds = rulesetNodes.map((node) => node.ruleset.id!);
-            console.debug(`Selecting rule IDs ${selectedIds}`);
+            const selectedRuleIds = rulesetNodes.map((node) => node.ruleset.id!);
+            console.debug(`Selecting rule IDs ${selectedRuleIds}`);
 
             // Deselect the group, and select either a new rule or group after that.
             this._deselectGroup().then(() => {

--- a/ui/component/or-rules/src/index.ts
+++ b/ui/component/or-rules/src/index.ts
@@ -1035,8 +1035,8 @@ export class OrRules extends translate(i18next)(LitElement) {
         } else {
             const groupNodes = selectedNodes.filter(n => n.type === "group") as RulesetGroupNode[]; // list of selected group nodes
             const rulesetNodes = selectedNodes.filter(n => n.type === "rule") as RulesetNode[]; // list of selected rule nodes
-            const selectedRuleIds = rulesetNodes.map((node) => node.ruleset.id!);
-            console.debug(`Selecting rule IDs ${selectedRuleIds}`);
+            const selectedIds = rulesetNodes.map((node) => node.ruleset.id!);
+            console.debug(`Selecting rule IDs ${selectedIds}`);
 
             // Deselect the group, and select either a new rule or group after that.
             this._deselectGroup().then(() => {


### PR DESCRIPTION
## Description
This PR adds support for deep linking to individual rules.

- Users can now navigate directly to a rule using its ID in the URL (e.g., /rules/123). 

- The URL now updates automatically when a user selects a rule in the UI.

### Requesting Feedback

1. The `_fetchRuleset(rulesetId: number)` method seems a bit hacky to me, as it tries to fetch the ruleset first from the realm API and then from global. However, this was unavoidable because we do not have any further information in the URL to distinguish between the two. Please let me know if this is acceptable.

2. I tried to follow the same flow as the Assets and Insights pages, but the implementation on the rules page is somewhat different. After spending some time trying to pass values from parent to children, I realized that the best way to handle this was to use the existing `_onNodeSelectionChanged` method in `or-rules`. This avoids unnecessary dependencies between the components and lets us decouple the Realm/Global logic from this flow.

### Execution
https://github.com/user-attachments/assets/408b8624-f5ce-4c94-b32d-8d4281f29425

Resolves #1520

## Checklist

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer