### PR TITLE
Exclude test tasks from report aggregation step and fix setups not provisioning for pipeline deployments

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -744,7 +744,7 @@ jobs:
         id: backend-test-reports
         run: |
           if [ "$IS_MAIN" = "true" ]; then
-            ./gradlew unitTestReport combinedCoverageReport
+            ./gradlew unitTestReport combinedCoverageReport -x test
             echo "coverage=build/reports/jacoco/combinedCoverageReport/html" >> $GITHUB_OUTPUT
           else
             echo "coverage=test/build/reports/jacoco/test/html" >> $GITHUB_OUTPUT

--- a/build.gradle
+++ b/build.gradle
@@ -114,12 +114,12 @@ tasks.register('checkCoverageDataExists') {
     mustRunAfter(getBackendProjects().collect { "${it.path}:test" })
     doLast {
         def testTasks = getActiveTestTasks()
-        def hasFiles = testTasks.any {
+        def allJacocoResultsExist = testTasks.every {
             it.extensions.findByType(JacocoTaskExtension)?.destinationFile?.exists()
         }
         // Check if any of the configured execution data files exist on disk
-        if (!hasFiles) {
-            println "Please run the following task to be able to generate a report."
+        if (!allJacocoResultsExist) {
+            println "Please run the following tasks to be able to generate a report."
             println "Required tasks: ${testTasks.collect { it.path }.join(', ')}"
             println "Run: gradle test -x npmTest checkCoverageDataExists"
             throw new StopExecutionException()

--- a/ui/app/manager/build.gradle
+++ b/ui/app/manager/build.gradle
@@ -76,12 +76,12 @@ tasks.register('npmBuild', Exec) {
 }
 
 tasks.register('npmTest', Exec) {
-    dependsOn getYarnInstallTask(), resolveTask(":clean")
+    dependsOn getYarnInstallTask(), resolveTask(":ui:test:clean")
     commandLine npmCommand("yarn"), "run", "test"
 }
 
 tasks.register('npmTestUI', Exec) {
-    dependsOn getYarnInstallTask(), resolveTask(":clean")
+    dependsOn getYarnInstallTask(), resolveTask(":ui:test:clean")
     commandLine npmCommand("yarn"), "run", "test", "--ui"
 }
 

--- a/ui/app/storybook/build.gradle
+++ b/ui/app/storybook/build.gradle
@@ -77,12 +77,12 @@ tasks.register('npmBuild', Exec) {
 }
 
 tasks.register('npmTest', Exec) {
-    dependsOn getYarnInstallTask(), resolveTask(":clean")
+    dependsOn getYarnInstallTask(), resolveTask(":ui:test:clean")
     commandLine npmCommand("yarn"), "run", "test"
 }
 
 tasks.register('npmTestUI', Exec) {
-    dependsOn getYarnInstallTask(), resolveTask(":clean")
+    dependsOn getYarnInstallTask(), resolveTask(":ui:test:clean")
     commandLine npmCommand("yarn"), "run", "test", "--ui"
 }
 

--- a/ui/test/build.gradle
+++ b/ui/test/build.gradle
@@ -1,0 +1,3 @@
+tasks.register("clean") {
+    delete "tmp"
+}

--- a/ui/test/build.gradle
+++ b/ui/test/build.gradle
@@ -1,3 +1,3 @@
-tasks.register("clean") {
+tasks.register("clean", Delete) {
     delete "tmp"
 }

--- a/ui/test/manager.cjs
+++ b/ui/test/manager.cjs
@@ -8,7 +8,7 @@ const os = require("node:os");
 process.chdir(path.resolve(__dirname, "../.."));
 
 // --- Default Environment Variables ---
-process.env.OR_STORAGE_DIR = process.env.OR_STORAGE_DIR || "tmp"; // Changed to relative local directory
+process.env.OR_STORAGE_DIR = process.env.OR_STORAGE_DIR || "ui/test/tmp"; // Changed to relative local directory
 process.env.OR_APP_DOCROOT = process.env.OR_APP_DOCROOT || "manager/build/install/manager/web";
 // Variables without defaults
 process.env.OR_LOGGING_CONFIG_FILE = process.env.OR_LOGGING_CONFIG_FILE || path.join("ui", "test", "logging.properties");


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Pipelines would run the unit tests through the `unitTestReport` task on the main repository (increasing pipeline minutes). The report aggregation step now explicitly excludes the test tasks.

This also fixes deployments missing the current openremote version causing the demo setup to not provision, which broke due to cleaning of the `tmp` dir in https://github.com/openremote/openremote/pull/2689

You can see a successful deployment on test4, ref https://github.com/openremote/openremote/actions/runs/24569007966

## Changelog

- The report aggregation step now explicitly excludes the test tasks
- Fixes demo setup not provisioning from pipeline deployments

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
