### PR TITLE
Improve Gradle plugin and dependency version catalog configuration

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -1,17 +1,10 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion"
-    }
+plugins {
+    id 'java-library'
+    id 'groovy'
+    id 'maven-publish'
+    id 'signing'
+    alias libs.plugins.protobuf
 }
-
-apply plugin: "java-library"
-apply plugin: "groovy"
-apply plugin: "maven-publish"
-apply plugin: "signing"
-apply plugin: "com.google.protobuf"
 
 dependencies {
 
@@ -69,13 +62,19 @@ dependencies {
     implementation libs.bouncycastleBcprovJdk18on
 }
 
+
+def artifactNotation = { dependencyProvider ->
+    def dependency = dependencyProvider.get()
+    "${dependency.group}:${dependency.name}:${dependency.version}"
+}
+
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:$protobufVersion"
+        artifact = artifactNotation(libs.protoc)
     }
     plugins {
         grpc {
-            artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
+            artifact = artifactNotation(libs.protocGenGrpcJava)
         }
     }
     generateProtoTasks {

--- a/build.gradle
+++ b/build.gradle
@@ -6,19 +6,36 @@ import static org.apache.tools.ant.taskdefs.condition.Os.isFamily
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
-apply plugin: 'java-base'
-apply plugin: 'test-report-aggregation'
-apply plugin: 'jacoco'
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath libs.asm
+        classpath libs.asmTree
+    }
+}
+
+plugins {
+    id 'java-base'
+    id 'jacoco'
+    id 'test-report-aggregation'
+    alias libs.plugins.axionRelease
+    alias libs.plugins.fileEncrypt
+    alias libs.plugins.nexusPublish
+}
+
+def jacocoToolVersion = libs.versions.jacoco.get()
 
 jacoco {
-    toolVersion = "0.8.14"
+    toolVersion = jacocoToolVersion
 }
 
 subprojects {
     if (project.path.startsWith(':ui')) return
     pluginManager.withPlugin('java') {
-        apply plugin: 'jacoco'
-        jacoco { toolVersion = "0.8.14" }
+        pluginManager.apply('jacoco')
+        jacoco { toolVersion = jacocoToolVersion }
     }
 }
 
@@ -126,7 +143,7 @@ def backendClassDirs = backendProjects.collectMany {
 tasks.register('checkCoverageDataExists') {
     group = 'reporting'
 
-    mustRunAfter(backendTestTaskPaths)
+    mustRunAfter backendTestTaskPaths
 
     inputs.files(jacocoExecutionDataFiles).optional()
 
@@ -151,7 +168,7 @@ tasks.register('combinedCoverageReport', JacocoReport) {
     description = 'Generates a unified coverage report for all Unit and Integration tests'
 
     dependsOn tasks.named('checkCoverageDataExists')
-    mustRunAfter(backendTestTaskPaths)
+    mustRunAfter backendTestTaskPaths
 
     reports {
         xml.required = true
@@ -173,7 +190,6 @@ tasks.register('combinedCoverageReport', JacocoReport) {
 }
 
 // Configure version based on Git tags
-apply plugin: 'pl.allegro.tech.build.axion-release'
 scmVersion {
     releaseOnlyOnReleaseBranches = true
     releaseBranchNames = ['main', 'master']
@@ -200,7 +216,6 @@ allprojects {
 // Each file must be explicitly added to .gitignore otherwise git commit will fail
 // When using encryption the the GFE_PASSWORD environment variable must be set or the build will fail
 // use ./gradlew encryptFiles to encrypt files
-apply plugin: 'io.openremote.com.cherryperry.gradle-file-encrypt'
 gradleFileEncrypt {
     // files to encrypt
     plainFiles.from('deployment/manager/fcm.json')
@@ -213,7 +228,6 @@ gradleFileEncrypt {
     }
 }
 
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
 nexusPublishing {
     repositories {
         sonatype {
@@ -248,16 +262,6 @@ tasks.named('clean') {
     delete 'tmp'
 }
 
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'org.ow2.asm:asm:9.10.1'
-        classpath 'org.ow2.asm:asm-tree:9.10.1'
-    }
-}
 
 subprojects {
     // Apply only if the project has a 'test' task

--- a/container/build.gradle
+++ b/container/build.gradle
@@ -1,7 +1,9 @@
-apply plugin: "java-library"
-apply plugin: "groovy"
-apply plugin: "maven-publish"
-apply plugin: "signing"
+plugins {
+    id 'java-library'
+    id 'groovy'
+    id 'maven-publish'
+    id 'signing'
+}
 
 dependencies {
 

--- a/deployment/build.gradle
+++ b/deployment/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: "java-library"
+plugins {
+    id 'java-library'
+}
 
 configurations {
     managerRuntime

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,16 +9,8 @@ systemProp.org.gradle.internal.repository.max.retries=10
 # the initial time before retrying, in milliseconds (default 125)
 systemProp.org.gradle.internal.repository.initial.backoff=500
 
-typescriptGeneratorVersion = 4.1.1
-gradleNexusPublishPluginVersion = 2.0.0
-gradleFileEncryptPluginVersion = 2.1.0
-ideaExtPluginVersion = 1.2
-axionReleasePluginVersion = 1.21.1
-testLoggerPluginVersion = 4.0.0
-swaggeruiVersion = 5.32.8
 snapshotsRepoUrl=https://central.sonatype.com/repository/maven-snapshots/
 releasesRepoUrl=https://ossrh-staging-api.central.sonatype.com/service/local/
-jbossLoggingManagerVersion=2.1.19.Final
-grpcVersion = 1.80.0
-protobufVersion = 3.25.5
-protobufPluginVersion = 0.10.0
+
+ideaExtPluginVersion = 1.4.1
+typescriptGeneratorVersion = 4.1.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,8 @@
 angusMail = "2.0.5"
 artemis = "2.55.0"
 apacheSshd = "2.18.0"
+asm = "9.10.1"
+axionRelease = "1.21.2"
 bouncyCastle = "1.84"
 byteBuddy = "1.18.10"
 bluetooth = "0.64"
@@ -14,6 +16,7 @@ corsFilter = "3.1"
 easyRules = "4.1.0"
 exp4j = "0.4.13"
 failsafe = "3.3.2"
+fileEncrypt = "2.1.0"
 firebaseAdmin = "9.8.0"
 flywaydb = "12.8.1"
 friendlyId = "1.0.4"
@@ -21,7 +24,6 @@ geotools = "34.3"
 glassfishSoteria = "3.0.4"
 greenmail = "2.1.9"
 grpc = "1.82.2"
-grpcAnnotations = "1.3.2"
 groovy = "5.0.7"
 groovySandbox = "4.3.2"
 guava = "33.6.0-jre"
@@ -31,11 +33,13 @@ hikaricp = "6.2.1"
 hiveMqttClient = "1.3.16"
 ical4j = "4.3.0"
 jackson = "2.21.4"
+jacoco = "0.8.14"
+jakartaAnnotationApi = "3.0.0"
 jakartaEl = "4.0.2"
 jakartaElApi = "6.0.1"
 jakartaSecurityEnterpriseApi = "4.0.0"
 jakartaWsRs = "3.1.0"
-javaxAnnotationApi = "3.0.0"
+javaxAnnotationApi = "1.3.2"
 jaywayJsonPath = "2.10.0"
 jdom = "2.0.6.1"
 jserialcomm = "2.11.4"
@@ -45,12 +49,15 @@ keycloak = "25.0.3"
 micrometer = "1.17.0"
 mockito = "5.23.0"
 netty = "4.2.15.Final"
+nexusPublish = "2.0.0"
 niftyModbus = "1.4.0"
 nimbusJoseJwt = "10.9.1"
 objenesis = "3.4"
 moquette = "0.18.0"
 postgresJdbc = "42.7.13"
 prometheus = "1.6.1"
+protobuf = "3.25.5"
+protobufPlugin = "0.10.0"
 quartz = "2.5.2"
 reflections = "0.10.2"
 resteasy = "6.2.16.Final"
@@ -61,6 +68,8 @@ spock = "2.4-groovy-5.0"
 sqlite = "3.53.2.0"
 suncalc = "3.11"
 swagger = "2.2.52"
+swaggerUi = "5.32.8"
+testLogger = "4.0.0"
 typescriptGenerator = "4.1.1"
 undertow = "2.3.24.Final"
 uuidGenerator = "5.2.0"
@@ -68,6 +77,8 @@ victoolsJsonSchemaGenerator = "4.38.0"
 zwave = "3.4.0"
 
 [libraries]
+asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
+asmTree = { module = "org.ow2.asm:asm-tree", version.ref = "asm" }
 angusMail = { module = "org.eclipse.angus:angus-mail", version.ref = "angusMail" }
 artemisMqttProtocol = { module = "org.apache.artemis:artemis-mqtt-protocol", version.ref = "artemis" }
 artemisServer = { module = "org.apache.artemis:artemis-server", version.ref = "artemis" }
@@ -123,13 +134,13 @@ jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", vers
 jacksonDatatypeJdk8 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jdk8", version.ref = "jackson" }
 jacksonDatatypeJsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jacksonModuleParameterNames = { module = "com.fasterxml.jackson.module:jackson-module-parameter-names", version.ref = "jackson" }
-jakartaAnnotationApi = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "javaxAnnotationApi" }
+jakartaAnnotationApi = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakartaAnnotationApi" }
 jakartaEl = { module = "org.glassfish:jakarta.el", version.ref = "jakartaEl" }
 jakartaElApi = { module = "jakarta.el:jakarta.el-api", version.ref = "jakartaElApi" }
 jakartaSecurityEnterpriseApi = { module = "jakarta.security.enterprise:jakarta.security.enterprise-api", version.ref = "jakartaSecurityEnterpriseApi" }
 jakartaWsRsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "jakartaWsRs" }
 javaUuidGenerator = { module = "com.fasterxml.uuid:java-uuid-generator", version.ref = "uuidGenerator" }
-javaxAnnotationApi = { module = "javax.annotation:javax.annotation-api", version.ref = "grpcAnnotations" }
+javaxAnnotationApi = { module = "javax.annotation:javax.annotation-api", version.ref = "javaxAnnotationApi" }
 jaywayJsonPath = { module = "com.jayway.jsonpath:json-path", version.ref = "jaywayJsonPath" }
 jdom2 = { module = "org.jdom:jdom2", version.ref = "jdom" }
 jserialcomm = { module = "com.fazecast:jSerialComm", version.ref = "jserialcomm" }
@@ -155,6 +166,8 @@ moquette = { module = "com.github.moquette-io:moquette", version.ref = "moquette
 orZwave = { module = "org.openremote:or-zwave", version.ref = "zwave" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresJdbc" }
 prometheusMetricsExporterHttpserver = { module = "io.prometheus:prometheus-metrics-exporter-httpserver", version.ref = "prometheus" }
+protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
+protocGenGrpcJava = { module = "io.grpc:protoc-gen-grpc-java", version.ref = "grpc" }
 quartz = { module = "org.quartz-scheduler:quartz", version.ref = "quartz" }
 reflections = { module = "org.reflections:reflections", version.ref = "reflections" }
 resteasyCacheCore = { module = "org.jboss.resteasy:resteasy-cache-core", version.ref = "resteasyCache" }
@@ -172,6 +185,7 @@ sqliteJdbc = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite" }
 suncalc = { module = "org.shredzone.commons:commons-suncalc", version.ref = "suncalc" }
 swaggerAnnotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "swagger" }
 swaggerJaxrs2Jakarta = { module = "io.swagger.core.v3:swagger-jaxrs2-jakarta", version.ref = "swagger" }
+swaggerUi = { module = "org.webjars:swagger-ui", version.ref = "swaggerUi" }
 sshdNetty = { module = "org.apache.sshd:sshd-netty", version.ref = "apacheSshd" }
 typescriptGeneratorCore = { module = "cz.habarta.typescript-generator:typescript-generator-core", version.ref = "typescriptGenerator" }
 undertowCore = { module = "io.undertow:undertow-core", version.ref = "undertow" }
@@ -179,3 +193,10 @@ undertowWebsocketsJsr = { module = "io.undertow:undertow-websockets-jsr", versio
 victoolsJsonschemaGenerator = { module = "com.github.victools:jsonschema-generator", version.ref = "victoolsJsonSchemaGenerator" }
 victoolsJsonschemaModuleJackson = { module = "com.github.victools:jsonschema-module-jackson", version.ref = "victoolsJsonSchemaGenerator" }
 victoolsJsonschemaModuleJakartaValidation = { module = "com.github.victools:jsonschema-module-jakarta-validation", version.ref = "victoolsJsonSchemaGenerator" }
+
+[plugins]
+axionRelease = { id = "pl.allegro.tech.build.axion-release", version.ref = "axionRelease" }
+fileEncrypt = { id = "io.openremote.com.cherryperry.gradle-file-encrypt", version.ref = "fileEncrypt" }
+nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
+testLogger = { id = "com.adarshr.test-logger", version.ref = "testLogger" }

--- a/manager/build.gradle
+++ b/manager/build.gradle
@@ -1,11 +1,13 @@
 import java.nio.file.Paths
 
-apply plugin: "java-library"
-apply plugin: "groovy"
-apply plugin: "application"
-apply plugin: "distribution"
-apply plugin: "maven-publish"
-apply plugin: "signing"
+plugins {
+    id 'java-library'
+    id 'groovy'
+    id 'application'
+    id 'distribution'
+    id 'maven-publish'
+    id 'signing'
+}
 
 application {
     mainClass = "org.openremote.manager.Main"

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: "java-library"
-apply plugin: "maven-publish"
-apply plugin: "signing"
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+    id 'signing'
+}
 
 dependencies {
     api libs.jacksonDatabind

--- a/project.gradle
+++ b/project.gradle
@@ -131,7 +131,7 @@ exit \$status
 
 // Configure Conditional plugins
 if (project == rootProject) {
-    apply plugin: "org.jetbrains.gradle.plugin.idea-ext"
+    pluginManager.apply('org.jetbrains.gradle.plugin.idea-ext')
 
     // Configure IDEA
     if (project.hasProperty("idea") && idea.project) {
@@ -215,10 +215,11 @@ repositories {
 }
 
 // Eclipse needs help
-apply plugin: "eclipse"
+pluginManager.apply('eclipse')
+
 
 // Intellij needs help
-apply plugin: 'idea'
+pluginManager.apply('idea')
 // Use the same output directories in IDE as in gradle
 idea {
     module {
@@ -232,17 +233,9 @@ idea {
     }
 }
 
-def resolveProject(String path) {
-    project(path)
-}
-
-def resolveTask(String path) {
-    tasks.getByPath(path)
-}
-
 def getYarnInstallTask() {
     // Just use openremote repo yarn install
-    resolveTask(":yarnInstall")
+    tasks.getByPath(":yarnInstall")
 }
 
 /**
@@ -361,8 +354,6 @@ def createTSGeneratorConfig(boolean outputAPIClient, String outputFileName, Proj
 }
 
 ext {
-    resolveProject = this.&resolveProject
-    resolveTask = this.&resolveTask
     getYarnInstallTask = this.&getYarnInstallTask
     createTSGeneratorConfigForClient = this.&createTSGeneratorConfigForClient
     createTSGeneratorConfigForModel = this.&createTSGeneratorConfigForModel

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,12 +15,13 @@ pluginManagement {
     }
 }
 
+// TODO: These plugins remain here because project.gradle imports their classes,
+// and version-catalog aliases cannot be used in settings.gradle. Move the related
+// configuration into convention plugins/build logic so their versions can be
+// managed through libs.versions.toml.
 plugins {
     id 'cz.habarta.typescript-generator' version "$typescriptGeneratorVersion" apply false
-    id 'io.github.gradle-nexus.publish-plugin' version "$gradleNexusPublishPluginVersion" apply false
-    id 'io.openremote.com.cherryperry.gradle-file-encrypt' version "$gradleFileEncryptPluginVersion" apply false
     id 'org.jetbrains.gradle.plugin.idea-ext' version "$ideaExtPluginVersion" apply false
-    id 'pl.allegro.tech.build.axion-release' version "$axionReleasePluginVersion" apply false
 }
 
 rootProject.name = "openremote"

--- a/setup/build.gradle
+++ b/setup/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: "java-library"
+plugins {
+    id 'java-library'
+}
 
 var setupJar = project.hasProperty("SETUP_JAR") ? project.getProperties().get("SETUP_JAR") : "demo"
 
@@ -49,7 +51,7 @@ tasks.register('installDist', Copy) {
     if (setupTask != null) {
         System.out.println(setupTask.name)
         dependsOn setupTask
-        dependsOn resolveTask(":manager:installDist")
+        dependsOn ":manager:installDist"
         from setupTask.archiveFile
         into project(":manager").layout.buildDirectory.dir("install/manager/deployment/manager/extensions")
     }

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -1,11 +1,10 @@
 plugins {
-    id 'com.adarshr.test-logger' version "$testLoggerPluginVersion"
+    id 'java-library'
+    id 'groovy'
+    id 'maven-publish'
+    id 'signing'
+    alias libs.plugins.testLogger
 }
-
-apply plugin: "java-library"
-apply plugin: "groovy"
-apply plugin: "maven-publish"
-apply plugin: "signing"
 
 dependencies {
 

--- a/ui/app/insights/build.gradle
+++ b/ui/app/insights/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'java'
-apply plugin: "maven-publish"
-apply plugin: "signing"
+plugins {
+    id 'java'
+    id 'maven-publish'
+    id 'signing'
+}
 
 sourceSets.main.resources.srcDirs += layout.buildDirectory.dir("classes/main")
 
@@ -95,7 +97,7 @@ tasks.register('publishUi') {
 
 tasks.register('installDist', Copy) {
     dependsOn npmBuild
-    mustRunAfter resolveTask(":manager:installDist")
+    mustRunAfter ":manager:installDist"
     from layout.projectDirectory.dir("dist")
     into project(':manager').layout.buildDirectory.dir("install/manager/web/${project.name}")
 }

--- a/ui/app/manager/build.gradle
+++ b/ui/app/manager/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'java'
-apply plugin: "maven-publish"
-apply plugin: "signing"
+plugins {
+    id 'java'
+    id 'maven-publish'
+    id 'signing'
+}
 
 sourceSets.main.resources.srcDirs += layout.buildDirectory.dir("classes/main")
 
@@ -76,13 +78,13 @@ tasks.register('npmBuild', Exec) {
 }
 
 tasks.register('npmTest', Exec) {
-    dependsOn resolveTask(":ui:test:installTestDeps"), resolveTask(":ui:test:clean")
+    dependsOn ":ui:test:installTestDeps", ":ui:test:clean"
     commandLine npmCommand("yarn"), "run", "test"
     args((findProperty('args')?.toString()?.tokenize()) ?: [])
 }
 
 tasks.register('npmTestUI', Exec) {
-    dependsOn resolveTask(":ui:test:installTestDeps"), resolveTask(":ui:test:clean")
+    dependsOn ":ui:test:installTestDeps", ":ui:test:clean"
     commandLine npmCommand("yarn"), "run", "test", "--ui"
 }
 
@@ -106,7 +108,7 @@ tasks.register('publishUi') {
 
 tasks.register('installDist', Copy) {
     dependsOn(npmBuild)
-    mustRunAfter(resolveTask(":manager:installDist"))
+    mustRunAfter ":manager:installDist"
     from layout.projectDirectory.dir("dist")
     into project(':manager').layout.buildDirectory.dir("install/manager/web/${project.name}")
 }

--- a/ui/app/shared/build.gradle
+++ b/ui/app/shared/build.gradle
@@ -2,9 +2,11 @@ import java.security.MessageDigest
 import javax.annotation.processing.Processor
 import javax.tools.ToolProvider
 
-apply plugin: 'java'
-apply plugin: "maven-publish"
-apply plugin: "signing"
+plugins {
+    id 'java'
+    id 'maven-publish'
+    id 'signing'
+}
 
 sourceSets.main.resources.srcDirs += layout.buildDirectory.dir('classes/main')
 
@@ -166,7 +168,7 @@ tasks.register('generateSources', Copy) {
 
 tasks.register('installDist', Copy) {
     dependsOn generateSources
-    mustRunAfter resolveTask(":manager:installDist")
+    mustRunAfter ":manager:installDist"
     from layout.buildDirectory.dir("classes/main/org/openremote/web/${project.name}")
     into project(':manager').layout.buildDirectory.dir("install/manager/web/${project.name}")
 }

--- a/ui/app/storybook/build.gradle
+++ b/ui/app/storybook/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'java'
-apply plugin: "maven-publish"
-apply plugin: "signing"
+plugins {
+    id 'java'
+    id 'maven-publish'
+    id 'signing'
+}
 
 sourceSets.main.resources.srcDirs += layout.buildDirectory.dir("classes/main")
 
@@ -77,13 +79,13 @@ tasks.register('npmBuild', Exec) {
 }
 
 tasks.register('npmTest', Exec) {
-    dependsOn resolveTask(":ui:test:installTestDeps"), resolveTask(":ui:test:clean")
+    dependsOn ":ui:test:installTestDeps", ":ui:test:clean"
     commandLine npmCommand("yarn"), "run", "test"
     args((findProperty('args')?.toString()?.tokenize()) ?: [])
 }
 
 tasks.register('npmTestUI', Exec) {
-    dependsOn resolveTask(":ui:test:installTestDeps"), resolveTask(":ui:test:clean")
+    dependsOn ":ui:test:installTestDeps", ":ui:test:clean"
     commandLine npmCommand("yarn"), "run", "test", "--ui"
 }
 
@@ -107,7 +109,7 @@ tasks.register('publishUi') {
 
 tasks.register('installDist', Copy) {
     dependsOn(npmBuild)
-    mustRunAfter(resolveTask(":manager:installDist"))
+    mustRunAfter ":manager:installDist"
     from layout.projectDirectory.dir("dist")
     into project(':manager').layout.buildDirectory.dir("install/manager/web/${project.name}")
 }

--- a/ui/app/swagger/build.gradle
+++ b/ui/app/swagger/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'java'
-apply plugin: "maven-publish"
-apply plugin: "signing"
+plugins {
+    id 'java'
+    id 'maven-publish'
+    id 'signing'
+}
 
 sourceSets.main.resources.srcDirs += layout.buildDirectory.dir('classes/main')
 
@@ -9,7 +11,7 @@ configurations {
 }
 
 dependencies {
-    sources "org.webjars:swagger-ui:$swaggeruiVersion"
+    sources libs.swaggerUi
 }
 
 base {
@@ -80,7 +82,7 @@ signing {
 tasks.register('generateSources', Copy) {
     // Copy Swagger UI resources from the WebJars dependency
     from zipTree(configurations.sources.singleFile).matching {
-        include "META-INF/resources/webjars/swagger-ui/$swaggeruiVersion/*"
+        include "META-INF/resources/webjars/swagger-ui/${libs.versions.swaggerUi.get()}/*"
         exclude('**/favicon*.png')
         exclude('**/index.html')
         exclude('**/swagger-initializer.js')
@@ -104,7 +106,7 @@ tasks.register('generateSources', Copy) {
 
 tasks.register('installDist', Copy) {
     dependsOn generateSources
-    mustRunAfter resolveTask(":manager:installDist")
+    mustRunAfter ":manager:installDist"
     from layout.buildDirectory.dir("classes/main/org/openremote/web/${project.name}")
     into project(':manager').layout.buildDirectory.dir("install/manager/web/${project.name}")
 }

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -2,21 +2,21 @@
 afterEvaluate {
     // Add dependencies on model and rest typescript generation
     rootProject.getTasksByName('installDist', true).forEach {
-        it.dependsOn resolveTask(":ui:component:model:generateTypeScript"), resolveTask(":ui:component:rest:generateTypeScript")
+        it.dependsOn ":ui:component:model:generateTypeScript", ":ui:component:rest:generateTypeScript"
     }
     rootProject.getTasksByName('prepareUi', true).forEach {
-        it.dependsOn resolveTask(":ui:component:model:generateTypeScript"), resolveTask(":ui:component:rest:generateTypeScript")
+        it.dependsOn ":ui:component:model:generateTypeScript", ":ui:component:rest:generateTypeScript"
     }
     rootProject.getTasksByName('publishUi', true).forEach {
-        it.dependsOn resolveTask(":ui:component:model:generateTypeScript"), resolveTask(":ui:component:rest:generateTypeScript")
+        it.dependsOn ":ui:component:model:generateTypeScript", ":ui:component:rest:generateTypeScript"
     }
     rootProject.getTasksByName('npmBuild', true).forEach {
-        it.dependsOn resolveTask(":ui:component:model:generateTypeScript"), resolveTask(":ui:component:rest:generateTypeScript")
+        it.dependsOn ":ui:component:model:generateTypeScript", ":ui:component:rest:generateTypeScript"
     }
 }
 
 tasks.register("modelWatch") {
-    dependsOn resolveTask(":ui:component:model:build"), resolveTask(":ui:component:rest:build")
+    dependsOn ":ui:component:model:build", ":ui:component:rest:build"
 }
 
 tasks.register("installKnipDeps", Exec) {

--- a/ui/component/or-icon/build.gradle
+++ b/ui/component/or-icon/build.gradle
@@ -27,7 +27,7 @@ tasks.register('publishUi') {
 
 tasks.register('installDist', Copy) {
     dependsOn getYarnInstallTask(), copyMdiFont, npmAnalyze
-    resolveTask(":ui:app:shared:generateSources").dependsOn it
+    tasks.getByPath(":ui:app:shared:generateSources").dependsOn it
     from "${layout.buildDirectory.get()}/Material Design Icons"
     into "${project(':ui:app:shared').projectDir}/fonts/Material Design Icons"
 }

--- a/ui/component/rest/build.gradle
+++ b/ui/component/rest/build.gradle
@@ -31,7 +31,7 @@ generateTypeScript createTSGeneratorConfigForClient(
 def generateTypeScriptTask = tasks.named("generateTypeScript") {
     // Work around typescript-generator exposing non-serializable configuration objects as Gradle task inputs.
     doNotTrackState("typescript-generator uses non-serializable task input types")
-    dependsOn resolveTask(":ui:component:model:generateTypeScript")
+    dependsOn ":ui:component:model:generateTypeScript"
 }
 
 tasks.named('clean', Delete) {

--- a/ui/test/build.gradle
+++ b/ui/test/build.gradle
@@ -3,7 +3,7 @@ tasks.register("clean", Delete) {
 }
 
 tasks.register("installBrowsers", Exec) {
-    mustRunAfter(resolveTask(":deployment:installDist"))
+    mustRunAfter ":deployment:installDist"
     commandLine npmCommand("npx"), "playwright", "install", "chromium"
 }
 


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description

- Replaced inline Gradle plugin version declarations with `libs.plugins` aliases where possible.
- Centralized plugin version and ID definitions in `gradle/libs.versions.toml`.
- Migrated multiple module `build.gradle` files from `apply plugin` usage to `plugins {}` blocks.
- Simplified root build configuration by moving shared plugin setup into the main `build.gradle`.
- Removed now-redundant plugin version properties from `gradle.properties` and plugin declarations from `settings.gradle`.
- Added/versioned plugin aliases for Axion Release, Nexus Publish, File Encrypt, Protobuf, and Test Logger.
- Fixed annotation API version mapping in the version catalog (`jakarta.annotation` and `javax.annotation`).
- Added catalog-managed JaCoCo version configuration and updated a few related plugin versions.
- Reworked protobuf dependency configuration to use catalog-managed artifact coordinates.
- Reworked ASM and Swagger UI dependency declarations to use the version catalog.
- Added a note in `settings.gradle` explaining why some plugin declarations still remain there for now.
- Removed `resolveTask` and `resolveProject` submodule left overs.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
