### PR TITLE
Fix demo setup JAR missing from deployment Docker image

### DIFF
--- a/setup/build.gradle
+++ b/setup/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: "java-library"
 
+var setupJar = project.hasProperty("SETUP_JAR") ? "${project.getProperties().get("SETUP_JAR")}" : "demo"
+
+base {
+    archivesName = "openremote-${setupJar}-${project.name}"
+}
+
 sourceSets {
     integration
     demo
@@ -17,25 +23,20 @@ dependencies {
     implementation project(":manager")
 }
 
+
 tasks.register('load1Jar', Jar) {
-    base {
-        archivesName = "openremote-load1-${project.name}"
-    }
+    archiveBaseName.set("openremote-load1-${project.name}")
     from sourceSets.load1.output
 }
 
-// Order of JAR tasks affects the name of the final jar but not the contents which is odd
-// So putting demo last
 tasks.register('demoJar', Jar) {
-    base {
-        archivesName = "openremote-demo-${project.name}"
-    }
+    archiveBaseName.set("openremote-demo-${project.name}")
     from sourceSets.demo.output
 }
 
 // Use demo setup sourceset by default for jar
 tasks.register('installDist', Copy) {
-    def setupTask = getTasksByName(project.hasProperty("SETUP_JAR") ? "${project.getProperties().get("SETUP_JAR")}Jar" : "demoJar", false)[0] as org.gradle.jvm.tasks.Jar
+    def setupTask = getTasksByName("${setupJar}Jar", false)[0] as org.gradle.jvm.tasks.Jar
     System.out.println(setupTask.name)
     dependsOn setupTask
     dependsOn resolveTask(":manager:installDist")


### PR DESCRIPTION
It seems to be a side effect from the changes in #2188.

Fixes #2169