### PR TITLE
Fix inconsistent parallel rspack builds

### DIFF
--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "incremental": true,
     "target": "es6",
     "module": "esNext",
     "moduleResolution": "node",

--- a/ui/util/package.json
+++ b/ui/util/package.json
@@ -27,6 +27,7 @@
     "querystring-es3": "^0.2.1",
     "shx": "~0.4.0",
     "source-map-loader": "^5.0.0",
+    "ts-checker-rspack-plugin": "^1.1.5",
     "ts-loader": "~9.5.2",
     "typescript": "~5.8.3",
     "webpack": "^5.99.8"

--- a/ui/util/webpack.util.js
+++ b/ui/util/webpack.util.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const { rspack } = require('@rspack/core');
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { TsCheckerRspackPlugin } = require('ts-checker-rspack-plugin');
 
 function getStandardModuleRules() {
     return {
@@ -32,7 +33,7 @@ function getStandardModuleRules() {
                     loader: "ts-loader",
                     options: {
                         projectReferences: true,
-                        transpileOnly: true,  // Disables type-checking (allows parallel builds).
+                        transpileOnly: true,  // Disables type-checking (allows parallel builds). Type-checking is handled by TsCheckerRspackPlugin.
                     }
                 }
             }
@@ -101,6 +102,13 @@ function getAppConfig(mode, isDevServer, dirname, managerUrl, keycloakUrl, port)
             chunksSortMode: 'none',
             inject: false,
             template: 'index.html'
+        }),
+        new TsCheckerRspackPlugin({
+          typescript: {
+            // Used for incremental builds
+            build: true,
+            mode: "write-references"
+          }
         })
     ];
 

--- a/ui/util/webpack.util.js
+++ b/ui/util/webpack.util.js
@@ -31,7 +31,8 @@ function getStandardModuleRules() {
                     // TODO: Switch to builtin:swc-loader, and remove ts-loader / webpack dependency
                     loader: "ts-loader",
                     options: {
-                        projectReferences: true
+                        projectReferences: true,
+                        transpileOnly: true,  // Disables type-checking (allows parallel builds).
                     }
                 }
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/code-frame@npm:7.27.1"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.27.1"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10c0/5dd9a18baa5fce4741ba729acc3a3272c49c25cb8736c4b18e113099520e7ef7b545a4096a26d600e4416157e63e87d66db46aa3fbf0a5f2286da2705c12da00
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-validator-identifier@npm:7.27.1"
+  checksum: 10c0/c558f11c4871d526498e49d07a84752d1800bf72ac0d3dad100309a2eaba24efbf56ea59af5137ff15e3a00280ebe588560534b0e894a4750f8b1411d8f78b84
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.9.2":
   version: 7.23.9
   resolution: "@babel/runtime@npm:7.23.9"
@@ -1774,6 +1792,7 @@ __metadata:
     querystring-es3: "npm:^0.2.1"
     shx: "npm:~0.4.0"
     source-map-loader: "npm:^5.0.0"
+    ts-checker-rspack-plugin: "npm:^1.1.5"
     ts-loader: "npm:~9.5.2"
     typescript: "npm:~5.8.3"
     webpack: "npm:^5.99.8"
@@ -2150,7 +2169,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rspack/lite-tapable@npm:1.0.1":
+"@rspack/lite-tapable@npm:1.0.1, @rspack/lite-tapable@npm:^1.0.1":
   version: 1.0.1
   resolution: "@rspack/lite-tapable@npm:1.0.1"
   checksum: 10c0/90bb1bc414dc51ea2d0933e09f78d25584f3f50a85f4cb8228930bd29e5931bf55eff4f348a06c51dd3149fc73b8ae3920bf0ae5ae8a0c9fe1d9b404e6ecf5b7
@@ -6154,6 +6173,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-tokens@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "js-tokens@npm:4.0.0"
+  checksum: 10c0/e248708d377aa058eacf2037b07ded847790e6de892bbad3dac0abba2e759cb9f121b00099a65195616badcb6eca8d14d975cb3e89eb1cfda644756402c8aeed
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
@@ -6530,6 +6556,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"memfs@npm:^4.28.0":
+  version: 4.36.0
+  resolution: "memfs@npm:4.36.0"
+  dependencies:
+    "@jsonjoy.com/json-pack": "npm:^1.0.3"
+    "@jsonjoy.com/util": "npm:^1.3.0"
+    tree-dump: "npm:^1.0.1"
+    tslib: "npm:^2.0.0"
+  checksum: 10c0/1ba2b507dde155568612737eadc0070c7709a05e7c7d720bf53866c3a68ef265ee5f4e27328c9566c6be4498563ee9afd081d8542be8ec885abd182d2df92e75
+  languageName: node
+  linkType: hard
+
 "memfs@npm:^4.6.0":
   version: 4.14.0
   resolution: "memfs@npm:4.14.0"
@@ -6654,7 +6692,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -8885,6 +8923,27 @@ __metadata:
   peerDependencies:
     tslib: 2
   checksum: 10c0/d1d180764e9c691b28332dbd74226c6b6af361dfb1e134bb11e60e17cb11c215894adee50ffc578da5dcf546006693947be8b6665eb1269b56e2f534926f1c1f
+  languageName: node
+  linkType: hard
+
+"ts-checker-rspack-plugin@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "ts-checker-rspack-plugin@npm:1.1.5"
+  dependencies:
+    "@babel/code-frame": "npm:^7.27.1"
+    "@rspack/lite-tapable": "npm:^1.0.1"
+    chokidar: "npm:^3.6.0"
+    is-glob: "npm:^4.0.3"
+    memfs: "npm:^4.28.0"
+    minimatch: "npm:^9.0.5"
+    picocolors: "npm:^1.1.1"
+  peerDependencies:
+    "@rspack/core": ^1.0.0
+    typescript: ">=3.8.0"
+  peerDependenciesMeta:
+    "@rspack/core":
+      optional: true
+  checksum: 10c0/5f8d04f5258deacfd38fd5a140aa68b66368a23e6a313db6cbb23aab619262d82eb0de7b0cbef94fbeffe5d7709fda2be4d1e4e601f78ed2f9c24995d32e2fea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

### Summary

The Rspack builds are inconsistent resulting in varying sizes of the JavaScript bundle missing critical code for the manager UI to function. This is can happen when running production builds in parallel. If multiple processes need to transpile the TypeScript code this will result in issues. I've found through my testing that for some unknown reason the `manager` app and the `console_loader` app if built at the same time will result broken JavaScript bundles around 30-40% of the time (when running it through `gradle clean installDist`). Running those builds in a loop separately at the same increases the rate of incorrect builds and can even cause one of the processes to exit.

Why did this issue not occur before Rspack? It could be that the Webpack builds were too slow for this to occur.

### Results

I tested this issue on the [frontend testing branch](https://github.com/openremote/openremote/pull/1890) and master branch.

Using variations of the following script I checked the bundle JS bundle size after each build.

```sh
set -e

while :
do
    out="$(gradle clean installDist 2>&1)"
    size=$(du -s ui/app/manager/dist/bundle.*.js | cut -f1)
    echo "$size"
done
```

Letting it run in the following scenarios led to the following results:
<img width="2834" height="1792" alt="image" src="https://github.com/user-attachments/assets/9c279fa5-96e3-4b9d-9467-422ba2fa92ff" />

I also tested this on the master branch:

<img width="2830" height="1088" alt="image" src="https://github.com/user-attachments/assets/c1aabe30-8069-460d-be59-74234f61bad0" />

As you can see the combination of building multiple apps in parallel is causing the bundle corruption issue. Disabling parallel task execution would be a possible solution, though not ideal.

I then tried to see if any particular app was conflicting with the manager:

<img width="2830" height="1533" alt="image" src="https://github.com/user-attachments/assets/9bbd3cff-fe64-491e-bd06-d33125f863c6" />

The results show that the `console_loader` app is causing the bundle corruption issue. Although I never found out why it is only the `console_loader` app causing this issue, it is clear that this must have something to do with TypeScript transpilation.

I inspected this with Rsdoctor and found errors like these:

<img width="1040" height="240" alt="image" src="https://github.com/user-attachments/assets/fa5da821-bb07-4c1b-a358-9dc83dab218e" />

I eventually found the [`transpileOnly`](https://github.com/TypeStrong/ts-loader?tab=readme-ov-file#transpileonly) option in ts-loader which effectively disables type checking and this resulted in consistent builds again (while running them in parallel.)

Though we don't want to remove type-checking, so to reintroduce this we use the [`TsCheckerRspackPlugin`](https://github.com/rspack-contrib/ts-checker-rspack-plugin) to run the type checking a separate process. This plugin uses TypeScript's module resolution (instead of Rspack). This may be slower (see https://rspack.rs/guide/tech/typescript#type-checking) so I've also enabled [incremental mode](https://github.com/rspack-contrib/ts-checker-rspack-plugin?tab=readme-ov-file#enabling-incremental-mode).

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
