### PR TITLE
Generate and publish OpenAPI YAML specification

### DIFF
--- a/manager/build.gradle
+++ b/manager/build.gradle
@@ -106,7 +106,7 @@ afterEvaluate {
 
 resolve {
     outputFileName = 'openapi'
-    outputFormat = 'JSON'
+    outputFormat = 'JSONANDYAML'
     outputDir = layout.buildDirectory.dir("openapi")
 
     prettyPrint = true
@@ -161,7 +161,8 @@ java {
     withSourcesJar()
 }
 
-def openApiFile = layout.buildDirectory.file('openapi/openapi.json')
+def openApiJsonFile = layout.buildDirectory.file('openapi/openapi.json')
+def openApiYamlFile = layout.buildDirectory.file('openapi/openapi.yaml')
 
 publishing {
     publications {
@@ -170,9 +171,15 @@ publishing {
             artifactId = "openremote-${project.name}"
             from components.java
 
-            artifact(openApiFile) {
+            artifact(openApiJsonFile) {
                 classifier = 'openapi'
                 extension = 'json'
+                builtBy tasks.named('resolve')
+            }
+
+            artifact(openApiYamlFile) {
+                classifier = 'openapi'
+                extension = 'yaml'
                 builtBy tasks.named('resolve')
             }
 


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description
<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Similar to https://github.com/openremote/openremote/pull/3116 also publish the YAML variant of the OpenAPI spec which is often used in tooling and more readable by humans.


The generated OpenAPI YAML specification is published to Maven Central with the following coordinates:

- Group: "io.openremote"
- Artifact: "openremote-manager"
- Version: the corresponding OpenRemote version
- Classifier: "openapi"
- Type: "yaml"

Maven:

```xml
<dependency>
    <groupId>io.openremote</groupId>
    <artifactId>openremote-manager</artifactId>
    <version>${openremote.version}</version>
    <classifier>openapi</classifier>
    <type>yaml</type>
</dependency>
```

Gradle dependency notation:

```
"io.openremote:openremote-manager:${openremoteVersion}:openapi@yaml"
```

## Checklist
<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
