### PR TITLE
Upgrade protobuf-gradle-plugin to 0.10.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ releasesRepoUrl=https://ossrh-staging-api.central.sonatype.com/service/local/
 jbossLoggingManagerVersion=2.1.19.Final
 grpcVersion = 1.80.0
 protobufVersion = 3.25.5
-protobufPluginVersion = 0.9.4
+protobufPluginVersion = 0.10.0


### PR DESCRIPTION
This version is compatible with newer Gradle versions which fixes the following deprecation warnings:

> Declaring dependencies using multi-string notation has been deprecated.
>
> This will fail with an error in Gradle 10.

See: https://github.com/google/protobuf-gradle-plugin/releases/tag/v0.10.0