### PR TITLE
Fix incorrect processing of docker tags

### DIFF
--- a/.github/actions/process-cicd-json/action.yml
+++ b/.github/actions/process-cicd-json/action.yml
@@ -80,6 +80,7 @@ runs:
         if isMainRepo and ((eventName == "release" and isRelease) or (eventName != "release" and not isRelease)):
 
           if dockerPublishTags is not None:
+            dockerPublishTags = ",".join(map(lambda t: t.strip(), dockerPublishTags.split(",")))
             if "$version" in dockerPublishTags:
                 firstDockerTag = version
                 dockerPublishTags = dockerPublishTags.replace("$version", version)
@@ -89,7 +90,6 @@ runs:
 
             os.system(f"echo 'firstDockerTag={firstDockerTag}' >> $GITHUB_OUTPUT")
             print("Manager tags to push to docker hub: {dockerPublishTags}")
-            dockerPublishTags = ",".join(map(lambda t: t.strip(), dockerPublishTags.split(",")))
             if repoOwner == 'openremote':
               os.system(f"echo 'dockerTags={dockerPublishTags}' >> $GITHUB_OUTPUT")
 

--- a/.github/actions/process-cicd-json/action.yml
+++ b/.github/actions/process-cicd-json/action.yml
@@ -89,7 +89,7 @@ runs:
 
             os.system(f"echo 'firstDockerTag={firstDockerTag}' >> $GITHUB_OUTPUT")
             print("Manager tags to push to docker hub: {dockerPublishTags}")
-            dockerPublishTags = " ".join(map(lambda t: t.strip(), dockerPublishTags.split(",")))
+            dockerPublishTags = ",".join(map(lambda t: t.strip(), dockerPublishTags.split(",")))
             if repoOwner == 'openremote':
               os.system(f"echo 'dockerTags={dockerPublishTags}' >> $GITHUB_OUTPUT")
 

--- a/.github/actions/process-cicd-json/action.yml
+++ b/.github/actions/process-cicd-json/action.yml
@@ -89,7 +89,7 @@ runs:
               firstDockerTag = dockerPublishTags.split(",")[0]
 
             os.system(f"echo 'firstDockerTag={firstDockerTag}' >> $GITHUB_OUTPUT")
-            print("Manager tags to push to docker hub: {dockerPublishTags}")
+            print(f"Manager tags to push to docker hub: {dockerPublishTags}")
             if repoOwner == 'openremote':
               os.system(f"echo 'dockerTags={dockerPublishTags}' >> $GITHUB_OUTPUT")
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Process ci_cd.json file
         id: ci-cd-output
-        uses: openremote/openremote/.github/actions/process-cicd-json@fa6f52032b1dea3d4ad080cc6436a3ef3843b0be
+        uses: openremote/openremote/.github/actions/process-cicd-json@e9e87797bed31cdf6c2de6ec30fd6a05753f35f4
         with:
           IS_MAIN_REPO: ${{ steps.is_main_repo.outputs.value }}
           MANAGER_VERSION: ${{ steps.is_main_repo.outputs.version }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Process ci_cd.json file
         id: ci-cd-output
-        uses: openremote/openremote/.github/actions/process-cicd-json@fa6f52032b1dea3d4ad080cc6436a3ef3843b0be
+        uses: openremote/openremote/.github/actions/process-cicd-json@e9e87797bed31cdf6c2de6ec30fd6a05753f35f4
         with:
           IS_MAIN_REPO: ${{ steps.is_main_repo.outputs.value }} # Shouldn't be needed in this context
           MANAGER_VERSION: ${{ steps.is_main_repo.outputs.version }}


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Resolves the issue encountered in the following release job https://github.com/openremote/openremote/actions/runs/27338877877/job/80771299506 of version 1.24.2.

Tested in my fork, with the following tags (https://github.com/Ekhorn/openremote/commit/56c4c6ddf17e7709cc8d3ea709b7a558d19549b3), see the following workflow run https://github.com/Ekhorn/openremote/actions/runs/27348816021/job/80805866382 (successfully published tags "develop, test1 and test2")

The problem is that the `build-manager-image.yml` workflow expects comma separated tags without whitespace between, but the `process-cicd-json` action would use a space as separator.

So we just simply use a comma separator instead now and still strip the tags of whitespace.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
