### PR TITLE
Upgrade manager base image to ubi10/openjdk-21-runtime:1.24-11 for security updates

### DIFF
--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -89,7 +89,7 @@ jobs:
         id: manager-anchore-scan
         with:
           image: ${{ steps.meta.outputs.first_tag }}
-          fail-build: false
+          fail-build: true
           severity-cutoff: critical
 
       - name: Upload Grype scan report

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24
+FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11
 
 # Add git commit label must be specified at build time using --build-arg GIT_COMMIT=dadadadadad
 ARG GIT_COMMIT=unknown

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-5
+FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24
 
 # Add git commit label must be specified at build time using --build-arg GIT_COMMIT=dadadadadad
 ARG GIT_COMMIT=unknown


### PR DESCRIPTION


## Description

* The pinned `1.24-5` tag prevents newer security fixes from being included.
* The `1.24` stream tag automatically picks up updated `1.24-*` builds.
* This fixes many known vulnerabilities reported for the outdated base image.
* It remains more controlled than using the unversioned or `latest` tag.

Follow-up to #2787.

See: 

* [ubi10/openjdk-21-runtime:1.24-5 Security](https://catalog.redhat.com/en/software/containers/ubi10/openjdk-21-runtime/690ca3b700d71ac7397b98c6?image=6a05c260f3b8eb8732882116&architecture=amd64#security)
* [ubi10/openjdk-21-runtime:1.24 Security](https://catalog.redhat.com/en/software/containers/ubi10/openjdk-21-runtime/690ca3b700d71ac7397b98c6?image=6a68b6655f901958da0b9958&architecture=amd64#security)

As the newer image no longer has CVE-2026-45445 build failures for critical vulnerability issues can be reenabled.

Closes #3127

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
