### PR TITLE
Offset support for AssetQuery

### DIFF
--- a/manager/src/main/java/org/openremote/manager/asset/AssetStorageService.java
+++ b/manager/src/main/java/org/openremote/manager/asset/AssetStorageService.java
@@ -1487,6 +1487,7 @@ public class AssetStorageService extends RouteBuilder implements ContainerServic
 
         sb.append(buildOrderByString(query));
         sb.append(buildLimitString(query));
+        sb.append(buildOffsetString(query));
         return new Pair<>(new PreparedAssetQuery(sb.toString(), binders), containsCalendarPredicate);
     }
 
@@ -1602,6 +1603,13 @@ public class AssetStorageService extends RouteBuilder implements ContainerServic
     protected static String buildLimitString(AssetQuery query) {
         if (query.limit > 0) {
             return " LIMIT " + query.limit;
+        }
+        return "";
+    }
+
+    protected static String buildOffsetString(AssetQuery query) {
+        if (query.offset > 0) {
+            return " OFFSET " + query.offset;
         }
         return "";
     }

--- a/model/src/main/java/org/openremote/model/query/AssetQuery.java
+++ b/model/src/main/java/org/openremote/model/query/AssetQuery.java
@@ -184,6 +184,7 @@ public class AssetQuery implements Serializable {
     // Ordering
     public OrderBy orderBy;
     public int limit;
+    public int offset;
 
     public AssetQuery() {
     }
@@ -385,6 +386,16 @@ public class AssetQuery implements Serializable {
         return this;
     }
 
+    public AssetQuery limit(int limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    public AssetQuery offset(int offset) {
+        this.offset = offset;
+        return this;
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{" +
@@ -398,6 +409,8 @@ public class AssetQuery implements Serializable {
                 ", type=" + Arrays.toString(types) +
                 ", attribute=" + (attributes != null ? attributes.toString() : "null") +
                 ", orderBy=" + orderBy +
+                ", limit=" + limit +
+                ", offset=" + offset +
                 ", recursive=" + recursive +
                 '}';
     }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetQueryTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetQueryTest.groovy
@@ -993,4 +993,111 @@ class AssetQueryTest extends Specification implements ManagerContainerTrait {
         assets.size() == 1
         assets[0].id == lobby.id
     }
+
+    def "Limit and offset queries"() {
+        when: "a non limited query is executed to get all assets"
+        // We use this query to determine whether offsets and limits are working correctly
+        def allAssets = assetStorageService.findAll(
+                new AssetQuery()
+                    .select(new Select().excludeAttributes())
+                    .ids(managerTestSetup.smartBuildingId)
+                    .recursive(true)
+                    .orderBy(new OrderBy(NAME))
+        )
+
+        then: "all assets should be returned"
+        allAssets.size() > 0
+        def allAssetsSize = allAssets.size()
+
+        when: "a query is executed with limit set to 0"
+        def zeroLimitAssets = assetStorageService.findAll(
+                new AssetQuery()
+                    .select(new Select().excludeAttributes())
+                    .ids(managerTestSetup.smartBuildingId)
+                    .recursive(true)
+                    .orderBy(new OrderBy(NAME))
+                    .limit(0)
+        )
+
+        then: "all assets should be returned"
+        zeroLimitAssets.size() == allAssetsSize
+        zeroLimitAssets.collect { it.id } == allAssets.collect { it.id }
+
+        when: "a query is executed with limit"
+        def limitedAssets = assetStorageService.findAll(
+                new AssetQuery()
+                    .select(new Select().excludeAttributes())
+                    .ids(managerTestSetup.smartBuildingId)
+                    .recursive(true)
+                    .orderBy(new OrderBy(NAME))
+                    .limit(3)
+        )
+
+        then: "only 3 assets should be returned"
+        limitedAssets.size() == 3
+        limitedAssets.collect { it.id } == allAssets.take(3).collect { it.id }
+
+        when: "a query is executed with a higher limit"
+        def higherLimitAssets = assetStorageService.findAll(
+                new AssetQuery()
+                    .select(new Select().excludeAttributes())
+                    .ids(managerTestSetup.smartBuildingId)
+                    .recursive(true)
+                    .orderBy(new OrderBy(NAME))
+                    .limit(5)
+        )
+
+        then: "then  5 assets should be returned"
+        higherLimitAssets.size() == 5
+
+        when: "a query is executed with a offset"
+        def offsetAssets = assetStorageService.findAll(
+                new AssetQuery()
+                    .select(new Select().excludeAttributes())
+                    .ids(managerTestSetup.smartBuildingId)
+                    .recursive(true)
+                    .orderBy(new OrderBy(NAME))
+                    .offset(2)
+        )
+
+        then: "all assets after the offset should be returned"
+        offsetAssets.size() == allAssetsSize - 2
+        offsetAssets.collect { it.id } == allAssets.drop(2).collect { it.id }
+
+        and: "the first 2 assets from the all assets should not be present"
+        offsetAssets.collect { it.id } != allAssets.take(2).collect { it.id }
+        
+        when: "another query is executed with a offset and limit"
+        def offsetLimitAssets = assetStorageService.findAll(
+                new AssetQuery()
+                    .select(new Select().excludeAttributes())
+                    .ids(managerTestSetup.smartBuildingId)
+                    .recursive(true)
+                    .orderBy(new OrderBy(NAME))
+                    .limit(2)
+                    .offset(3)
+        )
+
+        then: "the assets from the offset should be returned"
+        offsetLimitAssets.collect { it.id } == allAssets.drop(3).take(2).collect { it.id }
+
+        and: "the limit should be respected"
+        offsetLimitAssets.size() == 2
+
+        and: "the first 3 assets from the all assets should not be present"
+        offsetLimitAssets.collect { it.id } != allAssets.take(3).collect { it.id }
+
+        when: "a query is executed with an offset higher than the total number of assets"
+        def offsetHigherThanAssets = assetStorageService.findAll(
+                new AssetQuery()
+                    .select(new Select().excludeAttributes())
+                    .ids(managerTestSetup.smartBuildingId)
+                    .recursive(true)
+                    .orderBy(new OrderBy(NAME))
+                    .offset(allAssets.size() + 1)
+        )
+
+        then: "no assets should be returned"
+        offsetHigherThanAssets.size() == 0
+    }
 }


### PR DESCRIPTION
Closes #1992 

This PR adds support for providing an `offset` as part of the `AssetQuery`. 

## Changes
- Added `offset` support to `AssetQuery`.
- Added test cases covering both `limit` and `offset`, as they are generally used together to enable pagination.

An extra addition is the builder method for `limit`, which was missing.
