### PR TITLE
Fix z-index issues on or-rules page

### DIFF
--- a/ui/app/manager/src/components/configuration/or-conf-map/or-conf-map-geojson.ts
+++ b/ui/app/manager/src/components/configuration/or-conf-map/or-conf-map-geojson.ts
@@ -1,7 +1,7 @@
 import { GeoJsonConfig } from "@openremote/model";
-import {DialogAction, OrMwcDialog } from "@openremote/or-mwc-components/or-mwc-dialog";
+import { OrMwcDialog, showDialog } from "@openremote/or-mwc-components/or-mwc-dialog";
 import { html, LitElement } from "lit";
-import { customElement, property, state, query } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import "@openremote/or-components/or-ace-editor";
 import { OrAceEditorChangedEvent } from "@openremote/or-components/or-ace-editor";
 import { InputType } from "@openremote/or-mwc-components/or-mwc-input";
@@ -15,66 +15,59 @@ export class OrConfMapGeoJson extends LitElement {
     @state()
     protected _jsonValid: boolean = true;
 
-    @query("#geojson-modal")
     protected _dialog: OrMwcDialog
-
     // Value of or-ace-editor without state to prevent UI update
     protected _aceEditorValue: string;
-
 
     /* -------------- */
 
     protected render() {
-        const heading = "GeoJSON editor"
-        const content = html`
-            <or-ace-editor .value="${this.geoJson?.source}"
-                           @or-ace-editor-changed="${(ev: OrAceEditorChangedEvent) => {
-                               this._jsonValid = ev.detail.valid;
-                               if(this._jsonValid) {
-                                   this._aceEditorValue = ev.detail.value;
-                               }}}"
-            ></or-ace-editor>
-        `;
-        const actions: DialogAction[] = [
-            {
-                actionName: "close",
-                content: "close"
-            },
-            {
-                actionName: "ok",
-                content: "update",
-                disabled: !this._jsonValid,
-                action: () => {
-                    this.geoJson = this.parseGeoJson(this._aceEditorValue); // update with new value
-                    this.dispatchEvent(new CustomEvent("update", { detail: { value: this.geoJson }}))
-                }
-            },
-        ]
-        const styles = html`
-            <style>
-                .mdc-dialog__surface {
-                    width: 1024px;
-                    overflow-x: visible !important;
-                    overflow-y: visible !important;
-                }
-                #dialog-content {
-                    border-top-width: 1px;
-                    border-top-style: solid;
-                    border-bottom-width: 1px;
-                    border-bottom-style: solid;
-                    padding: 0;
-                    overflow: visible;
-                    height: 60vh;
-                }
-            </style>
-        `
-        return html`
-            <or-mwc-input type="${InputType.BUTTON}" label="geoJson" outlined icon="pencil" @or-mwc-input-changed="${() => {this.openJsonEditor()}}"></or-mwc-input>
-            <or-mwc-dialog id="geojson-modal" .heading="${heading}" .content="${content}" .actions="${actions}" .styles="${styles}" .dismissAction="${null}"></or-mwc-dialog>
-        `
+        return html`<or-mwc-input type="${InputType.BUTTON}" label="geoJson" outlined icon="pencil" @or-mwc-input-changed="${this.showDialog}"></or-mwc-input>`
     }
-    protected openJsonEditor() {
-        this._dialog.open();
+
+    protected showDialog() {
+        this._dialog = showDialog(new OrMwcDialog()
+            .setHeading("GeoJSON editor")
+            .setStyles(html`
+                <style>
+                    .mdc-dialog__surface {
+                        width: 1024px;
+                        overflow-x: visible !important;
+                        overflow-y: visible !important;
+                    }
+                    #dialog-content {
+                        border-top-width: 1px;
+                        border-top-style: solid;
+                        border-bottom-width: 1px;
+                        border-bottom-style: solid;
+                        padding: 0;
+                        overflow: visible;
+                        height: 60vh;
+                    }
+                </style>`)
+            .setActions([
+                {
+                    actionName: "close",
+                    content: "close"
+                },
+                {
+                    actionName: "ok",
+                    content: "update",
+                    disabled: !this._jsonValid,
+                    action: () => {
+                        this.geoJson = this.parseGeoJson(this._aceEditorValue); // update with new value
+                        this.dispatchEvent(new CustomEvent("update", { detail: { value: this.geoJson }}))
+                    }
+                },
+            ])
+            .setContent(() => html`
+                <or-ace-editor .value="${this.geoJson?.source}" @or-ace-editor-changed="${(ev: OrAceEditorChangedEvent) => {
+                    this._jsonValid = ev.detail.valid;
+                    if (this._jsonValid) {
+                        this._aceEditorValue = ev.detail.value;
+                    }}}"
+                ></or-ace-editor>`
+            ).setDismissAction(null));
     }
 
     protected parseGeoJson(jsonString: string): GeoJsonConfig {

--- a/ui/component/or-rules/src/index.ts
+++ b/ui/component/or-rules/src/index.ts
@@ -813,6 +813,10 @@ export const style = css`
         color: var(--internal-or-rules-list-text-color);
         box-shadow: ${unsafeCSS(DefaultBoxShadow)};
     }
+
+    or-rule-viewer, or-rule-group-viewer {
+        z-index: 0;
+    }
 `;
 
 @customElement("or-rules")

--- a/ui/component/or-scheduler/src/index.ts
+++ b/ui/component/or-scheduler/src/index.ts
@@ -18,7 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import { html, LitElement, PropertyValues, TemplateResult } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import { CalendarEvent } from "@openremote/model";
 import { InputType, OrInputChangedEvent } from "@openremote/or-mwc-components/or-mwc-input";
 import { translate, i18next } from "@openremote/or-translate";
@@ -108,9 +108,6 @@ export class OrScheduler extends translate(i18next)(LitElement) {
 
     @state()
     protected _rrule?: RRule;
-
-    @query("#radial-modal")
-    protected dialog?: OrMwcDialog;
 
     protected _byRRuleParts?: RulePartKey[];
     protected _count = 1;


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Resolves regression introduced by #2446

The `z-index` for `or-rule-viewer, or-rule-group-viewer` must be set as we currently rely on `z-index` of the tree to be set, so the box-shadow overlaps.

The original problem in https://github.com/openremote/openremote/issues/2355 is now properly resolved by using the `or-app` component dialog element, so the dialog is higher up in the DOM tree.

In the future we should remove all `<or-mwc-dialog>` elements from components and rely on an external `<slot>` element. We should also get rid of `z-index` to have box-shadow work and make asides like the tree menus be above in the DOM rather than a sibling.

## Changelog

- Resolve `z-index` regressions on or-rules page
- Remove redundant property from `or-scheduler`

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
