### PR TITLE
Align dependabot with yarnrc npmMinimalAgeGate setting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     directories: "/"
     schedule:
       interval: "daily"
-    cooldown: # To be inline with the minimal age gate option in the .yarnrc.yml file
+    cooldown: # To be inline with the npmMinimalAgeGate setting in the .yarnrc.yml file
       default-days: 7
       exclude:
         - "@openremote/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    cooldown: # To be inline with the npmMinimalAgeGate setting in the .yarnrc.yml file
+    cooldown: # Align with .yarnrc.yml npmMinimalAgeGate (1w) and npmPreapprovedPackages
       default-days: 7
       exclude:
         - "@openremote/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,28 +8,15 @@ updates:
     ignore:
       - dependency-name: "openremote/openremote"
 
-  # Do not maintain npm/Yarn dependencies, including security update PRs.
-  #  - package-ecosystem: "npm"
-  #    directories:
-  #      - "/"
-  #      - "/ui/component/*"
-  #      - "/ui/test"
-  #      - "/ui/util"
-  #      - "/ui/app/manager"
-  #      - "/ui/app/storybook"
-  #      - "/ui/app/insights"
-  #      - "/ui/demo/demo-core"
-  #      - "/ui/demo/demo-rest"
-  #    schedule:
-  #      interval: "daily"
-  #    exclude-paths:
-  #      - "node_modules/**"
-  #      - "**/node_modules/**"
-  #      - "**/dist/**"
-  #      - "**/build/**"
-  #    open-pull-requests-limit: 0
-  #    ignore:
-  #      - dependency-name: "*"
+  # Maintain npm/Yarn dependencies
+  - package-ecosystem: "npm"
+    directories: "/"
+    schedule:
+      interval: "daily"
+    cooldown: # To be inline with the minimal age gate option in the .yarnrc.yml
+      default-days: 7
+      exclude:
+        - "@openremote/*"
 
   # Maintain Java dependencies for the Gradle multi-project build.
   - package-ecosystem: "gradle"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     directories: "/"
     schedule:
       interval: "daily"
-    cooldown: # To be inline with the minimal age gate option in the .yarnrc.yml
+    cooldown: # To be inline with the minimal age gate option in the .yarnrc.yml file
       default-days: 7
       exclude:
         - "@openremote/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
 
   # Maintain npm/Yarn dependencies
   - package-ecosystem: "npm"
-    directories: "/"
+    directory: "/"
     schedule:
       interval: "daily"
     cooldown: # To be inline with the npmMinimalAgeGate setting in the .yarnrc.yml file


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Explicitly align the `dependabot.yml` configuration with the `npmMinimalAgeGate` setting in the `.yarnrc.yml` file.

The `npmMinimalAgeGate` check in Yarn can be bypassed by directly updated the lock file. I don't think dependabot handles this by default.

Ref https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
