### PR TITLE
Have a minimum timeout for load2 setup

### DIFF
--- a/setup/src/load2/java/org/openremote/setup/load2/KeycloakSetup.java
+++ b/setup/src/load2/java/org/openremote/setup/load2/KeycloakSetup.java
@@ -89,10 +89,10 @@ public class KeycloakSetup extends AbstractKeycloakSetup {
 
         // Wait until all users created
         int waitCounter = 0;
-        int waitCounterLimit = accounts / 3;
+        int waitCounterLimit = Math.max(300, accounts / 3);
         while (createdUsers.get() < 2 * accounts) {
             if (waitCounter > waitCounterLimit) {
-                throw new IllegalStateException("Failed to add all requested user in the specified time");
+                throw new IllegalStateException("Failed to add all requested user in the specified time (" + waitCounterLimit + " seconds).");
             }
             waitCounter++;
             Thread.sleep(1000);

--- a/setup/src/load2/java/org/openremote/setup/load2/ManagerSetup.java
+++ b/setup/src/load2/java/org/openremote/setup/load2/ManagerSetup.java
@@ -98,10 +98,10 @@ public class ManagerSetup extends org.openremote.manager.setup.ManagerSetup {
 
             // Wait until all devices created
             int waitCounter = 0;
-            int waitCounterLimit = (accounts * assets) / 150;
+            int waitCounterLimit = Math.max(60, (accounts * assets) / 150);
             while (createdAccounts.get() < accounts) {
                 if (waitCounter > waitCounterLimit) {
-                    throw new IllegalStateException("Failed to provision all requested devices in the specified time");
+                    throw new IllegalStateException("Failed to provision all requested devices in the specified time (" + (waitCounterLimit * 10) + " seconds).");
                 }
                 waitCounter++;
                 Thread.sleep(10000);


### PR DESCRIPTION
If there's no minimum, then timeout expires too fast when create only a few users/assets.