### PR TITLE
Load existing schedule into rule scheduler

### DIFF
--- a/ui/component/or-rules/src/or-rule-viewer.ts
+++ b/ui/component/or-rules/src/or-rule-viewer.ts
@@ -264,6 +264,7 @@ export class OrRuleViewer extends translate(i18next)(LitElement) {
                             header="scheduleRuleActivity"
                             defaultEventTypeLabel="validityAlways"
                             .disabledRRuleParts="${DISABLED_RRULE_PARTS}"
+                            .schedule="${this.ruleset?.meta?.validity}"
                             @or-scheduler-changed="${this._onSchedulerChanged}"
                         ></or-scheduler>
                         <or-mwc-input .type="${InputType.BUTTON}" id="save-btn" label="save" raised ?disabled="${this._cannotSave()}" @or-mwc-input-changed="${this._onSaveClicked}"></or-mwc-input>


### PR DESCRIPTION
## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

The rule scheduler should load existing schedules, so users know what was previously configured.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] ~~1. Acceptance criteria of the linked issue(s) are met~~
- [ ] ~~2. Tests are written and all tests pass~~
- [ ] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
