### PR TITLE
Fix unstable SimulatorProtocolTest

### DIFF
--- a/test/src/test/groovy/org/openremote/test/protocol/simulator/SimulatorProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/simulator/SimulatorProtocolTest.groovy
@@ -105,6 +105,11 @@ class SimulatorProtocolTest extends Specification implements ManagerContainerTra
         // Create and link asset to agent
         agent = new SimulatorAgent("Test agent").setRealm(Constants.MASTER_REALM)
         agent = assetStorageService.merge(agent)
+
+        // Wait until agent is connected before resetting the clock so attribute events are processed correctly
+        conditions.eventually {
+            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+        }
     }
 
     def setup() {


### PR DESCRIPTION
After inspecting the `SimulatorProtocolTest` logging, the root cause is that sometimes the `agentStatus` attribute event with the `CONNECTED` value is ignored:

```
2025-12-09 13:05:17.925  INFO    [ContainerExecutor-17          ] ote.manager.asset.AssetProcessingService : Event is older than current attribute value so marking as outdated: ref=AttributeRef{id='2hM0ITMpB5zpSaIXSaEgnq', name='agentStatus'}, event=1970-01-01T00:00:00Z, previous=2025-12-09T12:05:17.917Z
2025-12-09 13:05:17.925  FINER   [ContainerExecutor-17          ] nremote.manager.event.ClientEventService : Publishing to subscribers: OutdatedAttributeEvent{timestamp=Thu Jan 01 01:00:00 CET 1970}
```

This happens because another thread is creating the attribute events when starting the agent after the clock is reset in the `setup` method.

Fixes #2206