### PR TITLE
Add agents to translation processing

### DIFF
--- a/ui/app/shared/build.gradle
+++ b/ui/app/shared/build.gradle
@@ -172,13 +172,15 @@ tasks.register('installDist', Copy) {
 }
 
 tasks.register('processTranslations', JavaCompile) {
+    dependsOn(":agent:classes")
     dependsOn(":model:classes")
     outputs.upToDateWhen { false } // Always invalidate
 
+    def agentSourceSet = project(":agent").sourceSets.main
     def modelSourceSet = project(":model").sourceSets.main
 
-    source = modelSourceSet.allJava
-    classpath = modelSourceSet.compileClasspath
+    source = files(agentSourceSet.allJava, modelSourceSet.allJava)
+    classpath = files(agentSourceSet.compileClasspath, modelSourceSet.compileClasspath)
     destinationDirectory = layout.buildDirectory.dir("generated/i18n") // unused
     options.compilerArgs += [
         "-proc:only", // Only run the processor


### PR DESCRIPTION
## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

This introduces translation processing for `i18n` supporting Java annotations e.g. `@JsonSchemaDescription` on agents.

The following PR https://github.com/openremote/openremote/pull/2204 introduces descriptions to the SimulatorAgent that can be translated, however they are currently completely missing as the translation processor doesn't generate the required keys yet.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. ~~Acceptance criteria of the linked issue(s) are met~~
- [ ] 2. ~~Tests are written and all tests pass~~
- [ ] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
