### PR TITLE
Add missing accessPublicRead property in hashCode and equals methods

### DIFF
--- a/model/src/main/java/org/openremote/model/gateway/GatewayAssetSyncRule.java
+++ b/model/src/main/java/org/openremote/model/gateway/GatewayAssetSyncRule.java
@@ -76,11 +76,14 @@ public class GatewayAssetSyncRule {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         GatewayAssetSyncRule that = (GatewayAssetSyncRule) o;
-        return Objects.equals(excludeAttributes, that.excludeAttributes) && Objects.equals(excludeAttributeMeta, that.excludeAttributeMeta) && Objects.equals(addAttributeMeta, that.addAttributeMeta);
+        return Objects.equals(accessPublicRead, that.accessPublicRead)
+            && Objects.equals(excludeAttributes, that.excludeAttributes)
+            && Objects.equals(excludeAttributeMeta, that.excludeAttributeMeta)
+            && Objects.equals(addAttributeMeta, that.addAttributeMeta);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(excludeAttributes, excludeAttributeMeta, addAttributeMeta);
+        return Objects.hash(accessPublicRead, excludeAttributes, excludeAttributeMeta, addAttributeMeta);
     }
 }


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

https://github.com/openremote/openremote/pull/2624 introduces the new `accessPublicRead` property on the `GatewayAssetSyncRule` class. Whenever I changed the boolean value of the property it didn't update on the backend, that happened because we forgot to add the property to the `equals` and `hashCode` methods.

I also tested what happens when I set `null`, which removes the property.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
