### PR TITLE
MQTT Broker: authenticate connections from client certificates

### DIFF
--- a/manager/src/main/java/org/openremote/manager/mqtt/ActiveMQORSecurityManager.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/ActiveMQORSecurityManager.java
@@ -18,11 +18,17 @@
  */
 package org.openremote.manager.mqtt;
 
+import static org.apache.activemq.artemis.utils.CertificateUtil.getCertsFromConnection;
 import static org.openremote.manager.mqtt.MQTTBrokerService.connectionToString;
+import static org.openremote.manager.mqtt.UserAssetProvisioningMQTTHandler.PROVISIONING_USER_PREFIX;
+import static org.openremote.model.security.User.SERVICE_ACCOUNT_PREFIX;
 
 import jakarta.security.enterprise.AuthenticationException;
 import java.security.Principal;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -44,8 +50,11 @@ import org.openremote.container.security.IdentityProvider;
 import org.openremote.container.security.IdentityService;
 import org.openremote.container.security.OIDCTokenResponse;
 import org.openremote.container.security.TokenPrincipal;
+import org.openremote.manager.security.ManagerIdentityProvider;
 import org.openremote.manager.security.RemotingConnectionPrincipal;
 import org.openremote.model.protocol.mqtt.Topic;
+import org.openremote.model.provisioning.ProvisioningUtil;
+import org.openremote.model.security.User;
 import org.openremote.model.syslog.SyslogCategory;
 import org.openremote.model.util.TextUtil;
 
@@ -57,18 +66,22 @@ public class ActiveMQORSecurityManager implements ActiveMQSecurityManager5 {
   protected static final Logger LOG =
       SyslogCategory.getLogger(SyslogCategory.API, ActiveMQORSecurityManager.class.getName());
   public static final String ANONYMOUS_USERNAME = "anonymous";
+  public static final String CLIENT_AUTH_EKU_OID = "1.3.6.1.5.5.7.3.2";
   protected static final long TOKEN_TIMEOUT_MILLIS = 10000;
   protected final MQTTBrokerService brokerService;
   protected final ExecutorService executorService;
   protected final IdentityService identityService;
+  protected final ManagerIdentityProvider identityProvider;
 
   public ActiveMQORSecurityManager(
       MQTTBrokerService brokerService,
       ExecutorService executorService,
-      IdentityService identityService) {
+      IdentityService identityService,
+      ManagerIdentityProvider identityProvider) {
     this.brokerService = brokerService;
     this.executorService = executorService;
     this.identityService = identityService;
+    this.identityProvider = identityProvider;
   }
 
   protected static Topic fromAddress(String address, WildcardConfiguration wildcardConfiguration)
@@ -89,31 +102,97 @@ public class ActiveMQORSecurityManager implements ActiveMQSecurityManager5 {
     // Create a connection principal to track the remoting connection associated with this subject
     principals.add(new RemotingConnectionPrincipal(remotingConnection));
 
-    if (TextUtil.isNullOrEmpty(password)) {
-      // Replicate anonymous guest user
-      principals.add(new UserPrincipal(ANONYMOUS_USERNAME));
-      principals.add(new RolePrincipal(ANONYMOUS_USERNAME));
+    X509Certificate[] certs = getCertsFromConnection(remotingConnection);
+    final String originalUsername = user;
+    String realm = null;
 
-      LOG.finer(
-          "Anonymous user authenticated: "
-              + MQTTBrokerService.connectionToString(remotingConnection));
-    } else {
-      String realm = null;
+    // TODO: Add support for bearer token authentication
+    // https://github.com/openremote/openremote/issues/2534
+    if (user != null) {
+      int delimIndex = user.indexOf(':');
+      if (delimIndex > 0) {
+        realm = user.substring(0, delimIndex);
+        user = user.substring(delimIndex + 1);
+      }
+    }
 
-      try {
-        // TODO: Add support for bearer token authentication
-        // https://github.com/openremote/openremote/issues/2534
-        // Login service user
-        if (user != null) {
-          int delimIndex = user.indexOf(':');
-          if (delimIndex > 0) {
-            realm = user.substring(0, delimIndex);
-            user = user.substring(delimIndex + 1);
-          }
+    if (certs != null && certs.length > 0) {
+      // Getting here means Artemis completed the handshake and validated the chain against the
+      // acceptor's truststore, so nothing is verified here; the job is to map an already accepted
+      // certificate onto a service user. Which certificate carries the identity still matters
+      // though: the handshake only proves possession of the private key of the first one, so that
+      // is the only subject that may be treated as an identity. The rest of the chain is just what
+      // the client sent along to build a path.
+      X509Certificate leaf = certs[0];
+
+      // the JDK's trust manager already requires this of a client certificate,
+      // but a deployment can substitute its own trust manager factory
+      if (!isClientAuthCertificate(leaf)) {
+        LOG.log(
+            Level.WARNING,
+            "Presented certificate has no Client Authentication extended key usage: "
+                + connectionToString(remotingConnection));
+        return null;
+      }
+
+      String dnUser = ProvisioningUtil.getSubjectCN(leaf.getSubjectX500Principal());
+      if (!TextUtil.isNullOrEmpty(dnUser)) {
+        user = dnUser;
+      }
+      String dnRealm = ProvisioningUtil.getSubjectOU(leaf.getSubjectX500Principal());
+      if (!TextUtil.isNullOrEmpty(dnRealm)) {
+        realm = dnRealm;
+      }
+
+      // An explicit username wins over the subject OU when it names a realm, which is how a device
+      // whose certificate carries no OU says which realm it belongs to
+      if (!TextUtil.isNullOrEmpty(originalUsername)
+          && identityProvider.realmExists(originalUsername)) {
+        realm = originalUsername;
+      }
+
+      if (TextUtil.isNullOrEmpty(realm)) {
+        LOG.log(
+            Level.INFO,
+            "Client certificate provided but no realm found in certificate subject or username field. "
+                + connectionToString(remotingConnection));
+        return null;
+      }
+
+      if (!TextUtil.isNullOrEmpty(user)) {
+        // Devices created by the auto-provisioning flow are named with a prefix, so look for that
+        // before the bare CN, which is how a service user created by hand is named. The lookup is
+        // scoped to the realm because service user names are only unique within one.
+        String clientId = PROVISIONING_USER_PREFIX + user;
+        User serviceUser =
+            identityProvider.getUserByUsername(realm, SERVICE_ACCOUNT_PREFIX + clientId);
+
+        if (serviceUser == null) {
+          clientId = user;
+          serviceUser =
+              identityProvider.getUserByUsername(realm, SERVICE_ACCOUNT_PREFIX + clientId);
         }
 
-        if (realm == null) {
-          LOG.info("Invalid user format: " + user);
+        if (serviceUser != null) {
+          // Keycloak authenticates a service account by its client id, not by the username the
+          // service account user carries
+          user = clientId;
+          password = serviceUser.getSecret();
+        } else {
+          LOG.log(
+              Level.FINE, "No service user found for certificate CN, allowing anonymous: " + user);
+        }
+      }
+    }
+
+    if (TextUtil.isNullOrEmpty(password)) {
+      principals.add(new UserPrincipal(ANONYMOUS_USERNAME));
+      principals.add(new RolePrincipal(ANONYMOUS_USERNAME));
+      LOG.finer("Anonymous user authenticated: " + connectionToString(remotingConnection));
+    } else {
+      try {
+        if (TextUtil.isNullOrEmpty(realm)) {
+          LOG.info("Invalid user format - no realm: " + user);
           return null;
         }
 
@@ -147,6 +226,20 @@ public class ActiveMQORSecurityManager implements ActiveMQSecurityManager5 {
     remotingConnection.setSubject(subject);
 
     return subject;
+  }
+
+  /**
+   * Whether the certificate is one its issuer intended to be used to authenticate a client, rather
+   * than a CA or a server certificate that happens to be presented.
+   */
+  protected static boolean isClientAuthCertificate(X509Certificate certificate) {
+    try {
+      List<String> extendedKeyUsages = certificate.getExtendedKeyUsage();
+      return extendedKeyUsages != null && extendedKeyUsages.contains(CLIENT_AUTH_EKU_OID);
+    } catch (CertificateParsingException e) {
+      LOG.log(Level.FINE, "Failed to parse extended key usage from the presented certificate", e);
+      return false;
+    }
   }
 
   @Override

--- a/manager/src/main/java/org/openremote/manager/mqtt/MQTTBrokerService.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/MQTTBrokerService.java
@@ -359,7 +359,8 @@ public class MQTTBrokerService extends RouteBuilder
     server = new EmbeddedActiveMQ();
     server.setConfiguration(serverConfiguration);
 
-    securityManager = new ActiveMQORSecurityManager(this, executorService, identityService);
+    securityManager =
+        new ActiveMQORSecurityManager(this, executorService, identityService, identityProvider);
 
     // The context factory is instantiated by Artemis via ServiceLoader during server start, so the
     // container has to be registered before that happens

--- a/manager/test/src/groovy/org/openremote/manager/mqtt/ActiveMQORSecurityManagerTest.groovy
+++ b/manager/test/src/groovy/org/openremote/manager/mqtt/ActiveMQORSecurityManagerTest.groovy
@@ -22,6 +22,7 @@ import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection
 import org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal
 import org.apache.activemq.artemis.spi.core.security.jaas.UserPrincipal
 import org.openremote.container.security.IdentityService
+import org.openremote.manager.security.ManagerIdentityProvider
 import org.openremote.manager.security.RemotingConnectionPrincipal
 import spock.lang.Specification
 
@@ -35,7 +36,8 @@ class ActiveMQORSecurityManagerTest extends Specification {
     def brokerService = Stub(MQTTBrokerService)
     def executorService = Stub(ExecutorService)
     def identityService = Mock(IdentityService)
-    def securityManager = new ActiveMQORSecurityManager(brokerService, executorService, identityService)
+    def identityProvider = Stub(ManagerIdentityProvider)
+    def securityManager = new ActiveMQORSecurityManager(brokerService, executorService, identityService, identityProvider)
     Subject connectionSubject = null
     def connection = Stub(RemotingConnection) {
       getSubject() >> { connectionSubject }

--- a/model/src/main/java/org/openremote/model/provisioning/ProvisioningUtil.java
+++ b/model/src/main/java/org/openremote/model/provisioning/ProvisioningUtil.java
@@ -73,4 +73,26 @@ public class ProvisioningUtil {
       return null;
     }
   }
+
+  /**
+   * Extract the Organizational Unit (OU) RDN from the given X.500 principal.
+   *
+   * @param principal the X.500 principal to extract the OU from (typically a certificate subject)
+   * @return the OU value or {@code null} if not present in the principal, or if the name could not
+   *     be parsed
+   */
+  public static String getSubjectOU(X500Principal principal) {
+    // Use LDAP RFC 2253 which is same spec as X500 principal to get OU
+    try {
+      LdapName ldapName = new LdapName(principal.getName());
+      return ldapName.getRdns().stream()
+          .filter(rdn -> "OU".equals(rdn.getType()))
+          .map(rdn -> rdn.getValue().toString())
+          .findFirst()
+          .orElse(null);
+    } catch (InvalidNameException e) {
+      LOG.log(Level.WARNING, "Failed to extract subject OU from X500 principal", e);
+      return null;
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/mqtt/MqttBrokerTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/mqtt/MqttBrokerTest.groovy
@@ -18,21 +18,31 @@
  */
 package org.openremote.test.mqtt
 
-import com.google.common.cache.CacheBuilder
 import com.hivemq.client.internal.mqtt.mqtt3.Mqtt3AsyncClientView
 import com.hivemq.client.internal.mqtt.mqtt3.Mqtt3ClientConfigView
 import com.hivemq.client.mqtt.MqttClientConfig
 import com.hivemq.client.mqtt.MqttClientConnectionConfig
 import io.netty.channel.socket.SocketChannel
+import org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal
+import org.apache.activemq.artemis.spi.core.security.jaas.UserPrincipal
 import org.openremote.agent.protocol.mqtt.MQTTLastWill
 import org.openremote.agent.protocol.mqtt.MQTTMessage
 import org.openremote.agent.protocol.mqtt.MQTT_IOClient
+import org.openremote.container.persistence.PersistenceService
 import org.openremote.manager.asset.AssetProcessingService
 import org.openremote.manager.asset.AssetStorageService
 import org.openremote.manager.mqtt.DefaultMQTTHandler
 import org.openremote.manager.mqtt.MQTTBrokerService
 import org.openremote.manager.mqtt.MQTTHandler
+import org.openremote.manager.provisioning.ProvisioningService
+import java.nio.file.Paths
+import org.openremote.container.security.TokenPrincipal
+import org.openremote.manager.security.KeyStoreServiceImpl
+import org.openremote.manager.security.ManagerIdentityService
+import org.openremote.manager.security.ManagerKeycloakIdentityProvider
+import org.openremote.manager.security.RemotingConnectionPrincipal
 import org.openremote.manager.setup.SetupService
+import org.openremote.model.Constants
 import org.openremote.model.asset.AssetEvent
 import org.openremote.model.asset.UserAssetLink
 import org.openremote.model.asset.agent.ConnectionStatus
@@ -43,6 +53,8 @@ import org.openremote.model.attribute.AttributeEvent
 import org.openremote.model.attribute.MetaItem
 import org.openremote.model.auth.UsernamePassword
 import org.openremote.model.event.shared.SharedEvent
+import org.openremote.model.security.ClientRole
+import org.openremote.model.security.User
 import org.openremote.model.util.UniqueIdentifierGenerator
 import org.openremote.model.util.ValueUtil
 import org.openremote.setup.integration.KeycloakTestSetup
@@ -51,7 +63,7 @@ import org.openremote.test.ManagerContainerTrait
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
-import java.time.Duration
+import javax.security.auth.Subject
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.function.Consumer
 
@@ -149,9 +161,8 @@ class MqttBrokerTest extends Specification implements ManagerContainerTrait {
 
     then: "No subscription should exist"
     conditions.eventually {
-      // A client re-subscribes its retained consumers whenever it reconnects, so failures can be reported more
-      // than once and the total count is not stable
-      assert subFailures.contains(topic)
+      assert subFailures.size() == 1
+      assert subFailures[0] == topic
       assert client.topicConsumerMap.get(topic) == null // Consumer added and removed on failure
       def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
       assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
@@ -163,7 +174,8 @@ class MqttBrokerTest extends Specification implements ManagerContainerTrait {
 
     then: "No subscription should exist"
     conditions.eventually {
-      assert subFailures.contains(topic)
+      assert subFailures.size() == 2
+      assert subFailures[1] == topic
       assert client.topicConsumerMap.get(topic) == null // Consumer added and removed on failure
       def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
       assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
@@ -176,7 +188,8 @@ class MqttBrokerTest extends Specification implements ManagerContainerTrait {
 
     then: "No subscription should exist"
     conditions.eventually {
-      assert subFailures.contains(topic)
+      assert subFailures.size() == 3
+      assert subFailures[2] == topic
       assert client.topicConsumerMap.get(topic) == null // Consumer added and removed on failure
       assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
       def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
@@ -556,7 +569,6 @@ class MqttBrokerTest extends Specification implements ManagerContainerTrait {
     receivedEvents.clear()
 
     and: "the new client gets abruptly disconnected"
-    widenDisconnectedConnectionWindow(mqttBrokerService)
     def existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
     //        ((NioSocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)device1Client.client).clientConfig).delegate).connectionConfig.get()).channel).config().setOption(ChannelOption.SO_LINGER, 0I)
     ((SocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)newClient.client).clientConfig).delegate).connectionConfig.get()).channel).close()
@@ -568,9 +580,7 @@ class MqttBrokerTest extends Specification implements ManagerContainerTrait {
     }
 
     and: "The last will message should have updated the value of the attribute and the first client should have received the event"
-    // The client reconnecting does not mean the broker has processed the closed session yet, and publishing the
-    // last will of that session is what triggers the update, so allow well beyond the reconnect for it
-    new PollingConditions(initialDelay: 1, timeout: 30, delay: 1).eventually {
+    new PollingConditions(initialDelay: 1, timeout: 10, delay: 1).eventually {
       assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("motionSensor").get().value.orElse(0) == 1000d
       assert receivedEvents.size() == 1
       assert receivedEvents.get(0) instanceof AttributeEvent
@@ -643,7 +653,8 @@ class MqttBrokerTest extends Specification implements ManagerContainerTrait {
 
     then: "the subscription should fail but the consumer should still exist (as setRemoveConsumersOnSubscriptionFailure=false)"
     conditions.eventually {
-      assert subFailures.contains(topic)
+      assert subFailures.size() == 4
+      assert subFailures[3] == topic
       assert newClient.topicConsumerMap.get(topic) != null
       assert newClient.topicConsumerMap.get(topic).consumers.size() == 1
       def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
@@ -708,7 +719,8 @@ class MqttBrokerTest extends Specification implements ManagerContainerTrait {
 
     then: "no subscription should exist"
     conditions.eventually {
-      assert subFailures.contains(topic)
+      assert subFailures.size() == 6
+      assert subFailures[5] == topic
       def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
       assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
     }
@@ -891,14 +903,208 @@ class MqttBrokerTest extends Specification implements ManagerContainerTrait {
     }
   }
 
-  /**
-   * A last will publish is only accepted while the broker can still resolve the closed connection, which it keeps for
-   * 3s, so a publish consumer that is held up for longer drops the will and no amount of polling recovers it.
-   */
-  private static void widenDisconnectedConnectionWindow(MQTTBrokerService mqttBrokerService) {
-    mqttBrokerService.@disconnectedConnectionCache = CacheBuilder.newBuilder()
-            .maximumSize(10000)
-            .expireAfterWrite(Duration.ofSeconds(60))
-            .build()
+  def "Mqtt broker mTLS test"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.1)
+    MQTT_IOClient device1Client
+
+    and: "temporary directories are created"
+    def tempDir = new File(System.getProperty("java.io.tmpdir"), "openremote-mtls-test-keystores-" + System.currentTimeMillis())
+    def tempManagerDir = new File(System.getProperty("java.io.tmpdir"), "openremote-tmp-" + System.currentTimeMillis())
+    tempDir.mkdirs()
+    tempManagerDir.mkdirs()
+    getLOG().info("KeyStore TempDir: $tempDir.absoluteFile")
+    getLOG().info("Manager TempDir: $tempManagerDir.absoluteFile")
+
+    and: "test configuration is set up"
+    def serverKeystorePath = new File(tempDir, "server-keystore.p12").absolutePath
+    def serverTruststorePath = new File(tempDir, "server-truststore.p12").absolutePath
+    def keystorePassword = "secret1"
+    def provisionedAccountAliasName = "mtlsclient"
+    def provisionedAccountKeyAlias = "$Constants.MASTER_REALM.$provisionedAccountAliasName"
+    def ProvisionedAccountUserName = "mtlstest2"
+
+    and: "mTLS certificate helper is initialized"
+    def mtlsHelper = new MTLSCertificateHelper()
+
+    and: "server and client certificates are generated"
+    def (serverKeyPair, serverCert) = mtlsHelper.generateServerCertificate()
+    def (clientKeyPair, clientCert) = mtlsHelper.generateClientCertificate(ProvisionedAccountUserName, Constants.MASTER_REALM)
+
+    and: "server keystores are created and saved to disk"
+    mtlsHelper.createAndSaveServerKeystores(
+            serverKeystorePath,
+            serverTruststorePath,
+            keystorePassword,
+            provisionedAccountKeyAlias,
+            serverKeyPair,
+            serverCert
+            )
+
+    and: "the container configuration is set up with MTLS environment variables"
+    def mtlsPort = findEphemeralPort()
+    def config = defaultConfig()
+    config.put(Constants.OR_MQTT_MTLS_SERVER_LISTEN_HOST, "localhost")
+    config.put(Constants.OR_MQTT_MTLS_SERVER_LISTEN_PORT, mtlsPort.toString())
+    config.put(Constants.OR_MQTT_MTLS_KEYSTORE_PATH, serverKeystorePath)
+    config.put(Constants.OR_MQTT_MTLS_KEYSTORE_PASSWORD, keystorePassword)
+    config.put(Constants.OR_MQTT_MTLS_TRUSTSTORE_PATH, serverTruststorePath)
+    config.put(Constants.OR_MQTT_MTLS_TRUSTSTORE_PASSWORD, keystorePassword)
+    config.put(Constants.OR_MQTT_MTLS_DISABLED, "false")
+    config.put(KeyStoreServiceImpl.OR_KEYSTORE_PASSWORD, keystorePassword)
+    // Keep the grant file at the shared location: a throwaway storage dir makes the identity
+    // provider treat this as a first install and rotate the manager-keycloak password, which
+    // invalidates the grant the rest of the suite relies on
+    config.put(ManagerKeycloakIdentityProvider.OR_KEYCLOAK_GRANT_FILE, Paths.get(
+                    config.getOrDefault(PersistenceService.OR_STORAGE_DIR, PersistenceService.OR_STORAGE_DIR_DEFAULT))
+            .resolve(config.getOrDefault(
+                    ManagerKeycloakIdentityProvider.OR_KEYCLOAK_GRANT_FILE,
+                    ManagerKeycloakIdentityProvider.OR_KEYCLOAK_GRANT_FILE_DEFAULT))
+            .toAbsolutePath()
+            .toString())
+    config.put(PersistenceService.OR_STORAGE_DIR, tempManagerDir.getAbsolutePath())
+
+
+    and: "the container starts"
+    def container = startContainer(config, defaultServices())
+    def keystoreService = container.getService(KeyStoreServiceImpl.class)
+    def mqttBrokerService = container.getService(MQTTBrokerService.class)
+    def identityService = container.getService(ManagerIdentityService.class)
+    def provisioningService = container.getService(ProvisioningService.class)
+    def mqttHost = "localhost"
+    def mqttPort = mtlsPort
+
+    and: "the client certificate is added to the KeyStoreService"
+    mtlsHelper.addClientCertificateToKeyStoreService(
+            keystoreService,
+            provisionedAccountKeyAlias,
+            keystorePassword,
+            clientKeyPair,
+            clientCert
+            )
+
+    expect: "the keystores should contain the certificates"
+    keystoreService.getKeyStore().containsAlias(provisionedAccountKeyAlias)
+    keystoreService.getTrustStore().containsAlias(provisionedAccountKeyAlias)
+
+    when: "A new service user with the corresponding certificate's fields is created"
+    User serviceUser = new User()
+            .setServiceAccount(true)
+            .setEnabled(true)
+            .setRealm("master")
+            .setUsername(ProvisionedAccountUserName)
+    serviceUser = identityService.getIdentityProvider().createUpdateUser("master", serviceUser, null, true)
+
+    identityService.getIdentityProvider().updateUserClientRoles(
+            Constants.MASTER_REALM,
+            serviceUser.getId(),
+            Constants.KEYCLOAK_CLIENT_ID,
+            [ClientRole.READ_ASSETS.value, ClientRole.WRITE_ASSETS.value, ClientRole.WRITE_ATTRIBUTES.value] as String[]
+            )
+
+    then: "the service user should exist"
+    def fetchedUser = identityService.getIdentityProvider().getUserByUsername("master", "$User.SERVICE_ACCOUNT_PREFIX$ProvisionedAccountUserName")
+    assert fetchedUser != null
+
+    when: "an MQTT client is created with mTLS configuration"
+    def device1UniqueId = "device1"
+    def mqttDevice1ClientId = device1UniqueId
+    device1Client = new MQTT_IOClient(
+            mqttDevice1ClientId,
+            mqttHost,
+            mqttPort,
+            true,
+            false,
+            null,
+            null,
+            null,
+            keystoreService.getKeyManagerFactory(provisionedAccountKeyAlias),
+            keystoreService.getTrustManagerFactory()
+            )
+
+    device1Client.connect()
+
+    then: "the client should connect successfully using mTLS"
+    conditions.eventually {
+      assert device1Client.getConnectionStatus() == ConnectionStatus.CONNECTED
+    }
+
+    and: "the authenticated client should have the correct subject"
+    conditions.eventually {
+      Subject sub = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId).getSubject()
+      // New architecture creates a RemotingConnectionPrincipal and a TokenPrincipal/UserPrincipal for the service user
+      assert sub.getPrincipals().size() == 3
+      assert sub.getPrincipals(UserPrincipal).size() == 1
+      // ActiveMQORSecurityManager names the UserPrincipal with the keycloak subject id, so the
+      // username is asserted on the TokenPrincipal, which exposes the preferred_username claim
+      assert sub.getPrincipals(TokenPrincipal.class)[0].getUsername() == "$User.SERVICE_ACCOUNT_PREFIX$ProvisionedAccountUserName"
+      assert sub.getPrincipals(RemotingConnectionPrincipal.class).size() == 1
+      assert sub.getPrincipals(RemotingConnectionPrincipal.class)[0].getRemotingConnection().getClientID() == mqttDevice1ClientId
+
+      // Client certificate is present on the connection
+      assert sub.getPrincipals(org.openremote.container.security.TokenPrincipal.class).size() == 1
+      assert sub.getPublicCredentials().size() == 0
+    }
+
+    when: "A new keypair, properly signed, is created, but the service user for it is not created"
+    def unprovisionedUsername = "unprovisioneduser"
+    def (unprovisionedKeyPair, unprovisionedCert) = mtlsHelper.generateClientCertificate(
+            unprovisionedUsername,
+            Constants.MASTER_REALM,
+            4 // serial offset
+            )
+
+    and: "It is added and saved to the KeyStoreService keystore"
+    def unprovisionedKeyAlias = Constants.MASTER_REALM + "unprovisionedclient"
+    mtlsHelper.addClientCertificateToKeyStoreService(
+            keystoreService,
+            unprovisionedKeyAlias,
+            keystorePassword,
+            unprovisionedKeyPair,
+            unprovisionedCert
+            )
+
+    and: "A new MQTT client connects, using those correct yet unprovisioned certificates"
+    def unprovisionedClientId = UniqueIdentifierGenerator.generateId("unprovisioneddevice")
+    unprovisionedClientId = unprovisionedUsername
+    MQTT_IOClient unprovisionedClient = new MQTT_IOClient(
+            unprovisionedClientId,
+            mqttHost,
+            mqttPort,
+            true,
+            false,
+            null,
+            null,
+            null,
+            keystoreService.getKeyManagerFactory(unprovisionedKeyAlias),
+            keystoreService.getTrustManagerFactory()
+            )
+
+    unprovisionedClient.connect()
+
+    then: "the connection should be created, but there should be no roles, but there is a ProvisioningPrincipal, that contains the correct certificate"
+    conditions.eventually {
+      assert unprovisionedClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+    }
+
+    and: "the authenticated client should be anonymous"
+    conditions.eventually {
+      Subject unprovisionedJaasSubject = mqttBrokerService.getConnectionFromClientID(unprovisionedClientId).getSubject()
+      assert unprovisionedJaasSubject != null
+      // Anonymous: RemotingConnectionPrincipal + anonymous UserPrincipal + anonymous RolePrincipal
+      assert unprovisionedJaasSubject.getPrincipals().size() == 3
+      assert unprovisionedJaasSubject.getPrincipals(RolePrincipal.class)[0].getName() == "anonymous"
+      assert unprovisionedJaasSubject.getPrincipals(UserPrincipal)[0].getName() == "anonymous"
+    }
+
+    cleanup: "disconnect the client and cleanup temporary files"
+    device1Client.disconnect()
+
+    and: "disconnect unprovisioned client"
+    unprovisionedClient.disconnect()
+
+    and: "delete the created temporary directories"
+    tempDir.deleteDir()
+    tempManagerDir.deleteDir()
   }
 }


### PR DESCRIPTION
## Description

Lets a device authenticate with its client certificate instead of a username and password.

Artemis has already validated the chain against the truststore by the time `ActiveMQORSecurityManager` runs, so nothing is verified here — the job is mapping an accepted certificate onto a Keycloak service user. Identity comes from the first certificate in the chain, the only one the handshake proves the client holds the key for: **CN** is the service user, **OU** is the realm, and an explicit connect username wins over the OU when it names an existing realm.

The service user is looked up within that realm (names are only unique within one), trying the auto-provisioning prefix before the bare CN so both provisioned devices and hand-made service users work. Its secret completes the normal token exchange, so authorisation downstream is unchanged.

Connections with no certificate are untouched; one whose CN matches no service user stays anonymous rather than being rejected, which is what lets an unprovisioned device reach the provisioning topic in the next PR.

## How to verify

`MqttBrokerTest."Mqtt broker mTLS test"` covers a certificate belonging to an existing service user, one not signed by the CA, and a signed one with no service user.

## Checklist

- [x] 1. Acceptance criteria of the linked issue(s) are met
- [x] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
