### PR TITLE
Gateways: Disconnect and destroy all currently-active Gateway Tunnel instances when closing a `GatewayClientConnector`

### DIFF
--- a/manager/src/main/java/org/openremote/manager/gateway/GatewayClientConnector.java
+++ b/manager/src/main/java/org/openremote/manager/gateway/GatewayClientConnector.java
@@ -135,10 +135,8 @@ public class GatewayClientConnector implements AutoCloseable {
                 client.setEncoderDecoderProvider(null);
 
                 if (this.activeTunnelSessions != null) {
-                    synchronized (this.activeTunnelSessions) {
-                        this.activeTunnelSessions.forEach(GatewayTunnelSession::disconnect);
-                        this.activeTunnelSessions.clear();
-                    }
+                    this.activeTunnelSessions.forEach(GatewayTunnelSession::disconnect);
+                    this.activeTunnelSessions.clear();
                 }
 
             } catch (Exception e) {


### PR DESCRIPTION
Closes #2494 
