### PR TITLE
Fix RULE_RESET_IMMEDIATE not working as expected

### DIFF
--- a/manager/src/main/java/org/openremote/manager/rules/JsonRulesBuilder.java
+++ b/manager/src/main/java/org/openremote/manager/rules/JsonRulesBuilder.java
@@ -223,7 +223,8 @@ public class JsonRulesBuilder extends RulesBuilder {
                 // only need up to date values in the previously matched asset states previously unmatched asset states is only
                 // used to compare asset ID and attribute name.
                 if (event != null) {
-                    if (previouslyMatchedAssetStates.remove(event.assetState)) {
+                    boolean resetImmediately = event.assetState.getMeta().getValue(MetaItemType.RULE_RESET_IMMEDIATE).orElse(false);
+                    if (!resetImmediately && previouslyMatchedAssetStates.remove(event.assetState)) {
                         previouslyMatchedAssetStates.add(event.assetState);
                     }
                 }

--- a/test/src/test/groovy/org/openremote/test/rules/RuleResetImmediate.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/RuleResetImmediate.groovy
@@ -1,0 +1,134 @@
+package org.openremote.test.rules
+
+import org.openremote.manager.notification.EmailNotificationHandler
+import org.openremote.manager.notification.NotificationService
+import org.openremote.manager.asset.AssetProcessingService
+import org.openremote.manager.asset.AssetStorageService
+import org.openremote.manager.rules.RulesEngine
+import org.openremote.manager.rules.RulesService
+import org.openremote.manager.rules.RulesetStorageService
+import org.openremote.manager.setup.SetupService
+import org.openremote.model.asset.impl.LightAsset
+import org.openremote.model.attribute.AttributeEvent
+import org.openremote.model.attribute.MetaItem
+import org.openremote.model.notification.AbstractNotificationMessage
+import org.openremote.model.notification.Notification
+import org.openremote.model.util.UniqueIdentifierGenerator
+import org.openremote.model.value.MetaItemType
+import org.openremote.model.notification.NotificationSendResult
+import org.openremote.model.rules.RealmRuleset
+import org.openremote.model.rules.Ruleset
+import org.openremote.setup.integration.KeycloakTestSetup
+import org.openremote.test.ManagerContainerTrait
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+
+import static org.openremote.model.rules.RulesetStatus.DEPLOYED
+
+class RuleResetImmediate extends Specification implements ManagerContainerTrait {
+
+    def "Brightness repeatedly above threshold triggers rule again only with reset immediate"() {
+        given: "the container environment is started"
+        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+        def container = startContainer(defaultConfig(), defaultServices())
+        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+        def rulesService = container.getService(RulesService.class)
+        def assetStorageService = container.getService(AssetStorageService.class)
+        def assetProcessingService = container.getService(AssetProcessingService.class)
+        def rulesetStorageService = container.getService(RulesetStorageService.class)
+        def notificationService = container.getService(NotificationService.class)
+        def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
+        RulesEngine engine = null
+        def sentMessages = new CopyOnWriteArrayList<AbstractNotificationMessage>()
+
+        and: "email notifications are captured in-memory"
+        EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
+        mockEmailNotificationHandler.isValid() >> true
+        mockEmailNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
+            id, source, sourceId, target, message ->
+                sentMessages << message
+        }
+        mockEmailNotificationHandler.sendMessage(_ as jakarta.mail.Message) >> {
+            message -> NotificationSendResult.success()
+        }
+        notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
+
+        and: "two light assets are added, but only one has the reset immediate meta item"
+        def resetLightAsset = new LightAsset("Reset immediate light")
+                .setId(UniqueIdentifierGenerator.generateId("Reset immediate light"))
+                .setRealm(keycloakTestSetup.realmBuilding.name)
+        resetLightAsset.getAttributes().getOrCreate(LightAsset.BRIGHTNESS)
+                .addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+                .addMeta(new MetaItem<>(MetaItemType.RULE_RESET_IMMEDIATE))
+        resetLightAsset = assetStorageService.merge(resetLightAsset)
+
+        def normalLightAsset = new LightAsset("Normal light")
+                .setId(UniqueIdentifierGenerator.generateId("Normal light"))
+                .setRealm(keycloakTestSetup.realmBuilding.name)
+        normalLightAsset.getAttributes().getOrCreate(LightAsset.BRIGHTNESS)
+                .addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+        normalLightAsset = assetStorageService.merge(normalLightAsset)
+
+        and: "a JSON rule notifies when brightness is above the threshold"
+        def ruleset = new RealmRuleset(
+                keycloakTestSetup.realmBuilding.name,
+                "Brightness reset immediate rule",
+                Ruleset.Lang.JSON,
+                getClass().getResource("/org/openremote/test/rules/JsonRuleResetImmediate.json").text)
+        ruleset = rulesetStorageService.merge(ruleset)
+
+        expect: "the custom asset states and ruleset should be loaded into the rule engine"
+        conditions.eventually {
+            engine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+            assert engine != null
+            assert engine.isRunning()
+            assert engine.deployments.get(ruleset.id)?.status == DEPLOYED
+            assert engine.hasPreviouslyFired()
+            assert engine.facts.assetStates.any { it.id == resetLightAsset.id && it.name == LightAsset.BRIGHTNESS.name }
+            assert engine.facts.assetStates.any { it.id == normalLightAsset.id && it.name == LightAsset.BRIGHTNESS.name }
+        }
+
+        when: "the reset-immediate light enters the matching range"
+        advancePseudoClock(1, TimeUnit.SECONDS, container)
+        assetProcessingService.sendAttributeEvent(new AttributeEvent(resetLightAsset.id, LightAsset.BRIGHTNESS, 100))
+
+        then: "the rule action fires once"
+        conditions.eventually {
+            assert sentMessages.size() == 1
+        }
+
+        when: "the same matching value is received again for the reset-immediate light"
+        advancePseudoClock(1, TimeUnit.SECONDS, container)
+        assetProcessingService.sendAttributeEvent(new AttributeEvent(resetLightAsset.id, LightAsset.BRIGHTNESS, 100))
+
+        then: "the rule action fires again"
+        conditions.eventually {
+            assert sentMessages.size() == 2
+        }
+
+        when: "the normal light enters the matching range"
+        advancePseudoClock(1, TimeUnit.SECONDS, container)
+        assetProcessingService.sendAttributeEvent(new AttributeEvent(normalLightAsset.id, LightAsset.BRIGHTNESS, 100))
+
+        then: "the rule action fires for the first matching event"
+        conditions.eventually {
+            assert sentMessages.size() == 3
+        }
+
+        when: "the same matching value is received again for the normal light"
+        advancePseudoClock(1, TimeUnit.SECONDS, container)
+        assetProcessingService.sendAttributeEvent(new AttributeEvent(normalLightAsset.id, LightAsset.BRIGHTNESS, 100))
+
+        then: "the rule action does not fire again without reset immediate"
+        Thread.sleep(1000)
+        sentMessages.size() == 3
+
+        cleanup:
+        if (notificationService != null && emailNotificationHandler != null) {
+            notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
+        }
+    }
+}

--- a/test/src/test/resources/org/openremote/test/rules/JsonRuleResetImmediate.json
+++ b/test/src/test/resources/org/openremote/test/rules/JsonRuleResetImmediate.json
@@ -1,0 +1,61 @@
+{
+  "rules": [
+    {
+      "name": "Brightness Trigger Rule",
+      "recurrence": {
+        "mins": 0
+      },
+      "when": {
+        "operator": "OR",
+        "groups": [
+          {
+            "operator": "AND",
+            "items": [
+              {
+                "assets": {
+                  "types": [
+                    "LightAsset"
+                  ],
+                  "attributes": {
+                    "items": [
+                      {
+                        "name": {
+                          "predicateType": "string",
+                          "match": "EXACT",
+                          "value": "brightness"
+                        },
+                        "value": {
+                          "predicateType": "number",
+                          "operator": "GREATER_THAN",
+                          "value": 50
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "then": [
+        {
+          "action": "notification",
+          "notification": {
+            "message": {
+              "type": "email",
+              "subject": "%RULESET_NAME%",
+              "html": "%TRIGGER_ASSETS%",
+              "to": [
+                {
+                  "address": "test@openremote.io",
+                  "name": "OR Test"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# What was wrong

  JSON rule conditions track previouslyMatchedAssetStates to avoid firing repeatedly while an attribute remains matched. AttributeEvent.equals(...) only compares asset id and attribute name, not value or timestamp, so a newer event for the same attribute is considered the same set
  entry.

  Before the fix, every update did this:

  previouslyMatchedAssetStates.remove(event.assetState);
  previouslyMatchedAssetStates.add(event.assetState);

  That refreshed the previous-match set with the new timestamp before rule evaluation. Later, the RULE_RESET_IMMEDIATE logic tried to detect a newer matching event:

  resetImmediately && matchedAssetState.getTimestamp() > previousAssetState.getTimestamp()

  But both sides now referred to the new timestamp, so the comparison became effectively:

  newTimestamp > newTimestamp

  That is false, so the previous match was not cleared, and the rule did not fire again.

# What the fix does

  For normal attributes, behavior stays the same: the previous matched state is refreshed on update, so a rule does not retrigger just because an already-matching value is updated.

  For attributes with RULE_RESET_IMMEDIATE, we do not eagerly replace the previous matched state. That leaves the old timestamp in previouslyMatchedAssetStates until evaluation. Then the existing reset logic can correctly compare:

  newTimestamp > oldTimestamp

  When true, the previous match is removed. After that, the current matching state is no longer filtered out as “already matched,” so the rule becomes eligible to fire again.
