### PR TITLE
Add npmignore to theme package

### DIFF
--- a/ui/component/theme/.npmignore
+++ b/ui/component/theme/.npmignore
@@ -1,7 +1,6 @@
 build/
 build.gradle
 test/
-src/
 webpack.config.js
 rspack.config.js
 tsconfig.json


### PR DESCRIPTION
## Description
Adding the `.npmignore` file removes unnecessary files such as `build.gradle` from the artifacts that are published on NPM.

## Checklist
- [x] ~~1. Acceptance criteria of the linked issue(s) are met~~
- [x] ~~2. Tests are written and all tests pass~~
- [ ] 3. Changes are manually tested by you and the reviewer
- [x] ~~4. Documentation is written or updated~~
