### PR TITLE
Use category with Grype scan SARIF results

### DIFF
--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -106,6 +106,7 @@ jobs:
         if: ${{ always() && steps.meta.outputs.should_push == 'true' }}
         with:
           sarif_file: ${{ steps.manager-anchore-scan.outputs.sarif }}
+          category: grype-manager
 
       - name: Inspect Anchore scan SARIF report
         if: ${{ always() && steps.meta.outputs.should_push == 'true' }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -866,6 +866,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: ${{ steps.manager-anchore-scan.outputs.sarif }}
+          category: grype-manager
 
       - name: Inspect Anchore scan SARIF report
         if: |


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description

* Add a stable `grype-manager` category to the Grype SARIF upload.
* Prevent workflow or job renames from creating separate Code Scanning configurations.
* Ensure future scans update the same set of alerts.

## Follow-up

* After this is merged and the workflow has run on `master`, delete the obsolete implicit Grype configuration to remove stale alerts.

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
