### PR TITLE
Await code

### DIFF
--- a/ui/app/manager/src/pages/page-alarms.ts
+++ b/ui/app/manager/src/pages/page-alarms.ts
@@ -624,7 +624,7 @@ export class PageAlarms extends Page<AppStateKeyed> {
                             await this.loadAlarm(alarm);
                             return this.getSingleAlarmTemplate(alarm, readonly);
                         };
-                        const content: Promise<TemplateResult> = getTemplate();
+                        const content: Promise<TemplateResult> = await getTemplate();
                         return html`${until(content, html`
                             <or-translate value="loading"/>`)} `;
                     }


### PR DESCRIPTION
The code around line 627 in ui/app/manager/src/pages/page-alarms.ts looked like it might have an issue. The promise result gets used as if it were already resolved. this patch adds the missing await so the async path is actually sequenced.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.