### PR TITLE
Upgrade Bouncy Castle to 1.81

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -68,3 +68,4 @@ prometheusVersion=1.3.6
 micrometerVersion=1.14.5
 jdomVersion = 2.0.6.1
 jSchVersion = 0.2.24
+bouncyCastleVersion = 1.81

--- a/project.gradle
+++ b/project.gradle
@@ -22,6 +22,11 @@ import org.jetbrains.gradle.ext.JUnit
 configurations.all {
     resolutionStrategy {
 
+        // Force using a newer version to prevent vulnerabilities of the Bouncy Castle transitive dependencies of Keycloak
+        force "org.bouncycastle:bcpkix-jdk18on:$bouncyCastleVersion"
+        force "org.bouncycastle:bcprov-jdk18on:$bouncyCastleVersion"
+        force "org.bouncycastle:bcutil-jdk18on:$bouncyCastleVersion"
+
         //failOnVersionConflict()
 
         // This has been replaced with eclipse angus implementation


### PR DESCRIPTION
Prevents the following vulnerabilities:

* CVE-2024-29857
* CVE-2024-30172
* CVE-2024-30171
* CVE-2024-34447
* CVE-2025-8885
* CVE-2025-8916