### PR TITLE
UI fix for attribute picker not working in Flow Rules.

### DIFF
--- a/ui/component/or-rules/src/flow-viewer/components/internal-picker.ts
+++ b/ui/component/or-rules/src/flow-viewer/components/internal-picker.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, TemplateResult } from "lit";
 import {customElement, property} from "lit/decorators.js";
-import { Node, PickerType, AttributeInternalValue, Asset, NodeDataType, AttributeRef, AssetModelUtil } from "@openremote/model";
+import { Node, PickerType, AttributeInternalValue, Asset, NodeDataType, AssetModelUtil } from "@openremote/model";
 import { nodeConverter } from "../converters/node-converter";
 import { InputType, OrInputChangedEvent } from "@openremote/or-mwc-components/or-mwc-input";
 import rest from "@openremote/rest";
@@ -159,27 +159,10 @@ export class InternalPicker extends translate(i18next)(LitElement) {
     private get assetAttributeInput(): TemplateResult {
 
         const openDialog = () => {
-            let _selectedAttributes : AttributeRef[] = [];
-            let _selectedAssets: string[] = [];
-            let val = this.node.internals![this.internalIndex].value;
-
-            if (val){
-                _selectedAttributes = [{
-                    id: val.assetId,
-                    name: val.attributeName
-                }];
-            }
-
-            if (this.selectedAsset && this.selectedAsset.id) {
-                _selectedAssets = [ this.selectedAsset.id ];
-            }
-
             const dialog = showDialog(new OrAssetAttributePicker()
                 .setShowOnlyRuleStateAttrs(true)
                 .setShowOnlyDatapointAttrs(false)
-                .setMultiSelect(false)
-                .setSelectedAttributes(_selectedAttributes))
-                .setSelectedAssets(_selectedAssets);
+                .setMultiSelect(false));
 
             dialog.addEventListener(OrAssetAttributePickerPickedEvent.NAME, async (ev: OrAssetAttributePickerPickedEvent) => {
                 const value: AttributeInternalValue = {


### PR DESCRIPTION
## Description
Previously, you could not modify the selected asset/attribute within the Flow Rules UI.
A workaround was to delete the node, and recreate it with a different asset.
This PR resolves this issue.

Fixes #1828 

I simply removed the references of selected assets / attributes.
This might sound like a weird solution, by just removing it, but it makes the most sense to me.
Other pages like the 'Data Export', and widgets on the Insights, do not pre-select any asset/attributes upon opening the menu.
So, for me the easiest solution was to remove them.

Any feedback is appreciated! 👍 

## Checklist
- [x] 1. Acceptance criteria of the linked issue(s) are met
- [x] 2. Tests are written and all tests pass
- [x] 3. Changes are manually tested by you and the reviewer

## Screenshot

![image](https://github.com/user-attachments/assets/893a9114-742d-4abe-aab6-e9fa53418408)

