### PR TITLE
Fix for mobile view of or-app, by using % instead of viewport height.

### DIFF
--- a/ui/component/or-app/src/index.ts
+++ b/ui/component/or-app/src/index.ts
@@ -101,7 +101,7 @@ export class OrApp<S extends AppStateKeyed> extends LitElement {
                 fill: ${unsafeCSS(DefaultColor3)};
                 font-size: 14px;
 
-                height: 100vh;
+                height: 100%;
                 display: flex;
                 flex: 1;
                 flex-direction: column;


### PR DESCRIPTION
## Description
There were issues on mobile browsers / apps, where elements would "be hidden outside of the screen".
For example, a [forum user](https://forum.openremote.io/t/appearance-on-a-mobile-screens/3931/1) reported a button missing on the bottom of the /map page.
We've seen this behavior pass by on other apps, without consistent reproducible scenarios.

This PR is an attempt to improve the consistency across browsers,
by modifying the CSS to use `%` instead of viewport height (`vh`).

## Changelog

- Replaced original viewport CSS hardcode (using `vh`) in `or-app` with percentages `%`.

## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
