### PR TITLE
Remove OR_SSL_PORT from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The quickest way to get your own environment with full access is to make use of 
 [OpenRemote Stack](https://raw.githubusercontent.com/openremote/openremote/master/docker-compose.yml) (Right click 'Save link as...')
 3. In a terminal `cd` to where you just saved the compose file and then run:
 ```
-    docker compose pull
-    docker compose -p openremote up
+docker compose pull
+docker compose -p openremote up
 ```
 If all goes well then you should now be able to access the OpenRemote Manager UI at [https://localhost](https://localhost). You will need to accept the self-signed 
 certificate, see [here](https://www.technipages.com/google-chrome-bypass-your-connection-is-not-private-message) for details how to do this in Chrome (similar for other browsers).
@@ -36,17 +36,17 @@ Username: admin
 Password: secret
 
 ### Changing host and/or port
-The URL you use to access the system is important, the default is configured as `https://localhost` if you are using a VM or want to run on a different port then you will need to set the `OR_HOSTNAME` and `OR_SSL_PORT` environment variables, so if for example you will be accessing using `https://192.168.1.1:8443` then use the following startup command:
+The URL you use to access the system is important, the default is configured as `https://localhost` if you are using a VM then you will need to set the `OR_HOSTNAME` environment variable, so if for example you will be accessing using `https://192.168.1.1` then use the following startup command:
 
 BASH: 
-```
-OR_HOSTNAME=192.168.1.1 OR_SSL_PORT=8443 docker compose -p openremote up -d
+```shell
+OR_HOSTNAME=192.168.1.1 docker-compose -p openremote up -d
 ```
 or
 
 CMD:
-```
-cmd /C "set OR_HOSTNAME=192.168.1.1 && set OR_SSL_PORT=8443 && docker compose -p openremote up -d"
+```shell
+cmd /C "set OR_HOSTNAME=192.168.1.1 && docker-compose -p openremote up -d"
 ```
 
 ## What next


### PR DESCRIPTION
## Description
We're receiving an increasing number of questions from users encountering issues when starting OpenRemote using the Quick Start Guide.

Currently, the documentation includes a startup command that overrides the `OR_SSL_PORT` environment variable. However, when this variable is configured, OpenRemote may not be accessible via the hostname defined in the `OR_HOSTNAME` variable.
If the `OR_SSL_PORT` is not specified, OpenRemote uses the standard SSL port `443`, which is fine for most use cases.

To avoid confusion, it's better to remove the `OR_SSL_PORT` variable from the documentation.

## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
