### PR TITLE
Fix: AWS Marketplace CloudFormation Init script cannot start OpenRemote

### DIFF
--- a/.ci_cd/aws/cloudformation-aws-marketplace.yml
+++ b/.ci_cd/aws/cloudformation-aws-marketplace.yml
@@ -325,14 +325,14 @@ Resources:
                 # Avoid parameter expansion if the password contains `$`
                 if [ -n "${Password}" ]; then
                   export OR_ADMIN_PASSWORD=$(cat << 'EOF'
-                "${Password}"
+                ${Password}
                 EOF
                 )
                 fi
                 
                 if [ -n "${SMTPPassword}" ]; then
                   export OR_EMAIL_PASSWORD=$(cat << 'EOF'
-                "${SMTPPassword}"
+                ${SMTPPassword}
                 EOF
                 )
                 fi


### PR DESCRIPTION
## Description
Closes #2374

This PR includes the following changes:
- Removed the 8 GB and 16 GB storage options and set the default value to 32 GB.
- Changed the location for the Docker Compose binary to `/usr/bin/` instead of `/usr/local/bin/`, as this is the default directory for system binaries.
- Changed EC2 instance name to `OpenRemote` instead of dynamically assigning it based on the CloudFormation stack name.
- Replaced the `wget` command with `curl` and stored the Docker Compose file inside the `/home/ec2-user` directory.
- Changed the Docker Compose project name from `openremote` to `or` to keep it consistent with our custom projects.
- Fixed an issue where the manager container fails to start if the `OR_ADMIN_PASSWORD` variable is not configured. 
   An empty value caused the migration script (https://github.com/openremote/openremote/issues/2263) to fail. 
   Improved the parameter logic by exporting variables and checking whether they contain actual values.
  

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [x] 1. Acceptance criteria of the linked issue(s) are met
- [x] 2. Tests are written and all tests pass
- [x] 3. Changes are manually tested by you and the reviewer
- [x] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
