### PR TITLE
UI Hotfix for service user creation not being allowed

### DIFF
--- a/ui/app/manager/src/pages/page-users.ts
+++ b/ui/app/manager/src/pages/page-users.ts
@@ -338,7 +338,7 @@ export class PageUsers extends Page<AppStateKeyed> {
             return false;
         }
         // New service users with the 'gateway-' prefix are not allowed
-        if(user.serviceAccount && (user.email.startsWith('gateway-') || user.username.startsWith('gateway-'))) {
+        if(user.serviceAccount && (user.email?.startsWith('gateway-') || user.username?.startsWith('gateway-'))) {
             showSnackbar(undefined, "noGatewayUsername", "dismiss")
             return false;
         }
@@ -1059,6 +1059,7 @@ export class PageUsers extends Page<AppStateKeyed> {
                                                   this.reset();
                                               }
                                           }).catch((ex) => {
+                                              console.error(ex);
                                               if (isAxiosError(ex)) {
                                                   error = {
                                                       status: ex.response.status,

--- a/ui/app/manager/src/pages/page-users.ts
+++ b/ui/app/manager/src/pages/page-users.ts
@@ -338,7 +338,7 @@ export class PageUsers extends Page<AppStateKeyed> {
             return false;
         }
         // New service users with the 'gateway-' prefix are not allowed
-        if(user.serviceAccount && (user.email?.startsWith('gateway-') || user.username?.startsWith('gateway-'))) {
+        if(user.serviceAccount && user.username.startsWith('gateway-')) {
             showSnackbar(undefined, "noGatewayUsername", "dismiss")
             return false;
         }


### PR DESCRIPTION
## Description
This resolves an issue where no service users could be created through the UI.
It was accidentally introduced (by myself) in #1964, where users without an username or email would throw an error.
Since the error was never displayed in the console, we didn't notice it until now.

We should really start looking into frontend testing solutions, like the one proposed in #1890.

## Changelog
- Hotfix for service user creation not being allowed, because of an `undefined ` error.
- Added logging for every error that is thrown during user updates/creations.