### PR TITLE
Make simulator scheduler period end follow last datapoint

### DIFF
--- a/ui/component/or-attribute-input/src/scheduler-renderer.ts
+++ b/ui/component/or-attribute-input/src/scheduler-renderer.ts
@@ -73,7 +73,7 @@ const schedulerRenderer = (state: JsonFormsStateContext, props: ControlProps) =>
 
     // Init the schedule field with the default value
     if (!Object.keys(props.data).length) {
-        props.handleChange(props.path, defaultEvent);
+        return props.handleChange(props.path, defaultEvent);
     }
 
     const onSchedulerChanged = (event: OrSchedulerChangedEvent | undefined) => {


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

- Closes #2359 

## Changelog

- Makes the simulator scheduler follow the last datapoint
- Correctly instantiate the all day option in the simulator scheduler

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
