### PR TITLE
Exit schedule if the recurrence schedule has already ended

### DIFF
--- a/agent/src/main/java/org/openremote/agent/protocol/simulator/SimulatorProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/simulator/SimulatorProtocol.java
@@ -199,7 +199,7 @@ public class SimulatorProtocol extends AbstractProtocol<SimulatorAgent, Simulato
         }
 
         OptionalLong nextRun = getDelay(nextDatapoint.timestamp, timeSinceOccurrenceStarted, schedule.orElse(null));
-        if (nextRun.isEmpty()) {
+        if (nextRun.isEmpty() || nextRun.getAsLong() < 0) {
             LOG.warning("Replay schedule has ended for: " + attributeRef);
             return null;
         }


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

The simulator protocol now exits once the schedule has ended and `nextRun` is calculated as negative value (happens when updating the link with a recurring schedule that has ended using `UNTIL` or `COUNT`).

Resolves https://github.com/openremote/openremote/issues/2171#issuecomment-3346618616

## Changelog

- The simulator now exits when the recurrence rule has already ended

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
