### PR TITLE
Add Giga and Tera units

### DIFF
--- a/model/src/main/java/org/openremote/model/Constants.java
+++ b/model/src/main/java/org/openremote/model/Constants.java
@@ -97,6 +97,8 @@ public interface Constants {
     String UNITS_CUBED = "cubed";
     String UNITS_PEAK = "peak";
     String UNITS_MEGA = "mega";
+    String UNITS_GIGA = "giga";
+    String UNITS_TERA = "tera";
     String UNITS_KILO = "kilo";
     String UNITS_CENTI = "centi";
     String UNITS_HECTO = "hecto";

--- a/ui/app/shared/locales/ar/or.json
+++ b/ui/app/shared/locales/ar/or.json
@@ -294,6 +294,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "milli": "m",

--- a/ui/app/shared/locales/cn/or.json
+++ b/ui/app/shared/locales/cn/or.json
@@ -316,6 +316,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "milli": "m",

--- a/ui/app/shared/locales/de/or.json
+++ b/ui/app/shared/locales/de/or.json
@@ -342,6 +342,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "milli": "m",

--- a/ui/app/shared/locales/en/or.json
+++ b/ui/app/shared/locales/en/or.json
@@ -539,6 +539,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "hecto": "h",

--- a/ui/app/shared/locales/es/or.json
+++ b/ui/app/shared/locales/es/or.json
@@ -319,6 +319,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "milli": "m",

--- a/ui/app/shared/locales/fr/or.json
+++ b/ui/app/shared/locales/fr/or.json
@@ -319,6 +319,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "milli": "m",

--- a/ui/app/shared/locales/it/or.json
+++ b/ui/app/shared/locales/it/or.json
@@ -316,6 +316,8 @@
     "cubed": "Â³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "milli": "m",

--- a/ui/app/shared/locales/nl/or.json
+++ b/ui/app/shared/locales/nl/or.json
@@ -533,6 +533,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "hecto": "h",

--- a/ui/app/shared/locales/pl/or.json
+++ b/ui/app/shared/locales/pl/or.json
@@ -539,6 +539,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "hecto": "h",

--- a/ui/app/shared/locales/pt/or.json
+++ b/ui/app/shared/locales/pt/or.json
@@ -317,6 +317,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "milli": "m",

--- a/ui/app/shared/locales/ro/or.json
+++ b/ui/app/shared/locales/ro/or.json
@@ -391,6 +391,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "M",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "milli": "m",

--- a/ui/app/shared/locales/uk/or.json
+++ b/ui/app/shared/locales/uk/or.json
@@ -400,6 +400,8 @@
     "cubed": "³",
     "peak": "p",
     "mega": "М",
+    "giga": "G",
+    "tera": "T",
     "kilo": "k",
     "centi": "c",
     "milli": "m",


### PR DESCRIPTION
Feature/add giga and tera units

## Description
@KerstenTechniek could use the giga and tera units for clarification of values.
This small pr is solely to change giga and tera units from:

<img width="1069" height="240" alt="afbeelding" src="https://github.com/user-attachments/assets/6d725599-630c-496e-8b31-e1cd6d2b370b" />

To:

<img width="1033" height="313" alt="afbeelding" src="https://github.com/user-attachments/assets/e95a88b9-f661-42ed-a67e-0eb483b60d7a" />


## Checklist
- [x] 1. Acceptance criteria of the linked issue(s) are met (There was no issue)
- [x] 2. Tests are written and all tests pass (No test written and it passes the tests)
- [ ] 3. Changes are manually tested by you and the reviewer (on my side it works!)
- [x] 4. Documentation is written or updated

Documentation already references the units available in the code [in this chapter](https://docs.openremote.io/docs/user-guide/manager-ui/#configure-attributes). And since this code only updates the language packs and that file for units, i think its documented enough

