### PR TITLE
Only apply delay when enabling providers

### DIFF
--- a/ui/component/core/src/console.ts
+++ b/ui/component/core/src/console.ts
@@ -174,7 +174,7 @@ export class Console {
 
             // Get an ID for this console if it doesn't have one
             if (!this._registration.id) {
-                await this.sendRegistration(0);
+                await this.sendRegistration();
             }
 
             this._initialised = true;
@@ -237,7 +237,7 @@ export class Console {
         if (index >= 0) {
             this._pendingProviderEnables.splice(index, 1);
             if (this._pendingProviderEnables.length === 0) {
-                this.sendRegistration().catch(() => undefined);
+                this.sendRegistration(2000).catch(() => undefined);
                 this._callCompletedCallback();
             }
         }
@@ -299,14 +299,12 @@ export class Console {
     }
 
     // Uses a delayed mechanism to avoid excessive calls to the server during enabling providers
-    public sendRegistration(delay?: number): Promise<void> {
+    public sendRegistration(delay: number = 0): Promise<void> {
 
         if (this._registrationTimer) {
             window.clearTimeout(this._registrationTimer);
             this._registrationTimer = null;
         }
-
-        delay = delay !== undefined ? delay : 2000;
 
         console.debug("Sending registration in: " + delay + "ms");
 

--- a/ui/component/core/src/console.ts
+++ b/ui/component/core/src/console.ts
@@ -237,7 +237,7 @@ export class Console {
         if (index >= 0) {
             this._pendingProviderEnables.splice(index, 1);
             if (this._pendingProviderEnables.length === 0) {
-                this.sendRegistration(2000).catch(() => undefined);
+                this.sendRegistration().catch(() => undefined);
                 this._callCompletedCallback();
             }
         }

--- a/ui/component/core/src/console.ts
+++ b/ui/component/core/src/console.ts
@@ -298,15 +298,12 @@ export class Console {
         return deferred.promise;
     }
 
-    // Uses a delayed mechanism to avoid excessive calls to the server during enabling providers
-    public sendRegistration(delay: number = 0): Promise<void> {
+    public sendRegistration(): Promise<void> {
 
         if (this._registrationTimer) {
             window.clearTimeout(this._registrationTimer);
             this._registrationTimer = null;
         }
-
-        console.debug("Sending registration in: " + delay + "ms");
 
         return new Promise((resolve, reject) => {
             this._registrationTimer = window.setTimeout(async () => {
@@ -320,7 +317,7 @@ export class Console {
                     console.error("Failed to register console", e);
                     reject(e);
                 }
-            }, delay);
+            });
         });
     }
 


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

In c4b36206d5a139c826139f2f00caa68637e1b796 the `console.ts` provider changes applied a delay that was never applied before which causes the console registration to take 2s, which resulted in multiple UI app tests failing when navigating to the assets page and increased the test duration for each test by 2 seconds.

~~These changes adhere to the following comment, without defaulting to a 2 second delay for every `sendRegistration` call https://github.com/openremote/openremote/blob/4f208d7071a361653035db6d77f7c74de7944007/ui/component/core/src/console.ts#L301~~

I've decided to remove the delay. After hardcoding providers and testing these changes it seems that it waits for 2 seconds for every provider synchronously. Previously it didn't delay, so I've removed the delay now.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
