### PR TITLE
Update process-cicd-json SHAs

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Process ci_cd.json file
         id: ci-cd-output
-        uses: openremote/openremote/.github/actions/process-cicd-json@5beec5454f28eda1dd25331c9ce1d5b430266f7e
+        uses: openremote/openremote/.github/actions/process-cicd-json@9ea22e19db6711afd711f39517fe25509b018803
         with:
           IS_MAIN_REPO: ${{ steps.is_main_repo.outputs.value }}
           MANAGER_VERSION: ${{ steps.is_main_repo.outputs.version }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Process ci_cd.json file
         id: ci-cd-output
-        uses: openremote/openremote/.github/actions/process-cicd-json@f667c603a447af79dda980f1dd1d734fd4679b2e
+        uses: openremote/openremote/.github/actions/process-cicd-json@5beec5454f28eda1dd25331c9ce1d5b430266f7e
         with:
           IS_MAIN_REPO: ${{ steps.is_main_repo.outputs.value }}
           MANAGER_VERSION: ${{ steps.is_main_repo.outputs.version }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Process ci_cd.json file
         id: ci-cd-output
-        uses: openremote/openremote/.github/actions/process-cicd-json@f667c603a447af79dda980f1dd1d734fd4679b2e
+        uses: openremote/openremote/.github/actions/process-cicd-json@5beec5454f28eda1dd25331c9ce1d5b430266f7e
         with:
           IS_MAIN_REPO: ${{ steps.is_main_repo.outputs.value }} # Shouldn't be needed in this context
           MANAGER_VERSION: ${{ steps.is_main_repo.outputs.version }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Process ci_cd.json file
         id: ci-cd-output
-        uses: openremote/openremote/.github/actions/process-cicd-json@5beec5454f28eda1dd25331c9ce1d5b430266f7e
+        uses: openremote/openremote/.github/actions/process-cicd-json@9ea22e19db6711afd711f39517fe25509b018803
         with:
           IS_MAIN_REPO: ${{ steps.is_main_repo.outputs.value }} # Shouldn't be needed in this context
           MANAGER_VERSION: ${{ steps.is_main_repo.outputs.version }}


### PR DESCRIPTION
Succeeds https://github.com/openremote/openremote/pull/3087

Dependabot keeps updating SHAs because it thinks they refer to the default `master` branch.