### PR TITLE
Added meta item `Has predicted data points` to OpenWeatherMap Agent provisioned Weather Asset attributes

### DIFF
--- a/agent/src/main/java/org/openremote/agent/protocol/openweathermap/OpenWeatherMapProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/openweathermap/OpenWeatherMapProtocol.java
@@ -40,7 +40,6 @@ import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.attribute.MetaItem;
 import org.openremote.model.datapoint.ValueDatapoint;
-import static org.openremote.model.value.MetaItemType.HAS_PREDICTED_DATA_POINTS;
 import org.openremote.model.geo.GeoJSONPoint;
 import org.openremote.model.syslog.SyslogCategory;
 
@@ -50,6 +49,7 @@ import org.openremote.model.util.UniqueIdentifierGenerator;
 import static org.openremote.container.web.WebTargetBuilder.createClient;
 import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 import static org.openremote.model.value.MetaItemType.AGENT_LINK;
+import static org.openremote.model.value.MetaItemType.HAS_PREDICTED_DATA_POINTS;
 
 /**
  * Protocol for integrating with the OpenWeatherMap One Call 3.0 API.


### PR DESCRIPTION
Closes #2299 

Added `Has predicted data points` meta item for the attributes that can contain a forecast for the **Weather** asset that can be provisioned via the **OpenWeatherMap Agent**.

<img width="2264" height="518" alt="image" src="https://github.com/user-attachments/assets/5fc4d9a1-b48d-4fa8-a4b9-e40782b1407a" />
