### PR TITLE
Align javadoc with what code actually does

### DIFF
--- a/model/src/main/java/org/openremote/model/console/ConsoleResource.java
+++ b/model/src/main/java/org/openremote/model/console/ConsoleResource.java
@@ -44,8 +44,9 @@ public interface ConsoleResource {
      * stored in the appropriate {@link ConsoleAsset} {@link Attribute}s.
      * <p>
      * This is a public endpoint and allows the registration of consoles anonymously; if there is an authenticated user
-     * registering the console  then the console asset will be linked to that user. If multiple users login on the same
-     * console then it will be associated with each user (i.e. a 1-many relationship).
+     * registering the console then the console asset will be linked to that user.
+     * If it was previously linked to another user, that link is removed first.
+     * A console is linked to at most one user, the last one that performed a registration.
      */
     @POST
     @Path("register")


### PR DESCRIPTION
Code changes was made when fixing [Notifications: remove old asset user links when a new one is created on a console asset · Issue #1390 · openremote/openremote](https://github.com/openremote/openremote/issues/1390) but the javadoc was not updated at this time, this fixes it.