### PR TITLE
Bugfix: Modbus Write incorrectly displaying the filtered value as the actual value

### DIFF
--- a/agent/src/main/java/org/openremote/agent/protocol/modbus/AbstractModbusProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/modbus/AbstractModbusProtocol.java
@@ -33,7 +33,9 @@ import org.openremote.model.asset.agent.ConnectionStatus;
 import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.attribute.AttributeRef;
+import org.openremote.model.protocol.ProtocolUtil;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.util.Pair;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -301,13 +303,14 @@ public abstract class AbstractModbusProtocol<T extends AbstractModbusProtocol<T,
             if (event.getSource() != null) {
                 if (agentLink.getReadAddress() == null) {
                     // Write-only: update the local linkedAttributes cache and notify the system
+                    Object attributeValue = event.getValue().orElse(null);
                     Attribute<?> attribute = linkedAttributes.get(event.getRef());
                     if (attribute != null) {
                         @SuppressWarnings("unchecked")
                         Attribute<Object> attr = (Attribute<Object>) attribute;
-                        attr.setValue(processedValue);
+                        attr.setValue(attributeValue);
                     }
-                    updateLinkedAttribute(event.getRef(), processedValue);
+                    updateLinkedAttribute(event.getRef(), attributeValue);
                     LOG.finest(getProtocolName() + " - Write-only attribute updated: " + event.getRef());
                 } else {
                     // Write + Read: trigger immediate read to verify write
@@ -546,10 +549,18 @@ public abstract class AbstractModbusProtocol<T extends AbstractModbusProtocol<T,
                     return;
                 }
 
-                AttributeEvent syntheticEvent = new AttributeEvent(ref, currentValue);
-                doLinkedAttributeWrite(agentLink, syntheticEvent, currentValue);
+                Pair<Boolean, Object> ignoreAndConverted = ProtocolUtil.doOutboundValueProcessing(
+                        ref, agentLink, currentValue, dynamicAttributes.contains(ref), timerService.getNow());
 
-                LOG.finest(getProtocolName() + " - Write interval executed for " + ref + " with value: " + currentValue);
+                if (ignoreAndConverted.key) {
+                    LOG.finest(getProtocolName() + " - Skipping write interval for " + ref + " - value processing returned ignore");
+                    return;
+                }
+
+                AttributeEvent syntheticEvent = new AttributeEvent(ref, currentValue);
+                doLinkedAttributeWrite(agentLink, syntheticEvent, ignoreAndConverted.value);
+
+                LOG.finest(getProtocolName() + " - Write interval executed for " + ref + " with value: " + ignoreAndConverted.value);
             } catch (Exception e) {
                 LOG.log(Level.WARNING, getProtocolName() + " - Exception during write interval for " + ref + ": " + e.getMessage(), e);
             }

--- a/test/src/test/groovy/org/openremote/test/protocol/modbus/ModbusTcpTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/modbus/ModbusTcpTest.groovy
@@ -42,6 +42,8 @@ import org.openremote.model.attribute.Attribute
 import org.openremote.model.attribute.AttributeEvent
 import org.openremote.model.attribute.MetaItem
 import org.openremote.model.attribute.MetaMap
+import org.openremote.model.value.MathExpressionValueFilter
+import org.openremote.model.value.ValueFilter
 import org.openremote.model.value.ValueType
 import org.openremote.test.ManagerContainerTrait
 import spock.lang.Shared
@@ -922,6 +924,149 @@ class ModbusTcpTest extends Specification implements ManagerContainerTrait {
         conditions.eventually {
             agent = assetStorageService.find(agent.getId())
             assert agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+        }
+    }
+
+    def "Modbus TCP Test - Write Value Filter Only Applies To The Modbus Write"() {
+        given: "expected conditions"
+        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+        when: "the container starts"
+        def container = startContainer(defaultConfig(), defaultServices())
+        def assetStorageService = container.getService(AssetStorageService.class)
+        def assetProcessingService = container.getService(AssetProcessingService.class)
+        def agentService = container.getService(AgentService.class)
+
+        and: "a Modbus TCP agent is created"
+        def agent = new ModbusTcpAgent("Modbus TCP Write Filter Test")
+        agent.setRealm(MASTER_REALM)
+        agent.setHost("127.0.0.1")
+        agent.setPort(modbusServerPort)
+        agent = assetStorageService.merge(agent)
+
+        then: "the agent should connect successfully"
+        conditions.eventually {
+            assert agentService.getProtocolInstance(agent.id) != null
+            agent = assetStorageService.find(agent.getId())
+            assert agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+        }
+
+        when: "a write-only attribute with a x*10 write value filter is created"
+        def device = new ThingAsset("Write Filter Device")
+        device.setRealm(MASTER_REALM)
+        device.addOrReplaceAttributes(
+                new Attribute<>("scaledWrite", ValueType.NUMBER).addOrReplaceMeta(
+                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                                .tap {
+                                    it.setUnitId(1)
+                                    it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
+                                    it.setWriteAddress(600)
+                                    it.setWriteValueFilters([new MathExpressionValueFilter("x*10")] as ValueFilter[])
+                                }
+                        )
+                )
+        )
+        device = assetStorageService.merge(device)
+
+        then: "the attribute should be linked"
+        conditions.eventually {
+            device = assetStorageService.find(device.getId(), true)
+            assert device.getAttribute("scaledWrite").isPresent()
+        }
+
+        when: "the user writes 5 to the attribute"
+        latestWriteMessage.set(null)
+        assetProcessingService.sendAttributeEvent(
+                new AttributeEvent(device.getId(), "scaledWrite", 5), "ClientEventService")
+
+        then: "the filtered value should be sent to the Modbus server"
+        conditions.eventually {
+            def msg = (latestWriteMessage.get() as ModbusMessage)?.unwrap(RegistersModbusMessage)
+            assert msg != null
+            assert msg.getAddress() == 599
+            assert msg.dataDecodeUnsigned()[0] == 50
+        }
+
+        and: "the attribute should keep the value the user wrote, not the filtered one"
+        conditions.eventually {
+            device = assetStorageService.find(device.getId(), true)
+            assert device.getAttribute("scaledWrite").flatMap { it.getValue() }.orElse(null) == 5
+        }
+    }
+
+    def "Modbus TCP Test - Write Value Filter Applied To Interval Writes"() {
+        given: "expected conditions"
+        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+
+        when: "the container starts"
+        def container = startContainer(defaultConfig(), defaultServices())
+        def assetStorageService = container.getService(AssetStorageService.class)
+        def assetProcessingService = container.getService(AssetProcessingService.class)
+        def agentService = container.getService(AgentService.class)
+
+        and: "a Modbus TCP agent is created"
+        def agent = new ModbusTcpAgent("Modbus TCP Write Filter Interval Test")
+        agent.setRealm(MASTER_REALM)
+        agent.setHost("127.0.0.1")
+        agent.setPort(modbusServerPort)
+        agent = assetStorageService.merge(agent)
+
+        then: "the agent should connect successfully"
+        conditions.eventually {
+            assert agentService.getProtocolInstance(agent.id) != null
+            agent = assetStorageService.find(agent.getId())
+            assert agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+        }
+
+        when: "a write interval attribute with a x*10 write value filter is created"
+        def device = new ThingAsset("Write Filter Interval Device")
+        device.setRealm(MASTER_REALM)
+        device.addOrReplaceAttributes(
+                new Attribute<>("scaledIntervalWrite", ValueType.NUMBER, 7).addOrReplaceMeta(
+                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                                .tap {
+                                    it.setUnitId(1)
+                                    it.setRequestInterval(1000)
+                                    it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
+                                    it.setWriteAddress(601)
+                                    it.setWriteValueFilters([new MathExpressionValueFilter("x*10")] as ValueFilter[])
+                                }
+                        )
+                )
+        )
+        device = assetStorageService.merge(device)
+
+        then: "the periodic write should send the filtered value"
+        conditions.eventually {
+            def msg = (latestWriteMessage.get() as ModbusMessage)?.unwrap(RegistersModbusMessage)
+            assert msg != null
+            assert msg.getAddress() == 600
+            assert msg.dataDecodeUnsigned()[0] == 70
+        }
+
+        and: "the attribute should still hold the unfiltered value"
+        conditions.eventually {
+            device = assetStorageService.find(device.getId(), true)
+            assert device.getAttribute("scaledIntervalWrite").flatMap { it.getValue() }.orElse(null) == 7
+        }
+
+        when: "the user writes 3 to the attribute"
+        assetProcessingService.sendAttributeEvent(
+                new AttributeEvent(device.getId(), "scaledIntervalWrite", 3), "ClientEventService")
+        Thread.sleep(2000)
+        latestWriteMessage.set(null)
+
+        then: "the periodic writes should keep sending the newly filtered value"
+        conditions.eventually {
+            def msg = (latestWriteMessage.get() as ModbusMessage)?.unwrap(RegistersModbusMessage)
+            assert msg != null
+            assert msg.dataDecodeUnsigned()[0] == 30
+        }
+
+        and: "the attribute should still hold the unfiltered value"
+        conditions.eventually {
+            device = assetStorageService.find(device.getId(), true)
+            assert device.getAttribute("scaledIntervalWrite").flatMap { it.getValue() }.orElse(null) == 3
         }
     }
 


### PR DESCRIPTION

## Description
This PR fixes an issue in my modbus code.
When applying a write value filter, the filtered value was pushed to the actual value in addition to being send over the modbus.
Fixed that, and added tests that would have caught this bug.


- [x] 1. Acceptance criteria of the linked issue(s) are met
- [x] 2. Tests are written and all tests pass
- [x] 3. Changes are manually tested by you and the reviewer
- [x] 4. Documentation is written or updated

<!-- 
  Thank you for your contribution <3 
-->
