### PR TITLE
Fix flaky or-translate tests

### DIFF
--- a/ui/test/fixtures/shared.ts
+++ b/ui/test/fixtures/shared.ts
@@ -100,7 +100,7 @@ export class Shared {
 
     /**
      * Resolves a request URL to a local filesystem path.
-     * @param url The icoming request URL to resolve
+     * @param url The incoming request URL to resolve
      */
     private urlPathToFsPath(url: string) {
         return path.resolve(__dirname, decodeURI(`../../app${new URL(url).pathname}`));


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Ran the following script (on `ui/component/or-translate`) for about 10 iterations and I got a failure.

```
cat loop_test.sh
count=1
while true; do
  npm test
  echo "Iteration $count"
  ((count++))
done
```

After applying the fix in https://github.com/openremote/openremote/commit/6fd009312ab45236c4eba183fe37aef51e40f96a, it successfully ran for 105 iterations.

<img width="1158" height="581" alt="image" src="https://github.com/user-attachments/assets/15f2bd39-1d6b-4e62-a574-f6e0f10a6ae0" />

## Changelog

- Fixes flaky `shared` fixtures behavior
- Indents the shared fixture file to 4 spacees

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] ~~1. Acceptance criteria of the linked issue(s) are met~~
- [x] 2. Tests are written and all tests pass
- [x] 3. Changes are manually tested by you and the reviewer
- [ ] ~~4. Documentation is written or updated~~

<!-- 
  Thank you for your contribution <3 
-->
