### PR TITLE
Fix for UI access token update interval not being ran

### DIFF
--- a/ui/component/core/src/index.ts
+++ b/ui/component/core/src/index.ts
@@ -979,14 +979,14 @@ export class Manager implements EventProviderFactory {
                 this._name = this._keycloak.tokenParsed?.name;
                 this._username = this._keycloak.tokenParsed?.preferred_username;
 
-                this._createTokenUpdateInterval();
-
                 // If native shell is enabled store offline token
                 if (this.isMobile() && this._keycloak?.refreshTokenParsed?.typ === "Offline") {
                     console.debug("Storing offline refresh token");
                     this.console.storeData("REFRESH_TOKEN", this._keycloak!.refreshToken);
                 }
                 this._onAuthenticated();
+                this._createTokenUpdateInterval();
+
             } else if (this.config.autoLogin) {
                 this.login();
                 return false;
@@ -1002,6 +1002,7 @@ export class Manager implements EventProviderFactory {
 
     protected _createTokenUpdateInterval() {
         if (!this._authenticated) {
+            console.warn("User is not authenticated; skipping token update interval creation.")
             return;
         }
         if (!this._keycloakUpdateTokenInterval) {


### PR DESCRIPTION
## Description
This PR fixes a critical issue where the "access token update interval" was not being ran upon opening the page.
Normally, every 30 seconds, we automatically request a new access token, to stay authorized.
However, it recently broke after we've merged #2703.
Because the `_authenticated` variable was set to `true` **after** the `_createTokenUpdateInterval()` function was called.

## Changelog
- Moved `_createTokenUpdateInterval()` function **after** the `_onAuthenticated()` function.

## Checklist
- [x] ~~1. Acceptance criteria of the linked issue(s) are met~~
- [x] ~~2. Tests are written and all tests pass~~
- [ ] 3. Changes are manually tested by you and the reviewer
- [x] ~~4. Documentation is written or updated~~