### PR TITLE
Fix KPI panel showing 'add attribute' button while it should not

### DIFF
--- a/ui/component/or-attribute-card/src/index.ts
+++ b/ui/component/or-attribute-card/src/index.ts
@@ -343,7 +343,7 @@ export class OrAttributeCard extends LitElement {
                 <div class="panel panel-empty">
                     <div class="panel-content-wrapper">
                         <div class="panel-content">
-                            ${this.shouldHideAttributePicker() ? html`
+                            ${!this.shouldHideAttributePicker() ? html`
                                 <or-vaadin-button class="button" @click=${() => this._openDialog()}>
                                     <or-icon slot="prefix" icon="plus"></or-icon>
                                     <or-translate value="selectAttribute"></or-translate>


### PR DESCRIPTION
## Description
UI bugfix for `or-attribute-card`, aka the KPI widget, where the "Add attribute" button was shown.
However, in Insights, you can modify it from the Widget settings menu.
It was an accidental leftover from my Vaadin testing branch.

## Checklist
- [x] ~~1. Acceptance criteria of the linked issue(s) are met~~
- [x] 2. Tests are written and all tests pass
- [x] 3. Changes are manually tested by you and the reviewer
- [x] ~~4. Documentation is written or updated~~
