### PR TITLE
Add missing MASTER realm check to TokenVerifierImpl to ensure correct super user filtering at the token verficiation level

### DIFF
--- a/container/src/main/java/org/openremote/container/security/TokenVerifierImpl.java
+++ b/container/src/main/java/org/openremote/container/security/TokenVerifierImpl.java
@@ -132,7 +132,7 @@ public class TokenVerifierImpl implements TokenVerifier {
             // Only allow super users to cross realms
             String authRealm = principal.getRealm();
             if (!Objects.equals(authRealm, realm)) {
-                if (!principal.hasRealmRole(Constants.SUPER_USER_REALM_ROLE)) {
+                if (!Constants.MASTER_REALM.equals(authRealm) || !principal.hasRealmRole(Constants.SUPER_USER_REALM_ROLE)) {
                     throw new AuthenticationException("Invalid token realm");
                 }
             }


### PR DESCRIPTION
JWT token verification introduced super admin check which has always been carried out at in resource implementation code, this newly introduced check was not enforcing the MASTER realm requirement for crossing realms. 

This check never used to occur at the auth level so no new vulnerability was introduced but it should be addressed and in future the unified isSuperUser() check can be utilised