### PR TITLE
Filter repo.osgeo.org content

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -170,6 +170,11 @@ repositories {
     // Needs to be above central due to org.geotools:gt-main issues
     maven {
         url = "https://repo.osgeo.org/repository/release/"
+        content {
+            includeGroup "javax.media"
+            includeGroup "it.geosolutions.jgridshift"
+            includeGroupByRegex "org\\.geotools.*"
+        }
     }
     mavenCentral()
     maven {


### PR DESCRIPTION
This makes Gradle only download the artifacts we use from this repo. Filtering repo content prevents potential security issues. It should also make builds with empty caches faster as it will use Maven Central and its CDN immediately for downloading most artifacts. This should also reduce the number of download issues (Bad gateway) we have with this Maven repository.

<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
