### PR TITLE
Reconfigure Knip workspaces to reintroduce openremote/util dev dependencies

### DIFF
--- a/ui/app/insights/package.json
+++ b/ui/app/insights/package.json
@@ -36,6 +36,7 @@
     "lit": "^3.3.1"
   },
   "devDependencies": {
-    "@openremote/util": "workspace:*"
+    "@openremote/util": "workspace:*",
+    "@rspack/core": "~1.7.5"
   }
 }

--- a/ui/app/manager/package.json
+++ b/ui/app/manager/package.json
@@ -56,7 +56,8 @@
   },
   "devDependencies": {
     "@openremote/util": "workspace:*",
-    "@rsdoctor/rspack-plugin": "~1.4.0"
+    "@rsdoctor/rspack-plugin": "~1.4.0",
+    "@rspack/core": "~1.7.5"
   },
   "publishConfig": {
     "access": "public"

--- a/ui/component/core/package.json
+++ b/ui/component/core/package.json
@@ -35,6 +35,7 @@
     "url-search-params-polyfill": "^8.1.0"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "@types/lodash.transform": "^4",
     "@types/qs": "^6.9.7"
   },

--- a/ui/component/or-asset-tree/package.json
+++ b/ui/component/or-asset-tree/package.json
@@ -32,6 +32,7 @@
     "qs": "^6.8.0"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "@types/lodash.debounce": "^4"
   },
   "publishConfig": {

--- a/ui/component/or-asset-viewer/package.json
+++ b/ui/component/or-asset-viewer/package.json
@@ -36,6 +36,7 @@
     "lit": "^3.3.1"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "axios": "1.16.1"
   },
   "publishConfig": {

--- a/ui/component/or-attribute-barchart/package.json
+++ b/ui/component/or-attribute-barchart/package.json
@@ -28,6 +28,9 @@
     "lit": "^3.3.1",
     "moment": "^2.29.4"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-attribute-card/package.json
+++ b/ui/component/or-attribute-card/package.json
@@ -38,6 +38,7 @@
     "moment": "^2.29.4"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "@types/lodash.debounce": "^4"
   },
   "publishConfig": {

--- a/ui/component/or-attribute-history/package.json
+++ b/ui/component/or-attribute-history/package.json
@@ -36,6 +36,7 @@
     "moment": "^2.29.4"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "@types/lodash.debounce": "^4"
   },
   "publishConfig": {

--- a/ui/component/or-attribute-input/package.json
+++ b/ui/component/or-attribute-input/package.json
@@ -31,6 +31,9 @@
     "@openremote/or-translate": "workspace:*",
     "lit": "^3.3.1"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-attribute-picker/package.json
+++ b/ui/component/or-attribute-picker/package.json
@@ -28,6 +28,9 @@
     "@openremote/or-translate": "workspace:*",
     "lit": "^3.3.1"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-chart/package.json
+++ b/ui/component/or-chart/package.json
@@ -39,6 +39,7 @@
     "moment": "^2.29.4"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "@types/lodash.debounce": "^4",
     "@types/offscreencanvas": "^2019.6.4"
   },

--- a/ui/component/or-components/package.json
+++ b/ui/component/or-components/package.json
@@ -37,6 +37,9 @@
     "lit": "^3.3.1",
     "simplebar": "^5.3.6"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-dashboard-builder/package.json
+++ b/ui/component/or-dashboard-builder/package.json
@@ -45,6 +45,7 @@
     "moment": "^2.29.4"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "@types/lodash.debounce": "^4",
     "@types/lodash.throttle": "^4"
   },

--- a/ui/component/or-gauge/package.json
+++ b/ui/component/or-gauge/package.json
@@ -30,6 +30,7 @@
     "lodash.debounce": "^4.0.8"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "@types/lodash.debounce": "^4"
   },
   "publishConfig": {

--- a/ui/component/or-icon/package.json
+++ b/ui/component/or-icon/package.json
@@ -27,6 +27,9 @@
     "@openremote/model": "workspace:*",
     "lit": "^3.3.1"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-json-forms/package.json
+++ b/ui/component/or-json-forms/package.json
@@ -30,6 +30,9 @@
     "ajv": "^8.8.2",
     "lit": "^3.3.1"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-log-viewer/package.json
+++ b/ui/component/or-log-viewer/package.json
@@ -32,6 +32,9 @@
     "lit": "^3.3.1",
     "moment": "^2.29.4"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-map/package.json
+++ b/ui/component/or-map/package.json
@@ -35,6 +35,7 @@
     "maplibre-gl": "^5.19.0"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "@types/geojson": "^7946.0.7",
     "@types/lodash.debounce": "^4"
   },

--- a/ui/component/or-mwc-components/package.json
+++ b/ui/component/or-mwc-components/package.json
@@ -61,6 +61,9 @@
     "lit": "^3.3.1",
     "moment": "^2.29.4"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-rive-renderer/package.json
+++ b/ui/component/or-rive-renderer/package.json
@@ -25,6 +25,9 @@
     "lit": "^3.3.1",
     "lodash.debounce": "^4.0.8"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-rules/package.json
+++ b/ui/component/or-rules/package.json
@@ -43,6 +43,7 @@
     "shortid": "^2.2.15"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "@types/shortid": "^0.0.29"
   },
   "publishConfig": {

--- a/ui/component/or-scheduler/package.json
+++ b/ui/component/or-scheduler/package.json
@@ -29,6 +29,9 @@
         "moment": "^2.29.4",
         "rrule": "^2.6.4"
     },
+    "devDependencies": {
+        "@openremote/util": "workspace:*"
+    },
     "publishConfig": {
         "access": "public"
     }

--- a/ui/component/or-services/package.json
+++ b/ui/component/or-services/package.json
@@ -29,6 +29,9 @@
     "@openremote/or-tree-menu": "workspace:*",
     "lit": "^3.3.1"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-translate/package.json
+++ b/ui/component/or-translate/package.json
@@ -26,6 +26,9 @@
     "i18next": "^21.5.3",
     "lit": "^3.3.1"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/or-tree-menu/package.json
+++ b/ui/component/or-tree-menu/package.json
@@ -27,6 +27,9 @@
     "@openremote/or-translate": "workspace:*",
     "lit": "^3.3.1"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/component/rest/package.json
+++ b/ui/component/rest/package.json
@@ -25,6 +25,7 @@
     "qs": "^6.8.0"
   },
   "devDependencies": {
+    "@openremote/util": "workspace:*",
     "@types/qs": "^6.9.7"
   },
   "publishConfig": {

--- a/ui/component/theme/package.json
+++ b/ui/component/theme/package.json
@@ -21,6 +21,9 @@
   "dependencies": {
     "@vaadin/vaadin-lumo-styles": "~25.0.3"
   },
+  "devDependencies": {
+    "@openremote/util": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/ui/knip.jsonc
+++ b/ui/knip.jsonc
@@ -52,9 +52,6 @@
     "rspack": {
         "config": ["rspack.config.js"]
     },
-    "rsbuild": {
-        "config": ["rsbuild.config.ts"]
-    },
     "eslint": {
         "config": ["ui/.eslintrc.json"]
     }

--- a/ui/knip.jsonc
+++ b/ui/knip.jsonc
@@ -31,7 +31,6 @@
         "ts-loader"
     ],
     "ignoreUnresolved": [
-        "css-loader|ts-loader", // rspack.config.js files depend on the webpack config which uses css and ts-loaders, however these can't be resolved by Knip somehow.
         "./restclient", // Generated file
         "./model" // Generated file
     ],
@@ -49,10 +48,14 @@
         "ui/util": {},
         "ui/test": {}
     },
-    "rspack": {
-        "config": ["rspack.config.js"]
-    },
-    "eslint": {
-        "config": ["ui/.eslintrc.json"]
-    }
+    // Explicitly activate the rspack plugin,
+    // because we only indirectly reference @rspack/core through the @openremote/util package
+    "rspack": true,
+    // Webpack loaders resolving doesn't work because they're referenced under the @openremote/util package
+    // "webpack": true,
+    // ESlint plugin resolving doesn't work because they're referenced under the @openremote/util package
+    // "eslint": ["ui/.eslintrc.json"],
+    // Storybook story dependency resolving doesn't work because those reference the @storybook/web-components dependency
+    // installed indirectly throught the @openremote/storybook app
+    // "storybook": true
 }

--- a/ui/knip.jsonc
+++ b/ui/knip.jsonc
@@ -1,20 +1,34 @@
 {
     "$schema": "https://unpkg.com/knip@5/schema-jsonc.json",
-    "ignore": [
-        "**/*.stories.ts"
-    ],
-    "ignoreWorkspaces": [
-        "ui/util", // Many dev dependencies like eslint are considered unused
-        "ui/test" // Only ignoring because the index.js file in the Playwright app doesn't want to parse]
-
-    ],
+    "ignore": ["**/*.stories.ts"],
     "ignoreDependencies": [
         "@types/react", // Required by mdx which is used in Storybook
         "@webcomponents/webcomponentsjs", // Imported through index.html files for apps
         "@types/offscreencanvas", // Referenced in the tsconfig file
         "@vaadin/vaadin-lumo-styles", // Only imports CSS files
         "@openremote/theme", // Only imports CSS files
-        "@rsdoctor/rspack-plugin" // References in webpack config, and imported using require()
+        // --- HOISTED UTIL PACKAGE TOOLING ---
+        // Ignoring these stops Knip from flagging them as "Unused" in ui/util & ui/test
+        // AND stops Knip from flagging them as "Unlisted" when used by other workspaces.
+        "@custom-elements-manifest/analyzer",
+        "@rspack/cli",
+        "@typescript-eslint/eslint-plugin",
+        "@typescript-eslint/parser",
+        "@wc-toolkit/cem-inheritance",
+        "@wc-toolkit/jsx-types",
+        "@wc-toolkit/storybook-helpers",
+        "cross-env",
+        "css-loader",
+        "eslint",
+        "eslint-config-prettier",
+        "eslint-config-standard",
+        "eslint-plugin-import",
+        "eslint-plugin-node",
+        "eslint-plugin-promise",
+        "prettier",
+        "shx",
+        "source-map-loader",
+        "ts-loader"
     ],
     "ignoreUnresolved": [
         "css-loader|ts-loader", // rspack.config.js files depend on the webpack config which uses css and ts-loaders, however these can't be resolved by Knip somehow.
@@ -27,8 +41,21 @@
         "files": "off"
     },
     "workspaces": {
-        ".": {
-            "project": ["ui"]
-        }
+        "ui/{app,component,demo}/*": {
+            "paths": {
+                "@openremote/util": ["../../util/webpack.util.js"]
+            }
+        },
+        "ui/util": {},
+        "ui/test": {}
+    },
+    "rspack": {
+        "config": ["rspack.config.js"]
+    },
+    "rsbuild": {
+        "config": ["rsbuild.config.ts"]
+    },
+    "eslint": {
+        "config": ["ui/.eslintrc.json"]
     }
 }

--- a/ui/test/package.json
+++ b/ui/test/package.json
@@ -24,6 +24,9 @@
   },
   "license": "AGPL-3.0-or-later",
   "devDependencies": {
+    "@openremote/core": "workspace:*",
+    "@openremote/model": "workspace:*",
+    "@openremote/or-icon": "workspace:*",
     "@openremote/util": "workspace:*",
     "@playwright/experimental-ct-core": "1.57.0",
     "@playwright/test": "1.57.0",
@@ -33,6 +36,8 @@
     "@sand4rt/experimental-ct-web": "1.57.0",
     "css-loader": "^6.5.1",
     "html-webpack-plugin": "^5.6.6",
+    "i18next": "^21.5.3",
+    "i18next-http-backend": "^1.3.1",
     "playwright": "1.57.0",
     "playwright-core": "1.57.0",
     "ts-loader": "~9.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1743,6 +1743,7 @@ __metadata:
     "@openremote/model": "workspace:*"
     "@openremote/or-icon": "workspace:*"
     "@openremote/rest": "workspace:*"
+    "@openremote/util": "workspace:*"
     "@types/lodash.transform": "npm:^4"
     "@types/qs": "npm:^6.9.7"
     axios: "npm:1.16.1"
@@ -1794,6 +1795,7 @@ __metadata:
     "@openremote/rest": "workspace:*"
     "@openremote/util": "workspace:*"
     "@reduxjs/toolkit": "npm:^1.8.1"
+    "@rspack/core": "npm:~1.7.5"
     lit: "npm:^3.3.1"
   languageName: unknown
   linkType: soft
@@ -1824,6 +1826,7 @@ __metadata:
     "@openremote/util": "workspace:*"
     "@reduxjs/toolkit": "npm:^1.8.1"
     "@rsdoctor/rspack-plugin": "npm:~1.4.0"
+    "@rspack/core": "npm:~1.7.5"
     iso-639-1: "npm:^3.1.3"
     lit: "npm:^3.3.1"
     maplibre-gl: "npm:^5.12.0"
@@ -1866,6 +1869,7 @@ __metadata:
     "@openremote/or-icon": "workspace:*"
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     "@types/lodash.debounce": "npm:^4"
     lit: "npm:^3.3.1"
     lodash.debounce: "npm:^4.0.8"
@@ -1888,6 +1892,7 @@ __metadata:
     "@openremote/or-icon": "workspace:*"
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     axios: "npm:1.16.1"
     i18next: "npm:^21.5.3"
     lit: "npm:^3.3.1"
@@ -1904,6 +1909,7 @@ __metadata:
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
     "@openremote/rest": "workspace:*"
+    "@openremote/util": "workspace:*"
     echarts: "npm:~6.0.0"
     lit: "npm:^3.3.1"
     moment: "npm:^2.29.4"
@@ -1923,6 +1929,7 @@ __metadata:
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
     "@openremote/rest": "workspace:*"
+    "@openremote/util": "workspace:*"
     "@types/lodash.debounce": "npm:^4"
     chart.js: "npm:^3.6.0"
     chartjs-adapter-moment: "npm:^1.0.0"
@@ -1944,6 +1951,7 @@ __metadata:
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
     "@openremote/rest": "workspace:*"
+    "@openremote/util": "workspace:*"
     "@types/lodash.debounce": "npm:^4"
     echarts: "npm:~6.0.0"
     jsonpath-plus: "npm:^10.3.0"
@@ -1965,6 +1973,7 @@ __metadata:
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-scheduler": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     lit: "npm:^3.3.1"
   languageName: unknown
   linkType: soft
@@ -1978,6 +1987,7 @@ __metadata:
     "@openremote/or-asset-tree": "workspace:*"
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     lit: "npm:^3.3.1"
   languageName: unknown
   linkType: soft
@@ -1997,6 +2007,7 @@ __metadata:
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
     "@openremote/rest": "workspace:*"
+    "@openremote/util": "workspace:*"
     "@types/lodash.debounce": "npm:^4"
     "@types/offscreencanvas": "npm:^2019.6.4"
     echarts: "npm:~6.0.0"
@@ -2015,6 +2026,7 @@ __metadata:
     "@openremote/model": "workspace:*"
     "@openremote/or-icon": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     ace-builds: "npm:^1.41.0"
     lit: "npm:^3.3.1"
     simplebar: "npm:^5.3.6"
@@ -2042,6 +2054,7 @@ __metadata:
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
     "@openremote/rest": "workspace:*"
+    "@openremote/util": "workspace:*"
     "@types/lodash.debounce": "npm:^4"
     "@types/lodash.throttle": "npm:^4"
     gridstack: "npm:^12.4.2"
@@ -2060,6 +2073,7 @@ __metadata:
     "@openremote/model": "workspace:*"
     "@openremote/or-icon": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     "@types/lodash.debounce": "npm:^4"
     gaugeJS: "npm:^1.3.7"
     lit: "npm:^3.3.1"
@@ -2073,6 +2087,7 @@ __metadata:
   dependencies:
     "@mdi/font": "npm:latest"
     "@openremote/model": "workspace:*"
+    "@openremote/util": "workspace:*"
     lit: "npm:^3.3.1"
   languageName: unknown
   linkType: soft
@@ -2086,6 +2101,7 @@ __metadata:
     "@openremote/or-components": "workspace:*"
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     ajv: "npm:^8.8.2"
     lit: "npm:^3.3.1"
   languageName: unknown
@@ -2101,6 +2117,7 @@ __metadata:
     "@openremote/or-components": "workspace:*"
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     axios: "npm:1.16.1"
     http-link-header: "npm:^1.1.3"
     lit: "npm:^3.3.1"
@@ -2118,6 +2135,7 @@ __metadata:
     "@openremote/or-icon": "workspace:*"
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     "@types/geojson": "npm:^7946.0.7"
     "@types/lodash.debounce": "npm:^4"
     lit: "npm:^3.3.1"
@@ -2160,6 +2178,7 @@ __metadata:
     "@openremote/model": "workspace:*"
     "@openremote/or-icon": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     lit: "npm:^3.3.1"
     moment: "npm:^2.29.4"
   languageName: unknown
@@ -2169,6 +2188,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openremote/or-rive-renderer@workspace:ui/component/or-rive-renderer"
   dependencies:
+    "@openremote/util": "workspace:*"
     "@rive-app/webgl2": "npm:^2.35.4"
     lit: "npm:^3.3.1"
     lodash.debounce: "npm:^4.0.8"
@@ -2192,6 +2212,7 @@ __metadata:
     "@openremote/or-translate": "workspace:*"
     "@openremote/or-tree-menu": "workspace:*"
     "@openremote/rest": "workspace:*"
+    "@openremote/util": "workspace:*"
     "@types/shortid": "npm:^0.0.29"
     ace-builds: "npm:^1.41.0"
     iso-639-1: "npm:^3.1.3"
@@ -2212,6 +2233,7 @@ __metadata:
     "@openremote/or-icon": "workspace:*"
     "@openremote/or-translate": "workspace:*"
     "@openremote/or-vaadin-components": "workspace:*"
+    "@openremote/util": "workspace:*"
     lit: "npm:^3.3.1"
     moment: "npm:^2.29.4"
     rrule: "npm:^2.6.4"
@@ -2228,6 +2250,7 @@ __metadata:
     "@openremote/or-icon": "workspace:*"
     "@openremote/or-translate": "workspace:*"
     "@openremote/or-tree-menu": "workspace:*"
+    "@openremote/util": "workspace:*"
     lit: "npm:^3.3.1"
   languageName: unknown
   linkType: soft
@@ -2236,6 +2259,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openremote/or-translate@workspace:ui/component/or-translate"
   dependencies:
+    "@openremote/util": "workspace:*"
     i18next: "npm:^21.5.3"
     lit: "npm:^3.3.1"
   languageName: unknown
@@ -2248,6 +2272,7 @@ __metadata:
     "@openremote/core": "workspace:*"
     "@openremote/or-mwc-components": "workspace:*"
     "@openremote/or-translate": "workspace:*"
+    "@openremote/util": "workspace:*"
     lit: "npm:^3.3.1"
   languageName: unknown
   linkType: soft
@@ -2282,6 +2307,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openremote/rest@workspace:ui/component/rest"
   dependencies:
+    "@openremote/util": "workspace:*"
     "@types/qs": "npm:^6.9.7"
     axios: "npm:1.16.1"
     qs: "npm:^6.8.0"
@@ -2310,6 +2336,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openremote/test@workspace:ui/test"
   dependencies:
+    "@openremote/core": "workspace:*"
+    "@openremote/model": "workspace:*"
+    "@openremote/or-icon": "workspace:*"
     "@openremote/util": "workspace:*"
     "@playwright/experimental-ct-core": "npm:1.57.0"
     "@playwright/test": "npm:1.57.0"
@@ -2319,6 +2348,8 @@ __metadata:
     "@sand4rt/experimental-ct-web": "npm:1.57.0"
     css-loader: "npm:^6.5.1"
     html-webpack-plugin: "npm:^5.6.6"
+    i18next: "npm:^21.5.3"
+    i18next-http-backend: "npm:^1.3.1"
     playwright: "npm:1.57.0"
     playwright-core: "npm:1.57.0"
     ts-loader: "npm:~9.5.2"
@@ -2331,6 +2362,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openremote/theme@workspace:ui/component/theme"
   dependencies:
+    "@openremote/util": "workspace:*"
     "@vaadin/vaadin-lumo-styles": "npm:~25.0.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

In the referenced PR we want to reintroduce explicit usage of `@openremote/util` for packages that rely on the Webpack configuration. Since Knip was introduced we got rid of this as Knip reported those dependencies as unused (due to a miss configuration) and because the `@openremote/util` package is within the same workspace we didn't need to be explicitly reference it in the `devDependencies` of each package back then.

- Ref #2696 

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
