### PR TITLE
EKS cleanup

### DIFF
--- a/kubernetes/eks-cleanup-haproxy.sh
+++ b/kubernetes/eks-cleanup-haproxy.sh
@@ -38,7 +38,7 @@ for peering_id in $VPC_PEERING_IDS; do
 done
 
 # Give the AWS LB Controller time to delete the NLB after the Service is deleted
-while aws elbv2 describe-load-balancers  --profile or --query "LoadBalancers[?Type=='network']" 2>/dev/null | grep '"Code": "active"'; do
+while aws elbv2 describe-load-balancers  --profile or --query "LoadBalancers[?VpcId=='$CLUSTER_VPC_ID' && Type=='network']" 2>/dev/null | grep '"Code": "active"'; do
   echo "Waiting for load balancer to be deleted..."
   sleep 10
 done

--- a/kubernetes/eks-cleanup.sh
+++ b/kubernetes/eks-cleanup.sh
@@ -2,6 +2,12 @@
 
 . ./eks-common.sh
 
+CLUSTER_VPC_ID=$(aws eks describe-cluster --name $CLUSTER_NAME --query 'cluster.resourcesVpcConfig.vpcId' --output text --profile or)
+if [ -z "$CLUSTER_VPC_ID" ] || [ "$CLUSTER_VPC_ID" = "None" ]; then
+  echo "Error: Failed to retrieve VPC ID for cluster '$CLUSTER_NAME'. Aborting."
+  exit 1
+fi
+
 CERTIFICATE_ARN=$(kubectl get ingress manager -o jsonpath='{.metadata.annotations.\alb\.ingress\.kubernetes\.io\/certificate-arn}')
 
 DNS_RECORD_NAME=$(aws acm describe-certificate --certificate-arn $CERTIFICATE_ARN --profile or --query "Certificate.DomainValidationOptions[0].ResourceRecord.Name")
@@ -24,8 +30,8 @@ aws route53 change-resource-record-sets \
      '{"Changes": [ { "Action": "DELETE", "ResourceRecordSet": { "Name": '$DNS_RECORD_NAME', "Type": "CNAME", "TTL": 300, "ResourceRecords" : [ { "Value": '$DNS_RECORD_VALUE' } ] } } ]}' \
      --profile dnschg
 
-DNS_NAME=$(aws elbv2 describe-load-balancers --profile or --query "LoadBalancers[?Type=='application'].DNSName | [0]")
-HOSTED_ZONE_ID=$(aws elbv2 describe-load-balancers --profile or --query "LoadBalancers[?Type=='application'].CanonicalHostedZoneId | [0]")
+DNS_NAME=$(aws elbv2 describe-load-balancers --profile or --query "LoadBalancers[?VpcId=='$CLUSTER_VPC_ID' && Type=='application'].DNSName | [0]")
+HOSTED_ZONE_ID=$(aws elbv2 describe-load-balancers --profile or --query "LoadBalancers[?VpcId=='$CLUSTER_VPC_ID' && Type=='application'].CanonicalHostedZoneId | [0]")
 
 echo "Delete DNS record $FQDN"
 
@@ -63,11 +69,6 @@ helm uninstall postgresql
 
 echo "Delete VPC peerings"
 
-CLUSTER_VPC_ID=$(aws eks describe-cluster --name $CLUSTER_NAME --query 'cluster.resourcesVpcConfig.vpcId' --output text --profile or)
-if [ -z "$CLUSTER_VPC_ID" ] || [ "$CLUSTER_VPC_ID" = "None" ]; then
-  echo "Error: Failed to retrieve VPC ID for cluster '$CLUSTER_NAME'. Aborting."
-  exit 1
-fi
 VPC_PEERING_IDS=$(aws ec2 describe-vpc-peering-connections \
   --filters "Name=accepter-vpc-info.vpc-id,Values=$CLUSTER_VPC_ID" "Name=status-code,Values=active" \
   --query 'VpcPeeringConnections[*].VpcPeeringConnectionId' \
@@ -80,7 +81,7 @@ for peering_id in $VPC_PEERING_IDS; do
 done
 
 # Give the AWS LB Controller time to delete the ALB and NLB after the Service is deleted
-while aws elbv2 describe-load-balancers --profile or --query "LoadBalancers" --output text 2>/dev/null | grep -q .; do
+while aws elbv2 describe-load-balancers --profile or --query "LoadBalancers[?VpcId=='$CLUSTER_VPC_ID']" --output text 2>/dev/null | grep -q .; do
   echo "Waiting for load balancer to be deleted..."
   sleep 10
 done


### PR DESCRIPTION
Script was hanging because it did not filter on the specific cluster being deleted and was confused with objects from other cluster(s) in the same account.