### PR TITLE
Add JaCoCo integration to OpenRemote, for tracking code coverage

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -770,7 +770,6 @@ jobs:
           path: test/build/reports/tests
 
       - name: Archive coverage report
-        if: always()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: coverage-report

--- a/project.gradle
+++ b/project.gradle
@@ -5,11 +5,7 @@ import org.jetbrains.gradle.ext.JUnit
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.12"
-}
-
-tasks.withType(Test) {
-    finalizedBy "jacocoTestReport"
+    toolVersion = "0.8.14"
 }
 
 tasks.withType(JacocoReport) {

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "jacoco"
     id 'com.adarshr.test-logger' version '4.0.0'
 }
 
@@ -43,32 +44,35 @@ tasks.withType(Test) {
     environment("OR_LOGGING_CONFIG_FILE", "logging-dev.properties")
 }
 
-test {}
+test {
+    finalizedBy jacocoTestReport
+}
 
 jacocoTestReport {
-    dependsOn test // tests are required to run before generating the report
-    additionalSourceDirs.from(
-            project(':agent').sourceSets.main.allSource.srcDirs,
-            project(':container').sourceSets.main.allSource.srcDirs,
-            project(':manager').sourceSets.main.allSource.srcDirs,
-            project(':model').sourceSets.main.allSource.srcDirs,
-            project(':setup').sourceSets.main.allSource.srcDirs
-    )
+    dependsOn test
+
     sourceDirectories.from(
             project(':agent').sourceSets.main.allSource.srcDirs,
             project(':container').sourceSets.main.allSource.srcDirs,
             project(':manager').sourceSets.main.allSource.srcDirs,
             project(':model').sourceSets.main.allSource.srcDirs,
+            project(':model-util').sourceSets.main.allSource.srcDirs,
             project(':setup').sourceSets.main.allSource.srcDirs
     )
+
     classDirectories.from(
             project(':agent').sourceSets.main.output,
             project(':container').sourceSets.main.output,
             project(':manager').sourceSets.main.output,
             project(':model').sourceSets.main.output,
+            project(':model-util').sourceSets.main.output,
             project(':setup').sourceSets.main.output
     )
-    executionData.from(fileTree(dir: '.', include: '**/build/jacoco/test.exec'))
+
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }
 
 javadoc {


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
Would be cool to have access to a code coverage report. This PR simply adds a coverage report artifact that is the HTML source of the results of the code coverage tool JaCoCo after running the entirety of the test suite.

Please find one that was generated from this PR [here](https://github.com/openremote/openremote/actions/runs/20239725786/artifacts/4874600638).

From checking the results above, I am quite confident that JaCoCo is able to check async stack traces of side effects of the `PollingConditions` code blocks.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [x] 1. Acceptance criteria of the linked issue(s) are met
- [x] 2. Tests are written and all tests pass
- [x] 3. Changes are manually tested by you and the reviewer

<!-- 
  Thank you for your contribution <3 
-->
