### PR TITLE
UI Bugfix or-chart: undefined unit text in chart tooltip when dataset.unit is missing

### DIFF
--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -1582,7 +1582,7 @@ export class OrChart extends translate(i18next)(LitElement) {
                 if (displayValue) {
                     tooltipArray.push({
                         value: displayValue,
-                        text: `<div><span style="display:inline-block;margin-right:5px;border-radius:10px;width:9px;height:9px;background-color: ${dataset.lineStyle?.color}"></span> ${name}: <b>${displayValue} ${dataset.unit}</b></div>`
+                        text: `<div><span style="display:inline-block;margin-right:5px;border-radius:10px;width:9px;height:9px;background-color: ${dataset.lineStyle?.color}"></span> ${name}: <b>${displayValue}${dataset.unit ? ` ${dataset.unit}` : ""}</b></div>`
                     });
                 }
             }

--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -1582,7 +1582,7 @@ export class OrChart extends translate(i18next)(LitElement) {
                 if (displayValue) {
                     tooltipArray.push({
                         value: displayValue,
-                        text: `<div><span style="display:inline-block;margin-right:5px;border-radius:10px;width:9px;height:9px;background-color: ${dataset.lineStyle?.color}"></span> ${name}: <b>${displayValue}${dataset.unit ? ` ${dataset.unit}` : ""}</b></div>`
+                        text: `<div><span style="display:inline-block;margin-right:5px;border-radius:10px;width:9px;height:9px;background-color: ${dataset.lineStyle?.color}"></span> ${name}: <b>${displayValue}${dataset.unit ?? ""}</b></div>`
                     });
                 }
             }


### PR DESCRIPTION
<img width="1544" height="834" alt="afbeelding" src="https://github.com/user-attachments/assets/ba264965-d70e-4abb-b19f-72830eca5cac" />

When dataset.unit is missing, the tooltip was displaying undefined. This fix checks for the presence of dataset.unit and shows an empty string instead.