### PR TITLE
Align skip conditions with branch protection checks

### DIFF
--- a/.github/workflows/build-deployment-image.yml
+++ b/.github/workflows/build-deployment-image.yml
@@ -4,6 +4,10 @@ name: Build deployment image
 on:
   workflow_call:
     inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
       tag:
         type: string
         required: true
@@ -11,6 +15,7 @@ on:
 jobs:
   build-deployment-image:
     name: Deployment image
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -8,6 +8,10 @@ on:
       DOCKERHUB_PASSWORD:
         required: true
     inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
       TAGS:
         type: string
         default: ""
@@ -16,6 +20,7 @@ on:
 jobs:
   build-manager-image:
     name: Manager image
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,9 +1,16 @@
 name: Code Coverage
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
 
 jobs:
   code-coverage:
     name: Code Coverage
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/custom-review.yml
+++ b/.github/workflows/custom-review.yml
@@ -58,6 +58,6 @@ jobs:
 
   # code-coverage:
   #   name: Test
-  #   needs: [unit-tests, integration-tests]
+  #   needs: [detect-changes, unit-tests, integration-tests]
   #   if: needs.detect-changes.outputs.backend_any_modified == 'true'
   #   uses: "./.github/workflows/code-coverage.yml"

--- a/.github/workflows/custom-staging.yml
+++ b/.github/workflows/custom-staging.yml
@@ -58,7 +58,7 @@ jobs:
 
   # code-coverage:
   #   name: Test
-  #   needs: [unit-tests, integration-tests]
+  #   needs: [detect-changes, unit-tests, integration-tests]
   #   if: needs.detect-changes.outputs.backend_any_modified == 'true'
   #   uses: "./.github/workflows/code-coverage.yml"
 

--- a/.github/workflows/install-browsers.yml
+++ b/.github/workflows/install-browsers.yml
@@ -1,9 +1,16 @@
 name: Install browsers
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
 
 jobs:
   install-browsers:
     name: Install browsers
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/install-dist.yml
+++ b/.github/workflows/install-dist.yml
@@ -3,6 +3,10 @@ name: Install Dist
 on:
   workflow_call:
     inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
       VERSION_WITH_QUALIFIER:
         type: string
     outputs:
@@ -13,6 +17,7 @@ on:
 jobs:
   install-dist:
     name: Install Dist
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     outputs:
       npmTag: ${{ steps.update-package-json.outputs.tag }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,9 +1,16 @@
 name: Integration Tests
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
 
 jobs:
   integration-tests:
     name: Integration Tests
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-npm-dry-run.yml
+++ b/.github/workflows/publish-npm-dry-run.yml
@@ -1,9 +1,16 @@
 name: NPM publish dry run
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
 
 jobs:
   npm-dry-run:
     name: NPM publish dry run
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -36,62 +36,82 @@ jobs:
   ui-check-dependencies:
     name: Lint
     needs: detect-changes
-    if: needs.detect-changes.outputs.ui_any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/ui-check-dependencies.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.ui_any_modified != 'true' }}
 
   ui-check-outdated-translations:
     name: Lint
     needs: detect-changes
-    if: needs.detect-changes.outputs.backend_any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/ui-check-outdated-translations.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.backend_any_modified != 'true' }}
 
   install-browsers:
     name: Build
     needs: detect-changes
-    if: needs.detect-changes.outputs.any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/install-browsers.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.any_modified != 'true' }}
 
   install-dist:
     name: Build
     needs: detect-changes
-    if: needs.detect-changes.outputs.any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/install-dist.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.any_modified != 'true' }}
 
   unit-tests:
     name: Test
     needs: detect-changes
-    if: needs.detect-changes.outputs.backend_any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/unit-tests.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.backend_any_modified != 'true' }}
 
   integration-tests:
     name: Test
     needs: detect-changes
-    if: needs.detect-changes.outputs.backend_any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/integration-tests.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.backend_any_modified != 'true' }}
 
   code-coverage:
     name: Test
     needs: [unit-tests, integration-tests]
-    if: needs.detect-changes.outputs.backend_any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/code-coverage.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.backend_any_modified != 'true' }}
 
   ui-component-tests:
     name: Test
     needs: [detect-changes, install-dist, install-browsers]
-    if: needs.detect-changes.outputs.ui_any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/ui-component-tests.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.ui_any_modified != 'true' }}
 
   ui-app-tests:
     name: Test
     needs: [detect-changes, install-dist, install-browsers]
-    if: needs.detect-changes.outputs.any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/ui-app-tests.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.any_modified != 'true' }}
 
   build-manager-image:
     name: Build
     needs: [detect-changes, install-dist]
-    if: needs.detect-changes.outputs.any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/build-manager-image.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.any_modified != 'true' }}
     secrets:
       DOCKERHUB_USER: ${{ secrets._TEMP_DOCKERHUB_USER }}
       DOCKERHUB_PASSWORD: ${{ secrets._TEMP_DOCKERHUB_PASSWORD }}
@@ -99,16 +119,19 @@ jobs:
   build-deployment-image: # Only here to check if it can build successfully
     name: Build
     needs: [detect-changes, install-dist]
-    if: needs.detect-changes.outputs.any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/build-deployment-image.yml"
     with:
       tag: develop
+      skip: ${{ needs.detect-changes.outputs.any_modified != 'true' }}
 
   publish-npm-dry-run:
     name: Publish
     needs: [detect-changes, install-dist]
-    if: needs.detect-changes.outputs.ui_any_modified == 'true'
+    if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/publish-npm-dry-run.yml"
+    with:
+      skip: ${{ needs.detect-changes.outputs.ui_any_modified != 'true' }}
 
   get-version-details: # Only here to check if it can build successfully
     name: Build / Get version details

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -83,7 +83,7 @@ jobs:
 
   code-coverage:
     name: Test
-    needs: [unit-tests, integration-tests]
+    needs: [detect-changes, unit-tests, integration-tests]
     if: ${{ !failure() && !cancelled() }}
     uses: "./.github/workflows/code-coverage.yml"
     with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -125,6 +125,12 @@ jobs:
     if: needs.detect-changes.outputs.backend_any_modified == 'true'
     uses: "./.github/workflows/integration-tests.yml"
 
+  code-coverage:
+    name: Test
+    needs: [detect-changes, unit-tests, integration-tests]
+    if: needs.detect-changes.outputs.backend_any_modified == 'true'
+    uses: "./.github/workflows/code-coverage.yml"
+
   ui-component-tests:
     name: Test
     needs: [detect-changes, install-dist, install-browsers]

--- a/.github/workflows/ui-app-tests.yml
+++ b/.github/workflows/ui-app-tests.yml
@@ -57,3 +57,16 @@ jobs:
         with:
           name: or-ui-app-test-results-${{ matrix.shardIndex }}
           path: ui/app/*/app-test-report/**
+
+  ui-app-tests-status:
+    name: UI App Tests Status
+    needs: ui-app-tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix job result
+        if: ${{ needs.ui-app-tests.result == 'failure' || needs.ui-app-tests.result == 'cancelled' }}
+        run: exit 1
+      - name: Success or Skipped
+        if: ${{ needs.ui-app-tests.result == 'success' || needs.ui-app-tests.result == 'skipped' }}
+        run: echo "UI App Tests completed successfully or were skipped."

--- a/.github/workflows/ui-app-tests.yml
+++ b/.github/workflows/ui-app-tests.yml
@@ -1,9 +1,16 @@
 name: UI App Tests
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
 
 jobs:
   ui-app-tests:
     name: UI App Tests
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ui-check-dependencies.yml
+++ b/.github/workflows/ui-check-dependencies.yml
@@ -1,9 +1,16 @@
 name: UI Check Dependencies
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
 
 jobs:
   ui-check-dependencies:
     name: UI Check Dependencies
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ui-check-outdated-translations.yml
+++ b/.github/workflows/ui-check-outdated-translations.yml
@@ -1,9 +1,16 @@
 name: UI Check Outdated Translations
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
 
 jobs:
   ui-check-outdated-translations:
     name: Check for outdated translations
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ui-component-tests.yml
+++ b/.github/workflows/ui-component-tests.yml
@@ -1,9 +1,16 @@
 name: UI Component Tests
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
 
 jobs:
   ui-component-tests:
     name: UI Component Tests
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,9 +1,16 @@
 name: Unit Tests
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        description: Skip condition to allow branch protection checks to pass
+        default: false
 
 jobs:
   unit-tests:
     name: Unit Tests
+    if: ${{ !inputs.skip }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

There are still branch protection check issues when jobs are skipped, because jobs are skipped at the wrong level. They should be skipped not where they are called (reused), but inside the reusable workflow itself.

I had to add an aggregation job for the sharded UI App tests job, because matrix jobs are incompatible when a required status check is expected for each shard while being skipped.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
