### PR TITLE
Enforce test execution order and directly run the manager jar for app tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -726,11 +726,10 @@ jobs:
           composeProfile='profile/dev-testing.yml'
 
           # Make temp dir and set mask to 777 as docker seems to run as root
-          mkdir -p tmp
-          chmod 777 tmp
+          mkdir -pm 777 tmp
 
           # Define cleanup command
-          echo "cleanup=docker compose -f $composeProfile down" >> $GITHUB_OUTPUT
+          echo "cleanup=docker compose -f $composeProfile down -v" >> $GITHUB_OUTPUT
 
           # Start the stack
           echo "docker compose -f ${composeProfile} up -d --no-build"
@@ -820,16 +819,20 @@ jobs:
           path: ui/component/*/component-test-report/**
 
       - name: Run UI app tests
+        id: run-ui-app-tests
         # Skip UI app tests for custom projects until we want to use them there
         if: steps.test-ui-apps-command.outputs.value != '' && steps.is_main_repo.outputs.value == 'true'
         run: |
           composeProfile='profile/dev-testing.yml'
 
-          if [ $IS_MAIN_REPO == 'false' ]; then
-            composeProfile="openremote/$composeProfile"
-          fi
+          # Make temp dir and set mask to 777 as docker seems to run as root
+          mkdir -pm 777 tmp
+
+          # Define cleanup command
+          echo "cleanup=docker compose -f $composeProfile down -v" >> $GITHUB_OUTPUT
 
           # Start the stack
+          echo "docker compose -f ${composeProfile} up -d --no-build"
           docker compose -f $composeProfile up -d --no-build
 
           # Run the tests
@@ -846,6 +849,10 @@ jobs:
         with:
           name: ui-app-test-results
           path: ui/app/*/app-test-report/**
+
+      - name: Cleanup UI app tests
+        if: ${{ steps.test-ui-apps-command.outputs.value != '' }}
+        run: ${{ steps.run-ui-app-tests.outputs.cleanup }}
 
       - name: Run manager docker build command
         if: steps.manager-docker-command.outputs.value != ''

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -803,7 +803,7 @@ jobs:
 
       - name: Run install playwright browser(s)
         if: (steps.test-ui-components-command.outputs.value != '' || steps.test-ui-apps-command.outputs.value != '') && steps.is_main_repo.outputs.value == 'true'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium-headless-shell
         timeout-minutes: 20
 
       - name: Run UI component tests
@@ -819,27 +819,18 @@ jobs:
           name: ui-component-test-results
           path: ui/component/*/component-test-report/**
 
-      - name: Run manager docker build command
-        if: steps.manager-docker-command.outputs.value != ''
-        run: |
-          ${{ steps.manager-docker-command.outputs.value }}
-
       - name: Run UI app tests
-        # Skip UI app tests for custom projects until we want to use them there.
-        # .ci_cd/host_init/healthy.sh is missing initially for custom projects .ci_cd/host_init/healthy.sh
+        # Skip UI app tests for custom projects until we want to use them there
         if: steps.test-ui-apps-command.outputs.value != '' && steps.is_main_repo.outputs.value == 'true'
         run: |
-          composeProfile='profile/dev-ui.yml'
+          composeProfile='profile/dev-testing.yml'
 
           if [ $IS_MAIN_REPO == 'false' ]; then
             composeProfile="openremote/$composeProfile"
           fi
 
           # Start the stack
-          MANAGER_VERSION=$MANAGER_TAG docker compose -f $composeProfile up -d --no-build
-
-          # Wait for services to be healthy
-          bash .ci_cd/host_init/healthy.sh profile
+          docker compose -f $composeProfile up -d --no-build
 
           # Run the tests
           ${{ steps.test-ui-apps-command.outputs.value }}
@@ -855,6 +846,11 @@ jobs:
         with:
           name: ui-app-test-results
           path: ui/app/*/app-test-report/**
+
+      - name: Run manager docker build command
+        if: steps.manager-docker-command.outputs.value != ''
+        run: |
+          ${{ steps.manager-docker-command.outputs.value }}
 
       - name: Scan manager docker image
         if: steps.manager-docker-command.outputs.pushToDockerHub == 'true'

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,58 @@ import static org.apache.tools.ant.taskdefs.condition.Os.isFamily
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
+tasks.register('npmTest') {
+    group = 'verification'
+    description = 'Runs all UI tests sequentially (component then app)'
+}
+
+tasks.register('test') {
+    group = 'verification'
+    description = 'Executes all backend and UI tests in specific order'
+    // When './gradlew test' is run, ensure the UI tests are also pulled into the task graph
+    dependsOn 'npmTest'
+}
+
+// Enforce order in which we run the backend- and frontend tests
+// Order: 1. Unit tests
+//     -> 2. Integration tests
+//     -> 3. UI component tests
+//     -> 4. UI app tests
+gradle.projectsEvaluated {
+    def unitTests = subprojects.findAll { it.path != ':test' }
+        .collect { it.tasks.matching { t -> t.name == 'test' } }
+
+    def integrationTests = subprojects.findAll { it.path == ':test' }
+        .collect { it.tasks.matching { t -> t.name == 'test' } }
+
+    def uiComponentTests = subprojects.findAll { it.path.startsWith(':ui:component') }
+        .collect { it.tasks.matching { t -> t.name == 'npmTest' } }
+
+    def uiAppTests = subprojects.findAll { it.path.startsWith(':ui:app') }
+        .collect { it.tasks.matching { t -> t.name == 'npmTest' } }
+
+    tasks.named('npmTest').configure {
+        dependsOn(uiComponentTests, uiAppTests)
+    }
+
+    def rootTest = tasks.findByName('test') ?: tasks.register('test').get()
+    rootTest.configure {
+        dependsOn(unitTests, integrationTests, npmTest)
+    }
+
+    integrationTests.forEach { group ->
+        group.configureEach { it.mustRunAfter(unitTests) }
+    }
+
+    uiComponentTests.forEach { group ->
+        group.configureEach { it.mustRunAfter(unitTests, integrationTests) }
+    }
+
+    uiAppTests.forEach { group ->
+        group.configureEach { it.mustRunAfter(unitTests, integrationTests, uiComponentTests) }
+    }
+}
+
 // Configure version based on Git tags
 apply plugin: 'pl.allegro.tech.build.axion-release'
 scmVersion {
@@ -98,7 +150,7 @@ buildscript {
 subprojects {
     // Apply only if the project has a 'test' task
     tasks.withType(Test).configureEach { testTask ->
-        outputs.upToDateWhen { false }
+        outputs.upToDateWhen { false } // Always invalidate the test cache
         useJUnitPlatform()
 
         systemProperty "junit.jupiter.execution.parallel.enabled", "true"
@@ -204,18 +256,4 @@ subprojects {
             }
         }
     }
-}
-
-// Finalize the gradle test task with the npmTest task so that all tests can be run with gradle test.
-// Runs backend tests first and then frontend tests. UI tests are registered under npmTest to avoid
-// complications when configuring the test task on projects w/o the Java plugin where the test task is
-// already defined. It also allows for easy exclusion using the `-x` argument (e.g. `gradle test -x npmTest`.)
-tasks.register('test') {
-    dependsOn subprojects.collect { it.tasks.matching { it.name == 'test' } }
-}
-tasks.register('npmTest') {
-    dependsOn subprojects.collect { it.tasks.matching { it.name == 'npmTest' } }
-}
-tasks.named('test') {
-    finalizedBy tasks.named('npmTest')
 }

--- a/extension/energy/build.gradle
+++ b/extension/energy/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     testImplementation resolveProject(":test")
 }
 
+test {}
+
 jar {
     from sourceSets.main.allJava
 }

--- a/ui/app/manager/build.gradle
+++ b/ui/app/manager/build.gradle
@@ -76,12 +76,12 @@ tasks.register('npmBuild', Exec) {
 }
 
 tasks.register('npmTest', Exec) {
-    dependsOn getYarnInstallTask()
+    dependsOn getYarnInstallTask(), resolveTask(":clean")
     commandLine npmCommand("yarn"), "run", "test"
 }
 
 tasks.register('npmTestUI', Exec) {
-    dependsOn getYarnInstallTask()
+    dependsOn getYarnInstallTask(), resolveTask(":clean")
     commandLine npmCommand("yarn"), "run", "test", "--ui"
 }
 

--- a/ui/app/manager/test/insights.test.ts
+++ b/ui/app/manager/test/insights.test.ts
@@ -82,6 +82,7 @@ test("Create a Map widget with text thresholds", async ({ manager, shared, page,
             }),
         ],
     });
+    await manager.configureAppConfig({});
     await manager.goToRealmStartPage("smartcity");
     await manager.navigateToTab("Insights");
 

--- a/ui/app/storybook/build.gradle
+++ b/ui/app/storybook/build.gradle
@@ -77,12 +77,12 @@ tasks.register('npmBuild', Exec) {
 }
 
 tasks.register('npmTest', Exec) {
-    dependsOn getYarnInstallTask()
+    dependsOn getYarnInstallTask(), resolveTask(":clean")
     commandLine npmCommand("yarn"), "run", "test"
 }
 
 tasks.register('npmTestUI', Exec) {
-    dependsOn getYarnInstallTask()
+    dependsOn getYarnInstallTask(), resolveTask(":clean")
     commandLine npmCommand("yarn"), "run", "test", "--ui"
 }
 

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -18,19 +18,3 @@ afterEvaluate {
 task modelWatch {
     dependsOn resolveTask(":ui:component:model:build"), resolveTask(":ui:component:rest:build")
 }
-
-// Finalize gradle test tasks with npmTest tasks so that gradle :ui:test can also be used to run
-// UI tests. The tests are registered under npmTest to avoid complications when configuring the
-// test task on projects w/o the Java plugin where the test task is already defined.
-subprojects { subproj ->
-    subproj.tasks.matching { it.name == 'npmTest' }.all {
-        subproj.tasks.matching { it.name == 'test' }.all {
-            finalizedBy 'npmTest'
-        }
-        if (!subproj.tasks.findByName('test')) {
-            subproj.tasks.register('test') {
-                finalizedBy 'npmTest'
-            }
-        }
-    }
-}

--- a/ui/component/or-asset-viewer/package.json
+++ b/ui/component/or-asset-viewer/package.json
@@ -14,6 +14,7 @@
   },
   "types": "lib/index.d.ts",
   "scripts": {
+    "build": "npx tsc -b",
     "analyze": "npx cem analyze --config ../custom-elements-manifest.config.mjs",
     "test": "npx tsc -b && npx playwright test",
     "prepack": "npx rspack"

--- a/ui/component/or-asset-viewer/package.json
+++ b/ui/component/or-asset-viewer/package.json
@@ -14,7 +14,6 @@
   },
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "npx tsc -b",
     "analyze": "npx cem analyze --config ../custom-elements-manifest.config.mjs",
     "test": "npx tsc -b && npx playwright test",
     "prepack": "npx rspack"

--- a/ui/test/app.config.cts
+++ b/ui/test/app.config.cts
@@ -1,4 +1,5 @@
-import { basename, resolve } from "node:path";
+// These imports are transpiled by TypeScript to CommonJS
+import { basename, resolve, join } from "node:path";
 import { defineConfig as baseConfig, devices, Project } from ".";
 
 const { CI, DEV, managerUrl } = process.env;
@@ -64,6 +65,9 @@ export const defineAppConfig = (path: string) => {
       /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
       trace: "retain-on-failure",
       video: "on",
+    },
+    webServer: {
+      command: `node ${join(__dirname, "manager.cjs")}`
     },
     /* Configure projects */
     projects: [

--- a/ui/test/logging.properties
+++ b/ui/test/logging.properties
@@ -1,0 +1,23 @@
+# Log to STDOUT and internal syslog service (monitoring in Manager UI)
+handlers=java.util.logging.ConsoleHandler, \
+  org.openremote.manager.syslog.SyslogService
+
+# Output to the console
+java.util.logging.ConsoleHandler.level=WARNING
+java.util.logging.ConsoleHandler.formatter=org.openremote.container.util.LogFormatter
+
+# Root
+.level=WARNING
+
+# Third party overrides
+org.hibernate.cfg.beanvalidation.TypeSafeActivator.level=SEVERE
+org.apache.camel.impl.DefaultShutdownStrategy.level=SEVERE
+io.netty.level=SEVERE
+org.apache.sshd.level=SEVERE
+
+# Non-standard third party overrides (to reduce warning spam)
+org.flywaydb.level=SEVERE
+org.hibernate.validator.internal.metadata.aggregated.CascadingMetaDataBuilder.level=SEVERE
+
+### Disabled -- Set to SEVERE for debugging retries
+org.keycloak.adapters.BearerTokenRequestAuthenticator.level=OFF

--- a/ui/test/manager.cjs
+++ b/ui/test/manager.cjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+const { spawn } = require("node:child_process");
+const path = require("node:path");
+const os = require("node:os");
+
+// Change working directory to repository root
+process.chdir(path.resolve(__dirname, "../.."));
+
+// --- Default Environment Variables ---
+process.env.OR_STORAGE_DIR = process.env.OR_STORAGE_DIR || "tmp"; // Changed to relative local directory
+process.env.OR_APP_DOCROOT = process.env.OR_APP_DOCROOT || "manager/build/install/manager/web";
+// Variables without defaults
+process.env.OR_LOGGING_CONFIG_FILE = process.env.OR_LOGGING_CONFIG_FILE || path.join("ui", "test", "logging.properties");
+
+// --- Local Paths ---
+// Ensure you have run `./gradlew :manager:installDist` so these folders exist.
+const APP_LIB_DIR = path.join("manager", "build", "install", "manager", "lib", "*");
+const EXTENSIONS_DIR = path.join("deployment", "manager", "extensions", "*");
+// Handle Classpath Separator (':' on Unix, ';' on Windows)
+const separator = os.platform() === "win32" ? ";" : ":";
+const classPath = `${APP_LIB_DIR}${separator}${EXTENSIONS_DIR}`;
+
+// --- Execution ---
+console.log("Starting OpenRemote Manager...");
+console.log(`Classpath: ${classPath}`);
+
+// --- Prepare Java arguments ---
+// We split OR_JAVA_OPTS by space if it exists, or use the default JVM options defined in our Dockerfile
+const javaOpts = process.env.OR_JAVA_OPTS ? process.env.OR_JAVA_OPTS.split(" ") : [
+    "-Xms500m",
+    "-Xmx2g",
+    "-XX:NativeMemoryTracking=summary",
+    "-Xlog:all=warning:stdout:uptime,level,tags",
+    "-XX:+HeapDumpOnOutOfMemoryError",
+    "-XX:HeapDumpPath=./dump.hprof",
+];
+const args = [...javaOpts, "-cp", classPath, "org.openremote.manager.Main"];
+
+// --- Execute Java ---
+const child = spawn("java", args, {
+    stdio: "inherit", // Forwards all output/input to the terminal
+    shell: false
+});
+process.on("SIGINT", () => child.kill());
+process.on("SIGTERM", () => child.kill());

--- a/ui/test/package.json
+++ b/ui/test/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": "./index.ts",
     "./data": "./fixtures/data.ts",
-    "./app.config": "./app.config.ts",
+    "./app.config": "./app.config.cts",
     "./component.config": "./component.config.ts"
   },
   "files": [

--- a/ui/test/tsconfig.json
+++ b/ui/test/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../tsconfig",
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "outDir": "./lib",
     "rootDir": "."


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

This PR makes the test related tasks execute in the following order:

```mermaid
graph LR
    A[Unit tests] --> B[Integration tests]
    B --> C[UI component tests]
    C --> D[UI app tests]
```

It prevents both integration and UI app tests interacting with the postgres database at the same time. Resolving the referenced issue.

- Closes #2324

It also reduces the dependencies downloaded for the UI app tests and makes the manager start directly on the host from the jar, in preparation for #2683, where we remove the dependency on the manager Docker image to reduce wall time for UI app tests in the pipeline.

Also tested on Windows! (the manager start script for UI app tests)

<img width="2083" height="1308" alt="image" src="https://github.com/user-attachments/assets/ed68c56a-3b98-488a-9eed-b3db4e3b5cd6" />


## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [x] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [x] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
