### PR TITLE
Read OpenRemote version from Gradle version catalog

### DIFF
--- a/.ci_cd/README.md
+++ b/.ci_cd/README.md
@@ -20,7 +20,7 @@ docker image tag updates. The file layout is:
       },
       // Singleton or array of deployments to execute, a deployment consists of (environment and/or managerTag see variables for explanation)
       "deploy": {
-        "managerTag": "develop", // Can use #ref or exclude this to build COMMIT specific manager docker image (i.e. don't use an image from docker hub) for custom projects will always use openremoteVersion
+        "managerTag": "develop", // Can use #ref or exclude this to build COMMIT specific manager docker image (i.e. don't use an image from docker hub) for custom projects will always use openremote version from gradle/libs.versions.toml
         "environment": "staging"
       }
     },
@@ -40,7 +40,7 @@ docker image tag updates. The file layout is:
     },
     // Singleton or array of deployments to execute, a deployment consists of (environment and/or managerTag see variables for explanation)
     "deploy": {
-      "managerTag": "latest", // Can use #ref or exclude this to build COMMIT specific manager docker image (i.e. don't use an image from docker hub) for custom projects will always use openremoteVersion
+      "managerTag": "latest", // Can use #ref or exclude this to build COMMIT specific manager docker image (i.e. don't use an image from docker hub) for custom projects will always use openremote version from gradle/libs.versions.toml
       "environment": "production"
     }
   }

--- a/.github/actions/check-if-main-repo/action.yml
+++ b/.github/actions/check-if-main-repo/action.yml
@@ -30,9 +30,13 @@ runs:
           echo "value=false" >> $GITHUB_OUTPUT
           echo "repository=$(sed -E 's#(.+)/.+#\1/openremote#' <<< $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
 
-          version=$(cat gradle/libs.versions.toml | grep 'openremote = ' | sed -E 's#.+= "(.+)"#\1#')
-          if [ -z "$version" ]; then
-            version=$(cat gradle.properties | grep openremoteVersion | sed -E 's#.+=(.+)#\1#' | xargs)
+          version=""
+          if [ -f gradle/libs.versions.toml ]; then
+            version=$(sed -nE 's/^[[:space:]]*openremote[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' gradle/libs.versions.toml)
+          fi
+
+          if [ -z "$version" ] && [ -f gradle.properties ]; then
+            version=$(sed -nE 's/^[[:space:]]*openremoteVersion[[:space:]]*=[[:space:]]*([^[:space:]]+)[[:space:]]*$/\1/p' gradle.properties)
             if [ -n "$version" ]; then
               echo "::warning file=gradle.properties,title=Deprecated version configuration::Move openremoteVersion from gradle.properties to openremote in gradle/libs.versions.toml"
             fi

--- a/.github/actions/check-if-main-repo/action.yml
+++ b/.github/actions/check-if-main-repo/action.yml
@@ -30,10 +30,16 @@ runs:
           echo "value=false" >> $GITHUB_OUTPUT
           echo "repository=$(sed -E 's#(.+)/.+#\1/openremote#' <<< $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
 
-          version=$(cat gradle.properties | grep openremoteVersion | sed -E 's#.+=(.+)#\1#' | xargs)
+          version=$(cat gradle/libs.versions.toml | grep 'openremote = ' | sed -E 's#.+= "(.+)"#\1#')
+          if [ -z "$version" ]; then
+            version=$(cat gradle.properties | grep openremoteVersion | sed -E 's#.+=(.+)#\1#' | xargs)
+            if [ -n "$version" ]; then
+              echo "::warning file=gradle.properties,title=Deprecated version configuration::Move openremoteVersion from gradle.properties to openremote in gradle/libs.versions.toml"
+            fi
+          fi
 
           if [ -z "$version" ]; then
-            echo "openremoteVersion must be set in gradle.properties"
+            echo "::error::openremote version must be set in gradle/libs.versions.toml"
             exit 1
           fi
 

--- a/.github/actions/process-cicd-json/action.yml
+++ b/.github/actions/process-cicd-json/action.yml
@@ -121,14 +121,14 @@ runs:
               if isMainRepo:
                 deployStr += deploy['managerTag']
               else:
-                # Custom projects manager docker image must match the openremoteVersion from gradle.properties
+                # Custom projects manager docker image must match the openremote version from gradle/libs.versions.toml
                 deployStr += managerVersion
             else:
               if isMainRepo:
                 os.system("echo 'Manager tag not specified so using commit SHA'")
                 deployStr += managerTagDefault
               else:
-                # Custom projects manager docker image must match the openremoteVersion from gradle.properties
+                # Custom projects manager docker image must match the openremote version from gradle/libs.versions.toml
                 deployStr += managerVersion
 
             deployStr += ";"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -227,9 +227,13 @@ jobs:
             echo "value=false" >> $GITHUB_OUTPUT
             echo "repository=$(sed -E 's#(.+)/.+#\1/openremote#' <<< $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
 
-            version=$(cat gradle/libs.versions.toml | grep 'openremote = ' | sed -E 's#.+= "(.+)"#\1#')
-            if [ -z "$version" ]; then
-              version=$(cat gradle.properties | grep openremoteVersion | sed -E 's#.+=(.+)#\1#' | xargs)
+            version=""
+            if [ -f gradle/libs.versions.toml ]; then
+              version=$(sed -nE 's/^[[:space:]]*openremote[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' gradle/libs.versions.toml)
+            fi
+
+            if [ -z "$version" ] && [ -f gradle.properties ]; then
+              version=$(sed -nE 's/^[[:space:]]*openremoteVersion[[:space:]]*=[[:space:]]*([^[:space:]]+)[[:space:]]*$/\1/p' gradle.properties)
               if [ -n "$version" ]; then
                 echo "::warning file=gradle.properties,title=Deprecated version configuration::Move openremoteVersion from gradle.properties to openremote in gradle/libs.versions.toml"
               fi

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -227,10 +227,16 @@ jobs:
             echo "value=false" >> $GITHUB_OUTPUT
             echo "repository=$(sed -E 's#(.+)/.+#\1/openremote#' <<< $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
 
-            version=$(cat gradle.properties | grep openremoteVersion | sed -E 's#.+=(.+)#\1#' | xargs)
+            version=$(cat gradle/libs.versions.toml | grep 'openremote = ' | sed -E 's#.+= "(.+)"#\1#')
+            if [ -z "$version" ]; then
+              version=$(cat gradle.properties | grep openremoteVersion | sed -E 's#.+=(.+)#\1#' | xargs)
+              if [ -n "$version" ]; then
+                echo "::warning file=gradle.properties,title=Deprecated version configuration::Move openremoteVersion from gradle.properties to openremote in gradle/libs.versions.toml"
+              fi
+            fi
 
             if [ -z "$version" ]; then
-              echo "openremoteVersion must be set in gradle.properties"
+              echo "::error::openremote version must be set in gradle/libs.versions.toml"
               exit 1
             fi
 
@@ -386,14 +392,14 @@ jobs:
                 if isMainRepo:
                   deployStr += deploy['managerTag']
                 else:
-                  # Custom projects manager docker image must match the openremoteVersion from gradle.properties
+                  # Custom projects manager docker image must match the openremote version from gradle/libs.versions.toml
                   deployStr += managerVersion
               else:
                 if isMainRepo:
                   os.system("echo 'Manager tag not specified so using commit SHA'")
                   deployStr += managerTagDefault
                 else:
-                  # Custom projects manager docker image must match the openremoteVersion from gradle.properties
+                  # Custom projects manager docker image must match the openremote version from gradle/libs.versions.toml
                   deployStr += managerVersion
 
               deployStr += ";"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check if main repo
         id: is_main_repo
-        uses: openremote/openremote/.github/actions/check-if-main-repo@fa6f52032b1dea3d4ad080cc6436a3ef3843b0be
+        uses: openremote/openremote/.github/actions/check-if-main-repo@9ea22e19db6711afd711f39517fe25509b018803
 
   install-dist:
     name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check if main repo
         id: is_main_repo
-        uses: openremote/openremote/.github/actions/check-if-main-repo@9ea22e19db6711afd711f39517fe25509b018803
+        uses: openremote/openremote/.github/actions/check-if-main-repo@5beec5454f28eda1dd25331c9ce1d5b430266f7e
 
   install-dist:
     name: Build

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Check if main repo
         id: is_main_repo
-        uses: openremote/openremote/.github/actions/check-if-main-repo@9ea22e19db6711afd711f39517fe25509b018803
+        uses: openremote/openremote/.github/actions/check-if-main-repo@5beec5454f28eda1dd25331c9ce1d5b430266f7e
 
       - name: Checkout main repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Check if main repo
         id: is_main_repo
-        uses: openremote/openremote/.github/actions/check-if-main-repo@fa6f52032b1dea3d4ad080cc6436a3ef3843b0be
+        uses: openremote/openremote/.github/actions/check-if-main-repo@9ea22e19db6711afd711f39517fe25509b018803
 
       - name: Checkout main repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/install-dist.yml
+++ b/.github/workflows/install-dist.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check if main repo
         id: is_main_repo
-        uses: openremote/openremote/.github/actions/check-if-main-repo@9ea22e19db6711afd711f39517fe25509b018803
+        uses: openremote/openremote/.github/actions/check-if-main-repo@5beec5454f28eda1dd25331c9ce1d5b430266f7e
 
       - name: Set up JDK 21 and Gradle cache
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0

--- a/.github/workflows/install-dist.yml
+++ b/.github/workflows/install-dist.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check if main repo
         id: is_main_repo
-        uses: openremote/openremote/.github/actions/check-if-main-repo@fa6f52032b1dea3d4ad080cc6436a3ef3843b0be
+        uses: openremote/openremote/.github/actions/check-if-main-repo@9ea22e19db6711afd711f39517fe25509b018803
 
       - name: Set up JDK 21 and Gradle cache
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Check if main repo
         id: is_main_repo
-        uses: openremote/openremote/.github/actions/check-if-main-repo@9ea22e19db6711afd711f39517fe25509b018803
+        uses: openremote/openremote/.github/actions/check-if-main-repo@5beec5454f28eda1dd25331c9ce1d5b430266f7e
 
       - name: Process ci_cd.json file
         id: ci-cd-output

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Check if main repo
         id: is_main_repo
-        uses: openremote/openremote/.github/actions/check-if-main-repo@fa6f52032b1dea3d4ad080cc6436a3ef3843b0be
+        uses: openremote/openremote/.github/actions/check-if-main-repo@9ea22e19db6711afd711f39517fe25509b018803
 
       - name: Process ci_cd.json file
         id: ci-cd-output

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Check if main repo
         id: is_main_repo
-        uses: openremote/openremote/.github/actions/check-if-main-repo@9ea22e19db6711afd711f39517fe25509b018803
+        uses: openremote/openremote/.github/actions/check-if-main-repo@5beec5454f28eda1dd25331c9ce1d5b430266f7e
 
       - name: Run unit tests
         timeout-minutes: 20

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Check if main repo
         id: is_main_repo
-        uses: openremote/openremote/.github/actions/check-if-main-repo@fa6f52032b1dea3d4ad080cc6436a3ef3843b0be
+        uses: openremote/openremote/.github/actions/check-if-main-repo@9ea22e19db6711afd711f39517fe25509b018803
 
       - name: Run unit tests
         timeout-minutes: 20


### PR DESCRIPTION
## Description

Use the `openremote` version from `gradle/libs.versions.toml` in CI/CD workflows, allowing custom projects to define the OpenRemote version in a single place and remove `openremoteVersion` from `gradle.properties`.

Retain backwards compatibility by falling back to `openremoteVersion` in `gradle.properties` and emit a deprecation warning when it is used. Update the related documentation, comments, and error messages to reference the version catalog.

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
