### PR TITLE
Removed toolbox controls from the attribute history chart

### DIFF
--- a/ui/component/or-attribute-history/src/index.ts
+++ b/ui/component/or-attribute-history/src/index.ts
@@ -191,7 +191,7 @@ const style = css`
     
     #chart-container {
         position: relative;
-        min-height: 350px;
+        min-height: 250px;
     }
         
     #table-container {
@@ -399,6 +399,7 @@ export class OrAttributeHistory extends translate(i18next)(LitElement) {
                         borderColor: this._style.getPropertyValue("--internal-or-attribute-history-text-color"),
                         left: 4,
                         right: 4,
+                        top: 10,
                         containLabel: true
                     },
                     backgroundColor: this._style.getPropertyValue("--internal-or-asset-viewer-panel-color"),
@@ -413,18 +414,6 @@ export class OrAttributeHistory extends translate(i18next)(LitElement) {
                             }
                             return ''
                             }
-                    },
-                    toolbox: {
-                        right: '2%',
-                        top: '5%',
-                        feature: {
-                            dataView: {readOnly: true},
-                            saveAsImage: {
-                                name: ['History', this.assetId, this.attribute?.name, `${moment(this._startOfPeriod).format("DD-MM-YYYY HH:mm")} - ${moment(this._endOfPeriod).format("DD-MM-YYYY HH:mm")}`]
-                                    .filter(Boolean)
-                                    .join(' ')
-                            },
-                        }
                     },
                     xAxis: {
                         type: 'time',

--- a/ui/component/or-attribute-history/src/index.ts
+++ b/ui/component/or-attribute-history/src/index.ts
@@ -191,7 +191,7 @@ const style = css`
     
     #chart-container {
         position: relative;
-        min-height: 250px;
+        min-height: 350px;
     }
         
     #table-container {


### PR DESCRIPTION
## Description
This PR removes a feature that was present in the "Attribute History" panel on `/assets`.
After internal feedback / discussion we decided to disable this, as it doesn't fit the UX / functionality flow of the assets page.

## Changelog
- Removes the ECharts toolbox controls ('view as table', and 'save as image') from the attribute history chart.
- Updated / minimized the margin above the chart container.

## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

## Screenshot
![image](https://github.com/user-attachments/assets/b5531165-f84c-4be4-a693-5ed26ae58e3d)

