### PR TITLE
Flow node titles have weird formatting

### DIFF
--- a/ui/component/or-rules/src/flow-viewer/components/node-menu-item.ts
+++ b/ui/component/or-rules/src/flow-viewer/components/node-menu-item.ts
@@ -74,7 +74,7 @@ export class NodeMenuItem extends translate(i18next)(LitElement) {
         if (this.node.displayCharacter) {
             this.classList.add("small");
         }
-        this.title = i18next.t(this.node.name!, Utilities.humanLike(this.node.name!));
+        this.title = i18next.t(this.node.name!, Utilities.humanLike(this.node.name!.toLowerCase()));
         return html`
         <div class="label">${this.flowNodeName}</div>
         ${this.isDragging ? this.dragNodeTemplate : null}


### PR DESCRIPTION
## Description
Node titles are formatted as e.g. "b o o l e a n i n p u t" because the humanLike function that is used can't handle the all caps for the original nicely "BOOLEAN_INPUT".
So I made the original lowercase first, and then applied the humanLike, now it comes out nicely.
However, there might very well be a more sophisticated way to deal with this...

Additional thought:
This title is especially useful for the processors where only a sign is used to indicate its function. For some input for example its a bit inconsistent as the title will not be exactly the same as the label of the node. I would say this is fine for now.
