### PR TITLE
Fix broken log viewer after formatting

### DIFF
--- a/ui/component/or-log-viewer/build.gradle
+++ b/ui/component/or-log-viewer/build.gradle
@@ -13,6 +13,22 @@ tasks.register('installDist') {
   dependsOn npmAnalyze
 }
 
+tasks.register('npmBuild', Exec) {
+  mustRunAfter npmClean
+  dependsOn getYarnInstallTask()
+  commandLine npmCommand("yarn"), "run", "build"
+}
+
+tasks.register('npmTest', Exec) {
+  dependsOn getYarnInstallTask()
+  commandLine npmCommand("yarn"), "run", "test"
+}
+
+tasks.register('npmTestUI', Exec) {
+  dependsOn getYarnInstallTask()
+  commandLine npmCommand("yarn"), "run", "test", "--ui"
+}
+
 tasks.register('prepareUi') {
   dependsOn clean, npmAnalyze, npmPrepare
 }

--- a/ui/component/or-log-viewer/package.json
+++ b/ui/component/or-log-viewer/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "analyze": "npx cem analyze --config ../custom-elements-manifest.config.mjs",
     "build": "npx tsc -b",
-    "test": "echo \"No tests\" && exit 0",
+    "test": "npx tsc -b && npx playwright test",
     "prepack": "npx rspack"
   },
   "author": "OpenRemote",

--- a/ui/component/or-log-viewer/playwright.config.ts
+++ b/ui/component/or-log-viewer/playwright.config.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { defineCtConfig } from "@openremote/test/component.config";
+
+export default defineCtConfig(__dirname);

--- a/ui/component/or-log-viewer/src/index.ts
+++ b/ui/component/or-log-viewer/src/index.ts
@@ -164,6 +164,12 @@ const style = css`
     word-wrap: break-word;
     white-space: pre-wrap;
   }
+
+  #table th:not(.icon-cell) {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `;
 
 @customElement("or-log-viewer")

--- a/ui/component/or-log-viewer/src/index.ts
+++ b/ui/component/or-log-viewer/src/index.ts
@@ -24,6 +24,11 @@ import manager, { DefaultColor2, DefaultColor3, Util } from "@openremote/core";
 import "@openremote/or-mwc-components/or-mwc-input";
 import "@openremote/or-components/or-panel";
 import "@openremote/or-translate";
+import "@openremote/or-vaadin-components/or-vaadin-button";
+import "@openremote/or-vaadin-components/or-vaadin-checkbox";
+import "@openremote/or-vaadin-components/or-vaadin-multi-select-combo-box";
+import "@openremote/or-vaadin-components/or-vaadin-select";
+import "@openremote/or-vaadin-components/or-vaadin-text-field";
 import type { MDCDataTable } from "@material/data-table";
 import moment from "moment";
 import type { GenericAxiosResponse } from "axios";
@@ -413,8 +418,8 @@ export class OrLogViewer extends translate(i18next)(LitElement) {
               </or-vaadin-date-time-picker>
               <or-vaadin-button
                 theme="icon"
-                ?disabled="${disabled || isLive}@click"
-                =${() => (this.timestamp = this._calculateTimestamp(this.timestamp!, true))}
+                ?disabled=${disabled || isLive}
+                @click=${() => (this.timestamp = this._calculateTimestamp(this.timestamp!, true))}
               >
                 <or-icon icon="chevron-right"></or-icon>
               </or-vaadin-button>

--- a/ui/component/or-log-viewer/test/fixtures/or-log-viewer-test.js
+++ b/ui/component/or-log-viewer/test/fixtures/or-log-viewer-test.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+// Plain JS on purpose: the component-test bundle compiles .ts files against ui/test's tsconfig
+// (rootDir ui/test), so TS component sources outside that dir fail the build.
+import { OrLogViewer } from "@openremote/or-log-viewer";
+
+/** Fixed so the rendered ending timestamp is deterministic. */
+export const TIMESTAMP = new Date(2026, 0, 15, 10, 30, 0);
+
+const EVENTS = [
+  {
+    timestamp: TIMESTAMP.getTime(),
+    level: "INFO",
+    category: "DATA",
+    subCategory: "Attribute",
+    message: "Attribute updated",
+  },
+  {
+    timestamp: TIMESTAMP.getTime() - 60000,
+    level: "ERROR",
+    category: "AGENT",
+    subCategory: "Protocol",
+    message: "Connection refused",
+  },
+];
+
+/** Serves static events so the viewer renders without a manager REST connection. */
+export class OrLogViewerTest extends OrLogViewer {
+  constructor() {
+    super();
+    this.timestamp = TIMESTAMP;
+  }
+
+  _loadData() {
+    this._data = EVENTS;
+  }
+}
+customElements.define("or-log-viewer-test", OrLogViewerTest);

--- a/ui/component/or-log-viewer/test/or-log-viewer.test.ts
+++ b/ui/component/or-log-viewer/test/or-log-viewer.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { ct, expect } from "@openremote/test";
+
+import { OrLogViewerTest } from "./fixtures/or-log-viewer-test.js";
+
+const NOW = new Date(2026, 0, 15, 8, 0, 0);
+const step = (icon: string) => `#ending-controls or-vaadin-button:has(or-icon[icon="${icon}"])`;
+
+ct.beforeEach(async ({ page, shared }) => {
+  await page.clock.setFixedTime(NOW);
+  await shared.locales();
+  await shared.fonts();
+});
+
+ct("should show the timestamp the logs end at", async ({ mount }) => {
+  const component = await mount(OrLogViewerTest);
+
+  await expect(component.locator("#ending-date")).toHaveAttribute("value", "2026-01-15T10:30");
+});
+
+ct("should step the ending timestamp by the selected period", async ({ mount }) => {
+  const component = await mount(OrLogViewerTest);
+  const endingDate = component.locator("#ending-date");
+
+  await component.locator(step("chevron-right")).click();
+  // The forward step used to be swallowed by the preceding attribute, leaving the button without a
+  // click handler and shifting every binding after it onto the wrong part of the template
+  await expect(endingDate).toHaveAttribute("value", "2026-01-15T11:30");
+
+  await component.locator(step("chevron-left")).click();
+  await expect(endingDate).toHaveAttribute("value", "2026-01-15T10:30");
+});
+
+ct("should return the ending timestamp to the current time", async ({ mount }) => {
+  const component = await mount(OrLogViewerTest);
+
+  await component.locator(step("chevron-double-right")).click();
+
+  await expect(component.locator("#ending-date")).toHaveAttribute("value", "2026-01-15T08:00");
+});
+
+ct("should list the returned log events", async ({ mount }) => {
+  const component = await mount(OrLogViewerTest);
+  const rows = component.getByRole("table", { name: "logs list" }).getByRole("row");
+
+  await expect(rows).toHaveCount(3); // header + 2 events
+  await expect(rows.nth(1)).toContainText("Attribute updated");
+  await expect(rows.nth(2)).toContainText("Connection refused");
+});


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description

<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Spotless reformatted `?disabled=${...}@click=${...}` (missing space) into a
quoted attribute plus a dangling `=${...}`, which lit could not bind as an
attribute. That shifted every following binding onto the wrong part and
rendered a click handler's source as text on the logs page.

Also add the missing side-effect imports for the Vaadin components the
viewer renders, and component tests covering the ending controls.

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
