### PR TITLE
UI bugfix for the date formatting in Chart being incorrect

### DIFF
--- a/ui/component/or-attribute-barchart/src/index.ts
+++ b/ui/component/or-attribute-barchart/src/index.ts
@@ -1246,9 +1246,9 @@ export class OrAttributeBarChart extends LitElement {
                     interval: this._intervalConfig?.millis,
                     fontSize: 10,
                     formatter: {
-                        year: "{yyyy}",
-                        month: "{MMMM} '{yy}",
-                        day: "{MMM} {d}th",
+                        year: "1-{MMM}-{yyyy}",
+                        month: "1-{MMM}-'{yy}",
+                        day: "{d}-{MMM}",
                         hour: "{HH}:{mm}",
                         minute: "{HH}:{mm}",
                         second: "{HH}:{mm}:{ss}",

--- a/ui/component/or-attribute-history/src/index.ts
+++ b/ui/component/or-attribute-history/src/index.ts
@@ -438,15 +438,15 @@ export class OrAttributeHistory extends translate(i18next)(LitElement) {
                             hideOverlap: true,
                             fontSize: 10,
                             formatter: {
-                                year: '{yyyy}-{MMM}',
-                                month: '{yy}-{MMM}',
-                                day: '{d}-{MMM}',
-                                hour: '{HH}:{mm}',
-                                minute: '{HH}:{mm}',
-                                second: '{HH}:{mm}:{ss}',
-                                millisecond: '{d}-{MMM} {HH}:{mm}',
+                                year: "1-{MMM}-{yyyy}",
+                                month: "1-{MMM}-'{yy}",
+                                day: "{d}-{MMM}",
+                                hour: "{HH}:{mm}",
+                                minute: "{HH}:{mm}",
+                                second: "{HH}:{mm}:{ss}",
+                                millisecond: "{d}-{MMM} {HH}:{mm}",
                                 // @ts-ignore
-                                none: '{MMM}-{dd} {HH}:{mm}'
+                                none: "{MMM}-{dd} {HH}:{mm}"
                             }
                         }
                     },

--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -619,7 +619,7 @@ export class OrChart extends translate(i18next)(LitElement) {
                         hideOverlap: true,
                         fontSize: 10,
                          formatter: {
-                             year: "{yyyy}-{MMM}",
+                             year: "1-{MMM}-{yyyy}",
                              month: "1-{MMM}-'{yy}",
                              day: "{d}-{MMM}",
                              hour: "{HH}:{mm}",

--- a/ui/component/or-chart/src/index.ts
+++ b/ui/component/or-chart/src/index.ts
@@ -620,7 +620,7 @@ export class OrChart extends translate(i18next)(LitElement) {
                         fontSize: 10,
                          formatter: {
                              year: "{yyyy}-{MMM}",
-                             month: "{yy}-{MMM}",
+                             month: "1-{MMM}-'{yy}",
                              day: "{d}-{MMM}",
                              hour: "{HH}:{mm}",
                              minute: "{HH}:{mm}",


### PR DESCRIPTION
Fixes https://github.com/openremote/openremote/issues/2172
Maybe good to take a quick look if all the formattings are to your liking.
Echarts triggers these formats when exactly at a round number, so uses year format when at 00:00 1st jan 2025, month when at 00:00 1st of feb, day when at 00:00 etc.