### PR TITLE
UI Fix for MQTT sessions window not refreshing

### DIFF
--- a/ui/app/manager/src/pages/page-users.ts
+++ b/ui/app/manager/src/pages/page-users.ts
@@ -531,6 +531,7 @@ export class PageUsers extends Page<AppStateKeyed> {
                 ${when((this.userId && index !== undefined) || this.creationState, () => html`
                     ${when(mergedUserList[index] !== undefined || this.creationState, () => {
                         const user: UserModel = (index !== undefined ? mergedUserList[index] : this.creationState.userModel);
+                        const showMqttSessions = user.serviceAccount && this.userId;
                         return html`
                             <div id="content" class="panel">
                                 <p class="panel-title">
@@ -539,7 +540,7 @@ export class PageUsers extends Page<AppStateKeyed> {
                                 ${this.getSingleUserView(user, compositeRoleOptions, realmRoleOptions, ("user" + index), (readonly || this._saveUserPromise != undefined))}
                             </div>
                             
-                            ${user.serviceAccount && this.userId ? this.getMQTTSessionTemplate(user) : ``}
+                            ${when(showMqttSessions, () => this.getMQTTSessionTemplate(user))}
                         `;
                     })}
 

--- a/ui/app/manager/src/pages/page-users.ts
+++ b/ui/app/manager/src/pages/page-users.ts
@@ -224,7 +224,7 @@ export class PageUsers extends Page<AppStateKeyed> {
     protected _saveUserPromise?: Promise<any>;
 
     @state()
-    private _sessionLoader: Promise<TemplateResult>;
+    private _sessionLoader?: Promise<TemplateResult>;
 
     get name(): string {
         return "user_plural";
@@ -237,6 +237,7 @@ export class PageUsers extends Page<AppStateKeyed> {
             this.loadData();
         }
         if (changedProperties.has('userId')) {
+            this._sessionLoader = undefined; // Reset the MQTT sessions view
             this._updateRoute();
         } else if (changedProperties.has('creationState')) {
             this._updateNewUserRoute();
@@ -538,7 +539,7 @@ export class PageUsers extends Page<AppStateKeyed> {
                                 ${this.getSingleUserView(user, compositeRoleOptions, realmRoleOptions, ("user" + index), (readonly || this._saveUserPromise != undefined))}
                             </div>
                             
-                            ${user.serviceAccount ? this.getMQTTSessionTemplate(user) : ``}
+                            ${user.serviceAccount && this.userId ? this.getMQTTSessionTemplate(user) : ``}
                         `;
                     })}
 


### PR DESCRIPTION
## Description

This PR introduces a fix for the MQTT sessions window on the users page of the Manager UI.
There was an issue where the list of MQTT connections was not correct upon navigating to a different service user.
This was due to an caching error, where a request for new data was never issued.
It has been resolved with these changes.

Fixes #986 

## Changelog

- Fix for MQTT sessions table not refreshing, after navigating to a different service user.
- Removed the MQTT sessions table on the "create new service user" screen.

## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
