### PR TITLE
Dont wrap asset-tree menu items

### DIFF
--- a/ui/component/or-asset-tree/src/style.ts
+++ b/ui/component/or-asset-tree/src/style.ts
@@ -251,6 +251,7 @@ export const style = css`
 
   .node-name-noCheck {
     vertical-align: middle;
+    text-wrap: nowrap;
   }
 
   .node-name > or-icon {


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description

<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Broke due to the changes to the asset tree in https://github.com/openremote/openremote/pull/2673, exact commit: https://github.com/openremote/openremote/commit/46d64a46ba25cd87950b0d9d82830d2facc4fbd5.

Exact cause

```patch
    .node-name {
+       width: 100%;
        margin: -4px 0;
        flex: 1 0 auto;
        display: flex;
        align-items: center;
    }
```

The nowrap that was added to the withCheck class may also be added to the noCheck class. We prefer menu items to overflow in the tree rather than wrapping.

```patch
-    .node-name > span {
+    .node-name-withCheck {
+        flex: 1 1 auto;
+        white-space: nowrap;
+        overflow: hidden;
+        margin-right: 4px;
+        text-overflow: ellipsis;
+        vertical-align: middle;
+    }
+
+    .node-name-noCheck {
         vertical-align: middle;
     }
```

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
