### PR TITLE
UI fix: Support for filtering by boolean attribute in asset tree

### DIFF
--- a/ui/component/or-asset-tree/src/index.ts
+++ b/ui/component/or-asset-tree/src/index.ts
@@ -1267,7 +1267,7 @@ export class OrAssetTree extends subscribe(manager)(LitElement) {
                                                 atLeastOneAttributeMatchValue = true;
                                             }
                                         } else if (/\d/.test(normalizedValue)) {
-                                            if(normalizedValue.endsWith("%")) {
+                                            if (normalizedValue.endsWith("%")) {
                                                 normalizedValue = normalizedValue?.replace("%", "");
                                             }
                                             // If filter starts with a number, append '==' in front of it.


### PR DESCRIPTION
## Description
Fixes #1279.
Also addresses other issues during implementation phase; see changelog below.

## Changelog
- Added support for filtering by `boolean` attribute value in the `or-asset-tree` component.
It allows string input 'true' and 'false', and will compare that with the attribute value.
- Fix for negative numbers and decimals not working in filter.
Simplified number validation, and now allowing both `,` and `.` as decimal separators.
- Improvements to error handling when filtering numbers with an incorrect format.

## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

## Screenshots
<img width="1111" height="450" alt="image" src="https://github.com/user-attachments/assets/35e4147d-1028-4567-afcb-1ee45128567e" />
