### PR TITLE
Make UI app tests wait for the manager to be healthy

### DIFF
--- a/ui/app/manager/test/test.setup.ts
+++ b/ui/app/manager/test/test.setup.ts
@@ -9,25 +9,28 @@ import permissions from "./fixtures/data/permissions";
 
 const { admin, smartcity } = users; 
 
+// Must always run tests in setup sequentially to ensure the "Wait for manager to be healthy"
+// setup test runs first
 setup.describe.configure({ mode: "serial" });
 
-setup(`Login as "admin" user`, async ({ page, manager, context }) => {
-    const { username, password } = admin;
+setup(`Wait for the manager to be healthy`, async ({ manager }) => {
     await expect.poll(async () => {
         const noop = () => null;
-        const token = await manager.getAccessToken("master", username, password).catch(noop);
+        const token = await manager.getAccessToken("master", "admin", "secret").catch(noop);
         const response = await manager.api.StatusResource.getHealthStatus({
-            headers: { "Authorization": "Bearer " + token },
+            headers: { "Authorization": "Bearer " + token }
         }).catch(noop);
         return response?.status;
     }, {
         message: "Manager to become healthy",
         intervals: [5_000, 1_000, 2_000, 5_000],
-        timeout: 60_000,
+        timeout: 60_000
     }).toBe(200);
+});
 
+setup(`Login as "admin" user`, async ({ page, manager, context }) => {
     await manager.goToRealmStartPage("master");
-    await manager.login("admin");
+    await manager.login(admin.username);
     await page.waitForURL("**/manager/**");
     await page.waitForTimeout(2000);
     await context.storageState({ path: adminStatePath });


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

This ensures that the tests wait for the manager to be healthy. It retries for a minute until the manager is healthy using the following interval: 

1. Wait 5 seconds
2. If not healthy try 1 second later
3. Still not try 2 seconds later
4. Otherwise continue to try every 5 seconds

We'll also be needing this in the upcoming pipeline changes. 

- Closes #2323 

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
