### PR TITLE
Realm-scoped syslog: separate log entries per realm

### DIFF
--- a/agent/src/main/java/org/openremote/agent/protocol/AbstractProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/AbstractProtocol.java
@@ -34,6 +34,8 @@ import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.attribute.AttributeState;
 import org.openremote.model.protocol.ProtocolAssetService;
 import org.openremote.model.protocol.ProtocolUtil;
+import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmRegistry;
 import org.openremote.model.util.Pair;
 
 import java.util.*;
@@ -41,13 +43,20 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.openremote.model.protocol.ProtocolUtil.hasDynamicPlaceholders;
 import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 public abstract class AbstractProtocol<T extends Agent<T, ?, U>, U extends AgentLink<?>> implements Protocol<T> {
 
-    private static final System.Logger LOG = System.getLogger(AbstractProtocol.class.getName() + "." + PROTOCOL.name());
+    /**
+     * Per protocol instance logger so log records can be attributed to the realm of the linked
+     * {@link Agent} (see {@link SyslogRealmRegistry}); the syslog sub category becomes
+     * {@code <ProtocolClass>-<agentId>}.
+     */
+    protected final Logger LOG;
     protected final Map<AttributeRef, Attribute<?>> linkedAttributes = new ConcurrentHashMap<>();
     protected final Set<AttributeRef> dynamicAttributes = Collections.synchronizedSet(new HashSet<>());
     protected DefaultCamelContext messageBrokerContext;
@@ -63,6 +72,7 @@ public abstract class AbstractProtocol<T extends Agent<T, ?, U>, U extends Agent
 
     public AbstractProtocol(T agent) {
         this.agent = agent;
+        this.LOG = SyslogCategory.getLogger(PROTOCOL, getClass().getName() + "-" + agent.getId());
     }
 
     @Override
@@ -79,6 +89,7 @@ public abstract class AbstractProtocol<T extends Agent<T, ?, U>, U extends Agent
         datapointService = container.getService(ProtocolDatapointService.class);
         messageBrokerContext = container.getService(MessageBrokerService.class).getContext();
         this.producerTemplate = container.getService(MessageBrokerService.class).getProducerTemplate();
+        SyslogRealmRegistry.register(LOG.getName(), agent.getRealm());
         doStart(container);
     }
 
@@ -93,6 +104,8 @@ public abstract class AbstractProtocol<T extends Agent<T, ?, U>, U extends Agent
 
         } catch (Exception ex) {
             throw new RuntimeException(ex);
+        } finally {
+            SyslogRealmRegistry.unregister(LOG.getName());
         }
     }
 
@@ -144,7 +157,7 @@ public abstract class AbstractProtocol<T extends Agent<T, ?, U>, U extends Agent
     @Override
     public void processLinkedAttributeWrite(AttributeEvent event) {
         synchronized (processorLock) {
-            LOG.log(System.Logger.Level.TRACE, () -> "Processing linked attribute write on protocol '" + this + "': " + event);
+            LOG.log(Level.FINER, () -> "Processing linked attribute write on protocol '" + this + "': " + event);
             AgentLink<?> agentLink = agent.getAgentLink(event);
 
             Pair<Boolean, Object> ignoreAndConverted = ProtocolUtil.doOutboundValueProcessing(
@@ -155,7 +168,7 @@ public abstract class AbstractProtocol<T extends Agent<T, ?, U>, U extends Agent
                 timerService.getNow());
 
             if (ignoreAndConverted.key) {
-                LOG.log(System.Logger.Level.DEBUG, "Value conversion returned ignore so attribute will not write to protocol: " + event.getRef());
+                LOG.log(Level.FINE, "Value conversion returned ignore so attribute will not write to protocol: " + event.getRef());
                 return;
             }
 
@@ -183,7 +196,7 @@ public abstract class AbstractProtocol<T extends Agent<T, ?, U>, U extends Agent
     final protected void sendAttributeEvent(AttributeEvent event) {
         // Don't allow updating linked attributes with this mechanism as it could cause an infinite loop
         if (linkedAttributes.containsKey(event.getRef())) {
-            LOG.log(System.Logger.Level.WARNING, () -> "Cannot update an attribute linked to the same protocol; use updateLinkedAttribute for that: " + event);
+            LOG.log(Level.WARNING, () -> "Cannot update an attribute linked to the same protocol; use updateLinkedAttribute for that: " + event);
             return;
         }
         assetService.sendAttributeEvent(event);
@@ -195,19 +208,19 @@ public abstract class AbstractProtocol<T extends Agent<T, ?, U>, U extends Agent
         Attribute<?> attribute = linkedAttributes.get(attributeRef);
 
         if (attribute == null) {
-            LOG.log(System.Logger.Level.WARNING, () -> "Update linked attribute called for un-linked attribute: " + attributeRef);
+            LOG.log(Level.WARNING, () -> "Update linked attribute called for un-linked attribute: " + attributeRef);
             return;
         }
 
         Pair<Boolean, Object> ignoreAndConverted = ProtocolUtil.doInboundValueProcessing(attributeRef.getId(), attribute, agent.getAgentLink(attribute), value);
 
         if (ignoreAndConverted.key) {
-            LOG.log(System.Logger.Level.DEBUG, "Value conversion returned ignore so attribute will not be updated: " + attributeRef);
+            LOG.log(Level.FINE, "Value conversion returned ignore so attribute will not be updated: " + attributeRef);
             return;
         }
 
         AttributeEvent attributeEvent = new AttributeEvent(attributeRef, ignoreAndConverted.value, timestamp);
-        LOG.log(System.Logger.Level.TRACE, () -> "Sending linked attribute update: " + attributeEvent);
+        LOG.log(Level.FINER, () -> "Sending linked attribute update: " + attributeEvent);
         assetService.sendAttributeEvent(attributeEvent);
     }
 

--- a/agent/src/main/java/org/openremote/agent/protocol/bluetooth/mesh/BluetoothMeshProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/bluetooth/mesh/BluetoothMeshProtocol.java
@@ -59,14 +59,14 @@ public class BluetoothMeshProtocol extends AbstractProtocol<BluetoothMeshAgent, 
 
     // Class Members --------------------------------------------------------------------------------
 
-    public static final Logger LOG = SyslogCategory.getLogger(SyslogCategory.PROTOCOL, BluetoothMeshProtocol.class.getName());
+    public static final Logger MESH_LOG = SyslogCategory.getLogger(SyslogCategory.PROTOCOL, BluetoothMeshProtocol.class.getName());
 
     private static final MainThreadManager mainThread = new MainThreadManager();
     private static ScheduledFuture<?> mainThreadFuture = null;
     private static final BluetoothCentralManagerCallback bluetoothManagerCallback = new BluetoothCentralManagerCallback() {
         @Override
         public void onConnectedPeripheral(BluetoothPeripheral peripheral) {
-            LOG.info("BluetoothCentralManager::onConnectedPeripheral: [Name=" + peripheral.getName() + ", Address=" + peripheral.getAddress() + "]");
+            MESH_LOG.info("BluetoothCentralManager::onConnectedPeripheral: [Name=" + peripheral.getName() + ", Address=" + peripheral.getAddress() + "]");
 
             synchronized (BluetoothMeshProtocol.class) {
                 for (BluetoothMeshNetwork network : networkList) {
@@ -77,7 +77,7 @@ public class BluetoothMeshProtocol extends AbstractProtocol<BluetoothMeshAgent, 
 
         @Override
         public void onConnectionFailed(BluetoothPeripheral peripheral, BluetoothCommandStatus status) {
-            LOG.info("BluetoothCentralManager::onConnectionFailed: [Name=" + peripheral.getName() + ", Address=" + peripheral.getAddress() + ", Status=" + status +"]");
+            MESH_LOG.info("BluetoothCentralManager::onConnectionFailed: [Name=" + peripheral.getName() + ", Address=" + peripheral.getAddress() + ", Status=" + status +"]");
 
             synchronized (BluetoothMeshProtocol.class) {
                 for (BluetoothMeshNetwork network : networkList) {
@@ -88,7 +88,7 @@ public class BluetoothMeshProtocol extends AbstractProtocol<BluetoothMeshAgent, 
 
         @Override
         public void onDisconnectedPeripheral(BluetoothPeripheral peripheral, BluetoothCommandStatus status) {
-            LOG.info("BluetoothCentralManager::onDisconnectedPeripheral: [Name=" + peripheral.getName() + ", Address=" + peripheral.getAddress() + ", Status=" + status +"]");
+            MESH_LOG.info("BluetoothCentralManager::onDisconnectedPeripheral: [Name=" + peripheral.getName() + ", Address=" + peripheral.getAddress() + ", Status=" + status +"]");
 
             synchronized (BluetoothMeshProtocol.class) {
                 for (BluetoothMeshNetwork network : networkList) {
@@ -99,7 +99,7 @@ public class BluetoothMeshProtocol extends AbstractProtocol<BluetoothMeshAgent, 
 
         @Override
         public void onDiscoveredPeripheral(BluetoothPeripheral peripheral, ScanResult scanResult) {
-            LOG.info("BluetoothCentralManager::onDiscoveredPeripheral: [Name=" + peripheral.getName() + ", Address=" + peripheral.getAddress() + ", ScanResult=" + scanResult +"]");
+            MESH_LOG.info("BluetoothCentralManager::onDiscoveredPeripheral: [Name=" + peripheral.getName() + ", Address=" + peripheral.getAddress() + ", ScanResult=" + scanResult +"]");
 
             synchronized (BluetoothMeshProtocol.class) {
                 for (BluetoothMeshNetwork network : networkList) {
@@ -110,7 +110,7 @@ public class BluetoothMeshProtocol extends AbstractProtocol<BluetoothMeshAgent, 
 
         @Override
         public void onScanFailed(int errorCode) {
-            LOG.info("BluetoothCentralManager::onScanFailed: [errorCode=" + errorCode + "]");
+            MESH_LOG.info("BluetoothCentralManager::onScanFailed: [errorCode=" + errorCode + "]");
 
             synchronized (BluetoothMeshProtocol.class) {
                 for (BluetoothMeshNetwork network : networkList) {

--- a/agent/src/main/java/org/openremote/agent/protocol/http/AbstractHTTPServerProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/http/AbstractHTTPServerProtocol.java
@@ -31,20 +31,17 @@ import org.openremote.model.asset.agent.Agent;
 import org.openremote.model.asset.agent.AgentLink;
 import org.openremote.model.asset.agent.ConnectionStatus;
 import org.openremote.model.attribute.Attribute;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.TextUtil;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.logging.Level.INFO;
 import static org.openremote.container.web.WebService.getStandardProviders;
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 /**
  * This is an abstract protocol for creating JAX-RS deployments; a concrete implementation should be created for each
@@ -69,10 +66,6 @@ public abstract class AbstractHTTPServerProtocol<T extends AbstractHTTPServerPro
      */
     public static final String DEPLOYMENT_PATH_PREFIX = "/http_agent";
 
-    /**
-     * The regex used to validate the deployment path.
-     */
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, AbstractHTTPServerProtocol.class);
     protected Container container;
     protected boolean devMode;
     protected IdentityService identityService;

--- a/agent/src/main/java/org/openremote/agent/protocol/http/HTTPProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/http/HTTPProtocol.java
@@ -47,7 +47,6 @@ import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.auth.OAuthGrant;
 import org.openremote.model.auth.UsernamePassword;
 import org.openremote.model.protocol.ProtocolUtil;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.Pair;
 import org.openremote.model.util.TextUtil;
 import org.openremote.model.util.ValueUtil;
@@ -64,10 +63,8 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static org.openremote.container.web.WebTargetBuilder.addHeaders;
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 /**
  * This is a HTTP client protocol for communicating with HTTP servers; it uses the {@link WebTargetBuilder} factory to
@@ -273,7 +270,6 @@ public class HTTPProtocol extends AbstractProtocol<HTTPAgent, HTTPAgentLink> {
     public static final String PROTOCOL_DISPLAY_NAME = "HTTP Client";
     public static final String DEFAULT_HTTP_METHOD = HttpMethod.GET;
     public static final String DEFAULT_CONTENT_TYPE = MediaType.TEXT_PLAIN;
-    protected static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, HTTPProtocol.class);
     // Cannot be final due to adjustment needed in tests to speed up tests
     public static int MIN_POLLING_MILLIS = 5000;
     public static final int DEFAULT_READ_TIMEOUT_MILLIS = 10000;

--- a/agent/src/main/java/org/openremote/agent/protocol/io/AbstractIOClientProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/io/AbstractIOClientProtocol.java
@@ -36,7 +36,6 @@ import org.openremote.model.asset.agent.ConnectionStatus;
 import org.openremote.model.asset.agent.Protocol;
 import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.ValueUtil;
 
 import java.nio.charset.Charset;
@@ -45,9 +44,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 /**
  * This is an abstract {@link Protocol} for protocols that require an {@link IOClient}.
@@ -124,7 +120,6 @@ public abstract class AbstractIOClientProtocol<T extends AbstractIOClientProtoco
         };
     }
 
-    public static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, AbstractIOClientProtocol.class);
     protected W client;
 
     protected AbstractIOClientProtocol(U agent) {
@@ -174,7 +169,7 @@ public abstract class AbstractIOClientProtocol<T extends AbstractIOClientProtoco
             return;
         }
 
-        AbstractIOClientProtocol.LOG.finest("Sending message to IO client: " + client.getClientUri());
+        LOG.finest("Sending message to IO client: " + client.getClientUri());
         client.sendMessage(message);
     }
 

--- a/agent/src/main/java/org/openremote/agent/protocol/knx/KNXProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/knx/KNXProtocol.java
@@ -8,7 +8,6 @@ import org.openremote.model.asset.AssetTreeNode;
 import org.openremote.model.asset.impl.ThingAsset;
 import org.openremote.model.attribute.*;
 import org.openremote.model.protocol.ProtocolAssetImport;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.value.MetaItemType;
 import org.openremote.model.value.ValueDescriptor;
 import tuwien.auto.calimero.GroupAddress;
@@ -35,12 +34,10 @@ import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import static org.openremote.model.asset.agent.AgentLink.getOrThrowAgentLinkProperty;
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 import static org.openremote.model.value.MetaItemType.AGENT_LINK;
 
 /**
@@ -48,7 +45,6 @@ import static org.openremote.model.value.MetaItemType.AGENT_LINK;
  */
 public class KNXProtocol extends AbstractProtocol<KNXAgent, KNXAgentLink> implements ProtocolAssetImport {
 
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, KNXProtocol.class);
     public static final String PROTOCOL_DISPLAY_NAME = "KNX";
     protected static final String SUPPORT_DTD = XMLInputFactory.SUPPORT_DTD;
     protected static final String SUPPORTING_EXTERNAL_ENTITIES = "javax.xml.stream.isSupportingExternalEntities";

--- a/agent/src/main/java/org/openremote/agent/protocol/lorawan/AbstractLoRaWANProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/lorawan/AbstractLoRaWANProtocol.java
@@ -36,6 +36,7 @@ import org.openremote.model.attribute.MetaMap;
 import org.openremote.model.protocol.ProtocolAssetImport;
 import org.openremote.model.protocol.ProtocolAssetService;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmRegistry;
 import org.openremote.model.util.ValueUtil;
 import org.openremote.model.value.JsonPathFilter;
 import org.openremote.model.value.RegexValueFilter;
@@ -69,7 +70,7 @@ import static org.openremote.model.value.MetaItemType.STORE_DATA_POINTS;
 
 public abstract class AbstractLoRaWANProtocol<S extends AbstractLoRaWANProtocol<S,T>, T extends LoRaWANAgent<T, S>> implements Protocol<T>, ProtocolAssetImport {
 
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, AbstractLoRaWANProtocol.class);
+    protected final Logger LOG;
 
     protected volatile ExecutorService executorService;
     protected volatile ProtocolAssetService assetService;
@@ -80,6 +81,10 @@ public abstract class AbstractLoRaWANProtocol<S extends AbstractLoRaWANProtocol<
 
     public AbstractLoRaWANProtocol(T agent) {
         this.agent = agent;
+
+        // Dedicated per-instance logger so log records are attributed to the agent's realm
+        // (see SyslogRealmRegistry); the syslog subCategory becomes <SimpleClass>-<agentId>
+        LOG = SyslogCategory.getLogger(PROTOCOL, getClass().getName() + "-" + agent.getId());
 
         MQTTAgent mqttAgent = new MQTTAgent(agent.getName());
 
@@ -140,8 +145,14 @@ public abstract class AbstractLoRaWANProtocol<S extends AbstractLoRaWANProtocol<
 
     @Override
     public void start(Container container) throws Exception {
+        SyslogRealmRegistry.register(LOG.getName(), agent.getRealm());
         this.container = container;
         executorService = container.getExecutor();
+    }
+
+    @Override
+    public void stop(Container container) throws Exception {
+        SyslogRealmRegistry.unregister(LOG.getName());
     }
 
     @Override

--- a/agent/src/main/java/org/openremote/agent/protocol/lorawan/chirpstack/ChirpStackProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/lorawan/chirpstack/ChirpStackProtocol.java
@@ -46,7 +46,6 @@ import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.protocol.ProtocolAssetDiscovery;
 import org.openremote.model.query.filter.NumberPredicate;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.UniqueIdentifierGenerator;
 import org.openremote.model.util.ValueUtil;
 import org.openremote.model.value.AttributeDescriptor;
@@ -64,7 +63,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static org.openremote.agent.protocol.lorawan.LoRaWANAgent.API_KEY;
@@ -72,12 +70,9 @@ import static org.openremote.agent.protocol.lorawan.LoRaWANAgent.APPLICATION_ID;
 import static org.openremote.agent.protocol.lorawan.LoRaWANConstants.ASSET_TYPE_TAG;
 import static org.openremote.agent.protocol.lorawan.chirpstack.ChirpStackAgent.SECURE_GRPC;
 import static org.openremote.model.asset.agent.Agent.HOST;
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 import static org.openremote.model.util.TextUtil.isNullOrEmpty;
 
 public class ChirpStackProtocol extends AbstractLoRaWANProtocol<ChirpStackProtocol, ChirpStackAgent> implements ProtocolAssetDiscovery {
-
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, ChirpStackProtocol.class);
 
     public static final String PROTOCOL_DISPLAY_NAME = "ChirpStack";
     public static final String CHIRPSTACK_ASSET_TYPE_TAG = ASSET_TYPE_TAG;
@@ -107,7 +102,11 @@ public class ChirpStackProtocol extends AbstractLoRaWANProtocol<ChirpStackProtoc
 
     @Override
     public void stop(Container container) throws Exception {
-        stopMqttProtocol(container);
+        try {
+            stopMqttProtocol(container);
+        } finally {
+            super.stop(container);
+        }
     }
 
     @Override

--- a/agent/src/main/java/org/openremote/agent/protocol/lorawan/tts/TheThingsStackProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/lorawan/tts/TheThingsStackProtocol.java
@@ -43,7 +43,6 @@ import org.openremote.model.asset.agent.ConnectionStatus;
 import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.query.filter.NumberPredicate;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.UniqueIdentifierGenerator;
 import org.openremote.model.util.ValueUtil;
 import org.openremote.model.value.AttributeDescriptor;
@@ -73,17 +72,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static org.openremote.agent.protocol.lorawan.LoRaWANConstants.ASSET_TYPE_TAG;
 import static org.openremote.agent.protocol.lorawan.tts.TheThingsStackAgent.*;
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 import static org.openremote.model.util.TextUtil.isNullOrEmpty;
 
 public class TheThingsStackProtocol extends AbstractLoRaWANProtocol<TheThingsStackProtocol, TheThingsStackAgent> {
-
-    public static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, TheThingsStackProtocol.class);
 
     public static final String THE_THINGS_STACK_ASSET_TYPE_TAG = ASSET_TYPE_TAG;
     public static final String PROTOCOL_DISPLAY_NAME = "The Things Stack";
@@ -142,7 +137,11 @@ public class TheThingsStackProtocol extends AbstractLoRaWANProtocol<TheThingsSta
 
     @Override
     public void stop(org.openremote.model.Container container) throws Exception {
-        connectionStateManager.stop(container);
+        try {
+            connectionStateManager.stop(container);
+        } finally {
+            super.stop(container);
+        }
     }
 
     @Override

--- a/agent/src/main/java/org/openremote/agent/protocol/mail/AbstractMailProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/mail/AbstractMailProtocol.java
@@ -30,7 +30,6 @@ import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.auth.OAuthGrant;
 import org.openremote.model.auth.UsernamePassword;
 import org.openremote.model.mail.MailMessage;
-import org.openremote.model.syslog.SyslogCategory;
 
 import java.nio.file.Path;
 import java.util.Date;
@@ -40,14 +39,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 public abstract class AbstractMailProtocol<T extends AbstractMailAgent<T, U, V>, U extends AbstractMailProtocol<T, U, V>, V extends AgentLink<V>> extends AbstractProtocol<T, V> {
     protected MailClient mailClient;
     protected Map<AttributeRef, Function<MailMessage, String>> attributeMessageProcessorMap = new ConcurrentHashMap<>();
-    protected static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, AbstractMailProtocol.class);
     protected static int INITIAL_CHECK_DELAY_SECONDS = 10;
 
     public AbstractMailProtocol(T agent) {

--- a/agent/src/main/java/org/openremote/agent/protocol/modbus/AbstractModbusProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/modbus/AbstractModbusProtocol.java
@@ -33,7 +33,6 @@ import org.openremote.model.asset.agent.ConnectionStatus;
 import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.attribute.AttributeRef;
-import org.openremote.model.syslog.SyslogCategory;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -56,8 +54,6 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractModbusProtocol<T extends AbstractModbusProtocol<T, U, F>, U extends ModbusAgent<U, T>, F extends ModbusFrame>
         extends AbstractProtocol<U, ModbusAgentLink> {
-
-    public static final Logger LOG = SyslogCategory.getLogger(SyslogCategory.PROTOCOL, AbstractModbusProtocol.class);
 
     protected NettyIOClient<F> client;
     protected final Object requestLock = new Object();

--- a/agent/src/main/java/org/openremote/agent/protocol/modbus/ModbusSerialProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/modbus/ModbusSerialProtocol.java
@@ -27,19 +27,15 @@ import org.openremote.agent.protocol.modbus.util.ModbusRTUEncoder;
 import org.openremote.agent.protocol.modbus.util.ModbusSerialFrame;
 import org.openremote.agent.protocol.serial.SerialIOClient;
 import org.openremote.model.asset.agent.ConnectionStatus;
-import org.openremote.model.syslog.SyslogCategory;
 
 import java.util.concurrent.*;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 /**
  * Modbus Serial (RTU) protocol implementation.
  * Handles Serial-specific transport: half-duplex communication with timing gaps.
  */
 public class ModbusSerialProtocol extends AbstractModbusProtocol<ModbusSerialProtocol, ModbusSerialAgent, ModbusSerialFrame> {
-
-    public static final Logger LOG = SyslogCategory.getLogger(SyslogCategory.PROTOCOL, ModbusSerialProtocol.class);
 
     // Single pending request (RTU is half-duplex, no transaction IDs)
     private volatile CompletableFuture<ModbusSerialFrame> pendingRequest = null;

--- a/agent/src/main/java/org/openremote/agent/protocol/modbus/ModbusTcpProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/modbus/ModbusTcpProtocol.java
@@ -28,21 +28,17 @@ import org.openremote.agent.protocol.modbus.util.ModbusTcpEncoder;
 import org.openremote.agent.protocol.modbus.util.ModbusTcpFrame;
 import org.openremote.agent.protocol.tcp.TCPIOClient;
 import org.openremote.model.asset.agent.ConnectionStatus;
-import org.openremote.model.syslog.SyslogCategory;
 
 import java.util.Map;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 /**
  * Modbus TCP protocol implementation.
  * Handles TCP-specific transport: transaction ID correlation and full-duplex communication.
  */
 public class ModbusTcpProtocol extends AbstractModbusProtocol<ModbusTcpProtocol, ModbusTcpAgent, ModbusTcpFrame> {
-
-    public static final Logger LOG = SyslogCategory.getLogger(SyslogCategory.PROTOCOL, ModbusTcpProtocol.class);
 
     // Request/response correlation via transaction ID
     private final Map<Integer, CompletableFuture<ModbusTcpFrame>> pendingRequests = new ConcurrentHashMap<>();

--- a/agent/src/main/java/org/openremote/agent/protocol/mqtt/MQTTProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/mqtt/MQTTProtocol.java
@@ -29,7 +29,6 @@ import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.protocol.ProtocolUtil;
 import org.openremote.model.protocol.mqtt.Topic;
 import org.openremote.model.security.KeyStoreService;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.UniqueIdentifierGenerator;
 import org.openremote.model.util.ValueUtil;
 
@@ -39,13 +38,9 @@ import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
-
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 public class MQTTProtocol extends AbstractMQTTClientProtocol<MQTTProtocol, MQTTAgent, String, MQTT_IOClient, MQTTAgentLink> {
 
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, MQTTProtocol.class);
     public static final String PROTOCOL_DISPLAY_NAME = "MQTT Client";
     protected final Map<AttributeRef, Consumer<MQTTMessage<String>>> protocolMessageConsumers = new HashMap<>();
     protected final Map<String, Map<String, Map<AttributeRef, Consumer<MQTTMessage<String>>>>> wildcardTopicConsumerMap = new HashMap<>();

--- a/agent/src/main/java/org/openremote/agent/protocol/openweathermap/OpenWeatherMapProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/openweathermap/OpenWeatherMapProtocol.java
@@ -32,7 +32,6 @@ import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.attribute.MetaItem;
 import org.openremote.model.datapoint.ValueDatapoint;
 import org.openremote.model.geo.GeoJSONPoint;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.UniqueIdentifierGenerator;
 
 import java.util.ArrayList;
@@ -42,9 +41,7 @@ import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 import static org.openremote.model.value.MetaItemType.AGENT_LINK;
 import static org.openremote.model.value.MetaItemType.HAS_PREDICTED_DATA_POINTS;
 
@@ -71,7 +68,6 @@ import static org.openremote.model.value.MetaItemType.HAS_PREDICTED_DATA_POINTS;
  */
 public class OpenWeatherMapProtocol extends AbstractProtocol<OpenWeatherMapAgent, OpenWeatherMapAgentLink> {
 
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, OpenWeatherMapProtocol.class);
     public static final String PROTOCOL_DISPLAY_NAME = "OpenWeatherMap";
 
     // Initial delay to allow system to populate agent links

--- a/agent/src/main/java/org/openremote/agent/protocol/serial/SerialProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/serial/SerialProtocol.java
@@ -25,7 +25,6 @@ import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.protocol.ProtocolUtil;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.Pair;
 import org.openremote.model.util.ValueUtil;
 
@@ -33,9 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
-
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 /**
  * This is a generic Serial client protocol for communicating with Serial ports; it uses the {@link SerialIOClient} to
@@ -44,7 +40,6 @@ import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
  */
 public class SerialProtocol extends AbstractSerialProtocol<SerialProtocol, SerialAgent, DefaultAgentLink, String, SerialIOClient<String>> {
 
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, SerialProtocol.class);
     public static final String PROTOCOL_DISPLAY_NAME = "Serial";
 
     protected final List<Pair<AttributeRef, Consumer<String>>> protocolMessageConsumers = new ArrayList<>();

--- a/agent/src/main/java/org/openremote/agent/protocol/simulator/SimulatorProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/simulator/SimulatorProtocol.java
@@ -40,7 +40,6 @@ import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.calendar.CalendarEvent;
 import org.openremote.model.datapoint.ValueDatapoint;
 import org.openremote.model.simulator.SimulatorReplayDatapoint;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.JSONSchemaUtil.*;
 import org.openremote.model.value.AbstractNameValueHolder;
 
@@ -52,14 +51,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 import static org.openremote.model.value.MetaItemType.HAS_PREDICTED_DATA_POINTS;
 
 public class SimulatorProtocol extends AbstractProtocol<SimulatorAgent, SimulatorAgentLink> {
 
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, SimulatorProtocol.class);
     public static final String PROTOCOL_DISPLAY_NAME = "Simulator";
 
     protected final Map<AttributeRef, ScheduledFuture<?>> replayMap = new ConcurrentHashMap<>();

--- a/agent/src/main/java/org/openremote/agent/protocol/snmp/SNMPProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/snmp/SNMPProtocol.java
@@ -8,14 +8,10 @@ import org.openremote.model.asset.agent.ConnectionStatus;
 import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.attribute.AttributeRef;
-import org.openremote.model.syslog.SyslogCategory;
 import org.snmp4j.PDU;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Logger;
-
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 /**
  * This is a SNMP client protocol for receiving SNMP traps.
@@ -25,7 +21,6 @@ import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 public class SNMPProtocol extends AbstractProtocol<SNMPAgent, SNMPAgentLink> {
 
     public static final String PROTOCOL_DISPLAY_NAME = "SNMP Client";
-    protected static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, SNMPProtocol.class);
     protected final Map<String, AttributeRef> oidMap = new HashMap<>();
 
     public SNMPProtocol(SNMPAgent agent) {

--- a/agent/src/main/java/org/openremote/agent/protocol/tcp/TCPProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/tcp/TCPProtocol.java
@@ -25,7 +25,6 @@ import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.protocol.ProtocolUtil;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.Pair;
 import org.openremote.model.util.ValueUtil;
 
@@ -33,9 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
-
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 /**
  * This is a generic TCP client protocol for communicating with TCP servers; it uses the {@link TCPIOClient} to
@@ -46,7 +42,6 @@ import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
  */
 public class TCPProtocol extends AbstractTCPClientProtocol<TCPProtocol, TCPAgent, DefaultAgentLink, String, TCPIOClient<String>> {
 
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, TCPProtocol.class);
     public static final String PROTOCOL_DISPLAY_NAME = "TCP Client";
 
     protected final List<Pair<AttributeRef, Consumer<String>>> protocolMessageConsumers = new ArrayList<>();

--- a/agent/src/main/java/org/openremote/agent/protocol/tradfri/TradfriProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/tradfri/TradfriProtocol.java
@@ -15,15 +15,12 @@ import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.attribute.MetaItem;
 import org.openremote.model.query.AssetQuery;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.TextUtil;
 import org.openremote.model.value.ValueHolder;
 
 import java.util.*;
-import java.util.logging.Logger;
 
 import static org.openremote.model.asset.impl.LightAsset.BRIGHTNESS;
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 import static org.openremote.model.value.MetaItemType.AGENT_LINK;
 
 /**
@@ -32,11 +29,6 @@ import static org.openremote.model.value.MetaItemType.AGENT_LINK;
  * for a given {@link Agent} a device {@link Asset} will have a consistent ID.
  */
 public class TradfriProtocol extends AbstractProtocol<TradfriAgent, DefaultAgentLink> {
-
-    /**
-     * The logger for the IKEA TRÅDFRI protocol.
-     */
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, TradfriProtocol.class);
 
     /**
      * The display name for the IKEA TRÅDFRI protocol.

--- a/agent/src/main/java/org/openremote/agent/protocol/udp/UDPProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/udp/UDPProtocol.java
@@ -25,7 +25,6 @@ import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.protocol.ProtocolUtil;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.Pair;
 import org.openremote.model.util.ValueUtil;
 
@@ -33,9 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
-
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 /**
  * This is a UDP client protocol for communicating with UDP servers; it uses the {@link UDPIOClient} to handle the
@@ -46,7 +42,6 @@ import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
  */
 public class UDPProtocol extends AbstractUDPProtocol<UDPProtocol, UDPAgent, DefaultAgentLink, String, UDPIOClient<String>> {
 
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, UDPProtocol.class);
     public static final String PROTOCOL_DISPLAY_NAME = "UDP Client";
     protected final List<Pair<AttributeRef, Consumer<String>>> protocolMessageConsumers = new ArrayList<>();
 

--- a/agent/src/main/java/org/openremote/agent/protocol/websocket/WebsocketAgentProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/websocket/WebsocketAgentProtocol.java
@@ -37,7 +37,6 @@ import org.openremote.model.attribute.AttributeRef;
 import org.openremote.model.auth.OAuthGrant;
 import org.openremote.model.auth.UsernamePassword;
 import org.openremote.model.protocol.ProtocolUtil;
-import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.Pair;
 import org.openremote.model.util.TextUtil;
 import org.openremote.model.util.ValueUtil;
@@ -49,12 +48,10 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 import static org.openremote.agent.protocol.http.HTTPProtocol.DEFAULT_CONTENT_TYPE;
 import static org.openremote.agent.protocol.http.HTTPProtocol.DEFAULT_HTTP_METHOD;
 import static org.openremote.container.web.WebTargetBuilder.getClient;
-import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 
 /**
  * This is a generic {@link org.openremote.model.asset.agent.Protocol} for communicating with a Websocket server
@@ -69,7 +66,6 @@ import static org.openremote.model.syslog.SyslogCategory.PROTOCOL;
 public class WebsocketAgentProtocol extends AbstractNettyIOClientProtocol<WebsocketAgentProtocol, WebsocketAgent, String, WebsocketIOClient<String>, WebsocketAgentLink> {
 
     public static final String PROTOCOL_DISPLAY_NAME = "Websocket Client";
-    private static final Logger LOG = SyslogCategory.getLogger(PROTOCOL, WebsocketAgentProtocol.class);
     public static final int CONNECTED_SEND_DELAY_MILLIS = 2000;
     protected List<Runnable> protocolConnectedTasks;
     protected Map<AttributeRef, Runnable> attributeConnectedTasks;

--- a/agent/src/main/java/org/openremote/agent/protocol/zwave/ZWaveNetwork.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/zwave/ZWaveNetwork.java
@@ -26,6 +26,7 @@ import org.openremote.model.asset.agent.ConnectionStatus;
 import org.openremote.model.asset.impl.ThingAsset;
 import org.openremote.model.attribute.Attribute;
 import org.openremote.model.attribute.MetaItem;
+import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.ValueUtil;
 import org.openremote.model.value.MetaItemType;
 import org.openremote.model.value.impl.ColourRGB;
@@ -46,12 +47,15 @@ import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static java.util.stream.Collectors.toList;
 import static org.openremote.model.value.MetaItemType.AGENT_LINK;
 import static org.openremote.protocol.zwave.model.ZWNodeInitializerListener.NodeInitState.INITIALIZATION_FINISHED;
 
 public class ZWaveNetwork {
+
+    private static final Logger LOG = SyslogCategory.getLogger(SyslogCategory.PROTOCOL, ZWaveNetwork.class.getName());
 
     protected Controller controller;
     private final List<Consumer<ConnectionStatus>> connectionStatusConsumers = new CopyOnWriteArrayList<>();
@@ -96,7 +100,7 @@ public class ZWaveNetwork {
         try {
             controller.disconnect();
         } catch (ConnectionException e) {
-            ZWaveProtocol.LOG.log(Level.WARNING, "Exception thrown whilst disconnecting the controller", e);
+            LOG.log(Level.WARNING, "Exception thrown whilst disconnecting the controller", e);
         } finally {
             disposeClient();
             ioClient = null;

--- a/agent/src/main/java/org/openremote/agent/protocol/zwave/ZWaveProtocol.java
+++ b/agent/src/main/java/org/openremote/agent/protocol/zwave/ZWaveProtocol.java
@@ -48,8 +48,6 @@ public class ZWaveProtocol extends AbstractProtocol<ZWaveAgent, ZWaveAgentLink> 
 
     // Class Members --------------------------------------------------------------------------------
 
-    public static final Logger LOG = SyslogCategory.getLogger(SyslogCategory.PROTOCOL, ZWaveProtocol.class.getName());
-
     // Protected Instance Fields --------------------------------------------------------------------
 
     protected ZWaveNetwork network;

--- a/manager/src/main/java/org/openremote/manager/agent/AgentService.java
+++ b/manager/src/main/java/org/openremote/manager/agent/AgentService.java
@@ -50,6 +50,7 @@ import org.openremote.model.query.filter.AttributePredicate;
 import org.openremote.model.query.filter.NameValuePredicate;
 import org.openremote.model.query.filter.RealmPredicate;
 import org.openremote.model.query.filter.StringPredicate;
+import org.openremote.model.syslog.SyslogRealmMarker;
 import org.openremote.model.util.Pair;
 import org.openremote.model.util.TextUtil;
 
@@ -394,7 +395,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
     protected void doAgentInit(Agent<?,?,?> agent) {
         boolean isDisabled = agent.isDisabled().orElse(false);
         if (isDisabled) {
-            LOG.fine("Agent is disabled so not starting: " + agent);
+            LOG.log(Level.FINE, "Agent is disabled so not starting: " + agent, new SyslogRealmMarker(agent.getRealm()));
             sendAttributeEvent(new AttributeEvent(agent.getId(), Agent.STATUS.getName(), ConnectionStatus.DISABLED));
         } else {
             executorService.execute(() -> this.startAgent(agent));
@@ -411,10 +412,10 @@ public class AgentService extends RouteBuilder implements ContainerService {
                 protocol = agent.getProtocolInstance();
                 protocol.setAssetService(new AgentProtocolAssetService(agent));
 
-                LOG.fine("Starting protocol instance: " + protocol);
+                LOG.log(Level.FINE, "Starting protocol instance: " + protocol, new SyslogRealmMarker(agent.getRealm()));
                 protocol.start(container);
                 protocolInstanceMap.put(agent.getId(), protocol);
-                LOG.fine("Started protocol instance: " + protocol);
+                LOG.log(Level.FINE, "Started protocol instance: " + protocol, new SyslogRealmMarker(agent.getRealm()));
 
                 LOG.finest("Linking attributes to protocol instance: " + protocol);
 
@@ -447,7 +448,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
                     }
                 }
                 protocolInstanceMap.remove(agent.getId());
-                LOG.log(Level.SEVERE, "Failed to start protocol '" + protocol + "': " + agent + " msg=" + e.getMessage());
+                LOG.log(Level.SEVERE, "Failed to start protocol '" + protocol + "': " + agent + " msg=" + e.getMessage(), new SyslogRealmMarker(agent.getRealm()));
                 sendAttributeEvent(new AttributeEvent(agent.getId(), Agent.STATUS.getName(), ConnectionStatus.ERROR));
             }
         }

--- a/manager/src/main/java/org/openremote/manager/agent/AgentService.java
+++ b/manager/src/main/java/org/openremote/manager/agent/AgentService.java
@@ -103,12 +103,12 @@ public class AgentService extends RouteBuilder implements ContainerService {
                 asset.setRealm(agent.getRealm());
             } else if (!Objects.equals(asset.getRealm(), agent.getRealm())) {
                 String msg = "Protocol attempting to merge asset into another realm: " + agent;
-                Protocol.LOG.warning(msg);
+                Protocol.LOG.log(Level.WARNING, msg, new SyslogRealmMarker(agent.getRealm()));
                 throw new IllegalArgumentException(msg);
             }
 
             // TODO: Define access permissions for merged asset (user asset links inherit from parent agent?)
-            LOG.fine("Merging asset with protocol-provided: " + asset);
+            LOG.log(Level.FINE, "Merging asset with protocol-provided: " + asset, new SyslogRealmMarker(agent.getRealm()));
             return assetStorageService.merge(asset, true);
         }
 
@@ -118,23 +118,23 @@ public class AgentService extends RouteBuilder implements ContainerService {
                 Asset<?> asset = findAsset(assetId);
                 if (asset != null) {
                     if (!Objects.equals(asset.getRealm(), agent.getRealm())) {
-                        Protocol.LOG.warning("Protocol attempting to delete asset from another realm: " + agent);
+                        Protocol.LOG.log(Level.WARNING, "Protocol attempting to delete asset from another realm: " + agent, new SyslogRealmMarker(agent.getRealm()));
                         throw new IllegalArgumentException("Protocol attempting to delete asset from another realm");
                     }
                 }
             }
-            LOG.fine("Deleting protocol-provided: " + Arrays.toString(assetIds));
+            LOG.log(Level.FINE, "Deleting protocol-provided: " + Arrays.toString(assetIds), new SyslogRealmMarker(agent.getRealm()));
             return assetStorageService.delete(Arrays.asList(assetIds), false);
         }
 
         @SuppressWarnings("unchecked")
         @Override
         public <T extends Asset<?>> T findAsset(String assetId) {
-            LOG.fine("Getting protocol-provided: " + assetId);
+            LOG.log(Level.FINE, "Getting protocol-provided: " + assetId, new SyslogRealmMarker(agent.getRealm()));
             T asset = (T)assetStorageService.find(assetId);
             if (asset != null) {
                 if (!Objects.equals(asset.getRealm(), agent.getRealm())) {
-                    Protocol.LOG.warning("Protocol attempting to find asset from another realm: " + agent);
+                    Protocol.LOG.log(Level.WARNING, "Protocol attempting to find asset from another realm: " + agent, new SyslogRealmMarker(agent.getRealm()));
                     throw new IllegalArgumentException("Protocol attempting to find asset from another realm");
                 }
             }
@@ -146,7 +146,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
             List<Asset<?>> assets = assetStorageService.findAll(assetQuery.realm(new RealmPredicate(agent.getRealm())));
             for (Asset<?> asset : assets) {
                 if (!Objects.equals(asset.getRealm(), agent.getRealm())) {
-                    Protocol.LOG.warning("Protocol attempting to find asset from another realm: " + agent);
+                    Protocol.LOG.log(Level.WARNING, "Protocol attempting to find asset from another realm: " + agent, new SyslogRealmMarker(agent.getRealm()));
                     throw new IllegalArgumentException("Protocol attempting to find asset from another realm");
                 }
             }
@@ -158,7 +158,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
             if (TextUtil.isNullOrEmpty(attributeEvent.getRealm())) {
                 attributeEvent.setRealm(agent.getRealm());
             } else if (!Objects.equals(attributeEvent.getRealm(), agent.getRealm())) {
-                Protocol.LOG.warning("Protocol attempting to send attribute event to another realm: " + agent);
+                Protocol.LOG.log(Level.WARNING, "Protocol attempting to send attribute event to another realm: " + agent, new SyslogRealmMarker(agent.getRealm()));
                 throw new IllegalArgumentException("Protocol attempting to send attribute event to another realm");
             }
             AgentService.this.sendAttributeEvent(attributeEvent);
@@ -167,7 +167,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
         @Override
         public void subscribeChildAssetChange(Consumer<PersistenceEvent<Asset<?>>> assetChangeConsumer) {
             if (!getAgents().containsKey(agent.getId())) {
-                LOG.fine("Attempt to subscribe to child asset changes with an invalid agent ID: " + agent.getId());
+                LOG.log(Level.FINE, "Attempt to subscribe to child asset changes with an invalid agent ID: " + agent.getId(), new SyslogRealmMarker(agent.getRealm()));
                 return;
             }
 
@@ -281,7 +281,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
      */
     protected void processAgentChange(PersistenceEvent<Agent<?, ?, ?>> persistenceEvent) {
 
-        LOG.finest("Processing agent persistence event: " + persistenceEvent.getCause());
+        LOG.log(Level.FINEST, "Processing agent persistence event: " + persistenceEvent.getCause(), new SyslogRealmMarker(persistenceEvent.getEntity().getRealm()));
         Agent<?, ?, ?> agent = persistenceEvent.getEntity();
 
         switch (persistenceEvent.getCause()) {
@@ -312,7 +312,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
      */
     protected void processAssetChange(PersistenceEvent<Asset<?>> persistenceEvent) {
 
-        LOG.finest("Processing asset persistence event: " + persistenceEvent.getCause());
+        LOG.log(Level.FINEST, "Processing asset persistence event: " + persistenceEvent.getCause(), new SyslogRealmMarker(persistenceEvent.getEntity().getRealm()));
         Asset<?> asset = persistenceEvent.getEntity();
 
         switch (persistenceEvent.getCause()) {
@@ -417,7 +417,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
                 protocolInstanceMap.put(agent.getId(), protocol);
                 LOG.log(Level.FINE, "Started protocol instance: " + protocol, new SyslogRealmMarker(agent.getRealm()));
 
-                LOG.finest("Linking attributes to protocol instance: " + protocol);
+                LOG.log(Level.FINEST, "Linking attributes to protocol instance: " + protocol, new SyslogRealmMarker(protocol.getAgent().getRealm()));
 
                 // Get all assets that have attributes with agent link meta for this agent
                 List<Asset<?>> assets = assetStorageService.findAll(
@@ -429,7 +429,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
                         )
                 );
 
-                LOG.finest("Found '" + assets.size() + "' asset(s) with attributes linked to this protocol instance: " + protocol);
+                LOG.log(Level.FINEST, "Found '" + assets.size() + "' asset(s) with attributes linked to this protocol instance: " + protocol, new SyslogRealmMarker(protocol.getAgent().getRealm()));
 
                 assets.forEach(
                     asset ->
@@ -473,7 +473,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
             try {
                 protocol.stop(container);
             } catch (Exception e) {
-                LOG.log(Level.SEVERE, "Protocol instance threw an exception whilst being stopped", e);
+                SyslogRealmMarker.log(LOG, Level.SEVERE, "Protocol instance threw an exception whilst being stopped", e, protocol.getAgent().getRealm());
             }
 
             // Remove child asset subscriptions for this agent
@@ -490,17 +490,17 @@ public class AgentService extends RouteBuilder implements ContainerService {
         }
 
         synchronized (protocol) {
-            LOG.fine("Linking asset '" + assetId + "' attributes linked to protocol: assetId=" + assetId + ", attributes=" + attributes.size() + ", protocol=" + protocol);
+            LOG.log(Level.FINE, "Linking asset '" + assetId + "' attributes linked to protocol: assetId=" + assetId + ", attributes=" + attributes.size() + ", protocol=" + protocol, new SyslogRealmMarker(protocol.getAgent().getRealm()));
 
             attributes.forEach(attribute -> {
                 AttributeRef attributeRef = new AttributeRef(assetId, attribute.getName());
                 try {
                     if (!protocol.getLinkedAttributes().containsKey(attributeRef)) {
-                        LOG.finest("Linking attribute '" + attributeRef + "' to protocol: " + protocol);
+                        LOG.log(Level.FINEST, "Linking attribute '" + attributeRef + "' to protocol: " + protocol, new SyslogRealmMarker(protocol.getAgent().getRealm()));
                         protocol.linkAttribute(assetId, attribute);
                     }
                 } catch (Exception ex) {
-                    LOG.log(Level.SEVERE, "Failed to link attribute '" + attributeRef + "' to protocol: " + protocol + " msg=" + ex.getMessage());
+                    LOG.log(Level.SEVERE, "Failed to link attribute '" + attributeRef + "' to protocol: " + protocol + " msg=" + ex.getMessage(), new SyslogRealmMarker(protocol.getAgent().getRealm()));
                 }
             });
         }
@@ -514,17 +514,17 @@ public class AgentService extends RouteBuilder implements ContainerService {
         }
 
         synchronized (protocol) {
-            LOG.fine("Unlinking asset '" + assetId + "' attributes linked to protocol: assetId=" + assetId + ", attributes=" + attributes.size() + ", protocol=" + protocol);
+            LOG.log(Level.FINE, "Unlinking asset '" + assetId + "' attributes linked to protocol: assetId=" + assetId + ", attributes=" + attributes.size() + ", protocol=" + protocol, new SyslogRealmMarker(protocol.getAgent().getRealm()));
 
             attributes.forEach(attribute -> {
                 try {
                     AttributeRef attributeRef = new AttributeRef(assetId, attribute.getName());
                     if (protocol.getLinkedAttributes().containsKey(attributeRef)) {
-                        LOG.finest("Unlinking attribute '" + attributeRef + "' to protocol: " + protocol);
+                        LOG.log(Level.FINEST, "Unlinking attribute '" + attributeRef + "' to protocol: " + protocol, new SyslogRealmMarker(protocol.getAgent().getRealm()));
                         protocol.unlinkAttribute(assetId, attribute);
                     }
                 } catch (Exception ex) {
-                    LOG.log(Level.SEVERE, "Ignoring error on unlinking attribute '" + attribute + "' from protocol: " + protocol, ex);
+                    SyslogRealmMarker.log(LOG, Level.SEVERE, "Ignoring error on unlinking attribute '" + attribute + "' from protocol: " + protocol, ex, protocol.getAgent().getRealm());
                 }
             });
         }
@@ -620,9 +620,9 @@ public class AgentService extends RouteBuilder implements ContainerService {
                 return;
             }
 
-            LOG.finer("Notifying protocol instance of an event for one of its agent attributes: " + event.getRef());
+            LOG.log(Level.FINER, "Notifying protocol instance of an event for one of its agent attributes: " + event.getRef(), new SyslogRealmMarker(agent.getRealm()));
             if (protocolInstance.onAgentAttributeChanged(event)) {
-                LOG.info("Protocol has requested recreation following agent attribute event: " + event.getRef());
+                LOG.log(Level.INFO, "Protocol has requested recreation following agent attribute event: " + event.getRef(), new SyslogRealmMarker(agent.getRealm()));
                 deployAgent(agent);
             }
         }
@@ -662,10 +662,10 @@ public class AgentService extends RouteBuilder implements ContainerService {
 
         // Fully load agent asset if path and parent info not loaded
         if (agent.getPath() == null || (agent.getPath().length > 1 && agent.getParentId() == null)) {
-            LOG.fine("Agent is not fully loaded so retrieving the agent from the DB: " + agent.getId());
+            LOG.log(Level.FINE, "Agent is not fully loaded so retrieving the agent from the DB: " + agent.getId(), new SyslogRealmMarker(agent.getRealm()));
             final Agent<?, ?, ?> loadedAgent = assetStorageService.find(agent.getId(), true, Agent.class);
             if (loadedAgent == null) {
-                LOG.fine("Agent not found in the DB, maybe it has been removed: " + agent.getId());
+                LOG.log(Level.FINE, "Agent not found in the DB, maybe it has been removed: " + agent.getId(), new SyslogRealmMarker(agent.getRealm()));
                 return null;
             }
             agent = loadedAgent;
@@ -708,11 +708,11 @@ public class AgentService extends RouteBuilder implements ContainerService {
 
     protected void notifyChildAssetChange(String agentId, PersistenceEvent<Asset<?>> assetPersistenceEvent) {
         childAssetSubscriptions.computeIfPresent(agentId, (id, consumers) -> {
-            LOG.finest("Notifying child asset change consumers of change to agent child asset: Agent ID=" + id + ", Asset<?> ID=" + assetPersistenceEvent.getEntity().getId());
+            LOG.log(Level.FINEST, "Notifying child asset change consumers of change to agent child asset: Agent ID=" + id + ", Asset<?> ID=" + assetPersistenceEvent.getEntity().getId(), new SyslogRealmMarker(assetPersistenceEvent.getEntity().getRealm()));
             try {
                 consumers.forEach(consumer -> consumer.accept(assetPersistenceEvent));
             } catch (Exception e) {
-                LOG.log(Level.WARNING, "Child asset change consumer threw an exception: Agent ID=" + id + ", Asset<?> ID=" + assetPersistenceEvent.getEntity().getId(), e);
+                SyslogRealmMarker.log(LOG, Level.WARNING, "Child asset change consumer threw an exception: Agent ID=" + id + ", Asset<?> ID=" + assetPersistenceEvent.getEntity().getId(), e, assetPersistenceEvent.getEntity().getRealm());
             }
             return consumers;
         });
@@ -760,7 +760,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
             throw new UnsupportedOperationException("Agent protocol doesn't support asset discovery");
         }
 
-        LOG.fine("Initiating protocol asset discovery: Agent = " + agent);
+        LOG.log(Level.FINE, "Initiating protocol asset discovery: Agent = " + agent, new SyslogRealmMarker(agent.getRealm()));
 
         synchronized (agentDiscoveryImportFutureMap) {
             okToContinueWithImportOrDiscovery(agent.getId());
@@ -776,11 +776,11 @@ public class AgentService extends RouteBuilder implements ContainerService {
                     Future<Void> discoveryFuture = assetDiscovery.startAssetDiscovery(onDiscovered);
                     discoveryFuture.get();
                 } catch (InterruptedException e) {
-                    LOG.fine("Protocol asset discovery was cancelled");
+                    LOG.log(Level.FINE, "Protocol asset discovery was cancelled", new SyslogRealmMarker(agent.getRealm()));
                 } catch (Exception e) {
-                    LOG.log(Level.WARNING, "Failed to do protocol asset discovery: Agent = " + agent, e);
+                    SyslogRealmMarker.log(LOG, Level.WARNING, "Failed to do protocol asset discovery: Agent = " + agent, e, agent.getRealm());
                 } finally {
-                    LOG.fine("Finished protocol asset discovery: Agent = " + agent);
+                    LOG.log(Level.FINE, "Finished protocol asset discovery: Agent = " + agent, new SyslogRealmMarker(agent.getRealm()));
                     agentDiscoveryImportFutureMap.remove(agent.getId());
                 }
             };
@@ -803,7 +803,7 @@ public class AgentService extends RouteBuilder implements ContainerService {
             throw new UnsupportedOperationException("Agent protocol doesn't support asset import");
         }
 
-        LOG.fine("Initiating protocol asset import: Agent = " + agent);
+        LOG.log(Level.FINE, "Initiating protocol asset import: Agent = " + agent, new SyslogRealmMarker(agent.getRealm()));
         synchronized (agentDiscoveryImportFutureMap) {
             okToContinueWithImportOrDiscovery(agent.getId());
 
@@ -818,11 +818,11 @@ public class AgentService extends RouteBuilder implements ContainerService {
                     Future<Void> discoveryFuture = assetImport.startAssetImport(fileData, onDiscovered);
                     discoveryFuture.get();
                 } catch (InterruptedException e) {
-                    LOG.fine("Protocol asset import was cancelled");
+                    LOG.log(Level.FINE, "Protocol asset import was cancelled", new SyslogRealmMarker(agent.getRealm()));
                 } catch (Exception e) {
-                    LOG.log(Level.WARNING, "Failed to do protocol asset import: Agent = " + agent, e);
+                    SyslogRealmMarker.log(LOG, Level.WARNING, "Failed to do protocol asset import: Agent = " + agent, e, agent.getRealm());
                 } finally {
-                    LOG.fine("Finished protocol asset import: Agent = " + agent);
+                    LOG.log(Level.FINE, "Finished protocol asset import: Agent = " + agent, new SyslogRealmMarker(agent.getRealm()));
                     agentDiscoveryImportFutureMap.remove(agent.getId());
                 }
             };

--- a/manager/src/main/java/org/openremote/manager/alarm/AlarmService.java
+++ b/manager/src/main/java/org/openremote/manager/alarm/AlarmService.java
@@ -46,6 +46,7 @@ import org.openremote.model.query.UserQuery;
 import org.openremote.model.query.filter.RealmPredicate;
 import org.openremote.model.query.filter.StringPredicate;
 import org.openremote.model.security.User;
+import org.openremote.model.syslog.SyslogRealmMarker;
 import org.openremote.model.util.TextUtil;
 
 import java.sql.PreparedStatement;
@@ -53,6 +54,7 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.time.Instant;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -247,11 +249,11 @@ public class AlarmService extends RouteBuilder implements ContainerService {
         List<User> users = getAlarmNotificationUsers(alarm);
         users.removeIf(user -> excludeUserIds.contains(user.getId()));
         if (users.isEmpty()) {
-            LOG.fine("No matching users to send alarm notification");
+            LOG.log(Level.FINE, "No matching users to send alarm notification", new SyslogRealmMarker(alarm.getRealm()));
             return;
         }
 
-        LOG.fine("Sending alarm notification to " + users.size() + " matching user(s)");
+        LOG.log(Level.FINE, "Sending alarm notification to " + users.size() + " matching user(s)", new SyslogRealmMarker(alarm.getRealm()));
 
         String title = String.format("Alarm: %s - %s", alarm.getSeverity(), alarm.getTitle());
         String url = getAlarmNotificationUrl(alarm);

--- a/manager/src/main/java/org/openremote/manager/asset/AssetProcessingService.java
+++ b/manager/src/main/java/org/openremote/manager/asset/AssetProcessingService.java
@@ -47,6 +47,7 @@ import org.openremote.model.attribute.AttributeEvent;
 import org.openremote.model.attribute.MetaItem;
 import org.openremote.model.event.Event;
 import org.openremote.model.security.ClientRole;
+import org.openremote.model.syslog.SyslogRealmMarker;
 import org.openremote.model.util.ValueUtil;
 import org.openremote.model.value.MetaItemType;
 
@@ -149,7 +150,7 @@ public class AssetProcessingService extends RouteBuilder implements ContainerSer
             // Check realm against user
             if (!identityService.getIdentityProvider().isRealmActiveAndAccessible(authContext,
                 requestedRealm)) {
-                LOG.log(System.Logger.Level.INFO, "Realm is inactive, inaccessible or nonexistent: " + requestedRealm);
+                LOG.log(System.Logger.Level.INFO, "Realm is inactive, inaccessible or nonexistent: " + requestedRealm, new SyslogRealmMarker(requestedRealm));
                 return false;
             }
 
@@ -167,10 +168,14 @@ public class AssetProcessingService extends RouteBuilder implements ContainerSer
             Attribute<?> attribute = asset != null ? asset.getAttribute(attributeEvent.getName()).orElse(null) : null;
 
             if (asset == null || !asset.hasAttribute(attributeEvent.getName())) {
-                LOG.log(System.Logger.Level.INFO, () -> "Cannot authorize asset event as asset and/or attribute doesn't exist: " + attributeEvent.getRef());
+                if (LOG.isLoggable(System.Logger.Level.INFO)) {
+                    LOG.log(System.Logger.Level.INFO, "Cannot authorize asset event as asset and/or attribute doesn't exist: " + attributeEvent.getRef(), new SyslogRealmMarker(attributeEvent.getRealm()));
+                }
                 return false;
             } else if (!Objects.equals(requestedRealm, asset.getRealm())) {
-                LOG.log(System.Logger.Level.INFO, () -> "Asset is not in the requested realm: requestedRealm=" + requestedRealm + ", ref=" + attributeEvent.getRef());
+                if (LOG.isLoggable(System.Logger.Level.INFO)) {
+                    LOG.log(System.Logger.Level.INFO, "Asset is not in the requested realm: requestedRealm=" + requestedRealm + ", ref=" + attributeEvent.getRef(), new SyslogRealmMarker(attributeEvent.getRealm()));
+                }
                 return false;
             }
 
@@ -417,7 +422,9 @@ public class AssetProcessingService extends RouteBuilder implements ContainerSer
                     LOG.log(System.Logger.Level.TRACE, "Event intercepted: interceptor=" + interceptorName + ", ref=" + enrichedEvent.getRef() + ", source=" + enrichedEvent.getSource());
                 } else {
                     if (enrichedEvent.isOutdated()) {
-                        LOG.log(System.Logger.Level.INFO, () -> "Event is older than current attribute value so marking as outdated: ref=" + enrichedEvent.getRef() + ", event=" + Instant.ofEpochMilli(enrichedEvent.getTimestamp()) + ", previous=" + Instant.ofEpochMilli(enrichedEvent.getOldValueTimestamp()));
+                        if (LOG.isLoggable(System.Logger.Level.INFO)) {
+                            LOG.log(System.Logger.Level.INFO, "Event is older than current attribute value so marking as outdated: ref=" + enrichedEvent.getRef() + ", event=" + Instant.ofEpochMilli(enrichedEvent.getTimestamp()) + ", previous=" + Instant.ofEpochMilli(enrichedEvent.getOldValueTimestamp()), new SyslogRealmMarker(enrichedEvent.getRealm()));
+                        }
                         // Generate an event for this so internal subscribers can act on it if needed
                         eventToPublish = new OutdatedAttributeEvent(enrichedEvent);
                     } else {

--- a/manager/src/main/java/org/openremote/manager/asset/AssetStorageService.java
+++ b/manager/src/main/java/org/openremote/manager/asset/AssetStorageService.java
@@ -60,6 +60,7 @@ import org.openremote.model.query.LogicGroup;
 import org.openremote.model.query.filter.*;
 import org.openremote.model.security.ClientRole;
 import org.openremote.model.security.User;
+import org.openremote.model.syslog.SyslogRealmMarker;
 import org.openremote.model.util.LockByKey;
 import org.openremote.model.util.Pair;
 import org.openremote.model.util.TextUtil;
@@ -640,7 +641,7 @@ public class AssetStorageService extends RouteBuilder implements ContainerServic
             if (!validationFailures.isEmpty()) {
                 String msg = "Asset merge failed as asset has failed constraint validation: asset=" + asset;
                 ConstraintViolationException ex = new ConstraintViolationException(validationFailures);
-                LOG.log(Level.WARNING, msg + ", exception=" + ex.getMessage());
+                LOG.log(Level.WARNING, msg + ", exception=" + ex.getMessage(), new SyslogRealmMarker(asset.getRealm()));
                 throw ex;
             }
         }

--- a/manager/src/main/java/org/openremote/manager/gateway/GatewayConnector.java
+++ b/manager/src/main/java/org/openremote/manager/gateway/GatewayConnector.java
@@ -32,6 +32,7 @@ import org.openremote.model.event.shared.SharedEvent;
 import org.openremote.model.gateway.*;
 import org.openremote.model.query.AssetQuery;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmRegistry;
 import org.openremote.model.util.Pair;
 import org.openremote.model.util.VersionUtil;
 
@@ -55,7 +56,7 @@ import static org.openremote.model.syslog.SyslogCategory.GATEWAY;
  */
 public class GatewayConnector {
 
-    private static final Logger LOG = SyslogCategory.getLogger(GATEWAY, GatewayConnector.class.getName());
+    private final Logger LOG;
     public static int MAX_SYNC_RETRIES = 5;
     public static int SYNC_ASSET_BATCH_SIZE = 20;
     public static final String ASSET_READ_EVENT_NAME_INITIAL = "INITIAL";
@@ -123,6 +124,12 @@ public class GatewayConnector {
         this.gatewayId = gateway.getId();
         this.gatewayAsset = gateway;
 
+        // Dedicated per-connector logger so this connector's log records are attributed to the
+        // gateway's realm (see SyslogRealmRegistry); unregistered when GatewayService discards
+        // the connector. Syslog subCategory becomes GatewayConnector-<gatewayId>.
+        LOG = SyslogCategory.getLogger(GATEWAY, GatewayConnector.class.getName() + "-" + gatewayId);
+        SyslogRealmRegistry.register(LOG.getName(), realm);
+
         // Setup static inbound event handling
         synchronized(eventConsumerMap) {
             eventConsumerMap.put(AssetEvent.class, (e) -> onAssetEvent((AssetEvent) e));
@@ -130,6 +137,10 @@ public class GatewayConnector {
         }
         LOG.finest("Setting connection status=" + ConnectionStatus.DISCONNECTED + ": " + getGatewayIdString());
         publishAttributeEvent(new AttributeEvent(gatewayId, GatewayAsset.STATUS, ConnectionStatus.DISCONNECTED, timerService.getNow()));
+    }
+
+    protected String getLoggerName() {
+        return LOG.getName();
     }
 
     protected void sendMessageToGateway(Object message) {

--- a/manager/src/main/java/org/openremote/manager/gateway/GatewayService.java
+++ b/manager/src/main/java/org/openremote/manager/gateway/GatewayService.java
@@ -51,6 +51,7 @@ import org.openremote.model.rules.Ruleset;
 import org.openremote.model.security.Realm;
 import org.openremote.model.security.User;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmRegistry;
 import org.openremote.model.util.TextUtil;
 import org.openremote.model.value.MetaItemType;
 
@@ -756,6 +757,7 @@ public class GatewayService extends RouteBuilder implements ContainerService {
 
                 if (connector != null) {
                     connector.disconnect(GatewayDisconnectEvent.Reason.UNRECOGNISED);
+                    SyslogRealmRegistry.unregister(connector.getLoggerName());
                 }
 
                 removeGatewayServiceUser(gateway);

--- a/manager/src/main/java/org/openremote/manager/mqtt/ActiveMQORSecurityManager.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/ActiveMQORSecurityManager.java
@@ -36,6 +36,7 @@ import org.openremote.container.security.TokenPrincipal;
 import org.openremote.manager.security.RemotingConnectionPrincipal;
 import org.openremote.model.protocol.mqtt.Topic;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmMarker;
 
 import javax.security.auth.Subject;
 import java.security.Principal;
@@ -116,7 +117,7 @@ public class ActiveMQORSecurityManager implements ActiveMQSecurityManager5 {
               principals.add(userPrincipal);
            } catch (InterruptedException | TimeoutException | ExecutionException | AuthenticationException e) {
               Throwable cause = (e instanceof ExecutionException) ? e.getCause() : e;
-              LOG.info("Failed to authenticate user: realm=" + realm + ", username=" + user + ", exception=" + cause);
+              LOG.log(Level.INFO, "Failed to authenticate user: realm=" + realm + ", username=" + user + ", exception=" + cause, new SyslogRealmMarker(realm));
               return null;
            }
         }

--- a/manager/src/main/java/org/openremote/manager/mqtt/ConnectionMonitorHandler.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/ConnectionMonitorHandler.java
@@ -44,6 +44,7 @@ import org.openremote.model.query.filter.AttributePredicate;
 import org.openremote.model.query.filter.NameValuePredicate;
 import org.openremote.model.security.User;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmMarker;
 import org.openremote.model.util.Pair;
 import org.openremote.model.value.ValueHolder;
 import org.openremote.model.value.ValueType;
@@ -264,7 +265,7 @@ public class ConnectionMonitorHandler extends MQTTHandler {
                 String userID = userIds.get(usernames.indexOf(User.SERVICE_ACCOUNT_PREFIX + username));
 
                 if (userID == null) {
-                    LOG.warning("Invalid username so skipping add session attributes: realm=" + realm + ", username=" + username);
+                    LOG.log(Level.WARNING, "Invalid username so skipping add session attributes: realm=" + realm + ", username=" + username, new SyslogRealmMarker(realm));
                 } else {
                     addSessionAttribute(userID, new AttributeRef(assetIdAttr.key, assetIdAttr.getValue().getName()));
                 }

--- a/manager/src/main/java/org/openremote/manager/mqtt/DefaultMQTTHandler.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/DefaultMQTTHandler.java
@@ -38,6 +38,7 @@ import org.openremote.model.event.Event;
 import org.openremote.model.event.shared.EventSubscription;
 import org.openremote.model.protocol.mqtt.Topic;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmMarker;
 import org.openremote.model.util.ValueUtil;
 
 import java.nio.charset.StandardCharsets;
@@ -208,7 +209,7 @@ public class DefaultMQTTHandler extends MQTTHandler {
         AssetFilter<?> filter = buildAssetFilter(topic);
 
         if (filter == null) {
-            LOG.info("Failed to process subscription topic: topic=" + topic + ", " + mqttBrokerService.connectionToString(connection));
+            LOG.log(Level.INFO, "Failed to process subscription topic: topic=" + topic + ", " + mqttBrokerService.connectionToString(connection), new SyslogRealmMarker(topicRealm(topic)));
             return false;
         }
 

--- a/manager/src/main/java/org/openremote/manager/mqtt/UserAssetProvisioningMQTTHandler.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/UserAssetProvisioningMQTTHandler.java
@@ -44,6 +44,7 @@ import org.openremote.model.provisioning.*;
 import org.openremote.model.security.ClientRole;
 import org.openremote.model.security.User;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmMarker;
 import org.openremote.model.util.TextUtil;
 import org.openremote.model.util.UniqueIdentifierGenerator;
 import org.openremote.model.util.ValueUtil;
@@ -395,7 +396,9 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
         }
 
         if (!serviceUser.getEnabled()) {
-            LOG.info(() -> "Service user exists and has been disabled so cannot continue:  " + MQTTBrokerService.connectionToString(connection));
+            if (LOG.isLoggable(Level.INFO)) {
+                LOG.log(Level.INFO, "Service user exists and has been disabled so cannot continue:  " + MQTTBrokerService.connectionToString(connection), new SyslogRealmMarker(realm));
+            }
             publishMessage(getResponseTopic(topic), new ErrorResponseMessage(ErrorResponseMessage.Error.USER_DISABLED), MqttQoS.AT_MOST_ONCE);
             return;
         }
@@ -409,13 +412,13 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
 
             if (asset != null) {
                 if (!matchingConfig.getRealm().equals(asset.getRealm())) {
-                    LOG.warning("Client asset realm mismatch");
+                    LOG.log(Level.WARNING, "Client asset realm mismatch", new SyslogRealmMarker(matchingConfig.getRealm()));
                     publishMessage(getResponseTopic(topic), new ErrorResponseMessage(ErrorResponseMessage.Error.ASSET_ERROR), MqttQoS.AT_MOST_ONCE);
                     return;
                 }
             }
         } catch (Exception e) {
-            LOG.log(Level.WARNING, "Failed to retrieve/create asset: " + MQTTBrokerService.connectionToString(connection) + ", config=" + matchingConfig, e);
+            SyslogRealmMarker.log(LOG, Level.WARNING, "Failed to retrieve/create asset: " + MQTTBrokerService.connectionToString(connection) + ", config=" + matchingConfig, e, matchingConfig.getRealm());
             publishMessage(getResponseTopic(topic), new ErrorResponseMessage(ErrorResponseMessage.Error.SERVER_ERROR), MqttQoS.AT_MOST_ONCE);
             return;
         }
@@ -460,14 +463,14 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
 
                                 return true;
                             } catch (CertificateExpiredException | CertificateNotYetValidException e) {
-                                LOG.log(Level.INFO, "Client certificate failed validity check: " + MQTTBrokerService.connectionToString(connection) + ", timestamp=" + now, e);
+                                SyslogRealmMarker.log(LOG, Level.INFO, "Client certificate failed validity check: " + MQTTBrokerService.connectionToString(connection) + ", timestamp=" + now, e, config.getRealm());
                             } catch (Exception e) {
-                                LOG.log(Level.INFO, "Client certificate failed verification against CA certificate: " + MQTTBrokerService.connectionToString(connection) + ", config=" + config, e);
+                                SyslogRealmMarker.log(LOG, Level.INFO, "Client certificate failed verification against CA certificate: " + MQTTBrokerService.connectionToString(connection) + ", config=" + config, e, config.getRealm());
                             }
                         }
                     }
                 } catch (Exception e) {
-                    LOG.log(Level.WARNING, "Failed to extract certificate from provisioning config: " + MQTTBrokerService.connectionToString(connection) + ", config=" + config, e);
+                    SyslogRealmMarker.log(LOG, Level.WARNING, "Failed to extract certificate from provisioning config: " + MQTTBrokerService.connectionToString(connection) + ", config=" + config, e, config.getRealm());
                 }
                 return false;
             })

--- a/manager/src/main/java/org/openremote/manager/notification/NotificationService.java
+++ b/manager/src/main/java/org/openremote/manager/notification/NotificationService.java
@@ -40,6 +40,7 @@ import org.openremote.model.notification.SentNotification;
 import org.openremote.model.query.UserQuery;
 import org.openremote.model.query.filter.StringPredicate;
 import org.openremote.model.security.User;
+import org.openremote.model.syslog.SyslogRealmMarker;
 import org.openremote.model.util.TextUtil;
 import org.openremote.model.util.TimeUtil;
 
@@ -179,7 +180,7 @@ public class NotificationService extends RouteBuilder implements ContainerServic
                         }
                     }
 
-                    LOG.fine("Sending " + notification.getMessage().getType() + " notification '" + notification.getName() + "': '" + source + ":" + sourceId.get() + "' -> " + notification.getTargets());
+                    LOG.log(Level.FINE, "Sending " + notification.getMessage().getType() + " notification '" + notification.getName() + "': '" + source + ":" + sourceId.get() + "' -> " + notification.getTargets(), new SyslogRealmMarker(realm));
 
                     // Check access permissions
                     checkAccess(source, sourceId.get(), notification.getTargets(), realm, userId, isSuperUser, isRestrictedUser, assetId);
@@ -190,7 +191,7 @@ public class NotificationService extends RouteBuilder implements ContainerServic
                     if (mappedTargetsList == null || mappedTargetsList.isEmpty()) {
                         throw new NotificationProcessingException(MISSING_TARGETS, "Notification targets must be set");
                     } else if (LOG.isLoggable(Level.FINER)) {
-                        LOG.finer("Notification targets mapped from: [" + (notification.getTargets() != null ? notification.getTargets().stream().map(Object::toString).collect(Collectors.joining(",")) : "null") + "to: [" + mappedTargetsList.stream().map(Object::toString).collect(Collectors.joining(",")) + "]");
+                        LOG.log(Level.FINER, "Notification targets mapped from: [" + (notification.getTargets() != null ? notification.getTargets().stream().map(Object::toString).collect(Collectors.joining(",")) : "null") + "to: [" + mappedTargetsList.stream().map(Object::toString).collect(Collectors.joining(",")) + "]", new SyslogRealmMarker(realm));
                     }
 
                     // Filter targets based on repeat frequency
@@ -202,6 +203,9 @@ public class NotificationService extends RouteBuilder implements ContainerServic
 
                     // Send message to each applicable target
                     AtomicReference<Exception> error = new AtomicReference<>();
+
+                    // realm is reassigned above so capture an effectively final copy for use in the nested lambdas below
+                    final String notificationRealm = realm;
 
                     // As we can have multiple targets in a single exchange we'll track the first exception that occurs
                     mappedTargetsList.forEach(
@@ -231,7 +235,7 @@ public class NotificationService extends RouteBuilder implements ContainerServic
                                         notification.getMessage());
 
                                     NotificationSendResult result = NotificationSendResult.success();
-                                    LOG.fine("Notification sent '" + id + "': " + target);
+                                    LOG.log(Level.FINE, "Notification sent '" + id + "': " + target, new SyslogRealmMarker(notificationRealm));
 
                                     // Merge the sent notification again with the message included just in case the handler modified the message
                                     sentNotification.setMessage(notification.getMessage());
@@ -243,7 +247,7 @@ public class NotificationService extends RouteBuilder implements ContainerServic
                                     } else {
                                         notificationProcessingException = new NotificationProcessingException(SEND_FAILURE, e.getMessage());
                                     }
-                                    LOG.warning("Notification failed '" + id + "': " + target + ", reason=" + notificationProcessingException);
+                                    LOG.log(Level.WARNING, "Notification failed '" + id + "': " + target + ", reason=" + notificationProcessingException, new SyslogRealmMarker(notificationRealm));
                                     sentNotification.setError(TextUtil.isNullOrEmpty(notificationProcessingException.getMessage()) ? "Unknown error" : notificationProcessingException.getMessage());
                                     return notificationProcessingException;
                                 } finally {

--- a/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
+++ b/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
@@ -44,6 +44,7 @@ import org.openremote.model.query.filter.GeofencePredicate;
 import org.openremote.model.query.filter.LocationAttributePredicate;
 import org.openremote.model.rules.*;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmRegistry;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -160,6 +161,7 @@ public class RulesEngine<T extends Ruleset> {
 
         String ruleEngineCategory = id.scope.getSimpleName().replace("Ruleset", "Engine-") + id.getId().orElse("");
         LOG = SyslogCategory.getLogger(SyslogCategory.RULES, RulesEngine.class.getName() + "." + ruleEngineCategory);
+        id.getRealm().ifPresent(realm -> SyslogRealmRegistry.register(LOG.getName(), realm));
 
         AssetsFacade<T> assetsFacade = new AssetsFacade<>(id, assetStorageService, attributeEvent -> {
             try {
@@ -379,6 +381,8 @@ public class RulesEngine<T extends Ruleset> {
         }
 
         publishRulesEngineStatus();
+
+        SyslogRealmRegistry.unregister(LOG.getName());
     }
 
     @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")

--- a/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
+++ b/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
@@ -161,7 +161,6 @@ public class RulesEngine<T extends Ruleset> {
 
         String ruleEngineCategory = id.scope.getSimpleName().replace("Ruleset", "Engine-") + id.getId().orElse("");
         LOG = SyslogCategory.getLogger(SyslogCategory.RULES, RulesEngine.class.getName() + "." + ruleEngineCategory);
-        id.getRealm().ifPresent(realm -> SyslogRealmRegistry.register(LOG.getName(), realm));
 
         AssetsFacade<T> assetsFacade = new AssetsFacade<>(id, assetStorageService, attributeEvent -> {
             try {
@@ -306,6 +305,11 @@ public class RulesEngine<T extends Ruleset> {
             running = true;
         }
 
+        // Attribute this engine's logs to its realm while running; re-registered on restart and
+        // removed in stop(). A never-started engine never registers, so nothing leaks. Realm and
+        // asset engines carry a realm; global engines do not.
+        id.getRealm().ifPresent(realm -> SyslogRealmRegistry.register(LOG.getName(), realm));
+
         if (deployments.isEmpty()) {
             LOG.finest("No rulesets so nothing to start");
             return;
@@ -358,9 +362,6 @@ public class RulesEngine<T extends Ruleset> {
 
         synchronized (this) {
             if (!running) {
-                // Engine was never started (or already stopped); still drop the registry entry so a
-                // constructed-but-never-started engine does not leak its loggerName->realm mapping
-                SyslogRealmRegistry.unregister(LOG.getName());
                 return;
             }
             running = false;

--- a/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
+++ b/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
@@ -44,6 +44,7 @@ import org.openremote.model.query.filter.GeofencePredicate;
 import org.openremote.model.query.filter.LocationAttributePredicate;
 import org.openremote.model.rules.*;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmMarker;
 import org.openremote.model.syslog.SyslogRealmRegistry;
 
 import java.util.*;
@@ -662,11 +663,12 @@ public class RulesEngine<T extends Ruleset> {
         Collection<Object> anonFacts = facts.getAnonymousFacts();
         long temporaryFactsCount = facts.getTemporaryFacts().count();
         long total = assetStateFacts.size() + namedFacts.size() + anonFacts.size();
-        STATS_LOG.fine("Engine stats for '" + this + "', in memory facts are Total: " + total
+        STATS_LOG.log(Level.FINE, "Engine stats for '" + this + "', in memory facts are Total: " + total
             + ", AssetState: " + assetStateFacts.size()
             + ", Named: " + namedFacts.size()
             + ", Anonymous: " + anonFacts.size()
-            + ", Temporary: " + temporaryFactsCount);
+            + ", Temporary: " + temporaryFactsCount,
+            id.getRealm().map(SyslogRealmMarker::new).orElse(null));
 
         // Additional details if FINEST is enabled
         facts.logFacts(STATS_LOG, Level.FINEST);

--- a/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
+++ b/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
@@ -357,6 +357,9 @@ public class RulesEngine<T extends Ruleset> {
 
         synchronized (this) {
             if (!running) {
+                // Engine was never started (or already stopped); still drop the registry entry so a
+                // constructed-but-never-started engine does not leak its loggerName->realm mapping
+                SyslogRealmRegistry.unregister(LOG.getName());
                 return;
             }
             running = false;

--- a/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
+++ b/manager/src/main/java/org/openremote/manager/rules/RulesEngine.java
@@ -288,6 +288,7 @@ public class RulesEngine<T extends Ruleset> {
             stop();
             stopRuleset(deployment);
             deployments.values().remove(deployment);
+            SyslogRealmRegistry.unregister(deployment.LOG.getName());
             updateDeploymentInfo();
             if (wasRunning && !deployments.isEmpty()) {
                 start();

--- a/manager/src/main/java/org/openremote/manager/rules/RulesetDeployment.java
+++ b/manager/src/main/java/org/openremote/manager/rules/RulesetDeployment.java
@@ -43,6 +43,7 @@ import org.openremote.model.rules.Users;
 import org.openremote.model.rules.Webhooks;
 import org.openremote.model.rules.flow.NodeCollection;
 import org.openremote.model.syslog.SyslogCategory;
+import org.openremote.model.syslog.SyslogRealmRegistry;
 import org.openremote.model.util.Pair;
 import org.openremote.model.util.TextUtil;
 import org.openremote.model.util.ValueUtil;
@@ -144,6 +145,9 @@ public class RulesetDeployment {
 
         String ruleCategory = ruleset.getClass().getSimpleName() + "-" + ruleset.getId();
         LOG = SyslogCategory.getLogger(SyslogCategory.RULES, RulesEngine.class.getName() + "." + ruleCategory);
+        // Attribute this deployment's logs (compilation, per-rule logging) to the engine's realm; the
+        // registry entry is removed when the ruleset is undeployed (RulesEngine.removeRuleset)
+        rulesEngine.getId().getRealm().ifPresent(realm -> SyslogRealmRegistry.register(LOG.getName(), realm));
     }
 
     protected void init() throws IllegalStateException {

--- a/manager/src/main/java/org/openremote/manager/security/ManagerKeycloakIdentityProvider.java
+++ b/manager/src/main/java/org/openremote/manager/security/ManagerKeycloakIdentityProvider.java
@@ -58,6 +58,7 @@ import org.openremote.model.query.UserQuery;
 import org.openremote.model.query.filter.RealmPredicate;
 import org.openremote.model.rules.RealmRuleset;
 import org.openremote.model.security.*;
+import org.openremote.model.syslog.SyslogEvent;
 import org.openremote.model.util.TextUtil;
 import org.openremote.model.util.UniqueIdentifierGenerator;
 import org.openremote.model.util.ValueUtil;
@@ -976,6 +977,12 @@ public class ManagerKeycloakIdentityProvider extends KeycloakIdentityProvider im
             // Delete Rules
             query = entityManager.createQuery("delete from " + RealmRuleset.class.getSimpleName() + " rs " +
                 "where rs.realm = ?1");
+            query.setParameter(1, realmName);
+            query.executeUpdate();
+
+            // Delete syslog events
+            query = entityManager.createQuery("delete from " + SyslogEvent.class.getSimpleName() + " se " +
+                "where se.realm = ?1");
             query.setParameter(1, realmName);
             query.executeUpdate();
 

--- a/manager/src/main/java/org/openremote/manager/syslog/SyslogResourceImpl.java
+++ b/manager/src/main/java/org/openremote/manager/syslog/SyslogResourceImpl.java
@@ -19,12 +19,16 @@
  */
 package org.openremote.manager.syslog;
 
-import org.openremote.container.web.WebResource;
+import org.openremote.container.timer.TimerService;
+import org.openremote.manager.security.ManagerIdentityService;
+import org.openremote.manager.web.ManagerWebResource;
 import org.openremote.model.http.RequestParams;
 import org.openremote.model.syslog.*;
 import org.openremote.model.util.Pair;
+import org.openremote.model.util.TextUtil;
 
 import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 
@@ -34,19 +38,30 @@ import java.util.List;
 
 import static org.openremote.model.syslog.SyslogConfig.DEFAULT_LIMIT;
 
-public class SyslogResourceImpl extends WebResource implements SyslogResource {
+public class SyslogResourceImpl extends ManagerWebResource implements SyslogResource {
 
     final protected SyslogService syslogService;
 
-    public SyslogResourceImpl(SyslogService syslogService) {
+    public SyslogResourceImpl(TimerService timerService, ManagerIdentityService identityService, SyslogService syslogService) {
+        super(timerService, identityService);
         this.syslogService = syslogService;
     }
 
     @Override
-    public Response getEvents(@BeanParam RequestParams requestParams, SyslogLevel level, Integer perPage, Integer page, Long from, Long to, List<SyslogCategory> categories, List<String> subCategories) {
+    public Response getEvents(@BeanParam RequestParams requestParams, SyslogLevel level, Integer perPage, Integer page, Long from, Long to, List<SyslogCategory> categories, List<String> subCategories, String realm) {
 
         perPage = perPage != null ? perPage : DEFAULT_LIMIT;
         page = page != null ? page : 1;
+
+        // Non-superusers can only retrieve events of their own realm; system logs (no realm) and
+        // other realms' logs are only visible to superusers
+        String filterRealm = TextUtil.isNullOrEmpty(realm) ? null : realm;
+        if (!getAuthContext().isSuperUser()) {
+            filterRealm = filterRealm == null ? getAuthenticatedRealmName() : filterRealm;
+            if (!isRealmActiveAndAccessible(filterRealm)) {
+                throw new WebApplicationException(Response.Status.FORBIDDEN);
+            }
+        }
 
         Pair<Long, List<SyslogEvent>> result = syslogService.getEvents(
             level,
@@ -55,7 +70,8 @@ public class SyslogResourceImpl extends WebResource implements SyslogResource {
             from != null ? Instant.ofEpochMilli(from) : null,
             to != null ? Instant.ofEpochMilli(to) : null,
             categories,
-            subCategories
+            subCategories,
+            filterRealm
         );
 
         if (result == null) {

--- a/manager/src/main/java/org/openremote/manager/syslog/SyslogResourceImpl.java
+++ b/manager/src/main/java/org/openremote/manager/syslog/SyslogResourceImpl.java
@@ -92,8 +92,17 @@ public class SyslogResourceImpl extends ManagerWebResource implements SyslogReso
     }
 
     @Override
-    public void clearEvents(@BeanParam RequestParams requestParams) {
-        syslogService.clearStoredEvents();
+    public void clearEvents(@BeanParam RequestParams requestParams, String realm) {
+        // Non-superusers can only clear events of their own realm; clearing system logs (no realm)
+        // and other realms' logs requires superuser
+        String filterRealm = TextUtil.isNullOrEmpty(realm) ? null : realm;
+        if (!getAuthContext().isSuperUser()) {
+            filterRealm = filterRealm == null ? getAuthenticatedRealmName() : filterRealm;
+            if (!isRealmActiveAndAccessible(filterRealm)) {
+                throw new WebApplicationException(Response.Status.FORBIDDEN);
+            }
+        }
+        syslogService.clearStoredEvents(filterRealm);
     }
 
     @Override

--- a/manager/src/main/java/org/openremote/manager/syslog/SyslogService.java
+++ b/manager/src/main/java/org/openremote/manager/syslog/SyslogService.java
@@ -216,11 +216,20 @@ public class SyslogService extends Handler implements ContainerService {
         }
     }
 
-    public void clearStoredEvents() {
+    public void clearStoredEvents(String realm) {
         if (persistenceService == null)
             return;
         synchronized (batch) {
-            persistenceService.doTransaction(em -> em.createQuery("delete from SyslogEvent e").executeUpdate());
+            persistenceService.doTransaction(em -> {
+                if (realm == null) {
+                    // Global clear (superuser only); also removes system logs
+                    em.createQuery("delete from SyslogEvent e").executeUpdate();
+                } else {
+                    em.createQuery("delete from SyslogEvent e where e.realm = :realm")
+                        .setParameter("realm", realm)
+                        .executeUpdate();
+                }
+            });
         }
     }
 

--- a/manager/src/main/java/org/openremote/manager/syslog/SyslogService.java
+++ b/manager/src/main/java/org/openremote/manager/syslog/SyslogService.java
@@ -25,8 +25,11 @@ import org.openremote.model.Container;
 import org.openremote.model.ContainerService;
 import org.openremote.container.persistence.PersistenceService;
 import org.openremote.manager.event.ClientEventService;
+import org.openremote.manager.security.ManagerIdentityService;
 import org.openremote.manager.web.ManagerWebService;
 import org.openremote.model.Constants;
+import org.openremote.model.event.shared.EventSubscription;
+import org.openremote.model.event.shared.RealmFilter;
 import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.syslog.SyslogConfig;
 import org.openremote.model.syslog.SyslogEvent;
@@ -88,13 +91,34 @@ public class SyslogService extends Handler implements ContainerService {
         }
 
         if (clientEventService != null) {
-            clientEventService.addSubscriptionAuthorizer((realm, auth, subscription) ->
-                subscription.isEventType(SyslogEvent.class) && auth != null && (auth.isSuperUser() || auth.hasResourceRole(Constants.READ_LOGS_ROLE, Constants.KEYCLOAK_CLIENT_ID)));
+            clientEventService.addSubscriptionAuthorizer((realm, auth, subscription) -> {
+                if (!subscription.isEventType(SyslogEvent.class) || auth == null) {
+                    return false;
+                }
+                if (!auth.isSuperUser() && !auth.hasResourceRole(Constants.READ_LOGS_ROLE, Constants.KEYCLOAK_CLIENT_ID)) {
+                    return false;
+                }
+                if (!auth.isSuperUser()) {
+                    // Force the subscription to only receive events of the user's own realm; system
+                    // logs (no realm) are only visible to superusers
+                    @SuppressWarnings("unchecked")
+                    EventSubscription<SyslogEvent> syslogSubscription = (EventSubscription<SyslogEvent>) subscription;
+                    if (syslogSubscription.getFilter() instanceof SyslogEvent.LevelCategoryFilter levelCategoryFilter) {
+                        levelCategoryFilter.setRealm(auth.getAuthenticatedRealmName());
+                    } else {
+                        syslogSubscription.setFilter(new RealmFilter<>(auth.getAuthenticatedRealmName()));
+                    }
+                }
+                return true;
+            });
         }
 
         if (container.hasService(ManagerWebService.class)) {
             container.getService(ManagerWebService.class).addApiSingleton(
-                new SyslogResourceImpl(this)
+                new SyslogResourceImpl(
+                    container.getService(TimerService.class),
+                    container.getService(ManagerIdentityService.class),
+                    this)
             );
         }
 
@@ -200,7 +224,7 @@ public class SyslogService extends Handler implements ContainerService {
         }
     }
 
-    public Pair<Long, List<SyslogEvent>> getEvents(SyslogLevel level, int perPage, int page, Instant from, Instant to, List<SyslogCategory> categories, List<String> subCategories) {
+    public Pair<Long, List<SyslogEvent>> getEvents(SyslogLevel level, int perPage, int page, Instant from, Instant to, List<SyslogCategory> categories, List<String> subCategories, String realm) {
         if (persistenceService == null)
             return null;
 
@@ -226,6 +250,9 @@ public class SyslogService extends Handler implements ContainerService {
             if (subCategories != null && !subCategories.isEmpty()) {
                 sb.append(" and e.subCategory in :subCategories");
             }
+            if (realm != null) {
+                sb.append(" and e.realm = :realm");
+            }
 
             TypedQuery<Long> countQuery = em.createQuery("select count(e.id) " + sb.toString(), Long.class);
             countQuery.setParameter("from", fromInstant);
@@ -238,6 +265,9 @@ public class SyslogService extends Handler implements ContainerService {
             }
             if (subCategories != null && !subCategories.isEmpty()) {
                 countQuery.setParameter("subCategories", subCategories);
+            }
+            if (realm != null) {
+                countQuery.setParameter("realm", realm);
             }
             count.set(countQuery.getSingleResult());
 
@@ -258,6 +288,9 @@ public class SyslogService extends Handler implements ContainerService {
             }
             if (subCategories != null && !subCategories.isEmpty()) {
                 query.setParameter("subCategories", subCategories);
+            }
+            if (realm != null) {
+                query.setParameter("realm", realm);
             }
 
             query.setMaxResults(perPage);

--- a/manager/src/main/resources/org/openremote/manager/setup/database/V20260722_01__SyslogEventRealm.sql
+++ b/manager/src/main/resources/org/openremote/manager/setup/database/V20260722_01__SyslogEventRealm.sql
@@ -1,0 +1,3 @@
+alter table SYSLOG_EVENT add column REALM varchar(255);
+
+create index SYSLOG_EVENT_REALM_TIMESTAMP_IDX on SYSLOG_EVENT (REALM, TIMESTAMP desc);

--- a/model/src/main/java/org/openremote/model/syslog/SyslogCategory.java
+++ b/model/src/main/java/org/openremote/model/syslog/SyslogCategory.java
@@ -141,10 +141,27 @@ public enum SyslogCategory {
                     ? record.getMessage() + " -- " + record.getThrown().getMessage()
                     : record.getMessage();
 
-                return new SyslogEvent(record.getMillis(), level, category, subCategory, message);
+                return new SyslogEvent(record.getMillis(), level, category, subCategory, message, getRealm(record));
             }
         }
         return null;
+    }
+
+    /**
+     * Resolves the realm of a log record; an explicit {@link SyslogRealmMarker} parameter takes
+     * precedence over a {@link SyslogRealmRegistry} entry for the record's logger. Null means the
+     * record is a system log (not attributable to a realm).
+     */
+    protected static String getRealm(LogRecord record) {
+        Object[] parameters = record.getParameters();
+        if (parameters != null) {
+            for (Object parameter : parameters) {
+                if (parameter instanceof SyslogRealmMarker marker) {
+                    return marker.realm();
+                }
+            }
+        }
+        return SyslogRealmRegistry.getRealm(record.getLoggerName());
     }
 
     public static Logger getLogger(SyslogCategory category, Class<?> loggerName) {

--- a/model/src/main/java/org/openremote/model/syslog/SyslogEvent.java
+++ b/model/src/main/java/org/openremote/model/syslog/SyslogEvent.java
@@ -50,7 +50,7 @@ public class SyslogEvent extends RealmScopedEvent {
         }
 
         public List<SyslogCategory> getCategories() {
-            return categories;
+            return categories != null ? categories : Collections.emptyList();
         }
 
         public SyslogLevel getLevel() {

--- a/model/src/main/java/org/openremote/model/syslog/SyslogEvent.java
+++ b/model/src/main/java/org/openremote/model/syslog/SyslogEvent.java
@@ -22,7 +22,7 @@ package org.openremote.model.syslog;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import org.openremote.model.event.shared.EventFilter;
-import org.openremote.model.event.shared.SharedEvent;
+import org.openremote.model.event.shared.RealmScopedEvent;
 
 import java.util.*;
 
@@ -30,7 +30,7 @@ import static org.openremote.model.Constants.PERSISTENCE_SEQUENCE_ID_GENERATOR;
 
 @Entity
 @Table(name = "SYSLOG_EVENT")
-public class SyslogEvent extends SharedEvent {
+public class SyslogEvent extends RealmScopedEvent {
 
     static public class LevelCategoryFilter implements EventFilter<SyslogEvent> {
 
@@ -38,6 +38,7 @@ public class SyslogEvent extends SharedEvent {
 
         protected SyslogLevel level;
         protected List<SyslogCategory> categories = new ArrayList<>();
+        protected String realm;
 
         protected LevelCategoryFilter() {
         }
@@ -64,9 +65,18 @@ public class SyslogEvent extends SharedEvent {
             this.categories = categories;
         }
 
+        public String getRealm() {
+            return realm;
+        }
+
+        public void setRealm(String realm) {
+            this.realm = realm;
+        }
+
         @Override
         public SyslogEvent apply(SyslogEvent event) {
-            return (getCategories().isEmpty() || getCategories().contains(event.getCategory()))
+            return (realm == null || realm.equals(event.getRealm()))
+                && (getCategories().isEmpty() || getCategories().contains(event.getCategory()))
                 && (getLevel() == null || getLevel().ordinal() <= event.getLevel().ordinal()) ? event : null;
         }
 
@@ -75,6 +85,7 @@ public class SyslogEvent extends SharedEvent {
             return getClass().getSimpleName() + "{" +
                 "level=" + level +
                 ", categories=" + categories +
+                ", realm=" + realm +
                 '}';
         }
     }
@@ -105,7 +116,11 @@ public class SyslogEvent extends SharedEvent {
     }
 
     public SyslogEvent(long timestamp, SyslogLevel level, SyslogCategory category, String subCategory, String message) {
-        super(timestamp);
+        this(timestamp, level, category, subCategory, message, null);
+    }
+
+    public SyslogEvent(long timestamp, SyslogLevel level, SyslogCategory category, String subCategory, String message, String realm) {
+        super(timestamp, realm);
         this.level = level;
         this.category = category;
         this.subCategory = subCategory;
@@ -149,12 +164,32 @@ public class SyslogEvent extends SharedEvent {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SyslogEvent that = (SyslogEvent) o;
+        return Objects.equals(id, that.id)
+            && getTimestamp() == that.getTimestamp()
+            && level == that.level
+            && category == that.category
+            && Objects.equals(subCategory, that.subCategory)
+            && Objects.equals(message, that.message)
+            && Objects.equals(realm, that.realm);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, getTimestamp(), level, category, subCategory, message, realm);
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + "{" +
             "level=" + level +
             ", category=" + category +
             ", subCategory=" + subCategory +
             ", message='" + message + '\'' +
+            ", realm=" + realm +
             '}';
     }
 }

--- a/model/src/main/java/org/openremote/model/syslog/SyslogRealmMarker.java
+++ b/model/src/main/java/org/openremote/model/syslog/SyslogRealmMarker.java
@@ -19,6 +19,10 @@
  */
 package org.openremote.model.syslog;
 
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
 /**
  * Marker that can be passed as a {@link java.util.logging.LogRecord} parameter to attribute a
  * single log record to a realm, e.g. {@code LOG.log(Level.INFO, "Agent started", new SyslogRealmMarker(realm))}.
@@ -26,4 +30,20 @@ package org.openremote.model.syslog;
  * ignored by message formatters unless the message contains an explicit {@code {N}} placeholder.
  */
 public record SyslogRealmMarker(String realm) {
+
+    /**
+     * Logs a message with both a {@link Throwable} and a realm marker; the JUL convenience
+     * methods cannot carry both, so this builds the {@link LogRecord} manually. The logger
+     * name is set explicitly as {@link Logger#log(LogRecord)} does not fill it in.
+     */
+    public static void log(Logger logger, Level level, String message, Throwable thrown, String realm) {
+        if (!logger.isLoggable(level)) {
+            return;
+        }
+        LogRecord record = new LogRecord(level, message);
+        record.setLoggerName(logger.getName());
+        record.setThrown(thrown);
+        record.setParameters(new Object[]{new SyslogRealmMarker(realm)});
+        logger.log(record);
+    }
 }

--- a/model/src/main/java/org/openremote/model/syslog/SyslogRealmMarker.java
+++ b/model/src/main/java/org/openremote/model/syslog/SyslogRealmMarker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, OpenRemote Inc.
+ * Copyright 2026, OpenRemote Inc.
  *
  * See the CONTRIBUTORS.txt file in the distribution for a
  * full listing of individual contributors.
@@ -17,37 +17,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.openremote.model.event.shared;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.MappedSuperclass;
+package org.openremote.model.syslog;
 
 /**
- * An event that carries information about the realm it occurred in.
+ * Marker that can be passed as a {@link java.util.logging.LogRecord} parameter to attribute a
+ * single log record to a realm, e.g. {@code LOG.log(Level.INFO, "Agent started", new SyslogRealmMarker(realm))}.
+ * Takes precedence over any {@link SyslogRealmRegistry} entry for the logger. The marker is
+ * ignored by message formatters unless the message contains an explicit {@code {N}} placeholder.
  */
-@MappedSuperclass
-public abstract class RealmScopedEvent extends SharedEvent {
-
-    @Column(name = "REALM")
-    public String realm;
-
-    public RealmScopedEvent(long timestamp, String realm) {
-        super(timestamp);
-        this.realm = realm;
-    }
-
-    public RealmScopedEvent(String realm) {
-        this.realm = realm;
-    }
-
-    protected RealmScopedEvent() {
-    }
-
-    public String getRealm() {
-        return realm;
-    }
-
-    public void setRealm(String realm) {
-        this.realm = realm;
-    }
+public record SyslogRealmMarker(String realm) {
 }

--- a/model/src/main/java/org/openremote/model/syslog/SyslogRealmRegistry.java
+++ b/model/src/main/java/org/openremote/model/syslog/SyslogRealmRegistry.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * See the CONTRIBUTORS.txt file in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.openremote.model.syslog;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Registry that maps JUL logger names to the realm their log records belong to; used by
+ * {@link SyslogCategory#mapSyslogEvent} to attribute a {@link SyslogEvent} to a realm.
+ * Components that log through a dedicated per-realm logger (e.g. realm rules engines,
+ * protocol instances) register their logger name here on start and unregister on stop.
+ * Log records from unregistered loggers are treated as system logs (no realm).
+ */
+public final class SyslogRealmRegistry {
+
+    private static final ConcurrentMap<String, String> LOGGER_REALMS = new ConcurrentHashMap<>();
+
+    private SyslogRealmRegistry() {
+    }
+
+    public static void register(String loggerName, String realm) {
+        if (loggerName != null && realm != null) {
+            LOGGER_REALMS.put(loggerName, realm);
+        }
+    }
+
+    public static void unregister(String loggerName) {
+        if (loggerName != null) {
+            LOGGER_REALMS.remove(loggerName);
+        }
+    }
+
+    public static String getRealm(String loggerName) {
+        return loggerName == null ? null : LOGGER_REALMS.get(loggerName);
+    }
+}

--- a/model/src/main/java/org/openremote/model/syslog/SyslogResource.java
+++ b/model/src/main/java/org/openremote/model/syslog/SyslogResource.java
@@ -47,7 +47,7 @@ public interface SyslogResource {
     @Path("event")
     @RolesAllowed({Constants.WRITE_ADMIN_ROLE})
     @Operation(operationId = "clearEvents", summary = "Clear the syslog events")
-    void clearEvents(@BeanParam RequestParams requestParams);
+    void clearEvents(@BeanParam RequestParams requestParams, @QueryParam("realm") String realm);
 
     @GET
     @Path("config")

--- a/model/src/main/java/org/openremote/model/syslog/SyslogResource.java
+++ b/model/src/main/java/org/openremote/model/syslog/SyslogResource.java
@@ -41,7 +41,7 @@ public interface SyslogResource {
     @RolesAllowed({Constants.READ_LOGS_ROLE})
     @Operation(operationId = "getEvents", summary = "Retrieve the syslog events")
     @SuppressWarnings({"unusable-by-js"})
-    Response getEvents(@BeanParam RequestParams requestParams, @QueryParam("level") SyslogLevel level, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page, @QueryParam("from") Long from, @QueryParam("to") Long to, @QueryParam("category") List<SyslogCategory> categories, @QueryParam("subCategory") List<String> subCategories);
+    Response getEvents(@BeanParam RequestParams requestParams, @QueryParam("level") SyslogLevel level, @QueryParam("per_page") Integer perPage, @QueryParam("page") Integer page, @QueryParam("from") Long from, @QueryParam("to") Long to, @QueryParam("category") List<SyslogCategory> categories, @QueryParam("subCategory") List<String> subCategories, @QueryParam("realm") String realm);
 
     @DELETE
     @Path("event")

--- a/test/src/test/groovy/org/openremote/test/gateway/GatewayTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/gateway/GatewayTest.groovy
@@ -110,6 +110,10 @@ class GatewayTest extends Specification implements ManagerContainerTrait {
             assert gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).gatewayId == gateway.getId()
         }
 
+        and: "the connector's syslog logger is registered against the gateway's realm"
+        def connectorLoggerName = "org.openremote.manager.gateway.GatewayConnector-" + gateway.getId() + ".GATEWAY"
+        assert org.openremote.model.syslog.SyslogRealmRegistry.getRealm(connectorLoggerName) == gateway.getRealm()
+
         when: "the gateway service user credentials are used to try and access the asset resources"
         def accessToken = authenticate(
             container,
@@ -754,6 +758,11 @@ class GatewayTest extends Specification implements ManagerContainerTrait {
         assert deleted
         conditions.eventually {
             assert identityProvider.getClient(managerTestSetup.realmBuildingName, getGatewayClientId(gateway.getId())) == null
+        }
+
+        and: "the connector's syslog registry entry is removed"
+        new PollingConditions(timeout: 10, delay: 0.2).eventually {
+            assert org.openremote.model.syslog.SyslogRealmRegistry.getRealm(connectorLoggerName) == null
         }
 
         cleanup: "cleanup the gateway client"

--- a/test/src/test/groovy/org/openremote/test/rules/RulesetRealmAttributionTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/RulesetRealmAttributionTest.groovy
@@ -46,12 +46,15 @@ class RulesetRealmAttributionTest extends Specification implements ManagerContai
                 GROOVY,
                 NOOP_RULE))
 
-        then: "the deployment's syslog logger is registered against the building realm so its logs are attributed"
+        then: "both the engine and the deployment syslog loggers are registered against the building realm"
         String loggerName = null
         conditions.eventually {
             engine = rulesService.realmEngines.get(buildingRealm)
             assert engine != null
             assert engine.deployments[ruleset.id] != null
+            // Engine's own logger (subCategory RealmEngine-<realm>) must resolve to the realm
+            assert SyslogRealmRegistry.getRealm(engine.LOG.name) == buildingRealm
+            // Deployment's own logger (subCategory <RulesetClass>-<id>) must resolve to the realm
             loggerName = engine.deployments[ruleset.id].LOG.name
             assert SyslogRealmRegistry.getRealm(loggerName) == buildingRealm
         }

--- a/test/src/test/groovy/org/openremote/test/rules/RulesetRealmAttributionTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/RulesetRealmAttributionTest.groovy
@@ -1,0 +1,67 @@
+package org.openremote.test.rules
+
+import org.openremote.manager.rules.RulesEngine
+import org.openremote.manager.rules.RulesService
+import org.openremote.manager.rules.RulesetStorageService
+import org.openremote.manager.setup.SetupService
+import org.openremote.model.rules.RealmRuleset
+import org.openremote.model.syslog.SyslogRealmRegistry
+import org.openremote.setup.integration.KeycloakTestSetup
+import org.openremote.test.ManagerContainerTrait
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import static org.openremote.model.rules.Ruleset.Lang.GROOVY
+
+class RulesetRealmAttributionTest extends Specification implements ManagerContainerTrait {
+
+    private static final String OR_RULES_GROOVY_EXECUTION_ENABLED = "OR_RULES_GROOVY_EXECUTION_ENABLED"
+
+    private static final String NOOP_RULE = '''
+        package demo.rules
+
+        rules.add()
+                .name("noop")
+                .when({ facts -> false })
+                .then({ facts -> })
+    '''.stripIndent()
+
+    @SuppressWarnings("GroovyAccessibility")
+    def "Realm ruleset deployment attributes its syslog logger to the realm"() {
+        given: "the container is started"
+        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+        def config = defaultConfig()
+        config[OR_RULES_GROOVY_EXECUTION_ENABLED] = "true"
+        def container = startContainer(config, defaultServices())
+        def rulesService = container.getService(RulesService.class)
+        def rulesetStorageService = container.getService(RulesetStorageService.class)
+        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+        def buildingRealm = keycloakTestSetup.realmBuilding.name
+        RulesEngine engine = null
+
+        when: "a realm ruleset is deployed to the building realm"
+        def ruleset = rulesetStorageService.merge(new RealmRuleset(
+                buildingRealm,
+                "Realm attribution test",
+                GROOVY,
+                NOOP_RULE))
+
+        then: "the deployment's syslog logger is registered against the building realm so its logs are attributed"
+        String loggerName = null
+        conditions.eventually {
+            engine = rulesService.realmEngines.get(buildingRealm)
+            assert engine != null
+            assert engine.deployments[ruleset.id] != null
+            loggerName = engine.deployments[ruleset.id].LOG.name
+            assert SyslogRealmRegistry.getRealm(loggerName) == buildingRealm
+        }
+
+        when: "the ruleset is undeployed"
+        rulesetStorageService.delete(RealmRuleset.class, ruleset.id)
+
+        then: "the deployment's registry entry is removed so it does not leak"
+        conditions.eventually {
+            assert SyslogRealmRegistry.getRealm(loggerName) == null
+        }
+    }
+}

--- a/test/src/test/groovy/org/openremote/test/syslog/SysLogServiceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/syslog/SysLogServiceTest.groovy
@@ -149,6 +149,27 @@ class SysLogServiceTest extends Specification implements ManagerContainerTrait {
         markerEvent != null
         markerEvent.realm == "smartcity"
 
+        when: "the marker log helper is used with a throwable"
+        def capturedRecords = []
+        def handler = new java.util.logging.Handler() {
+            void publish(java.util.logging.LogRecord r) { capturedRecords << r }
+            void flush() {}
+            void close() {}
+        }
+        def helperLogger = java.util.logging.Logger.getLogger(loggerName)
+        helperLogger.addHandler(handler)
+        helperLogger.setLevel(Level.ALL)
+        SyslogRealmMarker.log(helperLogger, Level.SEVERE, "helper message", new RuntimeException("boom"), "smartcity")
+        def helperEvent = SyslogCategory.mapSyslogEvent(capturedRecords[0] as java.util.logging.LogRecord)
+        helperLogger.removeHandler(handler)
+
+        then: "the record carries logger name, throwable and realm, and maps to an attributed event"
+        capturedRecords.size() == 1
+        (capturedRecords[0] as java.util.logging.LogRecord).thrown instanceof RuntimeException
+        helperEvent != null
+        helperEvent.realm == "smartcity"
+        helperEvent.message.contains("helper message")
+
         cleanup:
         SyslogRealmRegistry.unregister(loggerName)
     }

--- a/test/src/test/groovy/org/openremote/test/syslog/SysLogServiceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/syslog/SysLogServiceTest.groovy
@@ -26,12 +26,12 @@ class SysLogServiceTest extends Specification implements ManagerContainerTrait {
         syslogService = new SyslogService()
         def container = startContainer(defaultConfig(), defaultServices(syslogService))
         persistenceService = container.getService(PersistenceService.class)
-        syslogService.clearStoredEvents()
+        syslogService.clearStoredEvents(null)
     }
 
     def cleanupSpec() {
         if (syslogService != null) {
-            syslogService.clearStoredEvents()
+            syslogService.clearStoredEvents(null)
         }
     }
 

--- a/test/src/test/groovy/org/openremote/test/syslog/SysLogServiceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/syslog/SysLogServiceTest.groovy
@@ -5,11 +5,15 @@ import org.openremote.manager.syslog.SyslogService
 import org.openremote.model.syslog.SyslogCategory
 import org.openremote.model.syslog.SyslogEvent
 import org.openremote.model.syslog.SyslogLevel
+import org.openremote.model.syslog.SyslogRealmMarker
+import org.openremote.model.syslog.SyslogRealmRegistry
 import org.openremote.test.ManagerContainerTrait
 import spock.lang.Shared
 import spock.lang.Specification
 
 import java.time.Instant
+import java.util.logging.Level
+import java.util.logging.LogRecord
 
 class SysLogServiceTest extends Specification implements ManagerContainerTrait {
 
@@ -46,7 +50,7 @@ class SysLogServiceTest extends Specification implements ManagerContainerTrait {
         }
 
         when: "requesting events for WARN+ API category with a subcategory filter"
-        def result = syslogService.getEvents(SyslogLevel.WARN, 2, 1, from, to, [SyslogCategory.API], [subCategory])
+        def result = syslogService.getEvents(SyslogLevel.WARN, 2, 1, from, to, [SyslogCategory.API], [subCategory], null)
 
         then: "only matching events are returned in descending timestamp order"
         result != null
@@ -58,11 +62,94 @@ class SysLogServiceTest extends Specification implements ManagerContainerTrait {
         result.value.every { it.level.ordinal() >= SyslogLevel.WARN.ordinal() }
 
         when: "requesting a limited page size"
-        def limited = syslogService.getEvents(SyslogLevel.WARN, 1, 1, from, to, [SyslogCategory.API], [subCategory])
+        def limited = syslogService.getEvents(SyslogLevel.WARN, 1, 1, from, to, [SyslogCategory.API], [subCategory], null)
 
         then: "pagination respects the per-page limit"
         limited.key == 2
         limited.value.size() == 1
         limited.value[0].message == "error"
+    }
+
+    def "Get events filters by realm"() {
+        given: "syslog events are stored for different realms and as system logs"
+        Instant now = getInstantTimeOf(container)
+        String subCategory = "SysLogServiceRealmTest-" + UUID.randomUUID()
+        Instant from = now.minusSeconds(600)
+        Instant to = now.plusSeconds(600)
+
+        persistenceService.doTransaction { em ->
+            em.persist(new SyslogEvent(now.minusSeconds(300).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "building event", "building"))
+            em.persist(new SyslogEvent(now.minusSeconds(200).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "smartcity event", "smartcity"))
+            em.persist(new SyslogEvent(now.minusSeconds(100).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "system event"))
+        }
+
+        when: "requesting events for a specific realm"
+        def buildingResult = syslogService.getEvents(null, 10, 1, from, to, null, [subCategory], "building")
+
+        then: "only that realm's events are returned and system logs (no realm) are excluded"
+        buildingResult.key == 1
+        buildingResult.value.size() == 1
+        buildingResult.value[0].message == "building event"
+        buildingResult.value[0].realm == "building"
+
+        when: "requesting events without a realm filter"
+        def allResult = syslogService.getEvents(null, 10, 1, from, to, null, [subCategory], null)
+
+        then: "events of all realms including system logs are returned"
+        allResult.key == 3
+        allResult.value.collect { it.message }.toSet() == ["building event", "smartcity event", "system event"].toSet()
+    }
+
+    def "Level category filter applies realm"() {
+        given: "a level/category filter restricted to a realm"
+        def filter = new SyslogEvent.LevelCategoryFilter(SyslogLevel.INFO)
+        filter.setRealm("building")
+
+        expect: "an event of the realm passes and other/system events are dropped"
+        filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "building")) != null
+        filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "smartcity")) == null
+        filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", null)) == null
+
+        and: "without a realm the filter passes events of any realm"
+        def unrestricted = new SyslogEvent.LevelCategoryFilter(SyslogLevel.INFO)
+        unrestricted.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "building")) != null
+        unrestricted.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", null)) != null
+    }
+
+    def "Map syslog event resolves realm from registry and marker"() {
+        given: "a logger name registered for a realm"
+        def loggerName = "org.openremote.manager.rules.RulesEngine.RealmEngine-building.RULES"
+        SyslogRealmRegistry.register(loggerName, "building")
+
+        when: "a log record of the registered logger is mapped"
+        def record = new LogRecord(Level.INFO, "rules message")
+        record.setLoggerName(loggerName)
+        def event = SyslogCategory.mapSyslogEvent(record)
+
+        then: "the event is attributed to the realm"
+        event != null
+        event.realm == "building"
+
+        when: "a log record of an unregistered logger is mapped"
+        def systemRecord = new LogRecord(Level.INFO, "system message")
+        systemRecord.setLoggerName("org.openremote.manager.rules.RulesEngine.GlobalEngine-.RULES")
+        def systemEvent = SyslogCategory.mapSyslogEvent(systemRecord)
+
+        then: "the event has no realm"
+        systemEvent != null
+        systemEvent.realm == null
+
+        when: "a log record carries an explicit realm marker parameter"
+        def markerRecord = new LogRecord(Level.INFO, "marker message")
+        markerRecord.setLoggerName(loggerName)
+        markerRecord.setParameters([new SyslogRealmMarker("smartcity")] as Object[])
+        def markerEvent = SyslogCategory.mapSyslogEvent(markerRecord)
+
+        then: "the marker wins over the registry"
+        markerEvent != null
+        markerEvent.realm == "smartcity"
+
+        cleanup:
+        SyslogRealmRegistry.unregister(loggerName)
     }
 }

--- a/test/src/test/groovy/org/openremote/test/syslog/SyslogResourceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/syslog/SyslogResourceTest.groovy
@@ -228,6 +228,30 @@ class SyslogResourceTest extends Specification implements ManagerContainerTrait 
         ((SyslogEvent.LevelCategoryFilter) filteredSubscription.filter).realm == "building"
         filteredSubscription.filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "smartcity")) == null
 
+        when: "a non superuser subscribes with a level/category filter that pre-sets another realm"
+        def hostileLevelFilter = new SyslogEvent.LevelCategoryFilter(SyslogLevel.INFO)
+        hostileLevelFilter.setRealm("smartcity")
+        def hostileLevelSubscription = new EventSubscription(SyslogEvent.class, hostileLevelFilter)
+        def hostileLevelAuthorized = clientEventService.authorizeEventSubscription("building", buildingAuth, hostileLevelSubscription)
+
+        then: "the pre-set realm is overwritten with the user's own realm"
+        hostileLevelAuthorized
+        hostileLevelSubscription.filter instanceof SyslogEvent.LevelCategoryFilter
+        ((SyslogEvent.LevelCategoryFilter) hostileLevelSubscription.filter).realm == "building"
+        hostileLevelSubscription.filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "building")) != null
+        hostileLevelSubscription.filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "smartcity")) == null
+
+        when: "a non superuser subscribes with a realm filter targeting another realm"
+        def hostileRealmSubscription = new EventSubscription(SyslogEvent.class, new RealmFilter<>("smartcity"))
+        def hostileRealmAuthorized = clientEventService.authorizeEventSubscription("building", buildingAuth, hostileRealmSubscription)
+
+        then: "the filter is replaced with one scoped to the user's own realm"
+        hostileRealmAuthorized
+        hostileRealmSubscription.filter instanceof RealmFilter
+        ((RealmFilter) hostileRealmSubscription.filter).name == "building"
+        hostileRealmSubscription.filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "building")) != null
+        hostileRealmSubscription.filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "smartcity")) == null
+
         when: "a superuser subscribes without a filter"
         def superSubscription = new EventSubscription(SyslogEvent.class)
         def superAuthorized = clientEventService.authorizeEventSubscription(MASTER_REALM, superAuth, superSubscription)

--- a/test/src/test/groovy/org/openremote/test/syslog/SyslogResourceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/syslog/SyslogResourceTest.groovy
@@ -1,18 +1,31 @@
 package org.openremote.test.syslog
 
 import jakarta.ws.rs.core.Response
+import org.openremote.container.persistence.PersistenceService
+import org.openremote.container.security.AuthContext
 import org.openremote.container.security.IdentityProvider
 import org.openremote.container.security.IdentityService
+import org.openremote.manager.event.ClientEventService
 import org.openremote.manager.security.ManagerIdentityProvider
 import org.openremote.manager.security.ManagerIdentityService
 import org.openremote.manager.setup.SetupService
 import org.openremote.manager.syslog.SyslogService
+import org.openremote.model.event.shared.EventSubscription
+import org.openremote.model.event.shared.RealmFilter
 import org.openremote.model.security.ClientRole
+import org.openremote.model.syslog.SyslogCategory
+import org.openremote.model.syslog.SyslogEvent
+import org.openremote.model.syslog.SyslogLevel
 import org.openremote.setup.integration.KeycloakTestSetup
 import org.openremote.test.ManagerContainerTrait
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.time.Instant
+
+import static org.openremote.container.security.IdentityProvider.OR_ADMIN_PASSWORD
+import static org.openremote.container.security.IdentityProvider.OR_ADMIN_PASSWORD_DEFAULT
+import static org.openremote.model.util.MapAccess.getString
 import static org.openremote.model.Constants.*
 
 class SyslogResourceTest extends Specification implements ManagerContainerTrait {
@@ -64,6 +77,178 @@ class SyslogResourceTest extends Specification implements ManagerContainerTrait 
         deleteUser(identityProvider)
     }
 
+    def "Realm users only see events of their own realm"() {
+        given: "the server container is started with the syslog resource"
+        def container = startContainer(defaultConfig(), defaultServices(new SyslogService()))
+        def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
+        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+        def persistenceService = container.getService(PersistenceService.class)
+        def buildingRealm = keycloakTestSetup.realmBuilding.name
+        def cityRealm = keycloakTestSetup.realmCity.name
+
+        and: "syslog events exist for multiple realms and as system logs"
+        def subCategory = "SyslogResourceRealmTest-" + UUID.randomUUID()
+        def now = getInstantTimeOf(container)
+        persistenceService.doTransaction { em ->
+            em.persist(new SyslogEvent(now.minusSeconds(30).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "building event", buildingRealm))
+            em.persist(new SyslogEvent(now.minusSeconds(20).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "smartcity event", cityRealm))
+            em.persist(new SyslogEvent(now.minusSeconds(10).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "system event"))
+        }
+
+        and: "a building realm user with the logs role"
+        def username = "syslog-test-building"
+        def user = keycloakTestSetup.createUser(
+            buildingRealm,
+            username,
+            username,
+            "Syslog",
+            "Building",
+            "${username}@openremote.local",
+            true,
+            [ClientRole.READ_LOGS] as ClientRole[]
+        )
+        userId = user.id
+        def buildingAccessToken = authenticate(container, buildingRealm, KEYCLOAK_CLIENT_ID, username, username)
+
+        when: "the building user requests syslog events"
+        def response = getSyslogEvents(buildingAccessToken, buildingRealm, null, subCategory)
+
+        then: "only events of the building realm are returned (no system logs, no other realms)"
+        response.withCloseable { r ->
+            assert r.status == Response.Status.OK.statusCode
+            def events = r.readEntity(SyslogEvent[].class)
+            assert events.length == 1
+            assert events[0].message == "building event"
+            assert events[0].realm == buildingRealm
+            return true
+        }
+
+        when: "the building user requests another realm's syslog events"
+        def forbiddenResponse = getSyslogEvents(buildingAccessToken, buildingRealm, cityRealm, subCategory)
+
+        then: "the request is rejected"
+        forbiddenResponse.withCloseable { r ->
+            assert r.status == Response.Status.FORBIDDEN.statusCode
+            return true
+        }
+
+        cleanup: "the test user is removed"
+        identityProvider.deleteUser(buildingRealm, userId)
+        userId = null
+    }
+
+    def "Superusers see events of all realms and can filter by realm"() {
+        given: "the server container is started with the syslog resource"
+        def container = startContainer(defaultConfig(), defaultServices(new SyslogService()))
+        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+        def persistenceService = container.getService(PersistenceService.class)
+        def buildingRealm = keycloakTestSetup.realmBuilding.name
+        def cityRealm = keycloakTestSetup.realmCity.name
+
+        and: "syslog events exist for multiple realms and as system logs"
+        def subCategory = "SyslogResourceSuperTest-" + UUID.randomUUID()
+        def now = getInstantTimeOf(container)
+        persistenceService.doTransaction { em ->
+            em.persist(new SyslogEvent(now.minusSeconds(30).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "building event", buildingRealm))
+            em.persist(new SyslogEvent(now.minusSeconds(20).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "smartcity event", cityRealm))
+            em.persist(new SyslogEvent(now.minusSeconds(10).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "system event"))
+        }
+
+        and: "the superuser is authenticated"
+        def adminAccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+        )
+
+        when: "the superuser requests syslog events without a realm filter"
+        def response = getSyslogEvents(adminAccessToken, MASTER_REALM, null, subCategory)
+
+        then: "events of all realms including system logs are returned"
+        response.withCloseable { r ->
+            assert r.status == Response.Status.OK.statusCode
+            def events = r.readEntity(SyslogEvent[].class)
+            assert events.length == 3
+            assert events.collect { it.message }.toSet() == ["building event", "smartcity event", "system event"].toSet()
+            return true
+        }
+
+        when: "the superuser filters by realm"
+        def filteredResponse = getSyslogEvents(adminAccessToken, MASTER_REALM, buildingRealm, subCategory)
+
+        then: "only that realm's events are returned"
+        filteredResponse.withCloseable { r ->
+            assert r.status == Response.Status.OK.statusCode
+            def events = r.readEntity(SyslogEvent[].class)
+            assert events.length == 1
+            assert events[0].realm == buildingRealm
+            return true
+        }
+    }
+
+    def "Syslog event subscriptions are realm scoped for non superusers"() {
+        given: "the server container is started with the syslog resource"
+        def container = startContainer(defaultConfig(), defaultServices(new SyslogService()))
+        def clientEventService = container.getService(ClientEventService.class)
+
+        and: "a non superuser auth context of the building realm with the logs role"
+        def buildingAuth = [
+            isSuperUser: { -> false },
+            hasResourceRole: { String role, String client -> role == READ_LOGS_ROLE },
+            getAuthenticatedRealmName: { -> "building" }
+        ] as AuthContext
+
+        and: "a superuser auth context"
+        def superAuth = [
+            isSuperUser: { -> true },
+            hasResourceRole: { String role, String client -> true },
+            getAuthenticatedRealmName: { -> MASTER_REALM }
+        ] as AuthContext
+
+        when: "a non superuser subscribes without a filter"
+        def subscription = new EventSubscription(SyslogEvent.class)
+        def authorized = clientEventService.authorizeEventSubscription("building", buildingAuth, subscription)
+
+        then: "the subscription is authorized and a realm filter is forced that drops other realms and system logs"
+        authorized
+        subscription.filter instanceof RealmFilter
+        subscription.filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "building")) != null
+        subscription.filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "smartcity")) == null
+        subscription.filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", null)) == null
+
+        when: "a non superuser subscribes with a level/category filter"
+        def filteredSubscription = new EventSubscription(SyslogEvent.class, new SyslogEvent.LevelCategoryFilter(SyslogLevel.INFO))
+        def filteredAuthorized = clientEventService.authorizeEventSubscription("building", buildingAuth, filteredSubscription)
+
+        then: "the client filter is preserved but forced to the user's realm"
+        filteredAuthorized
+        filteredSubscription.filter instanceof SyslogEvent.LevelCategoryFilter
+        ((SyslogEvent.LevelCategoryFilter) filteredSubscription.filter).realm == "building"
+        filteredSubscription.filter.apply(new SyslogEvent(0, SyslogLevel.INFO, SyslogCategory.API, null, "msg", "smartcity")) == null
+
+        when: "a superuser subscribes without a filter"
+        def superSubscription = new EventSubscription(SyslogEvent.class)
+        def superAuthorized = clientEventService.authorizeEventSubscription(MASTER_REALM, superAuth, superSubscription)
+
+        then: "the subscription is authorized and no filter is forced"
+        superAuthorized
+        superSubscription.filter == null
+
+        when: "a user without the logs role subscribes"
+        def noRoleAuth = [
+            isSuperUser: { -> false },
+            hasResourceRole: { String role, String client -> false },
+            getAuthenticatedRealmName: { -> "building" },
+            getUsername: { -> "syslog-test" }
+        ] as AuthContext
+        def deniedSubscription = new EventSubscription(SyslogEvent.class)
+
+        then: "the subscription is not authorized"
+        !clientEventService.authorizeEventSubscription("building", noRoleAuth, deniedSubscription)
+    }
+
     private String createUserToken(container, KeycloakTestSetup keycloakTestSetup, String roleName, ClientRole role) {
         def username = "syslog-test-${roleName}"
         def user = keycloakTestSetup.createUser(
@@ -87,11 +272,16 @@ class SyslogResourceTest extends Specification implements ManagerContainerTrait 
       }
    }
 
-    private def getSyslogEvents(String accessToken) {
-        getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken)
+    private def getSyslogEvents(String accessToken, String requestRealm = MASTER_REALM, String realm = null, String subCategory = null) {
+        def target = getClientApiTarget(serverUri(serverPort), requestRealm, accessToken)
             .path("syslog")
             .path("event")
-            .request()
-            .get()
+        if (realm != null) {
+            target = target.queryParam("realm", realm)
+        }
+        if (subCategory != null) {
+            target = target.queryParam("subCategory", subCategory)
+        }
+        target.request().get()
     }
 }

--- a/ui/app/manager/src/pages/page-logs.ts
+++ b/ui/app/manager/src/pages/page-logs.ts
@@ -1,7 +1,8 @@
 import {css, html} from "lit";
-import {customElement, property} from "lit/decorators.js";
+import {customElement, property, state} from "lit/decorators.js";
 import "@openremote/or-log-viewer";
 import {ViewerConfig} from "@openremote/or-log-viewer";
+import manager from "@openremote/core";
 import {Page, PageProvider} from "@openremote/or-app";
 import {AppStateKeyed} from "@openremote/or-app";
 import {Store} from "@reduxjs/toolkit";
@@ -32,9 +33,9 @@ export class PageLogs extends Page<AppStateKeyed> {
         return css`
             :host {
                 flex: 1;
-                width: 100%;            
+                width: 100%;
             }
-            
+
             or-log-viewer {
                 width: 100%;
             }
@@ -43,6 +44,9 @@ export class PageLogs extends Page<AppStateKeyed> {
 
     @property()
     public config?: PageLogsConfig;
+
+    @state()
+    protected _realm?: string;
 
     get name(): string {
         return "logs";
@@ -53,11 +57,21 @@ export class PageLogs extends Page<AppStateKeyed> {
     }
 
     public stateChanged(state: AppStateKeyed) {
+        this._realm = state.app.realm || manager.displayRealm;
+    }
+
+    protected _getViewerRealm(): string | undefined {
+        // A superuser viewing their own (master) realm sees logs of all realms including system
+        // logs (no realm); non-superusers are restricted to their own realm by the server anyway
+        if (manager.isSuperUser() && this._realm === manager.config.realm) {
+            return undefined;
+        }
+        return this._realm;
     }
 
     protected render() {
         return html`
-            <or-log-viewer .config="${this.config?.viewer}"></or-log-viewer>
+            <or-log-viewer .realm="${this._getViewerRealm()}" .config="${this.config?.viewer}"></or-log-viewer>
         `;
     }
 }

--- a/ui/component/or-log-viewer/src/index.ts
+++ b/ui/component/or-log-viewer/src/index.ts
@@ -172,6 +172,9 @@ export class OrLogViewer extends translate(i18next)(LitElement) {
     @property({type: String})
     public level?: Model.SyslogLevel;
 
+    @property({type: String})
+    public realm?: string;
+
     @property({type: Boolean})
     public live: boolean = false;
 
@@ -210,6 +213,7 @@ export class OrLogViewer extends translate(i18next)(LitElement) {
             || _changedProperties.has("limit")
             || _changedProperties.has("categories")
             || _changedProperties.has("filter")
+            || _changedProperties.has("realm")
             || _changedProperties.has("live")) {
             if (!this.live) {
                 this._pageCount = undefined;
@@ -510,7 +514,8 @@ export class OrLogViewer extends translate(i18next)(LitElement) {
             from: this._getFrom(),
             to: this.timestamp ? this.timestamp.getTime() : undefined,
             category: this.categories as Model.SyslogCategory[],
-            subCategory: this.filter ? this.filter.split(";") : undefined
+            subCategory: this.filter ? this.filter.split(";") : undefined,
+            realm: this.realm
         });
 
         this._loading = false;
@@ -611,6 +616,10 @@ export class OrLogViewer extends translate(i18next)(LitElement) {
     protected _onEvent(event: Model.SyslogEvent) {
 
         // TODO: Move filtering to server side
+        if (this.realm && event.realm !== this.realm) {
+            return;
+        }
+
         if (this.categories && !this.categories.find((c) => c === event.category)) {
             return;
         }


### PR DESCRIPTION
Closes #590.

Separates syslog entries per realm: events carry the realm they belong to, and access is scoped to the caller's realm.

## Model and storage

- `SyslogEvent` gains a nullable `realm` column (null = system log). Migration: `V20260722_01__SyslogEventRealm.sql`.
- Realm is resolved at capture time from two mechanisms:
  - `SyslogRealmMarker` — record attached as a `LogRecord` parameter for shared-logger call sites; includes a static `log` helper for sites that need both a throwable and a realm.
  - `SyslogRealmRegistry` — logger name → realm map for per-instance loggers (rules engines, ruleset deployments, protocol instances, gateway connectors). Registered on start, unregistered on true teardown only — transient stop/reconnect paths keep the mapping.
- Marker wins over registry when both apply. `LevelCategoryFilter` can filter on realm.

## Access scoping

- REST `getEvents` and `clearEvents` (`DELETE /syslog/event`): non-superusers are forced to their own realm; requesting a foreign realm returns 403. Superusers can pass `?realm=` or omit it for all realms.
- Websocket subscriptions: the subscription authorizer forces the filter to the caller's realm.
- Manager UI logs page gains a realm filter (superuser only).

## Attribution coverage

- Rules: per-engine and per-ruleset-deployment loggers registered with the engine realm; `RulesEngineStats` line marked.
- Protocols: `AbstractProtocol` instance loggers registered with the agent realm. LoRaWAN family, ZWave, and Bluetooth Mesh no longer shadow the inherited logger with static ones.
- AgentService: 34 sites marked (link/unlink failures, discovery/import lifecycle).
- Gateway connectors: per-instance logger `GatewayConnector-<gatewayId>`, registered for the gateway's realm, unregistered on connector removal.
- AlarmService, NotificationService, MQTT handlers (9 sites with realm derivable from topic/provisioning config/connection), asset processing/storage (5 sites).

## subCategory shape changes

Users filtering on subCategory text will see new shapes:

- `GatewayConnector-<gatewayId>` (was `GatewayConnector`)
- `TheThingsStackProtocol-<agentId>` / `ChirpStackProtocol-<agentId>` (was static class names)
- ZWave/Bluetooth Mesh instance logs: `<Class>-<agentId>` via the inherited protocol logger

## Deliberately left as system logs

No realm context available at these sites: Velbus package logger (statically imported by device classes), Bluetooth Mesh static manager callbacks and mesh helper classes, IO clients/servers (Websocket/UDP/Netty/MQTT client, KNX/Tradfri connections), broker-level MQTT sites, service lifecycle logs.

## Wire compatibility

`SyslogRealmMarker` is never serialized. `SyslogEvent.realm` follows the existing `RealmScopedEvent` shape; no REST client regeneration needed beyond the generated model.

## Testing

- New/extended Spock specs: `SysLogServiceTest`, `SyslogResourceTest` (realm filter injection cases), `RulesetRealmAttributionTest`, `GatewayTest` registry assertions.
- Full backend sweep: 129 tests, 0 failed (13 pre-existing env-dependent skips).
