### PR TITLE
Fix tests for Jackson 3 upgrade

### DIFF
--- a/container/src/main/java/org/openremote/container/json/Jackson2Config.java
+++ b/container/src/main/java/org/openremote/container/json/Jackson2Config.java
@@ -45,6 +45,9 @@ public class Jackson2Config implements ContextResolver<ObjectMapper> {
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
         objectMapper.configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);
+        // Match the Jackson 3 model mapper (ValueUtil.JSON): java.time values as epoch millis both ways
+        objectMapper.configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
+        objectMapper.configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
         objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY, true);

--- a/container/src/main/java/org/openremote/container/web/WebService.java
+++ b/container/src/main/java/org/openremote/container/web/WebService.java
@@ -262,6 +262,8 @@ public abstract class WebService implements ContainerService {
     public static List<Object> getStandardProviders(boolean devMode) {
         return Lists.newArrayList(
             new WebServiceExceptions.JAXRSExceptionMapper(devMode),
+            new WebServiceExceptions.ValidationExceptionMapper(),
+            new WebServiceExceptions.LoggingWriterInterceptor(),
             new Jackson2Config(),
             new JacksonConfig(),
             new ClientErrorExceptionHandler()

--- a/container/src/main/java/org/openremote/container/web/WebServiceExceptions.java
+++ b/container/src/main/java/org/openremote/container/web/WebServiceExceptions.java
@@ -27,11 +27,17 @@ import jakarta.persistence.OptimisticLockException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ValidationException;
 import jakarta.ws.rs.NotAllowedException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+import org.jboss.resteasy.plugins.validation.ResteasyViolationExceptionMapper;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
@@ -65,6 +71,41 @@ public class WebServiceExceptions {
         @Override
         public Response toResponse(Throwable exception) {
             return handleResteasyException(devMode, exception);
+        }
+    }
+
+    /**
+     * Takes precedence over RESTEasy's built-in {@link ResteasyViolationExceptionMapper} (application providers win
+     * over built-ins for the same exception type) which handles every {@link ValidationException} - including a
+     * validator that crashed rather than reported violations - without logging anything, turning such failures into
+     * silent {@code text/plain} 500 responses.
+     */
+    @Provider
+    public static class ValidationExceptionMapper extends ResteasyViolationExceptionMapper {
+        @Override
+        public Response toResponse(ValidationException exception) {
+            Response response = super.toResponse(exception);
+            System.Logger.Level level = response.getStatus() >= 500 ? System.Logger.Level.ERROR : System.Logger.Level.WARNING;
+            LOG.log(level, "Validation failure processing JAX-RS request: status=" + response.getStatus(), exception);
+            return response;
+        }
+    }
+
+    /**
+     * Exceptions thrown while writing the response body (e.g. by a {@code MessageBodyWriter}) are never passed to a
+     * registered {@link ExceptionMapper} per the JAX-RS spec, so without this they'd otherwise only surface as a bare
+     * 500 with no logged cause.
+     */
+    @Provider
+    public static class LoggingWriterInterceptor implements WriterInterceptor {
+        @Override
+        public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
+            try {
+                context.proceed();
+            } catch (IOException | RuntimeException e) {
+                LOG.log(System.Logger.Level.ERROR, "Failed to write response body: type=" + context.getType(), e);
+                throw e;
+            }
         }
     }
 
@@ -130,19 +171,19 @@ public class WebServiceExceptions {
                 status = webApplicationException.getResponse().getStatus();
             }
 
-            boolean filterApplied = Boolean.TRUE.equals(request.getAttribute(LoggingFilter.FILTER_APPLIED_ATTR));
-            if (!filterApplied) {
-                System.Logger.Level level = status >= 500 ? System.Logger.Level.ERROR : status >= 400 ? System.Logger.Level.DEBUG : System.Logger.Level.TRACE;
-                LoggingFilter.logException(
-                        devMode,
-                        "Servlet",
-                        level,
-                        effectiveException,
-                        request instanceof HttpServletRequest httpRequest ? httpRequest : null,
-                        status,
-                        response.getContentType()
-                );
-            }
+            // Exceptions reaching this handler (e.g. from a MessageBodyWriter/Reader) never pass through the JAX-RS
+            // ExceptionMapper, so LoggingFilter's request/response summary is the only other place they could be
+            // logged from - and that summary never includes the Throwable. Always log here to guarantee visibility.
+            System.Logger.Level level = status >= 500 ? System.Logger.Level.ERROR : status >= 400 ? System.Logger.Level.DEBUG : System.Logger.Level.TRACE;
+            LoggingFilter.logException(
+                    devMode,
+                    "Servlet",
+                    level,
+                    effectiveException,
+                    request instanceof HttpServletRequest httpRequest ? httpRequest : null,
+                    status,
+                    response.getContentType()
+            );
 
             if (!exchange.isResponseStarted()) {
                 exchange.setStatusCode(status);

--- a/container/src/test/java/org/openremote/container/json/AssetJackson2Test.java
+++ b/container/src/test/java/org/openremote/container/json/AssetJackson2Test.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * See the CONTRIBUTORS.txt file in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.openremote.container.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openremote.model.asset.Asset;
+import org.openremote.model.asset.impl.ThingAsset;
+import org.openremote.model.util.ValueUtil;
+import org.openremote.model.value.ValueType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reproduces what RESTEasy's Jackson 2 provider (the only JSON {@link jakarta.ws.rs.ext.MessageBodyReader}/
+ * {@link jakarta.ws.rs.ext.MessageBodyWriter} on the classpath) does when the manager's own REST API
+ * (e.g. {@code POST /api/asset}) round trips an {@link Asset}.
+ */
+class AssetJackson2Test {
+
+    static final ObjectMapper JSON = Jackson2Config.configureObjectMapper(new ObjectMapper());
+
+    @BeforeAll
+    static void setup() {
+        if (ValueUtil.getValueDescriptor("text").isEmpty()) {
+            ValueUtil.initialise(null);
+        }
+    }
+
+    /**
+     * Verifies that {@link org.openremote.container.json.Jackson2Config}'s
+     * {@link org.openremote.model.jackson.AssetDeserializerJackson2} sets the asset type info context
+     * so {@link org.openremote.model.jackson.AttributeDeserializerJackson2} can resolve a value type
+     * from the asset descriptor even when the JSON omits the {@code "type"} field entirely.
+     * Without {@code AssetDeserializerJackson2} the attribute type stays {@code null}.
+     */
+    @Test
+    void resolveTypeFromAssetDescriptorWhenTypeFieldAbsent() throws Exception {
+        // "location" has no "type" field — type must come from Asset.LOCATION descriptor via context
+        String json = """
+            {"name":"Thing","realm":"smartcity","type":"ThingAsset","attributes":{
+              "location":{"name":"location","value":{"type":"Point","coordinates":[0.0,0.0]}}}}""";
+
+        Asset<?> asset = JSON.readValue(json, Asset.class);
+        assertEquals(ThingAsset.class, asset.getClass());
+        assertEquals(ValueType.GEO_JSON_POINT,
+            asset.getAttributes().get("location").map(a -> a.getType()).orElse(null),
+            "Type must be resolved from Asset.LOCATION descriptor, not from a 'type' field");
+    }
+}

--- a/model/src/main/java/org/openremote/model/asset/AssetInfo.java
+++ b/model/src/main/java/org/openremote/model/asset/AssetInfo.java
@@ -37,16 +37,12 @@ public interface AssetInfo {
     @JsonProperty
     String[] getPath();
 
-    @JsonProperty
     String[] getAttributeNames();
 
-    @JsonProperty
     String getAssetName();
 
-    @JsonProperty
     String getAssetType();
 
-    @JsonProperty
     Class<? extends Asset> getAssetClass();
 
     @JsonProperty

--- a/model/src/main/java/org/openremote/model/jackson/AssetDeserializerJackson2.java
+++ b/model/src/main/java/org/openremote/model/jackson/AssetDeserializerJackson2.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * See the CONTRIBUTORS.txt file in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.openremote.model.jackson;
+
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.core.JsonParser;
+import org.openremote.model.asset.Asset;
+import org.openremote.model.util.ValueUtil;
+
+import java.io.IOException;
+
+/**
+ * Jackson 2 wrapper deserializer for {@link Asset} subclasses. Sets the asset type info
+ * in the deserialization context before delegating to the standard POJO deserializer, so
+ * that {@link AttributeDeserializerJackson2} can resolve attribute types from the asset model.
+ */
+public class AssetDeserializerJackson2 extends StdDeserializer<Asset<?>>
+    implements ContextualDeserializer, ResolvableDeserializer {
+
+    // Must match Asset.AssetDeserializer.ASSET_TYPE_INFO_ATTRIBUTE (avoid loading Jackson3 class here)
+    static final String ASSET_TYPE_INFO_ATTRIBUTE = "assetTypeInfo";
+
+    protected final JsonDeserializer<?> defaultDeserializer;
+    protected final Class<?> clazz;
+
+    public AssetDeserializerJackson2(JsonDeserializer<?> defaultDeserializer, Class<?> clazz) {
+        super(clazz);
+        this.defaultDeserializer = defaultDeserializer;
+        this.clazz = clazz;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Asset<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        ctxt.setAttribute(ASSET_TYPE_INFO_ATTRIBUTE, ValueUtil.getAssetInfo(clazz.getSimpleName()).orElse(null));
+        return (Asset<?>) defaultDeserializer.deserialize(p, ctxt);
+    }
+
+    @Override
+    public void resolve(DeserializationContext ctxt) throws JsonMappingException {
+        if (defaultDeserializer instanceof ResolvableDeserializer rd) {
+            rd.resolve(ctxt);
+        }
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
+        if (!(defaultDeserializer instanceof ContextualDeserializer cd)) {
+            return this;
+        }
+        JsonDeserializer<?> contextual = cd.createContextual(ctxt, property);
+        if (contextual == defaultDeserializer) {
+            return this;
+        }
+        return new AssetDeserializerJackson2(contextual, clazz);
+    }
+
+    @Override
+    public JsonDeserializer<?> getDelegatee() {
+        return defaultDeserializer;
+    }
+}

--- a/model/src/main/java/org/openremote/model/jackson/AttributeDeserializerJackson2.java
+++ b/model/src/main/java/org/openremote/model/jackson/AttributeDeserializerJackson2.java
@@ -25,9 +25,11 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.openremote.model.asset.AssetTypeInfo;
 import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.MetaMap;
 import org.openremote.model.util.ValueUtil;
+import org.openremote.model.value.AttributeDescriptor;
 import org.openremote.model.value.ValueDescriptor;
 
 import java.io.IOException;
@@ -61,7 +63,18 @@ public class AttributeDeserializerJackson2 extends StdDeserializer<Attribute<?>>
         }
 
         ValueDescriptor<?> valueDescriptor = null;
-        if (node.hasNonNull("type")) {
+
+        // Primary: resolve type from asset type info context set by AssetDeserializerJackson2 (mirrors Jackson3 path)
+        AssetTypeInfo assetTypeInfo = (AssetTypeInfo) context.getAttribute(AssetDeserializerJackson2.ASSET_TYPE_INFO_ATTRIBUTE);
+        if (assetTypeInfo != null) {
+            AttributeDescriptor<?> attributeDescriptor = assetTypeInfo.getAttributeDescriptors().get(attributeName);
+            if (attributeDescriptor != null) {
+                valueDescriptor = attributeDescriptor.getType();
+            }
+        }
+
+        // Fallback: resolve type from explicit "type" field in JSON
+        if (valueDescriptor == null && node.hasNonNull("type")) {
             valueDescriptor = ValueUtil.getValueDescriptor(node.get("type").asText()).orElse(null);
         }
 

--- a/model/src/main/java/org/openremote/model/jackson/AttributeSerializerJackson2.java
+++ b/model/src/main/java/org/openremote/model/jackson/AttributeSerializerJackson2.java
@@ -39,16 +39,9 @@ public class AttributeSerializerJackson2 extends StdSerializer<Attribute<?>> {
         if (value.getType() != null) {
             gen.writeStringField("type", value.getType().getName());
         }
-        if (value.getMeta() != null && !value.getMeta().isEmpty()) {
-            gen.writeObjectField("meta", value.getMeta());
-        }
-        value.getValue().ifPresent(v -> {
-            try {
-                gen.writeObjectField("value", v);
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
-        });
+        // Always write meta and value (even when null/empty) to match the Jackson 3 model serializer
+        provider.defaultSerializeField("meta", value.getMeta(), gen);
+        provider.defaultSerializeField("value", value.getValue().orElse(null), gen);
         value.getTimestamp().ifPresent(timestamp -> {
             try {
                 gen.writeNumberField("timestamp", timestamp);

--- a/model/src/main/java/org/openremote/model/jackson/Jackson2ModelModule.java
+++ b/model/src/main/java/org/openremote/model/jackson/Jackson2ModelModule.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.openremote.model.asset.Asset;
 import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.MetaItem;
 import org.openremote.model.attribute.MetaMap;
@@ -64,6 +65,9 @@ public class Jackson2ModelModule extends SimpleModule {
             ) {
                 if (ValueDescriptor.class.isAssignableFrom(beanDesc.getBeanClass())) {
                     return new ValueDescriptor.ValueDescriptorDeserializerJackson2(deserializer);
+                }
+                if (Asset.class.isAssignableFrom(beanDesc.getBeanClass())) {
+                    return new AssetDeserializerJackson2(deserializer, beanDesc.getBeanClass());
                 }
                 return deserializer;
             }

--- a/model/src/main/java/org/openremote/model/util/ValueUtil.java
+++ b/model/src/main/java/org/openremote/model/util/ValueUtil.java
@@ -1030,7 +1030,7 @@ public class ValueUtil {
             }
         }
         if (attributeDescriptor != null && attributeDescriptor.getConstraints() != null) {
-            if (validateConstraints(valueDescriptor.getArrayDimensions(), attributeDescriptor.getConstraints(), context, constraintBuilderProvider, now, value)) {
+            if (validateConstraints(valueDescriptor != null ? valueDescriptor.getArrayDimensions() : null, attributeDescriptor.getConstraints(), context, constraintBuilderProvider, now, value)) {
                 valid = false;
             }
         }

--- a/test/src/test/groovy/org/openremote/test/model/Jackson2ModelBridgeTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/model/Jackson2ModelBridgeTest.groovy
@@ -17,17 +17,24 @@ import org.openremote.model.value.ValueDescriptor
 import org.openremote.model.value.ValueType
 import spock.lang.Shared
 import spock.lang.Specification
+import tools.jackson.databind.SerializationFeature
 
 class Jackson2ModelBridgeTest extends Specification {
 
     @Shared
     ObjectMapper jackson2
 
+    // ValueUtil.JSON is a mutable global that a dev mode container (started by another test in the
+    // same JVM) rebuilds with INDENT_OUTPUT, so pin a compact writer to keep output deterministic
+    @Shared
+    tools.jackson.databind.ObjectWriter jackson3
+
     def setupSpec() {
         if (ValueUtil.getValueDescriptor("text").isEmpty() || ValueUtil.getMetaItemDescriptor("readOnly").isEmpty()) {
             ValueUtil.initialise(null)
         }
         jackson2 = Jackson2Config.configureObjectMapper(new ObjectMapper())
+        jackson3 = ValueUtil.JSON.writer().without(SerializationFeature.INDENT_OUTPUT)
     }
 
     def "Jackson 2 reads asset model descriptors emitted by Jackson 3"() {
@@ -105,6 +112,36 @@ class Jackson2ModelBridgeTest extends Specification {
         agentLink instanceof DefaultAgentLink
         agentLink.id == "agent-1"
         agentLink.writeValue.orElse(null) == "fixed"
+    }
+
+    def "Jackson 2 preserves null attribute values and empty meta"() {
+        given: "an attribute with an explicit null value, empty meta and a timestamp"
+        def attribute = new Attribute<Double>("power", ValueType.NUMBER)
+            .setMeta(new MetaMap())
+            .setTimestamp(123L)
+
+        when: "the attribute is serialized with the Jackson 2 bridge"
+        String json = jackson2.writeValueAsString(attribute)
+
+        then: "the null value and empty meta are not stripped"
+        json.contains('"value":null')
+        json.contains('"meta":{}')
+        json.contains('"timestamp":123')
+
+        and: "Jackson 3 emits the same fields"
+        String json3 = jackson3.writeValueAsString(attribute)
+        json3.contains('"value":null')
+        json3.contains('"meta":{}')
+        json3.contains('"timestamp":123')
+
+        when: "the Jackson 2 JSON is read back by the bridge"
+        Attribute<?> result = jackson2.readValue(json, Attribute.class)
+
+        then: "the attribute state survives the round trip"
+        result.name == "power"
+        result.type == ValueType.NUMBER
+        result.value.isEmpty()
+        result.timestamp.orElse(null) == 123L
     }
 
     def "Jackson 2 reads Jackson 3 object nodes emitted by Jackson 3"() {

--- a/ui/app/manager/test/assets.test.ts
+++ b/ui/app/manager/test/assets.test.ts
@@ -25,10 +25,13 @@ assets.forEach(({ type, name, attributes }) => {
         await manager.goToRealmStartPage("smartcity");
         await assetsPage.goto();
         await assetsPage.addAsset(assetMap[name!], name!);
+        await page.click(`#list-container >> text=${name}`);
         await assetViewer.switchMode("modify");
         await assetViewer.getAttributeValueLocator(attribute1).fill(value1);
         await assetViewer.getAttributeValueLocator(attribute2).fill(value2);
-        await assetViewer.save();
+        const saveBtn = page.getByRole("button", { name: "Save" });
+        await saveBtn.click();
+        await expect(saveBtn).toBeDisabled();
         await expect(page.locator(`text=${name}`)).toHaveCount(1);
     });
 
@@ -43,10 +46,11 @@ assets.forEach(({ type, name, attributes }) => {
      * @and Saving the changes
      * @then The updated asset is saved and changes are persisted
      */
-    test(`Update a ${name} asset's attributes and location`, async ({ page, manager, assetsPage, assetViewer }) => {
+    test(`Update a ${name} asset's attributes and location`, async ({ page, manager, assetViewer }) => {
         await manager.setup("smartcity", { assets });
         await manager.goToRealmStartPage("smartcity");
-        await assetsPage.gotoAssetId("smartcity", manager.assets.find(asset => asset.name === name)!.id!);
+        await manager.navigateToTab("asset");
+        await page.click(`text=${name}`);
 
         const type = attributes[attribute3 as keyof typeof attributes].type;
         const item = page.locator(`#field-${attribute3} input[type="${type}"]`);
@@ -60,7 +64,9 @@ assets.forEach(({ type, name, attributes }) => {
         await page.mouse.click(x, y, { delay: 1000 });
         await page.getByRole("button", { name: "OK" }).click();
 
-        await assetViewer.save();
+        const saveBtn = page.getByRole("button", { name: "Save" });
+        await saveBtn.click();
+        await expect(saveBtn).toBeDisabled();
     });
 
     /**
@@ -74,24 +80,27 @@ assets.forEach(({ type, name, attributes }) => {
      * @and Navigating to the asset's view panel
      * @then The correct read-only indicators should be present for the attributes
      */
-    test(`Toggle read-only for two attributes on a ${name} asset`, async ({ page, manager, assetsPage, assetViewer }) => {
+    test(`Toggle read-only for two attributes on a ${name} asset`, async ({ page, manager, assetViewer }) => {
         await manager.setup("smartcity", { assets });
         await manager.goToRealmStartPage("smartcity");
-        await assetsPage.gotoAssetId("smartcity", manager.assets.find(asset => asset.name === name)!.id!);
+        await manager.navigateToTab("asset");
+        await page.click(`text=${name}`);
 
         await assetViewer.switchMode("modify");
-        await assetViewer.expandAll();
+        await page.getByRole("button", { name: "Expand all" }).click();
 
         await assetViewer.getAttributeLocator(attribute1).click();
-        await assetViewer.getConfigurationItemLocator(attribute1, "Read only").getByRole("checkbox").click();
+        await assetViewer.getConfigurationItemLocator(attribute1, "Read only").locator("label").click();
 
         await assetViewer.getAttributeLocator(attribute2).click();
-        await assetViewer.getConfigurationItemLocator(attribute2, "Read only").getByRole("checkbox").click();
+        await assetViewer.getConfigurationItemLocator(attribute2, "Read only").locator("label").click();
 
-        await assetViewer.save();
+        const saveBtn = page.getByRole("button", { name: "Save" });
+        await saveBtn.click();
+        await expect(saveBtn).toBeDisabled();
 
-        await assetViewer.switchMode("view");
-        await expect(page.locator("or-asset-viewer #edit-btn")).toBeVisible();
+        await page.getByRole("button", { name: "View" }).click();
+        await expect(page.getByRole("button", { name: "Modify" })).toBeVisible();
 
         await expect(page.locator(`#field-${attribute1} #send-btn`)).toBeVisible();
         await expect(page.locator(`#field-${attribute2} #send-btn`)).not.toBeVisible();
@@ -110,20 +119,22 @@ assets.forEach(({ type, name, attributes }) => {
     test(`Set "ruleState" and "storeDataPoints" for ${name} asset attributes`, async ({
         page,
         manager,
-        assetsPage,
         assetViewer,
     }) => {
         await manager.setup("smartcity", { assets });
         await manager.goToRealmStartPage("smartcity");
-        await assetsPage.gotoAssetId("smartcity", manager.assets.find(asset => asset.name === name)!.id!);
+        await manager.navigateToTab("asset");
+        await page.click(`text=${name}`);
 
         await assetViewer.switchMode("modify");
-        await assetViewer.expandAll();
+        await page.getByRole("button", { name: "Expand all" }).click();
 
         await assetViewer.addConfigurationItems(attribute1, "ruleState", "storeDataPoints");
         await assetViewer.addConfigurationItems(attribute2, "ruleState", "storeDataPoints");
 
-        await assetViewer.save();
+        const saveBtn = page.getByRole("button", { name: "Save" });
+        await saveBtn.click();
+        await expect(saveBtn).toBeDisabled();
     });
 });
 
@@ -175,13 +186,12 @@ test.describe("Parent asset", () => {
         await page.getByText("Thing").click();
         await assetViewer.switchMode("modify");
 
-        await page.locator("or-edit-asset-panel #change-parent-btn").getByRole("button").click();
-        const parentDialog = page.locator("or-mwc-dialog").last();
-        await parentDialog.locator("or-asset-tree .node-container", { hasText: "Parent" }).click();
-        await parentDialog.getByRole("button", { name: /^OK$|^ok$/i }).click();
-        await assetViewer.save();
+        await page.getByText("Parent Edit").getByRole("button").click();
+        await page.getByLabel("Select parent asset").getByText("Parent").click();
+        await page.getByLabel("Select parent asset").getByRole("button", { name: "OK" }).click();
+        await page.getByRole("button", { name: "Save" }).click();
 
-        await expect(page.locator("or-edit-asset-panel #property-parentId input")).toHaveValue("Parent");
+        await expect(page.getByRole("textbox", { name: "Parent" })).toHaveValue("Parent");
     });
 
     /**
@@ -198,12 +208,11 @@ test.describe("Parent asset", () => {
         await assetTree.getFilterInput().fill("Thing");
         await assetViewer.switchMode("modify");
 
-        await page.locator("or-edit-asset-panel #change-parent-btn").getByRole("button").click();
-        const parentDialog = page.locator("or-mwc-dialog").last();
-        await parentDialog.getByRole("button", { name: /^NONE$|^none$/i }).click();
-        await assetViewer.save();
+        await page.getByText("Parent Edit").getByRole("button").click();
+        await page.getByLabel("Select parent asset").getByRole("button", { name: "NONE" }).click();
+        await page.getByRole("button", { name: "Save" }).click();
 
-        await expect(page.locator("or-edit-asset-panel #property-parentId input")).toBeEmpty();
+        await expect(page.getByRole("textbox", { name: "Parent" })).toBeEmpty();
     });
 });
 
@@ -217,21 +226,21 @@ test.describe("Attributes", () => {
      * @then The attribute should be visible
      * @and be of type "Integer"
      */
-    test("can be added", async ({ page, assetViewer, manager }) => {
+    test("can be added", async ({ page, mwcInput, assetViewer, manager }) => {
         await manager.setup("smartcity", { assets: [thing] });
         await manager.goToRealmStartPage("smartcity");
         await manager.navigateToTab("Assets");
         await page.getByText("Thing").click();
         await assetViewer.switchMode("modify");
 
-        await page.getByRole("button", { name: /Add attribute|addAttribute/i }).click();
+        await page.getByRole("button", { name: "Add attribute" }).click();
 
-        const dialog = page.getByLabel(/Add attribute|addAttribute/i);
-        await dialog.getByLabel(/Name|name/i).fill("test");
-        await dialog.getByRole("combobox", { name: /Value type|valueType/i }).fill("Int");
+        const dialog = page.getByLabel("Add attribute");
+        await dialog.getByLabel("Name").fill("test");
+        await dialog.getByRole("combobox", { name: "Value type", exact: true }).fill("Int");
         await dialog.getByRole("option", { name: "Integer", exact: true }).click();
-        await dialog.getByRole("button", { name: /^Add$|^add$/i }).click();
-        await assetViewer.save();
+        await dialog.getByRole("button", { name: "Add", exact: true }).click();
+        await page.getByRole("button", { name: "Save", exact: true }).click();
 
         await expect(assetViewer.getAttributeLocator("test")).toBeVisible();
         await expect(assetViewer.getAttributeLocator("test")).toContainText(/Integer/);
@@ -262,7 +271,7 @@ test.describe("Attributes", () => {
         const attribute = assetViewer.getAttributeLocator("test");
         await expect(attribute).toBeVisible();
         await attribute.getByRole("button").last().click();
-        await assetViewer.save();
+        await page.getByRole("button", { name: "Save" }).click();
 
         await expect(attribute).not.toBeVisible();
     });
@@ -348,7 +357,7 @@ test.describe("Configuration items", () => {
                 realm: "smartcity",
                 attributes: {
                     ...commonAttrs,
-                    notes: { ...commonAttrs.notes, meta: Object.fromEntries([...primitiveItemsWithValues /*, ...complexItemsWithValues */]) },
+                    notes: { meta: Object.fromEntries([...primitiveItemsWithValues /*, ...complexItemsWithValues */]) },
                 },
             });
             await manager.goToRealmStartPage("smartcity");
@@ -383,7 +392,7 @@ test.describe("Configuration items", () => {
                 }
             }
 
-            await assetViewer.save();
+            await page.getByRole("button", { name: "Save" }).click();
 
             for (const [item, value] of updatedPrimitivesWithValues) {
                 const itemLocator = assetViewer.getConfigurationItemLocator("notes");
@@ -412,7 +421,7 @@ test.describe("Configuration items", () => {
             // Remove complex configuration items
             // await assetViewer.removeConfigurationItems("notes", ...complexItemsWithValues.map(([item]) => item));
 
-            await assetViewer.save();
+            await page.getByRole("button", { name: "Save" }).click();
 
             const configurationItems = AssetModelUtil.getMetaItemDescriptors().map(
                 ({ name }) => name as `${WellknownMetaItems}`

--- a/ui/app/manager/test/fixtures/manager.ts
+++ b/ui/app/manager/test/fixtures/manager.ts
@@ -30,19 +30,6 @@ export const userStatePath = path.join(__dirname, "data/.auth/user.json");
 export class Manager {
     private readonly clientId = "openremote";
     private readonly managerHost: String;
-    private readonly menuItemAliases = new Map<string, string>([
-        ["Export", "dataExport"],
-        ["Realms", "realm_plural"],
-        ["Roles", "role_plural"],
-        ["Users", "user_plural"],
-        ["export", "dataExport"],
-    ]);
-    private readonly tabAliases = new Map<string, string>([
-        ["Assets", "asset_plural"],
-        ["Insights", "insights"],
-        ["Rules", "rule_plural"],
-        ["asset", "asset_plural"],
-    ]);
     readonly api: RestApi["api"];
     readonly axios: RestApi["_axiosInstance"];
 
@@ -91,16 +78,7 @@ export class Manager {
     }
 
     async goToRealmStartPage(realm: string) {
-        this.realm = realm;
         await this.page.goto(this.getAppUrl(realm));
-    }
-
-    async clearStoredConsole() {
-        await this.page.evaluate(() => {
-            Object.keys(localStorage)
-                .filter((key) => key.startsWith("OpenRemoteConsole:"))
-                .forEach((key) => localStorage.removeItem(key));
-        });
     }
 
     /**
@@ -109,7 +87,7 @@ export class Manager {
      */
     async navigateToMenuItem(setting: string) {
         await this.page.click("#drawer-menu");
-        const menu = this.page.locator("#drawer-menu").getByRole("menuitem").filter({ hasText: this.getNavigationTextMatcher(setting, this.menuItemAliases) });
+        const menu = this.page.locator("#drawer-menu").getByRole("menuitem").filter({ hasText: setting });
         await menu.waitFor({ state: "visible" });
         await menu.click();
     }
@@ -121,7 +99,6 @@ export class Manager {
     async switchToRealmByRealmPicker(realm: string) {
         await this.page.click("#realm-picker");
         await this.page.locator("#realm-picker").getByRole("option").filter({ hasText: realm }).click();
-        this.realm = realm;
     }
 
     /**
@@ -129,8 +106,7 @@ export class Manager {
      * @param tab Tab name
      */
     async navigateToTab(tab: string) {
-        const tabLink = this.page.locator("#desktop-left a").filter({ hasText: this.getNavigationTextMatcher(tab, this.tabAliases) });
-        await tabLink.click();
+        await this.page.click(`#desktop-left a:has-text("${tab}")`);
     }
 
     /**
@@ -322,19 +298,6 @@ export class Manager {
         }
     }
 
-    async updateUserRolesByUsername(realm: string, username: string, roles: string[]) {
-        const access_token = await this.getAccessToken("master", admin.username, admin.password);
-        const config = { headers: { Authorization: `Bearer ${access_token}` } };
-        const usersResponse = await rest.api.UserResource.query({ realmPredicate: { name: realm } }, config);
-        expect(usersResponse.status).toBe(200);
-        const user = usersResponse.data.find((user) => user.username === username);
-        expect(user?.id, { message: `Failed to find user ${username}` }).toBeTruthy();
-        const response = await rest.api.UserResource.updateUserClientRoles(realm, user!.id!, this.clientId, roles, config);
-        expect(response.status).toBe(204);
-        this.realm = realm;
-        this.user = user as UserModel;
-    }
-
     /**
      * Create an asset
      * @param asset The asset to create
@@ -510,16 +473,6 @@ export class Manager {
 
     getAppUrl(realm: string) {
         return `${new URL(this.baseURL).origin}/manager/?realm=${realm}`;
-    }
-
-    private getNavigationTextMatcher(text: string, aliases: Map<string, string>) {
-        const alias = aliases.get(text);
-        const options = alias ? [text, alias] : [text];
-        return new RegExp(options.map(Manager.escapeRegExp).join("|"), "i");
-    }
-
-    private static escapeRegExp(value: string) {
-        return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     }
 }
 

--- a/ui/app/manager/test/fixtures/pages/assets.ts
+++ b/ui/app/manager/test/fixtures/pages/assets.ts
@@ -1,26 +1,16 @@
 import { BasePage, Page, Shared, expect } from "@openremote/test";
 import { Manager } from "../manager";
-import { Asset, AssetModelUtil } from "@openremote/model";
+import { Asset } from "@openremote/model";
 
 export class AssetsPage implements BasePage {
   constructor(private readonly page: Page, private readonly shared: Shared, private readonly manager: Manager) {}
 
   async goto() {
-    await this.manager.navigateToTab("Assets");
+    this.manager.navigateToTab("Assets");
   }
 
   async gotoAssetId(realm: string, id: string, editor = false) {
-    const currentUrl = this.page.url().startsWith("http") ? new URL(this.page.url()) : undefined;
-    const appLoaded = await this.page.locator("#desktop-left").isVisible().catch(() => false);
-    if (!appLoaded && (!currentUrl || currentUrl.searchParams.get("realm") !== realm)) {
-      await this.page.goto(this.manager.getAppUrl(realm));
-    }
-    await this.page.locator("#desktop-left").waitFor({ state: "visible" });
-    await this.page.waitForFunction(() => !window.location.hash.includes("code=") && !window.location.hash.includes("state="));
-    await this.page.evaluate((route) => {
-      window.location.hash = route;
-    }, `/assets/${editor}/${id}`);
-    await expect(this.page.locator("or-asset-viewer#viewer")).toHaveJSProperty("assetId", id);
+    this.page.goto(this.manager.getAppUrl(realm) + `#/assets/${editor}/${id}`);
   }
 
   /**
@@ -31,36 +21,14 @@ export class AssetsPage implements BasePage {
    * @param type The asset type
    * @param name The name of the asset
    */
-  async addAsset(type: string, name: string): Promise<Asset> {
-    const realm = this.manager.realm ?? new URL(this.page.url()).searchParams.get("realm");
-    let assetTypeInfo = AssetModelUtil.getAssetTypeInfo(type);
-    if (!assetTypeInfo) {
-      AssetModelUtil._assetTypeInfos = (await this.manager.api.AssetModelResource.getAssetInfos()).data;
-      assetTypeInfo = AssetModelUtil.getAssetTypeInfo(type);
-    }
-    expect(assetTypeInfo, { message: `Missing asset type info for ${type}` }).toBeTruthy();
-    const asset: Asset = {
-      name,
-      type,
-      realm,
-      attributes: Object.fromEntries(
-        Object.values(assetTypeInfo!.attributeDescriptors ?? {})
-          .filter(attributeDescriptor => !attributeDescriptor.optional)
-          .map(attributeDescriptor => [
-            attributeDescriptor.name!,
-            {
-              name: attributeDescriptor.name,
-              type: typeof attributeDescriptor.type === "string" ? attributeDescriptor.type : attributeDescriptor.type?.name,
-              meta: attributeDescriptor.meta ? { ...attributeDescriptor.meta } : undefined,
-            },
-          ])
-      ),
-    };
-    await this.manager.createAsset(asset);
-    const createdAsset = this.manager.assets[this.manager.assets.length - 1];
-    expect(createdAsset?.id, { message: `Failed to create ${name}` }).toBeTruthy();
-    await this.gotoAssetId(createdAsset.realm ?? realm!, createdAsset.id!);
-    return createdAsset;
+  async addAsset(type: string, name: string) {
+    await this.page.click(".mdi-plus");
+    await this.page.getByRole("option", { name: type }).click();
+    await this.page.locator("#name-input").getByRole("textbox").fill(name);
+    await this.shared.interceptResponse<Asset>("**/asset", (asset) => {
+      if (asset) this.manager.assets.push(asset);
+    });
+    await this.page.click("#add-btn");
   }
 
   /**

--- a/ui/app/manager/test/fixtures/pages/insights.ts
+++ b/ui/app/manager/test/fixtures/pages/insights.ts
@@ -79,69 +79,12 @@ export class InsightsPage implements BasePage {
 
         // Manual drag and drop
         const count = await this.getWidgets().count();
-        const widget = this.page.locator(`#sidebar .grid-stack-item:has-text("${type}")`).first();
-        const widgetBox = await widget.boundingBox();
-        const gridBox = await this.getDashboardGrid().boundingBox();
-        expect(widgetBox).toBeTruthy();
-        expect(gridBox).toBeTruthy();
-
-        await this.page.mouse.move(widgetBox!.x + 10, widgetBox!.y + 10);
-        await this.page.mouse.down();
-        await this.page.mouse.move(gridBox!.x + x + cellWidth / 2, gridBox!.y + y + cellHeight / 2, { steps: 50 });
-        await this.page.mouse.up();
-
-        if ((await this.getWidgets().count()) === count) {
-            const widgetTypeId = (await widget.getAttribute("gs-id")) ?? type;
-            await this.getPreview().evaluate((el, createdWidget) => {
-                el.dispatchEvent(new CustomEvent("created", { detail: createdWidget }));
-            }, this.createWidget(widgetTypeId, type, gridX, gridY));
-        }
+        await this.page.dragAndDrop(`#sidebar .grid-stack-item :has-text("${type}")`, ".maingrid", {
+            sourcePosition: { x: 10, y: 10 }, // To drop the widget at the intended cell, we grab it close to its top left corner
+            targetPosition: { x, y },
+            steps: 50,
+        });
         await expect(this.getWidgets()).toHaveCount(count + 1);
-        await this.getWidgets().last().click();
-    }
-
-    private createWidget(widgetTypeId: string, displayName: string, x: number, y: number) {
-        const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-        return {
-            id,
-            displayName,
-            gridItem: { id, x, y, w: 2, h: 2, minW: 2, minH: 2, noResize: false, noMove: false, locked: false },
-            widgetConfig: this.createWidgetConfig(widgetTypeId),
-            widgetTypeId,
-        };
-    }
-
-    private createWidgetConfig(widgetTypeId: string) {
-        if (widgetTypeId === "map") {
-            return {
-                attributeRefs: [],
-                showLabels: false,
-                showUnits: false,
-                showGeoJson: true,
-                boolColors: { type: "boolean", false: "#ef5350", true: "#4caf50" },
-                textColors: [["example1", "#4caf50"], ["example2", "#ef5350"]],
-                thresholds: [[0, "#4caf50"], [75, "#ff9800"], [90, "#ef5350"]],
-                assetTypes: [],
-                assetType: undefined,
-                allOfType: true,
-                assetIds: [],
-                attributes: [],
-            };
-        }
-
-        const toTimestamp = Date.now();
-        const fromTimestamp = toTimestamp - 24 * 60 * 60 * 1000;
-        return {
-            attributeRefs: [],
-            attributeColors: [],
-            datapointQuery: { type: "lttb", fromTimestamp, toTimestamp },
-            chartOptions: { options: { scales: { y: {}, y1: {} } } },
-            showTimestampControls: false,
-            defaultTimePresetKey: "thisday",
-            showLegend: true,
-            showZoomBar: false,
-            stacked: false,
-        };
     }
 
     /**
@@ -150,13 +93,27 @@ export class InsightsPage implements BasePage {
      * @param to The grid cell coordinates to resize the widget to
      */
     async resizeWidgetTo(widget: Locator, [cellsWidth, cellsHeight] = [8, 8]) {
-        const gridItem = widget.locator("..").locator("..");
-        await gridItem.evaluate((el: any, { w, h }) => {
-            el.parentElement.gridstack.update(el, { w, h });
-        }, { w: cellsWidth, h: cellsHeight });
+        const [gridX, gridY] = await this.getWidgetLocation(widget);
+        const [cellWidth, cellHeight] = await this.getGridCellDimensions();
+        const [width, height] = [cellsWidth * cellWidth, cellsHeight * cellHeight];
+
+        await this.page.dragAndDrop(`.ui-resizable-handle.ui-resizable-se`, ".maingrid", {
+            // We apply -cellWidth/Height / 2 as the handle causes the source position to be offset
+            targetPosition: {
+                x: gridX * cellWidth + width - cellWidth / 2,
+                y: gridY * cellHeight + height - cellHeight / 2,
+            },
+            steps: 10,
+        });
 
         const bbox = await widget.boundingBox();
-        expect(bbox).toBeTruthy();
+        // The dashboard dimensions should be equal to the specified cells,
+        // or between the specified cells and the specified cells - 1 cell,
+        // due to margins.
+        expect(bbox?.width).toBeGreaterThan(width - cellWidth);
+        expect(bbox?.width).toBeLessThanOrEqual(width);
+        expect(bbox?.height).toBeGreaterThan(cellHeight - cellHeight);
+        expect(bbox?.height).toBeLessThanOrEqual(height);
     }
 
     async addAttributes(assetName: string, attributeNames: string[]) {

--- a/ui/app/manager/test/fixtures/pages/realms.ts
+++ b/ui/app/manager/test/fixtures/pages/realms.ts
@@ -5,7 +5,7 @@ export class RealmsPage implements BasePage {
   constructor(private readonly page: Page, private readonly shared: Shared, private readonly manager: Manager) {}
 
   async goto() {
-    await this.manager.navigateToMenuItem("Realms");
+    this.manager.navigateToMenuItem("Realms");
   }
 
   /**
@@ -21,7 +21,7 @@ export class RealmsPage implements BasePage {
       await this.page.click("text=Add Realm");
       const realmRow = this.page.locator("#realm-row-1");
       const realmNameInput = realmRow.getByLabel("Realm");
-      const displayNameInput = realmRow.getByLabel(/Friendly name|displayName/i);
+      const displayNameInput = realmRow.getByLabel("Friendly name");
       await realmNameInput.fill(name);
       await realmNameInput.dispatchEvent("change");
       await displayNameInput.fill(name);

--- a/ui/app/manager/test/fixtures/pages/realms.ts
+++ b/ui/app/manager/test/fixtures/pages/realms.ts
@@ -1,4 +1,4 @@
-import { BasePage, Page, Shared, expect } from "@openremote/test";
+import { BasePage, Page, Shared } from "@openremote/test";
 import { Manager } from "../manager";
 
 export class RealmsPage implements BasePage {
@@ -13,30 +13,20 @@ export class RealmsPage implements BasePage {
    * @param name The realm name
    */
   async addRealm(name: string) {
+    const locator = this.page.getByRole("button", { name, exact: true });
     await this.page.getByRole("button", { name: "Master", exact: true }).waitFor();
-    await this.page.getByRole("cell", { name: "master", exact: true }).first().waitFor();
-    const existingRealmCell = this.page.getByRole("cell", { name, exact: true }).first();
-    if (await existingRealmCell.isVisible()) {
+    if (await locator.isVisible()) {
       console.warn(`Realm "${name}" already present`);
     } else {
       await this.page.click("text=Add Realm");
-      const realmRow = this.page.locator("tr.realm-row").filter({
-        has: this.page.getByRole("button", { name: /Create|create/i })
-      });
+      const realmRow = this.page.locator("#realm-row-1");
       const realmNameInput = realmRow.getByLabel("Realm");
       const displayNameInput = realmRow.getByLabel(/Friendly name|displayName/i);
-      await expect(realmRow).toBeVisible();
-      await expect(realmNameInput).toBeEditable();
       await realmNameInput.fill(name);
       await realmNameInput.dispatchEvent("change");
       await displayNameInput.fill(name);
       await displayNameInput.dispatchEvent("change");
-      const response = this.page.waitForResponse((res) =>
-        res.request().method() === "POST" && res.url().endsWith("/api/master/realm")
-      );
-      await realmRow.getByRole("button", { name: /Create|create/i }).click();
-      expect((await response).status()).toBe(204);
-      await expect(existingRealmCell).toBeVisible();
+      await this.page.getByRole("button", { name: "create" }).click();
     }
   }
 

--- a/ui/app/manager/test/fixtures/pages/roles.ts
+++ b/ui/app/manager/test/fixtures/pages/roles.ts
@@ -5,6 +5,6 @@ export class RolesPage implements BasePage {
   constructor(private readonly page: Page, private readonly shared: Shared, private readonly manager: Manager) {}
 
   async goto() {
-    await this.manager.navigateToMenuItem("Roles");
+    this.manager.navigateToMenuItem("Roles");
   }
 }

--- a/ui/app/manager/test/fixtures/pages/rules.ts
+++ b/ui/app/manager/test/fixtures/pages/rules.ts
@@ -5,6 +5,6 @@ export class RulesPage implements BasePage {
   constructor(private readonly page: Page, private readonly shared: Shared, private readonly manager: Manager) {}
 
   async goto() {
-    await this.manager.navigateToTab("Rules");
+    this.manager.navigateToTab("Rules");
   }
 }

--- a/ui/app/manager/test/fixtures/pages/users.ts
+++ b/ui/app/manager/test/fixtures/pages/users.ts
@@ -7,7 +7,7 @@ export class UsersPage implements BasePage {
   constructor(private readonly page: Page, private readonly shared: Shared, private readonly manager: Manager) {}
 
   async goto() {
-    await this.manager.navigateToMenuItem("Users");
+    this.manager.navigateToMenuItem("Users");
   }
 
   async gotoUserCreation(realm: string, type: "serviceuser" | "regular") {
@@ -27,10 +27,10 @@ export class UsersPage implements BasePage {
    * @param roles The roles to toggle
    */
   async toggleUserRoles(...roles: string[]) {
-    const roleSelector = this.page.locator("or-vaadin-multi-select-combo-box", { hasText: /Manager roles|manager_role_plural/i });
+    const roleSelector = this.page.locator("or-vaadin-multi-select-combo-box", { hasText: "Manager roles" });
     await roleSelector.click();
     for (const role of roles) {
-      await this.page.getByRole("option", { name: new RegExp(`^\\s*${escapeRegExp(role)}\\s*$`, "i") }).click();
+      await this.page.getByRole("option", {name: role}).click();
     }
     await roleSelector.locator("#toggleButton").click();
   }
@@ -63,21 +63,21 @@ export class UsersPage implements BasePage {
   async addUser(username: string, password: string, tag?: string) {
     await this.page
       .locator("#content")
-      .filter({ hasText: /Regular users|regularUser_plural/i })
-      .getByRole("button", { name: /Add User|add user/i })
+      .filter({ hasText: "Regular users" })
+      .getByRole("button", { name: "Add User" })
       .click();
-    await this.page.getByLabel(/Username|username/i, { exact: true }).fill(username);
-    await this.page.getByLabel(/^Password$|^password$/i, { exact: true }).fill(password);
-    await this.page.getByLabel(/Repeat password|repeatPassword/i, { exact: true }).fill(password);
+    await this.page.getByLabel("Username", {exact: true}).fill(username);
+    await this.page.getByLabel("Password", {exact: true}).fill(password);
+    await this.page.getByLabel("Repeat password", {exact: true}).fill(password);
     if (tag) {
-      await this.page.getByLabel(/Tag|tag/i, { exact: true }).fill(tag);
+        await this.page.getByLabel("Tag", {exact: true}).fill(tag);
     }
     await this.toggleUserRoles("Read", "Write");
     await this.toHavePermissions(...permissions);
     await this.shared.interceptResponse<UserModel>(`user/${this.manager.realm}/users`, (user) => {
       if (user) this.manager.user = user;
     });
-    await this.page.getByRole("button", { name: /Create|create/i }).click();
+    await this.page.getByRole("button", { name: "Create" }).click();
   }
 
   /**
@@ -89,19 +89,19 @@ export class UsersPage implements BasePage {
   async addServiceUser(username: string, tag?: string): Promise<void> {
     await this.page
       .locator("#content")
-      .filter({ hasText: /Service users|serviceUser_plural/i })
-      .getByRole("button", { name: /Add User|add user/i })
+      .filter({ hasText: "Service users" })
+      .getByRole("button", { name: "Add User" })
       .click();
-    await this.page.getByLabel(/Username|username/i).fill(username);
+    await this.page.getByLabel("Username").fill(username);
     if (tag) {
-      await this.page.getByLabel(/Tag|tag/i).fill(tag);
+      await this.page.getByLabel("Tag").fill(tag);
     }
     await this.toggleUserRoles("Read", "Write");
     await this.toHavePermissions(...permissions);
     await this.shared.interceptResponse<UserModel>(`user/${this.manager.realm}/users`, (user) => {
       if (user) this.manager.user = user;
     });
-    await this.page.getByRole("button", { name: /Create|create/i }).click();
+    await this.page.getByRole("button", { name: "Create" }).click();
   }
 
   /**
@@ -109,7 +109,7 @@ export class UsersPage implements BasePage {
    * @param searchTerm The term to search for
    */
   async searchRegularUsers(searchTerm: string) {
-    const panel = this.page.locator("#content").filter({ hasText: /Regular users|regularUser_plural/i }).first();
+    const panel = this.page.locator("#content").filter({ hasText: "Regular users" }).first();
     const input = panel.locator('*[placeholder="Search"] input');
     await input.fill(searchTerm);
   }
@@ -119,12 +119,8 @@ export class UsersPage implements BasePage {
    * @param searchTerm The term to search for
    */
   async searchServiceUsers(searchTerm: string) {
-    const panel = this.page.locator("#content").filter({ hasText: /Service users|serviceUser_plural/i }).first();
+    const panel = this.page.locator("#content").filter({ hasText: "Service users" }).first();
     const input = panel.locator('*[placeholder="Search"] input');
     await input.fill(searchTerm);
   }
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/ui/app/manager/test/insights.test.ts
+++ b/ui/app/manager/test/insights.test.ts
@@ -108,8 +108,8 @@ test("Create a Map widget with text thresholds", async ({ manager, shared, page,
     await page.getByRole("combobox", { name: "Asset type" }).fill("Thing");
     await page.getByRole("option", { name: "Thing asset" }).click();
     await expect(thresholdPanel).toBeHidden();
-    await insightsPage.getWidgetSettings().getByRole("combobox", { name: /Attribute|attribute/i }).click();
-    await insightsPage.getWidgetSettings().getByRole("option", { name: /Notes|notes/i }).click();
+    await insightsPage.getWidgetSettings().getByRole("combobox", { name: "Attribute" }).click();
+    await insightsPage.getWidgetSettings().getByRole("option", { name: "Notes" }).click();
     await expect(page.locator(".or-map-marker")).toBeVisible();
     await expect(thresholdPanel).toBeVisible();
 

--- a/ui/app/manager/test/map.test.ts
+++ b/ui/app/manager/test/map.test.ts
@@ -79,7 +79,7 @@ test.describe("Map markers", () => {
     ].map(([name, meta, ...coordinates]) => Object.assign({ name, type: "ThingAsset", realm: "smartcity" }, {
       attributes: {
         ...commonAttrs,
-        location: { ...commonAttrs.location, meta, value: { type: "Point", coordinates } }
+        location: { meta, value: { type: "Point", coordinates } }
       }
     })) as Asset[];
     await manager.setup("smartcity", { assets });
@@ -112,7 +112,7 @@ test.describe("Map markers", () => {
     ].map(([name, direction, ...coordinates]) => Object.assign({ name, type: "ThingAsset", realm: "smartcity" }, {
       attributes: {
         ...commonAttrs,
-        location: { ...commonAttrs.location, value: { type: "Point", coordinates } },
+        location: { value: { type: "Point", coordinates } },
         direction: { type: "direction", value: direction }
       }
     })) as Asset[];

--- a/ui/app/manager/test/test.setup.ts
+++ b/ui/app/manager/test/test.setup.ts
@@ -34,7 +34,6 @@ setup(`Login as "admin" user`, async ({ page, manager, context }) => {
     await manager.login(admin.username);
     await page.waitForURL("**/manager/**");
     await page.waitForTimeout(2000);
-    await manager.clearStoredConsole();
     await context.storageState({ path: adminStatePath });
 });
 
@@ -75,7 +74,6 @@ setup.describe(async () => {
         await expect(page.getByRole("cell", { name: "smartcity" })).toHaveCount(1);
         await page.getByRole("cell", { name: "smartcity" }).click();
         await usersPage.toHavePermissions(...permissions);
-        await manager.updateUserRolesByUsername("smartcity", username, smartcity.roles);
     });
 });
 
@@ -84,7 +82,6 @@ setup(`Login as "smartcity" user`, async ({ page, manager, context }) => {
     await manager.goToRealmStartPage("smartcity");
     await manager.login("smartcity");
     await page.waitForURL("**/manager/**");
-    await manager.clearStoredConsole();
     await context.storageState({ path: userStatePath });
     await expect(page.getByRole("menuitem", { name: "More options" })).toBeVisible();
     await expect(page.locator("#realm-picker")).not.toBeVisible();

--- a/ui/component/or-asset-viewer/src/index.ts
+++ b/ui/component/or-asset-viewer/src/index.ts
@@ -1503,16 +1503,14 @@ export class OrAssetViewer extends subscribe(manager)(translate(i18next)(LitElem
         if (saveResult.success) {
             try {
                 const assetInfo = await this.loadAssetInfo(saveResult.asset!);
-                assetInfo.modified = false;
                 this._assetInfo = assetInfo;
                 this.assetId = saveResult.asset?.id;
             } catch (e) {
                 // We can ignore this as it should indicate that the asset has changed
             }
             if (this.saveBtnElem) {
-                this.saveBtnElem.disabled = !this.isModified();
+                this.saveBtnElem.disabled = false;
             }
-            this.requestUpdate();
         }
         this._saveInProgress = false;
         this.wrapperElem?.classList.remove("saving");

--- a/ui/component/or-asset-viewer/test/fixtures/index.ts
+++ b/ui/component/or-asset-viewer/test/fixtures/index.ts
@@ -17,50 +17,9 @@ export class AssetViewer {
      * @param targetMode The mode to switch to
      */
     async switchMode(targetMode: "modify" | "view") {
-        const targetEditMode = targetMode === "modify";
-        const viewer = this.page.locator("or-asset-viewer#viewer");
-        const isEditMode = await viewer.evaluate((element) => !!(element as HTMLElement & { editMode?: boolean }).editMode);
-        if (isEditMode === targetEditMode) {
-            return;
-        }
-
-        const selector = this.page.locator("or-asset-viewer #edit-btn").getByRole("button");
+        const selector = this.page.getByRole("button", { name: targetMode });
         await selector.waitFor({ state: "visible" });
         await selector.click();
-        await expect(viewer).toHaveJSProperty("editMode", targetEditMode);
-    }
-
-    async expandAll() {
-        await this.page.getByRole("button", { name: /Expand all|expandAll/i }).click();
-    }
-
-    getSaveButton() {
-        return this.page.locator("or-asset-viewer #save-btn").getByRole("button");
-    }
-
-    async save() {
-        const saveBtn = this.getSaveButton();
-        const viewer = this.page.locator("or-asset-viewer#viewer");
-        await Promise.all([
-            viewer.evaluate((viewer) => new Promise<void>((resolve, reject) => {
-                viewer.addEventListener("or-asset-viewer-save", (event) => {
-                    const saveResult = (event as CustomEvent<{ success?: boolean }>).detail;
-                    if (saveResult.success) {
-                        resolve();
-                    } else {
-                        reject(new Error("Asset save failed"));
-                    }
-                }, { once: true });
-            })),
-            saveBtn.click()
-        ]);
-        await viewer.evaluate((element) => {
-            const viewer = element as HTMLElement & { _assetInfo?: { modified: boolean }; requestUpdate?: () => void };
-            if (viewer._assetInfo) {
-                viewer._assetInfo.modified = false;
-            }
-            viewer.requestUpdate?.();
-        });
     }
 
     /**
@@ -94,11 +53,13 @@ export class AssetViewer {
      */
     async addConfigurationItems(attribute: string, ...items: `${WellknownMetaItems}`[]) {
         const configItemLocator = await this.expandAttribute(attribute);
-        await configItemLocator.getByRole("button", { name: /Add configuration items|addMetaItems/i }).click();
+        await configItemLocator.getByRole("button", { name: "Add configuration items" }).click();
         for (const item of items) {
-            await this.page.locator(`li[data-value="${item}"]`).check();
+            await this.page
+                .locator("li", { has: this.page.getByText(Util.camelCaseToSentenceCase(item), { exact: true }) })
+                .check();
         }
-        await this.page.getByRole("button", { name: /^Add$|^add$/i }).click();
+        await this.page.getByRole("button", { name: "Add", exact: true }).click();
     }
 
     /**
@@ -109,14 +70,14 @@ export class AssetViewer {
     async removeConfigurationItems(attribute: string, ...items: `${WellknownMetaItems}`[]) {
         const configItemLocator = await this.expandAttribute(attribute);
         for (const item of items) {
-            const byText = AssetViewer.textMatcher(Util.camelCaseToSentenceCase(item), item);
-            await expect(configItemLocator.filter({ hasText: byText })).toBeVisible();
+            const byText = this.page.getByText(Util.camelCaseToSentenceCase(item), { exact: true });
+            await expect(configItemLocator.filter({ has: byText })).toBeVisible();
             const removeButton = configItemLocator
-                .locator("[class=meta-item-wrapper]", { hasText: byText })
+                .locator("[class=meta-item-wrapper]", { has: byText })
                 .locator("button:last-child");
             await removeButton.hover({ force: true });
             await removeButton.click({ force: true });
-            await expect(configItemLocator.filter({ hasText: byText })).not.toBeVisible();
+            await expect(configItemLocator.filter({ has: byText })).not.toBeVisible();
         }
     }
 
@@ -131,7 +92,7 @@ export class AssetViewer {
     getConfigurationItemLocator(attribute: string, item?: string): Locator {
         return item
             ? // match the sibling row i.e. the configuration items row of the attribute
-              this.getAttributeLocator(attribute).locator("+ tr", { hasText: AssetViewer.textMatcher(item, AssetViewer.translationKey(item)) })
+              this.getAttributeLocator(attribute).locator("+ tr", { hasText: new RegExp(`\\b${item}\\b`, "i") })
             : this.getAttributeLocator(attribute).locator("+ tr");
     }
 
@@ -148,18 +109,6 @@ export class AssetViewer {
             await expect(configItemLocator).toHaveClass(/expanded/);
         }
         return configItemLocator;
-    }
-
-    private static textMatcher(...values: (string | undefined)[]) {
-        return new RegExp(values.filter(Boolean).map(AssetViewer.escapeRegExp).join("|"), "i");
-    }
-
-    private static translationKey(value: string) {
-        return value.replace(/\s+([a-z])/g, (_, letter) => letter.toUpperCase()).replace(/\s/g, "");
-    }
-
-    private static escapeRegExp(value: string) {
-        return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     }
 }
 

--- a/ui/component/or-mwc-components/test/or-mwc-input.test.ts
+++ b/ui/component/or-mwc-components/test/or-mwc-input.test.ts
@@ -28,7 +28,7 @@ ct("Switch should switch", async ({ mount }) => {
   });
   const locator = component.getByRole("switch", { name: "switch" });
   await expect(locator).not.toBeChecked();
-  await locator.click();
+  await component.getByText("switch").click();
   await expect(locator).toBeChecked();
 });
 


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Summary
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Fixes the manager UI app tests and related backend regressions on top of `enhancement/jackson3-upgrade`.

**Reverts (2 commits)** - e671f309b, c0e8ed8af: the previous UI test fixes prevented the UI app tests from getting past the test setup at all. Reverting them lets the suite run again, which surfaced the actual failures underneath: *toggle read-only asset attributes* and *configuration items edit / remove* tests and for the map page the *show on dashboard* and *marker direction* tests.

**UI App test fixes for Toggle Read-only on Attributes** - 40529b2bc, 017159410:

- `Remove JsonProperty annotations from AssetInfo`: the Jackson 3 migration added `@JsonProperty` to all `AssetInfo` interface methods. Jackson inherits method annotations from interfaces, so every serialized `Asset` gained extra `assetName`, `assetType`, `assetClass` and `attributeNames` properties (and the explicit annotation also overrode `@JsonIgnore`d fields in `AttributeEvent`). Removed the four that were never part of the JSON model.
- `Fix attribute serializer stripping null and empty object values`: the Jackson 2 bridge serializer dropped `"value": null` and empty `"meta": {}` from attributes, diverging from the Jackson 3 model serializer output the UI expects.

**Configuration items edit / remove (and map) UI test fixes + backend regressions** (remaining commits)

- `Surface JAX-RS validation and serialisation errors in server logs` (ebe2e59f0): RESTEasy's built-in `ValidationExceptionMapper` and response-writer failures produced silent 500s. Registered a logging validation mapper and writer interceptor, and made the servlet exception handler always log.
- `Fix POST /api/asset 400/500: Jackson2 attribute type resolution` (a64be85 `attributes have no explicit `"type"` field failed, because the Jackson 2bridge couldn't resolve attribute value types from the asset model. A wrapper deserializer now sets the asset type info in the deserialization context, mirroring the Jackson 3 path. Also guards an NPE in `ValueUtil.validateValue` when no value descriptor is resolved.
- `Read/write java.time as epoch millis in Jackson 2 bridge to match Jackson 3` (aa08c4b18): the Jackson 2 bridge serialized `Instant` values (e.g. `Asset.createdOn`) using Jackson's default format - decimal epoch seconds (`1783511596.268219`) - while the Jackson 3 model mapper, attribute timestamps and the UI all use integer epoch millis. The Jackson 2 mapper now disables the nanosecond timestamp features on both the read and write side, matching the Jackson 3 config.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] ~~1. Acceptance criteria of the linked issue(s) are met~~
- [x] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
