### PR TITLE
Logs: deselect all categories by default, making filtering 1 category easier

### DIFF
--- a/ui/component/or-log-viewer/src/index.ts
+++ b/ui/component/or-log-viewer/src/index.ts
@@ -289,7 +289,7 @@ export class OrLogViewer extends translate(i18next)(LitElement) {
                         ${hideCategories ? `` : getContentWithMenuTemplate(
                             html`<or-mwc-input .type=${InputType.BUTTON} raised ?disabled="${disabled}" .label="${i18next.t("categories")}" icontrailing="chevron-down"></or-mwc-input>`,
                             this._getCategoryMenuItems(),
-                            this.categories,
+                            undefined,
                             (v) => this._onCategoriesChanged(v as Model.SyslogCategory[]),
                             () => this._onCategoriesClosed(),
                             true


### PR DESCRIPTION
## Description
The category multiselect allows the user to filter the messages shown in the logs.
When I use the logs I often only want to see 1 log category, then its annoying to have to deselect all other categories to end up with the one you want. This change has all categories deselected by default (still showing all logs), so that you only have to click the one category you want to see.

I realize another use case would be that you want to see all logs, except for one of two that are filling the page that you don't need. @richturner , is that why it was implemented like this you think?
