### PR TITLE
Temporarily make manager image vulnerability scan non-blocking

### DIFF
--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -92,6 +92,16 @@ jobs:
           fail-build: false
           severity-cutoff: critical
 
+      - name: Upload Grype scan report on failure
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        # Only run this step if the previous steps failed AND it was specifically the scan step that failed
+        if: failure() && steps.manager-anchore-scan.outcome == 'failure'
+        with:
+          name: grype-critical-vulnerability-report
+          # The scan-action automatically outputs the path to the SARIF file
+          path: ${{ steps.manager-anchore-scan.outputs.sarif }}
+          retention-days: 7
+
       - name: Upload Anchore scan SARIF report
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         if: ${{ always() && steps.meta.outputs.should_push == 'true' }}

--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -92,7 +92,7 @@ jobs:
           fail-build: false
           severity-cutoff: critical
 
-      - name: Upload Grype scan report on failure
+      - name: Upload Grype scan report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # Only run this step if the previous steps failed AND it was specifically the scan step that failed
         if: always() && steps.manager-anchore-scan.outcome == 'failure'

--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Upload Grype scan report on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # Only run this step if the previous steps failed AND it was specifically the scan step that failed
-        if: failure() && steps.manager-anchore-scan.outcome == 'failure'
+        if: always() && steps.manager-anchore-scan.outcome == 'failure'
         with:
           name: grype-critical-vulnerability-report
           # The scan-action automatically outputs the path to the SARIF file

--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload Grype scan report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always() && steps.manager-anchore-scan.outcome == 'failure'
+        if: always()
         with:
           name: grype-critical-vulnerability-report
           # The scan-action automatically outputs the path to the SARIF file

--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -94,7 +94,6 @@ jobs:
 
       - name: Upload Grype scan report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        # Only run this step if the previous steps failed AND it was specifically the scan step that failed
         if: always() && steps.manager-anchore-scan.outcome == 'failure'
         with:
           name: grype-critical-vulnerability-report

--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -89,7 +89,7 @@ jobs:
         id: manager-anchore-scan
         with:
           image: ${{ steps.meta.outputs.first_tag }}
-          fail-build: true
+          fail-build: false
           severity-cutoff: critical
 
       - name: Upload Anchore scan SARIF report


### PR DESCRIPTION
## Description

Temporarily make the Grype vulnerability scan non-blocking for manager image builds.

The scan currently detects **CVE-2026-51302** in `sqlite-libs` version `3.46.1-5.el10_1`, inherited from the `registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-5` base image. Grype classifies this vulnerability as critical with a CVSS score of 10.0, but currently reports no available fixed package version.

Because this vulnerability cannot currently be resolved within OpenRemote, failing the build prevents manager images from being published without providing an actionable remediation path.

This change:

* Keeps the Grype vulnerability scan enabled with a `critical` severity cutoff.
* Makes detected vulnerabilities non-blocking by setting `fail-build` to `false`.
* Continues uploading the SARIF report to GitHub Code Scanning.
* Retains a scan report as a workflow artifact .

This should be reverted once an updated base image containing a fixed `sqlite-libs` package becomes available.

## Checklist

* [ ] 1. Acceptance criteria of the linked issue(s) are met
* [ ] 2. Tests are written and all tests pass
* [ ] 3. Changes are manually tested by you and the reviewer
* [ ] 4. Documentation is written or updated
