### PR TITLE
Fix alarm status filter and update the table in place

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ Access control belongs in the resource implementation, not in the service. Exten
 
 Own Lit components extend `OrElement` from `@openremote/or-element` instead of `LitElement` (also through mixins, e.g. `translate(i18next)(OrElement)`). It applies the shared shadow-DOM styling automatically. Vaadin wrappers are exempt; they extend their Vaadin base and are themed via Lumo.
 
+### Fine-grained rendering
+
+A state change should re-render only the part it affects. Re-rendering a whole page, or a large component such as a table, flickers and discards the state that component holds: sort order, pagination, selection, scroll position. Keep those children mounted and update their properties.
+
 ### Adding a new component package
 
 New packages under `ui/component/` are picked up automatically by the yarn workspace and by Gradle (any dir with a `build.gradle`). The rsbuild apps are not automatic: add the package to the `@openremote/*` alias maps in `ui/app/manager/rsbuild.config.ts` and `ui/app/storybook/rsbuild.config.ts`, which resolve workspace packages to their `src` dirs. A missing entry fails the build with "Module not found" for any file importing the package.
@@ -79,6 +83,7 @@ Stories call `getORStorybookHelpers(tagName)` (from `ui/component/storybook-util
 
 - **Test Naming:** `test.describe` blocks describe a feature. Tests should be named starting with "should ...".
 - **Test Structure:** Keep tests flat by default. Omit top-level `test.describe` blocks. If grouping is needed, target a specific feature (e.g., filtering notifications) rather than a parent concept like the whole page. Example: `test.describe("Filter Notifications", ...)` instead of `test.describe("Notifications", ...)`.
+- **Regression Tests:** Every bug fix ships with a test that fails without it. Name it after the behaviour that should hold rather than the defect, and record what used to go wrong in a comment on the assertion that catches it.
 
 #### Fixtures
 

--- a/ui/app/manager/src/pages/page-alarms.ts
+++ b/ui/app/manager/src/pages/page-alarms.ts
@@ -744,7 +744,7 @@ export class PageAlarms extends Page<AppStateKeyed> {
                                                   value=${this._getSourceText()}>
                                 <or-translate slot="label" value="alarm.source"></or-translate>
                             </or-vaadin-text-field>
-                            
+
                             <or-vaadin-select class="alarm-input" ?readonly=${!write}
                                               .items=${this._getAddSeverityOptions()} value=${alarm.severity}
                                               @change=${(ev: Event) => {
@@ -926,12 +926,17 @@ export class PageAlarms extends Page<AppStateKeyed> {
     if (!ev.detail.index && ev.detail.index != 0) {
       return;
     }
-    this.alarm = this._data?.[ev.detail.index] as AlarmModel;
-    this.alarm.loaded = false;
-    this.alarm.loading = false;
-    this.alarm.alarmAssetLinks = [];
-    this.loadAlarm(this.alarm);
-    this.requestUpdate();
+    const alarm = this._data?.[ev.detail.index] as AlarmModel;
+    if (alarm) {
+      this.alarm = alarm;
+      this.alarm.loaded = false;
+      this.alarm.loading = false;
+      this.alarm.alarmAssetLinks = [];
+      this.loadAlarm(this.alarm);
+      this.requestUpdate();
+    } else {
+      console.warn("Tried selecting an alarm that does not exist?");
+    }
   }
 
   protected _getUsers() {

--- a/ui/app/manager/src/pages/page-alarms.ts
+++ b/ui/app/manager/src/pages/page-alarms.ts
@@ -37,7 +37,6 @@ import { type GenericAxiosResponse, isAxiosError } from "@openremote/rest";
 import { getAlarmsRoute } from "../routes";
 import { when } from "lit/directives/when.js";
 import { until } from "lit/directives/until.js";
-import { guard } from "lit/directives/guard.js";
 import { OrMwcDialog, showDialog } from "@openremote/or-mwc-components/or-mwc-dialog";
 import type { OrAssetTreeRequestSelectionEvent, OrAssetTreeSelectionEvent } from "@openremote/or-asset-tree";
 import type {
@@ -335,11 +334,14 @@ export class PageAlarms extends Page<AppStateKeyed> {
     if (changedProperties.has("alarm")) {
       this._updateRoute();
     }
-    if (changedProperties.has("severity") || changedProperties.has("status") || changedProperties.has("allActive")) {
-      this._data = undefined;
-    }
+    // Keep the previous rows on screen while reloading, so the table updates in place instead of being torn down
+    const filterChanged =
+      changedProperties.has("severity") ||
+      changedProperties.has("status") ||
+      changedProperties.has("allActive") ||
+      changedProperties.has("assign");
 
-    if (!this._data) {
+    if (filterChanged || !this._data) {
       this._loadData();
     }
 
@@ -508,11 +510,7 @@ export class PageAlarms extends Page<AppStateKeyed> {
                           <or-translate value="loading" />
                         </div>
                       `
-                    : html`
-                        <div id="table-container">
-                          ${when(this._data, () => guard([this._data], () => this.getAlarmsTable(writeAlarms)))}
-                        </div>
-                      `
+                    : html` <div id="table-container">${this.getAlarmsTable(writeAlarms)}</div> `
                 }
               </div>
             `;
@@ -573,7 +571,7 @@ export class PageAlarms extends Page<AppStateKeyed> {
   protected getAlarmsTable(writeAlarms: boolean) {
     return html`
       <or-alarms-table
-        .alarms=${this._data}
+        .alarms=${this._data ?? []}
         .readonly=${!writeAlarms}
         @or-mwc-table-row-select="${(e: OrMwcTableRowSelectEvent) => this._onRowSelect(e)}"
         @or-mwc-table-row-click="${(e: OrMwcTableRowClickEvent) => this._onRowClick(e)}"
@@ -604,7 +602,7 @@ export class PageAlarms extends Page<AppStateKeyed> {
       this._data = this._data.filter((e) => e.realm === manager.displayRealm);
       this._selectedIds = [];
 
-      if (this.config?.assignOnly) {
+      if (this.config?.assignOnly || this.assign) {
         const userResponse = await manager.rest.api.UserResource.getCurrent();
         if (userResponse.status === 200) {
           this._data = this._data.filter((e) => e.assigneeId === userResponse.data.id);
@@ -618,9 +616,6 @@ export class PageAlarms extends Page<AppStateKeyed> {
       }
       if (!this.status && this.allActive) {
         this._data = this._data.filter((e) => e.status !== AlarmStatus.RESOLVED && e.status !== AlarmStatus.CLOSED);
-      }
-      if (this.assign) {
-        await this._onAssignCheckChanged(this.assign);
       }
     }
     this._loading = false;
@@ -895,57 +890,21 @@ export class PageAlarms extends Page<AppStateKeyed> {
   }
 
   protected _onSeverityChanged(severity: AlarmSeverity | "all") {
-    console.debug(severity);
-    if (severity === "all") {
-      this.severity = undefined;
-      this._loadData();
-      return;
-    }
-
-    this.severity = severity;
-    this._data = this._data?.filter((e) => e.severity === this.severity);
+    this.severity = severity === "all" ? undefined : severity;
   }
 
-  protected async _onAssignCheckChanged(assign: boolean) {
+  protected _onAssignCheckChanged(assign: boolean) {
     this.assign = assign;
-
-    if (this.assign === undefined) {
-      return;
-    }
-    const response = await manager.rest.api.UserResource.getCurrent();
-    if (response.status === 200 && this.assign) {
-      this._data = this._data!.filter((e) => e.assigneeId === response.data.id);
-    } else if (!this.assign) {
-      this._loadData();
-    }
   }
 
+  // Filtering itself happens in _loadData; changing the state below is what triggers the reload.
   protected _onStatusChanged(status: AlarmStatus | "all" | "allActive") {
-    if (status === "all") {
-      this.status = undefined;
-      this.allActive = undefined;
-      this.requestUpdate();
-      return;
-    }
-    if (status === "allActive") {
-      this.status = undefined;
-      this.allActive = true;
-      this.requestUpdate();
-      return;
-    }
-    this.allActive = undefined;
-    this.status = this._getStatusOptions()
-      .filter((obj) => obj.label === status)
-      .map((obj) => obj.value)[0] as AlarmStatus;
-    if (!this.status) {
-      return;
-    }
-
-    this._data = this._data!.filter((e) => e.status === this.status);
+    this.status = status === "all" || status === "allActive" ? undefined : status;
+    this.allActive = status === "allActive";
   }
 
   protected _onRowSelect(ev: OrMwcTableRowSelectEvent) {
-    const alarm = this._data[ev.detail.index];
+    const alarm = this._data?.[ev.detail.index];
     if (alarm) {
       if (ev.detail.state) {
         if (this._selectedIds === undefined) {
@@ -967,7 +926,7 @@ export class PageAlarms extends Page<AppStateKeyed> {
     if (!ev.detail.index && ev.detail.index != 0) {
       return;
     }
-    this.alarm = this._data[ev.detail.index] as AlarmModel;
+    this.alarm = this._data?.[ev.detail.index] as AlarmModel;
     this.alarm.loaded = false;
     this.alarm.loading = false;
     this.alarm.alarmAssetLinks = [];

--- a/ui/app/manager/test/alarms.test.ts
+++ b/ui/app/manager/test/alarms.test.ts
@@ -120,6 +120,172 @@ test("should drop a resolved alarm from the default active filter", async ({ man
  * The assertions below count table rows, so they run against "smartcity", which holds only the alarms seeded here
  * rather than the master realm's demo data.
  */
+test.describe("Filter alarms", () => {
+  // Keycloak sessions are per realm, so the stored admin state (master) cannot view "smartcity". Start clean and
+  // log in as a user of that realm instead.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  /**
+   * One alarm per status, each with a distinct severity so the same set also exercises the severity filter.
+   * OPEN, ACKNOWLEDGED and IN_PROGRESS make up the "All active" set; RESOLVED and CLOSED fall outside it.
+   */
+  async function seedOnePerStatus(manager: Manager) {
+    return {
+      open: await seedAlarm(manager, { realm: "smartcity", status: AlarmStatus.OPEN, severity: AlarmSeverity.LOW }),
+      acknowledged: await seedAlarm(manager, {
+        realm: "smartcity",
+        status: AlarmStatus.ACKNOWLEDGED,
+        severity: AlarmSeverity.MEDIUM,
+      }),
+      inProgress: await seedAlarm(manager, {
+        realm: "smartcity",
+        status: AlarmStatus.IN_PROGRESS,
+        severity: AlarmSeverity.HIGH,
+      }),
+      resolved: await seedAlarm(manager, {
+        realm: "smartcity",
+        status: AlarmStatus.RESOLVED,
+        severity: AlarmSeverity.MEDIUM,
+      }),
+      closed: await seedAlarm(manager, {
+        realm: "smartcity",
+        status: AlarmStatus.CLOSED,
+        severity: AlarmSeverity.HIGH,
+      }),
+    };
+  }
+
+  async function loginAsAlarmUser(manager: Manager, username: string) {
+    await manager.provisionUserAndLogin("smartcity", {
+      username,
+      roles: ["read:alarms", "write:alarms"],
+    });
+  }
+
+  /**
+   * @given One alarm of every status in "smartcity"
+   * @when Each of the status filter's options is picked in turn
+   * @then Only the alarms carrying that status are listed
+   */
+  test("should list only the alarms with the selected status", async ({ manager, alarmsPage }) => {
+    const alarms = await seedOnePerStatus(manager);
+    await loginAsAlarmUser(manager, "e2e-alarm-status-filterer");
+    await alarmsPage.goto();
+
+    // the overview opens on "All active", which leaves out the resolved and closed alarms
+    await expect(alarmsPage.getRows()).toHaveCount(3);
+
+    // picking a concrete status used to leave the filter unset, listing every alarm instead
+    for (const [label, alarm] of [
+      ["Open", alarms.open],
+      ["Acknowledged", alarms.acknowledged],
+      ["In Progress", alarms.inProgress],
+      ["Resolved", alarms.resolved],
+      ["Closed", alarms.closed],
+    ] as const) {
+      await alarmsPage.setStatusFilter(label);
+      await expect(alarmsPage.getRows()).toHaveCount(1);
+      await expect(alarmsPage.getRowByText(alarm.title)).toBeVisible();
+    }
+
+    await alarmsPage.setStatusFilter("All");
+    await expect(alarmsPage.getRows()).toHaveCount(5);
+
+    // and the default is reachable again from a concrete status
+    await alarmsPage.setStatusFilter("All active");
+    await expect(alarmsPage.getRows()).toHaveCount(3);
+  });
+
+  /**
+   * @given One alarm of every status in "smartcity", spread across the three severities
+   * @when Each of the severity filter's options is picked in turn, with the status filter widened to "All"
+   * @then Only the alarms carrying that severity are listed
+   */
+  test("should list only the alarms with the selected severity", async ({ manager, alarmsPage }) => {
+    const alarms = await seedOnePerStatus(manager);
+    await loginAsAlarmUser(manager, "e2e-alarm-severity-filterer");
+    await alarmsPage.goto();
+
+    // widen the status first, so the counts below reflect the severity filter alone
+    await alarmsPage.setStatusFilter("All");
+    await expect(alarmsPage.getRows()).toHaveCount(5);
+
+    await alarmsPage.setSeverityFilter("Low");
+    await expect(alarmsPage.getRows()).toHaveCount(1);
+    await expect(alarmsPage.getRowByText(alarms.open.title)).toBeVisible();
+
+    await alarmsPage.setSeverityFilter("Medium");
+    await expect(alarmsPage.getRows()).toHaveCount(2);
+    await expect(alarmsPage.getRowByText(alarms.acknowledged.title)).toBeVisible();
+    await expect(alarmsPage.getRowByText(alarms.resolved.title)).toBeVisible();
+
+    await alarmsPage.setSeverityFilter("High");
+    await expect(alarmsPage.getRows()).toHaveCount(2);
+    await expect(alarmsPage.getRowByText(alarms.inProgress.title)).toBeVisible();
+    await expect(alarmsPage.getRowByText(alarms.closed.title)).toBeVisible();
+
+    await alarmsPage.setSeverityFilter("All");
+    await expect(alarmsPage.getRows()).toHaveCount(5);
+  });
+
+  /**
+   * @given One alarm of every status in "smartcity", spread across the three severities
+   * @when Both the severity and the status filter are narrowed
+   * @then Each filter is applied on top of the other rather than replacing it
+   */
+  test("should apply the severity and status filters together", async ({ manager, alarmsPage }) => {
+    const alarms = await seedOnePerStatus(manager);
+    await loginAsAlarmUser(manager, "e2e-alarm-combined-filterer");
+    await alarmsPage.goto();
+
+    // "All active" hides the closed alarm, leaving only the in-progress one at high severity
+    await alarmsPage.setSeverityFilter("High");
+    await expect(alarmsPage.getRows()).toHaveCount(1);
+    await expect(alarmsPage.getRowByText(alarms.inProgress.title)).toBeVisible();
+
+    // narrowing the status on top of it must keep the severity filter rather than replace it
+    await alarmsPage.setStatusFilter("Closed");
+    await expect(alarmsPage.getRows()).toHaveCount(1);
+    await expect(alarmsPage.getRowByText(alarms.closed.title)).toBeVisible();
+
+    // and widening the severity back out leaves the status filter in place
+    await alarmsPage.setSeverityFilter("All");
+    await expect(alarmsPage.getRows()).toHaveCount(1);
+    await expect(alarmsPage.getRowByText(alarms.closed.title)).toBeVisible();
+  });
+
+  /**
+   * @given Alarms in "smartcity", none of them assigned to the logged-in user
+   * @when The "assigned to me" checkbox is ticked and unticked again
+   * @then The list empties and is restored, on top of whichever status filter is set
+   */
+  test("should list only the alarms assigned to the current user", async ({ manager, alarmsPage }) => {
+    await seedOnePerStatus(manager);
+    await loginAsAlarmUser(manager, "e2e-alarm-assignee-filterer");
+    await alarmsPage.goto();
+    await expect(alarmsPage.getRows()).toHaveCount(3);
+
+    // the seeded alarms have no assignee, so none of them belong to this user
+    await alarmsPage.getAssignedToMeCheckbox().check();
+    await expect(alarmsPage.getRows()).toHaveCount(0);
+
+    // unticking reloads rather than leaving the list emptied
+    await alarmsPage.getAssignedToMeCheckbox().uncheck();
+    await expect(alarmsPage.getRows()).toHaveCount(3);
+
+    // and it composes with the status filter instead of resetting it
+    await alarmsPage.setStatusFilter("All");
+    await alarmsPage.getAssignedToMeCheckbox().check();
+    await expect(alarmsPage.getRows()).toHaveCount(0);
+    await alarmsPage.getAssignedToMeCheckbox().uncheck();
+    await expect(alarmsPage.getRows()).toHaveCount(5);
+  });
+});
+
+/**
+ * The assertions below count table rows, so they run against "smartcity", which holds only the alarms seeded here
+ * rather than the master realm's demo data.
+ */
 test.describe("Delete alarms", () => {
   // Keycloak sessions are per realm, so the stored admin state (master) cannot view "smartcity". Start clean and
   // log in as a user of that realm instead.

--- a/ui/app/manager/test/fixtures/pages/alarms.ts
+++ b/ui/app/manager/test/fixtures/pages/alarms.ts
@@ -22,10 +22,10 @@ import type { Manager } from "../manager.js";
 /**
  * Page object for the alarms page (page-alarms).
  *
- * The overview is an `or-alarms-table`; clicking a row opens the single-alarm view, whose properties column
- * (`#prop-panel`) holds the severity, status and assignee `or-vaadin-select`s. Those carry no id, so they are
- * located by the translation key of their slotted label. Opening one shows its items in a
- * `vaadin-select-list-box`.
+ * The overview is an `or-alarms-table` with its own severity and status filters above it, which do carry ids.
+ * Clicking a row opens the single-alarm view, whose properties column (`#prop-panel`) holds the severity,
+ * status and assignee `or-vaadin-select`s. Those carry no id, so they are located by the translation key of
+ * their slotted label. Opening any of them shows its items in a `vaadin-select-list-box`.
  */
 export class AlarmsPage implements BasePage {
   constructor(
@@ -57,6 +57,33 @@ export class AlarmsPage implements BasePage {
 
   getAddButton(): Locator {
     return this.page.getByRole("button", { name: "Add Alarm" });
+  }
+
+  // --- Overview filters ---------------------------------------------------
+
+  getStatusFilter(): Locator {
+    return this.page.locator("#status-select");
+  }
+
+  getSeverityFilter(): Locator {
+    return this.page.locator("#severity-select");
+  }
+
+  /** Pick a status in the overview filter (e.g. "Open", "All active", "All"). */
+  async setStatusFilter(label: string) {
+    await this.getStatusFilter().click();
+    await this.pickOverlayOption(label);
+  }
+
+  /** Pick a severity in the overview filter (e.g. "High", "All"). */
+  async setSeverityFilter(label: string) {
+    await this.getSeverityFilter().click();
+    await this.pickOverlayOption(label);
+  }
+
+  /** The "assigned to me" checkbox above the overview table. */
+  getAssignedToMeCheckbox(): Locator {
+    return this.page.locator("#assign-check").getByRole("checkbox");
   }
 
   // --- Selection and deletion --------------------------------------------


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description

<!--
  Please describe the changes and add a link to the related issue(s) #
-->

The Vaadin select emits an option's value, but the handler looked the status up by label. Nothing matched, so both the status and the active-only filter were left unset and every alarm was listed.

Changing a filter also cleared the page's data before reloading, which unmounted the table and rebuilt it from scratch, losing its sort order and selection. Keep the previous rows on screen while the new ones load, and route the assignee checkbox through the same reload instead of filtering the loaded data in place.

Covers every status and severity option, and the assignee filter, with end-to-end tests.

- Closes #3160 

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
