### PR TITLE
Replace moment-timezone with `Intl.supportedValuesOf`

### DIFF
--- a/ui/component/or-json-forms/package.json
+++ b/ui/component/or-json-forms/package.json
@@ -28,8 +28,7 @@
     "@openremote/or-mwc-components": "workspace:*",
     "@openremote/or-translate": "workspace:*",
     "ajv": "^8.8.2",
-    "lit": "^3.3.1",
-    "moment-timezone": "0.6.0"
+    "lit": "^3.3.1"
   },
   "publishConfig": {
     "access": "public"

--- a/ui/component/or-json-forms/src/controls/control-input-element.ts
+++ b/ui/component/or-json-forms/src/controls/control-input-element.ts
@@ -13,7 +13,6 @@ import {
     JsonSchema
 } from "@jsonforms/core";
 import {isEnumArray} from "../standard-renderers";
-import moment from "moment-timezone";
 
 let defaultTz: string;
 
@@ -132,7 +131,7 @@ export class ControlInputElement extends ControlBaseElement {
                 this.inputType = InputType.PASSWORD;
             } else if (format === "timezone") {
                 this.inputType = InputType.SELECT;
-                options = moment.tz.names().map(z => [z, z]);
+                options = Intl.supportedValuesOf("timeZone").map(z => [z, z]);
                 if (!(defaultTz && value)) {
                     defaultTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
                     this.handleChange(this.path, defaultTz);

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -8,7 +8,8 @@
       "dom",
       "es2017",
       "es2019",
-      "es2021"
+      "es2021",
+      "es2022"
     ],
     "strict": true,
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,7 +2143,6 @@ __metadata:
     "@openremote/or-translate": "workspace:*"
     ajv: "npm:^8.8.2"
     lit: "npm:^3.3.1"
-    moment-timezone: "npm:0.6.0"
   languageName: unknown
   linkType: soft
 
@@ -8798,15 +8797,6 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 10c0/46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
-  languageName: node
-  linkType: hard
-
-"moment-timezone@npm:0.6.0":
-  version: 0.6.0
-  resolution: "moment-timezone@npm:0.6.0"
-  dependencies:
-    moment: "npm:^2.29.4"
-  checksum: 10c0/16164cf321d8be0bf7d43855286b426c94c8200e0634f2e42cf469f591c6a230ac43f37d3826d76b05ac221f69a571400323fb8625e3d4e8669f4d9ab00fe779
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Replaces `moment-timezone` with `Intl.supportedValuesOf("timeZone)` to get all timezones. Just found out about this. Previously I thought the only available browser API to get timezones was through https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTimeZones, which is supported by Firefox.

The result of this is a 36kB reduction.

<img width="542" height="200" alt="image" src="https://github.com/user-attachments/assets/7c6c0ff2-28a9-4631-b081-0f25e161e64b" />

<img width="542" height="200" alt="image" src="https://github.com/user-attachments/assets/e4d34d74-3804-4f65-8383-a8d45762340a" />


- Ref #2389 

## Changelog

- Replace `moment-timezone` in `or-json-forms` with `Intl.supportedValuesOf("timeZone)` to reduce bundle size

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
