### PR TITLE
Improve UserAssetProvisioningMQTTHandler unsubscribe handling

### DIFF
--- a/manager/src/main/java/org/openremote/manager/mqtt/UserAssetProvisioningMQTTHandler.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/UserAssetProvisioningMQTTHandler.java
@@ -228,7 +228,11 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
 
     @Override
     public void onUnsubscribe(RemotingConnection connection, Topic topic) {
-        responseSubscribedConnections.remove(topic.toString());
+        responseSubscribedConnections.computeIfPresent(topic.toString(), (t, existingConnection) -> {
+            // Don't remove the existing entry if it is for a different connection; this is a possibility if a client
+            // disconnects and quickly reconnects as we have no guaranteed ordering of subscribe/unsubscribe calls
+            return existingConnection == connection ? null : existingConnection;
+        });
     }
 
     @Override


### PR DESCRIPTION
A quick change to ensure that the client that is unsubscribing is using the same connection as the one currently subscribed