### PR TITLE
UI bugfix for unscrollable dashboards on mobile

### DIFF
--- a/ui/component/or-dashboard-builder/src/index.ts
+++ b/ui/component/or-dashboard-builder/src/index.ts
@@ -660,7 +660,7 @@ export class OrDashboardBuilder extends LitElement {
                             </div>
                         </div>
                     `}
-                    <div id="content" style="flex: 1;">
+                    <div id="content" style="flex: 1; overflow: auto;">
                         <div id="container">
                             ${(this.editMode && (this._isReadonly() || !this._hasEditAccess())) ? html`
                                 <div style="display: flex; justify-content: center; align-items: center; height: 100%;">


### PR DESCRIPTION
Fixes https://github.com/openremote/openremote/issues/2519

I think the gridstack upgrade in commit 37131b61b caused some internal styling changes. Just a simple hard-coded overflow auto on the content fixes this.

I've had quite some comments from collegues/clients about this, so a kind request to add this in a new release asap :) @MartinaeyNL 