### PR TITLE
Hotfix for CI/CD failure: updated externals API usage to Webpack version 5

### DIFF
--- a/ui/util/webpack.util.js
+++ b/ui/util/webpack.util.js
@@ -212,11 +212,11 @@ function getLibName(componentName) {
     return "OR" + componentName.charAt(0).toUpperCase() + componentName.substring(1);
 }
 
-function ORExternals(context, request, callback) {
-    const match = request.match(/^@openremote\/([^\/]*)$/);
+function ORExternals(context, callback) {
+    const match = context.request.match(/^@openremote\/([^\/]*)$/);
     if (match) {
         let component = getLibName(match[1]);
-        console.log(request + " => " + component);
+        console.log(context.request + " => " + component);
         return callback(null, "umd " + component);
     }
     callback();


### PR DESCRIPTION
## Description
After a failed CI/CD run in the main branch (see [here](https://github.com/openremote/openremote/actions/runs/16499278023)), I investigated the matter.
Apparently the `npm publish` command was failing, which wasn't tested in CI/CD runs before.
This was issued after the RSPack PR #1857 has been merged.

### How has it been solved?

There were issues generating the externals, the RSPack API is slightly different than how we use it.
We were using the API spec of Webpack 4, which might explain why Webpack 5 still supported it, and RSPack doesn't.
The function callback uses an object, instead of individual parameters;
```typescript
Before:  (context, request, callback) => void
After:  ({context, request, ...}, callback) => void
```
See the documentation pages:
**RSPack**: https://rspack.rs/config/externals#function
**Webpack 5**: https://webpack.js.org/configuration/externals/#function
**Webpack 4**: https://v4.webpack.js.org/configuration/externals/#function

Feel free to review 😄 