### PR TITLE
Replace PAT with App tokens

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -8,11 +8,12 @@ on:
       is_release:
         type: string
     secrets:
-      GH_EXTENSIONS_TOKEN:
+      CI_AUTOMATION_APP_CLIENT_ID:
+        required: true
+      CI_AUTOMATION_APP_PRIVATE_KEY:
         required: true
 
 permissions:
-  actions: write
   contents: read
 
 jobs:
@@ -31,13 +32,24 @@ jobs:
     needs: check-artifacts
     if: ${{ github.event_name != 'pull_request' }}
     steps:
+      - name: Create extensions contents token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CI_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: openremote
+          repositories: extensions
+          permission-contents: write
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: openremote/extensions
           path: extensions
           ref: main
           sparse-checkout: gradle/libs.versions.toml
-          token: ${{ secrets.GH_EXTENSIONS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+
       - name: Update OpenRemote version in gradle/libs.versions.toml
         run: |
           CURRENT=$(grep '^openremote = ' extensions/gradle/libs.versions.toml | sed -E 's/^openremote = "([^\"]+)".*/\1/' | head -n 1)
@@ -58,15 +70,35 @@ jobs:
     needs: [ check-artifacts, update-openremote-version ]
     if: ${{ inputs.is_release == 'true' }}
     steps:
+      - name: Create extensions release token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CI_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: openremote
+          repositories: extensions
+          permission-contents: write
+
       - run: gh release create "${{ inputs.version }}" -R openremote/extensions --generate-notes
         env:
-          GH_TOKEN: ${{ secrets.GH_EXTENSIONS_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   trigger-extensions-ci-cd:
     name: Run CI/CD
     runs-on: ubuntu-latest
     needs: check-artifacts
     steps:
+      - name: Create extensions Actions token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.CI_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: openremote
+          repositories: extensions
+          permission-actions: write
+
       - run: gh workflow run ci_cd.yml -R openremote/extensions -f version="${{ inputs.version }}" -f is_release="${{ inputs.is_release }}"
         env:
-          GH_TOKEN: ${{ secrets.GH_EXTENSIONS_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -193,5 +193,5 @@ jobs:
       version: ${{ needs.detect-changes.outputs.version_with_qualifier }}
       is_release: ${{ needs.detect-changes.outputs.is_release }}
     secrets:
-      GH_EXTENSIONS_TOKEN: ${{ secrets._TEMP_GH_EXTENSIONS_TOKEN }}
-
+      CI_AUTOMATION_APP_CLIENT_ID: ${{ secrets._TEMP_CI_AUTOMATION_APP_CLIENT_ID }}
+      CI_AUTOMATION_APP_PRIVATE_KEY: ${{ secrets._TEMP_CI_AUTOMATION_APP_PRIVATE_KEY }}


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description

Replaces the personal access token used for cross-repository extension automation with short-lived GitHub App installation tokens.

* Generate repository-scoped tokens for `openremote/extensions`
* Use `Contents: write` only for version updates and release creation
* Use `Actions: write` only for triggering the extensions CI/CD workflow
* Pass the GitHub App client ID and private key through the reusable workflow
* Remove the previous PAT-based `GH_EXTENSIONS_TOKEN` usage

Related: openremote/extensions#69


## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
