### PR TITLE
UI: Added ability to filter by ID in the asset tree

### DIFF
--- a/ui/app/manager/src/pages/page-assets.ts
+++ b/ui/app/manager/src/pages/page-assets.ts
@@ -13,7 +13,7 @@ import {
 } from "@openremote/or-asset-viewer";
 import {
     AssetTreeConfig, ChangeParentEventDetail,
-    OrAssetTree,
+    OrAssetTree, OrAssetTreeFilter,
     OrAssetTreeAddEvent,
     OrAssetTreeAssetEvent,
     OrAssetTreeChangeParentEvent, OrAssetTreeRequestAddEvent,
@@ -269,7 +269,17 @@ export class PageAssets extends Page<AssetsStateKeyed>  {
     stateChanged(state: AssetsStateKeyed) {
         this.getRealmState(state); // Order is important here!
         this._editMode = !!(state.app.params && state.app.params.editMode === "true");
-        this._assetIds = state.app.params && state.app.params.ids ? state.app.params.ids.split(",") : undefined;
+        if(state.app.params?.ids) {
+            const newIds = state.app.params.ids.split(",");
+            if(!Util.objectsEqual(this._assetIds, newIds, true)) {
+                this._assetIds = newIds;
+                if(this._assetIds.length === 1) {
+                    this.updateComplete.finally(() => this._tree?.applyFilter(new OrAssetTreeFilter(this._assetIds[0]), true));
+                }
+            }
+        } else {
+            this._assetIds = undefined;
+        }
     }
 
     protected _onParentChangeClick() {


### PR DESCRIPTION
## Description
Fixes #1994.

This PR adds the ability to filter the asset tree UI by asset ID.
It utilizes the same behavior and input field as filtering by asset name, or by attribute value.
Navigating to `/asset/.../<my asset ID>` will now automatically apply the filter for you.

> Be reminded, although this is part of #1990, there is no change in asset querying logic / pagination here.
> It is still using local asset cache, and all assets are fetched beforehand.

## Checklist
- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
