### PR TITLE
Comment NPM ecosystem in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,27 +9,27 @@ updates:
       - dependency-name: "openremote/openremote"
 
   # Do not maintain npm/Yarn dependencies, including security update PRs.
-  - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/ui/component/*"
-      - "/ui/test"
-      - "/ui/util"
-      - "/ui/app/manager"
-      - "/ui/app/storybook"
-      - "/ui/app/insights"
-      - "/ui/demo/demo-core"
-      - "/ui/demo/demo-rest"
-    schedule:
-      interval: "daily"
-    exclude-paths:
-      - "node_modules/**"
-      - "**/node_modules/**"
-      - "**/dist/**"
-      - "**/build/**"
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
+  #  - package-ecosystem: "npm"
+  #    directories:
+  #      - "/"
+  #      - "/ui/component/*"
+  #      - "/ui/test"
+  #      - "/ui/util"
+  #      - "/ui/app/manager"
+  #      - "/ui/app/storybook"
+  #      - "/ui/app/insights"
+  #      - "/ui/demo/demo-core"
+  #      - "/ui/demo/demo-rest"
+  #    schedule:
+  #      interval: "daily"
+  #    exclude-paths:
+  #      - "node_modules/**"
+  #      - "**/node_modules/**"
+  #      - "**/dist/**"
+  #      - "**/build/**"
+  #    open-pull-requests-limit: 0
+  #    ignore:
+  #      - dependency-name: "*"
 
   # Maintain Java dependencies for the Gradle multi-project build.
   - package-ecosystem: "gradle"


### PR DESCRIPTION
This configuration causes many failed "Dependabot Updates" GHA runs, see: https://github.com/openremote/openremote/actions/workflows/dependabot/dependabot-updates?query=is%3Afailure 