### PR TITLE
Enhancement: allow overwriting asset accessPublicRead in gateway sync rules

### DIFF
--- a/manager/src/main/java/org/openremote/manager/gateway/GatewayClientConnector.java
+++ b/manager/src/main/java/org/openremote/manager/gateway/GatewayClientConnector.java
@@ -738,6 +738,10 @@ public class GatewayClientConnector implements AutoCloseable {
             return asset;
         }
 
+        if (syncRule.accessPublicRead != null) {
+            asset.setAccessPublicRead(syncRule.accessPublicRead);
+        }
+
         List<Attribute<?>> attributes = asset.getAttributes().stream()
                 .filter(it -> syncRule.excludeAttributes == null || !syncRule.excludeAttributes.contains(it.getName()))
                 .peek(attribute -> applySyncRuleToMeta(attribute.getName(), attribute.getMeta(), syncRule)).toList();

--- a/model/src/main/java/org/openremote/model/gateway/GatewayAssetSyncRule.java
+++ b/model/src/main/java/org/openremote/model/gateway/GatewayAssetSyncRule.java
@@ -30,6 +30,11 @@ public class GatewayAssetSyncRule {
      */
     public Map<String, MetaMap> addAttributeMeta;
 
+    /**
+     * If set, overrides the {@link org.openremote.model.asset.Asset#accessPublicRead} value on the asset before syncing.
+     */
+    public Boolean accessPublicRead;
+
     public List<String> getExcludeAttributes() {
         return excludeAttributes;
     }
@@ -57,16 +62,25 @@ public class GatewayAssetSyncRule {
         return this;
     }
 
+    public Boolean getAccessPublicRead() {
+        return accessPublicRead;
+    }
+
+    public GatewayAssetSyncRule setAccessPublicRead(Boolean accessPublicRead) {
+        this.accessPublicRead = accessPublicRead;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         GatewayAssetSyncRule that = (GatewayAssetSyncRule) o;
-        return Objects.equals(excludeAttributes, that.excludeAttributes) && Objects.equals(excludeAttributeMeta, that.excludeAttributeMeta) && Objects.equals(addAttributeMeta, that.addAttributeMeta);
+        return Objects.equals(excludeAttributes, that.excludeAttributes) && Objects.equals(excludeAttributeMeta, that.excludeAttributeMeta) && Objects.equals(addAttributeMeta, that.addAttributeMeta) && Objects.equals(accessPublicRead, that.accessPublicRead);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(excludeAttributes, excludeAttributeMeta, addAttributeMeta);
+        return Objects.hash(excludeAttributes, excludeAttributeMeta, addAttributeMeta, accessPublicRead);
     }
 }


### PR DESCRIPTION
Add the possibility of overwriting accessPublicRead on the asset level via manager interconnect sync rules

```
  {                                                                         
    "assetSyncRules": {                                                                                                                                                                                                            
      "WeatherAsset": {                                                                                                                                                                                                                                                                                                                                                                                                    
        "accessPublicRead": true
      },
      "*": {
        "accessPublicRead": false
      }
    }
  }
```

- [ ] might need to include this into a gateway test