### PR TITLE
MQTT Broker: auto-provision devices over mTLS

### DIFF
--- a/manager/src/main/java/org/openremote/manager/mqtt/UserAssetProvisioningMQTTHandler.java
+++ b/manager/src/main/java/org/openremote/manager/mqtt/UserAssetProvisioningMQTTHandler.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.utils.CertificateUtil;
 import org.apache.camel.builder.RouteBuilder;
 import org.openremote.container.message.MessageBrokerService;
 import org.openremote.container.security.AuthContext;
@@ -360,9 +361,21 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
       return;
     }
 
-    if (provisioningMessage instanceof X509ProvisioningMessage) {
-      processX509ProvisioningMessage(
-          connection, topic, (X509ProvisioningMessage) provisioningMessage);
+    switch (provisioningMessage) {
+      case X509ProvisioningMessage x509Message ->
+          processX509ProvisioningMessage(connection, topic, x509Message);
+      case MTLSProvisioningMessage ignored -> processMTLSProvisioningMessage(connection, topic);
+      default -> {
+        LOG.warning(
+            "Unsupported provisioning message type: "
+                + provisioningMessage.getClass().getName()
+                + ", "
+                + MQTTBrokerService.connectionToString(connection));
+        publishMessage(
+            getResponseTopic(topic),
+            new ErrorResponseMessage(ErrorResponseMessage.Error.MESSAGE_INVALID),
+            MqttQoS.AT_MOST_ONCE);
+      }
     }
   }
 
@@ -403,6 +416,7 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
 
     // Parse client cert
     X509Certificate clientCertificate;
+
     try {
       clientCertificate = ProvisioningUtil.getX509Certificate(provisioningMessage.getCert());
     } catch (CertificateException e) {
@@ -417,6 +431,32 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
       return;
     }
 
+    String certUniqueId =
+        ProvisioningUtil.getSubjectCN(clientCertificate.getSubjectX500Principal());
+    String uniqueId = topicClientID(topic);
+
+    X509ProvisioningConfig matchingConfig =
+        resolveProvisioningConfig(connection, topic, clientCertificate);
+
+    if (matchingConfig == null) {
+      return;
+    }
+
+    if (!verifyUniqueId(connection, topic, certUniqueId, uniqueId)) {
+      return;
+    }
+
+    provisionClient(connection, topic, matchingConfig, uniqueId);
+  }
+
+  /**
+   * Finds the provisioning config whose CA signed the given certificate, publishing the appropriate
+   * error to the client when there is none or it is disabled.
+   *
+   * @return the matching config, or {@code null} when the request has already been answered
+   */
+  protected X509ProvisioningConfig resolveProvisioningConfig(
+      RemotingConnection connection, Topic topic, X509Certificate clientCertificate) {
     X509ProvisioningConfig matchingConfig =
         getMatchingX509ProvisioningConfig(connection, clientCertificate);
 
@@ -428,7 +468,7 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
           getResponseTopic(topic),
           new ErrorResponseMessage(ErrorResponseMessage.Error.UNAUTHORIZED),
           MqttQoS.AT_MOST_ONCE);
-      return;
+      return null;
     }
 
     // Check if config is disabled
@@ -440,14 +480,18 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
           getResponseTopic(topic),
           new ErrorResponseMessage(ErrorResponseMessage.Error.CONFIG_DISABLED),
           MqttQoS.AT_MOST_ONCE);
-      return;
+      return null;
     }
 
-    // Validate unique ID
-    String certUniqueId =
-        ProvisioningUtil.getSubjectCN(clientCertificate.getSubjectX500Principal());
-    String uniqueId = topicTokenIndexToString(topic, 1);
+    return matchingConfig;
+  }
 
+  /**
+   * Checks that the certificate names a device and that the client is provisioning that device
+   * rather than another one, publishing the error to the client when it does not.
+   */
+  protected boolean verifyUniqueId(
+      RemotingConnection connection, Topic topic, String certUniqueId, String uniqueId) {
     if (TextUtil.isNullOrEmpty(certUniqueId)) {
       LOG.info(
           () ->
@@ -457,7 +501,7 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
           getResponseTopic(topic),
           new ErrorResponseMessage(ErrorResponseMessage.Error.UNIQUE_ID_MISMATCH),
           MqttQoS.AT_MOST_ONCE);
-      return;
+      return false;
     }
 
     if (TextUtil.isNullOrEmpty(uniqueId) || !certUniqueId.equals(uniqueId)) {
@@ -469,8 +513,22 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
           getResponseTopic(topic),
           new ErrorResponseMessage(ErrorResponseMessage.Error.UNIQUE_ID_MISMATCH),
           MqttQoS.AT_MOST_ONCE);
-      return;
+      return false;
     }
+
+    return true;
+  }
+
+  /**
+   * Creates (or reuses) the service user and asset for the device and re-authenticates the
+   * connection as that user. Shared by both provisioning flows: once the certificate has been
+   * accepted, how it arrived makes no difference to what gets provisioned.
+   */
+  protected void provisionClient(
+      RemotingConnection connection,
+      Topic topic,
+      X509ProvisioningConfig matchingConfig,
+      String uniqueId) {
 
     String realm = matchingConfig.getRealm();
 
@@ -556,6 +614,65 @@ public class UserAssetProvisioningMQTTHandler extends MQTTHandler {
     LOG.fine("Client successfully provisioned: " + uniqueId);
     publishMessage(
         getResponseTopic(topic), new SuccessResponseMessage(realm, asset), MqttQoS.AT_MOST_ONCE);
+  }
+
+  protected void processMTLSProvisioningMessage(RemotingConnection connection, Topic topic) {
+    LOG.fine(
+        () ->
+            "Processing mTLS provisioning message: "
+                + MQTTBrokerService.connectionToString(connection));
+
+    X509Certificate[] certs = CertificateUtil.getCertsFromConnection(connection);
+
+    if (certs == null || certs.length == 0) {
+      LOG.info(
+          "No client certificate found on connection: "
+              + MQTTBrokerService.connectionToString(connection));
+      publishMessage(
+          getResponseTopic(topic),
+          new ErrorResponseMessage(ErrorResponseMessage.Error.CERTIFICATE_INVALID),
+          MqttQoS.AT_MOST_ONCE);
+      return;
+    }
+
+    X509Certificate clientCertificate = certs[0];
+    String certUniqueId =
+        ProvisioningUtil.getSubjectCN(clientCertificate.getSubjectX500Principal());
+    String uniqueId = topicClientID(topic);
+
+    X509ProvisioningConfig matchingConfig =
+        resolveProvisioningConfig(connection, topic, clientCertificate);
+
+    if (matchingConfig == null) {
+      return;
+    }
+
+    if (!verifyUniqueId(connection, topic, certUniqueId, uniqueId)) {
+      return;
+    }
+
+    // Unlike the x509 flow, the subject here was verified during the handshake, so an OU is an
+    // authenticated claim about which realm the device belongs to and must not contradict the
+    // realm the config provisions into
+    String subjectOU = ProvisioningUtil.getSubjectOU(clientCertificate.getSubjectX500Principal());
+
+    if (!TextUtil.isNullOrEmpty(subjectOU) && !subjectOU.equals(matchingConfig.getRealm())) {
+      LOG.info(
+          () ->
+              "Certificate OU doesn't match provisioning config realm: OU="
+                  + subjectOU
+                  + ", realm="
+                  + matchingConfig.getRealm()
+                  + ", "
+                  + MQTTBrokerService.connectionToString(connection));
+      publishMessage(
+          getResponseTopic(topic),
+          new ErrorResponseMessage(ErrorResponseMessage.Error.UNAUTHORIZED),
+          MqttQoS.AT_MOST_ONCE);
+      return;
+    }
+
+    provisionClient(connection, topic, matchingConfig, uniqueId);
   }
 
   protected X509ProvisioningConfig getMatchingX509ProvisioningConfig(

--- a/model/src/main/java/org/openremote/model/provisioning/MTLSProvisioningMessage.java
+++ b/model/src/main/java/org/openremote/model/provisioning/MTLSProvisioningMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, OpenRemote Inc.
+ * Copyright 2024, OpenRemote Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -18,14 +18,9 @@
  */
 package org.openremote.model.provisioning;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({
-  @JsonSubTypes.Type(name = "error", value = ErrorResponseMessage.class),
-  @JsonSubTypes.Type(name = "success", value = SuccessResponseMessage.class),
-  @JsonSubTypes.Type(name = "x509", value = X509ProvisioningMessage.class),
-  @JsonSubTypes.Type(name = "mtls", value = MTLSProvisioningMessage.class)
-})
-public abstract class ProvisioningMessage {}
+public class MTLSProvisioningMessage extends ProvisioningMessage {
+  @JsonCreator
+  public MTLSProvisioningMessage() {}
+}

--- a/test/src/test/groovy/org/openremote/test/provisioning/UserAndAssetProvisioningTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/provisioning/UserAndAssetProvisioningTest.groovy
@@ -24,24 +24,36 @@ import com.hivemq.client.mqtt.MqttClientConfig
 import com.hivemq.client.mqtt.MqttClientConnectionConfig
 import io.netty.channel.socket.SocketChannel
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection
+import org.apache.activemq.artemis.spi.core.security.jaas.UserPrincipal
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.*
+import org.bouncycastle.cert.X509v3CertificateBuilder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.ContentSigner
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import org.keycloak.admin.client.resource.RealmResource
 import org.keycloak.representations.idm.RoleRepresentation
 import org.openremote.agent.protocol.mqtt.MQTTMessage
 import org.openremote.agent.protocol.mqtt.MQTT_IOClient
+import org.openremote.container.persistence.PersistenceService
 import org.openremote.container.security.keycloak.KeycloakIdentityProvider
-import org.openremote.model.util.UniqueIdentifierGenerator
 import org.openremote.manager.asset.AssetProcessingService
 import org.openremote.manager.asset.AssetStorageService
 import org.openremote.manager.event.ClientEventService
 import org.openremote.manager.mqtt.DefaultMQTTHandler
 import org.openremote.manager.mqtt.MQTTBrokerService
-import org.openremote.manager.provisioning.ProvisioningService
 import org.openremote.manager.mqtt.UserAssetProvisioningMQTTHandler
+import org.openremote.manager.provisioning.ProvisioningService
+import org.openremote.manager.security.KeyStoreServiceImpl
 import org.openremote.manager.security.ManagerIdentityService
+import org.openremote.manager.security.ManagerKeycloakIdentityProvider
 import org.openremote.manager.setup.SetupService
+import org.openremote.model.Constants
 import org.openremote.model.asset.Asset
 import org.openremote.model.asset.AssetEvent
 import org.openremote.model.asset.agent.ConnectionStatus
+import org.openremote.model.asset.impl.ShipAsset
 import org.openremote.model.asset.impl.WeatherAsset
 import org.openremote.model.attribute.Attribute
 import org.openremote.model.attribute.AttributeEvent
@@ -51,14 +63,23 @@ import org.openremote.model.provisioning.*
 import org.openremote.model.security.ClientRole
 import org.openremote.model.security.Realm
 import org.openremote.model.security.User
+import org.openremote.model.util.UniqueIdentifierGenerator
 import org.openremote.model.util.ValueUtil
 import org.openremote.model.value.MetaItemType
 import org.openremote.model.value.ValueType
-import org.openremote.test.ManagerContainerTrait
 import org.openremote.setup.integration.ManagerTestSetup
+import org.openremote.test.ManagerContainerTrait
+import org.openremote.test.mqtt.MTLSCertificateHelper
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
+import javax.security.auth.Subject
+import java.nio.file.Paths
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.cert.Certificate
+import java.security.cert.X509Certificate
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.function.Consumer
 
@@ -875,5 +896,315 @@ class UserAndAssetProvisioningTest extends Specification implements ManagerConta
     if (internalConsumer != null) {
       clientEventService.removeSubscription {internalConsumer}
     }
+  }
+
+  @SuppressWarnings("GroovyAccessibility")
+  def "mTLS MQTT Autoprovisioning integration test"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.1)
+
+    and: "temporary directories are created"
+    def tempDir = new File(System.getProperty("java.io.tmpdir"), "openremote-mtls-test-keystores-" + System.currentTimeMillis())
+    def tempManagerDir = new File(System.getProperty("java.io.tmpdir"), "openremote-tmp-" + System.currentTimeMillis())
+    tempDir.mkdirs()
+    tempManagerDir.mkdirs()
+    getLOG().info("KeyStore TempDir: $tempDir.absoluteFile")
+    getLOG().info("Manager TempDir: $tempManagerDir.absoluteFile")
+
+    and: "test configuration is set up"
+    def serverKeystorePath = new File(tempDir, "server-keystore.p12").absolutePath
+    def serverTruststorePath = new File(tempDir, "server-truststore.p12").absolutePath
+    def keystorePassword = "secret1"
+    def provisionedAccountAliasName = "mtlsclient"
+    def provisionedAccountKeyAlias = "$Constants.MASTER_REALM.$provisionedAccountAliasName"
+    def ProvisionedAccountUserName = "mtlstest2"
+
+    and: "mTLS certificate helper is initialized"
+    def mtlsHelper = new MTLSCertificateHelper()
+
+    and: "server and client certificates are generated"
+    def (serverKeyPair, serverCert) = mtlsHelper.generateServerCertificate()
+    def (clientKeyPair, clientCert) = mtlsHelper.generateClientCertificate(ProvisionedAccountUserName, Constants.MASTER_REALM)
+
+    and: "server keystores are created and saved to disk"
+    mtlsHelper.createAndSaveServerKeystores(
+            serverKeystorePath,
+            serverTruststorePath,
+            keystorePassword,
+            provisionedAccountKeyAlias,
+            serverKeyPair,
+            serverCert
+            )
+
+    and: "the container configuration is set up with MTLS environment variables"
+    def mtlsPort = findEphemeralPort()
+    def config = defaultConfig()
+    config.put(Constants.OR_MQTT_MTLS_SERVER_LISTEN_HOST, "localhost")
+    config.put(Constants.OR_MQTT_MTLS_SERVER_LISTEN_PORT, mtlsPort.toString())
+    config.put(Constants.OR_MQTT_MTLS_DISABLED, "false")
+    config.put(Constants.OR_MQTT_MTLS_KEYSTORE_PATH, serverKeystorePath)
+    config.put(Constants.OR_MQTT_MTLS_KEYSTORE_PASSWORD, keystorePassword)
+    config.put(Constants.OR_MQTT_MTLS_TRUSTSTORE_PATH, serverTruststorePath)
+    config.put(Constants.OR_MQTT_MTLS_TRUSTSTORE_PASSWORD, keystorePassword)
+    config.put(KeyStoreServiceImpl.OR_KEYSTORE_PASSWORD, keystorePassword)
+
+    and: "the keycloak grant file is pinned to the shared location before the storage dir is redirected"
+    // A throwaway storage dir isolates this test's keystores, but it must not take the keycloak
+    // grant file with it: the identity provider treats a missing grant file as a first install and
+    // rotates the manager-keycloak password, which lives in keycloak's shared database. That would
+    // invalidate the grant every other test - and the keycloak Flyway migrations - depend on.
+    def sharedGrantFile = Paths.get(
+            config.getOrDefault(PersistenceService.OR_STORAGE_DIR, PersistenceService.OR_STORAGE_DIR_DEFAULT))
+            .resolve(config.getOrDefault(
+                    ManagerKeycloakIdentityProvider.OR_KEYCLOAK_GRANT_FILE,
+                    ManagerKeycloakIdentityProvider.OR_KEYCLOAK_GRANT_FILE_DEFAULT))
+            .toAbsolutePath()
+            .toString()
+    config.put(ManagerKeycloakIdentityProvider.OR_KEYCLOAK_GRANT_FILE, sharedGrantFile)
+    config.put(PersistenceService.OR_STORAGE_DIR, tempManagerDir.getAbsolutePath())
+
+
+    and: "the container starts"
+    def container = startContainer(config, defaultServices())
+    def keystoreService = container.getService(KeyStoreServiceImpl.class)
+    def mqttBrokerService = container.getService(MQTTBrokerService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def identityService = container.getService(ManagerIdentityService.class)
+    def provisioningService = container.getService(ProvisioningService.class)
+    def testSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def mqttHost = "localhost"
+    def mqttPort = mtlsPort
+    when: "A new keypair, properly signed, is created, but the service user for it is not created"
+    def unprovisionedUsername = "unprovisioneduser"
+    def (unprovisionedKeyPair, unprovisionedCert) = mtlsHelper.generateClientCertificate(
+            unprovisionedUsername,
+            Constants.MASTER_REALM,
+            4 // serial offset
+            )
+
+    and: "It is added and saved to the KeyStoreService keystore"
+    def unprovisionedKeyAlias = Constants.MASTER_REALM + "unprovisionedclient"
+    mtlsHelper.addClientCertificateToKeyStoreService(
+            keystoreService,
+            unprovisionedKeyAlias,
+            keystorePassword,
+            unprovisionedKeyPair,
+            unprovisionedCert
+            )
+
+    and: "a client with unprovisioned certificate connects, for testing mTLS autoprovisioning"
+    String autoprovisioningClientId = "unprovisionedDevice"
+    MQTT_IOClient autoprovisioningClient = new MQTT_IOClient(
+            autoprovisioningClientId,
+            mqttHost,
+            mqttPort,
+            true,
+            false,
+            null,
+            null,
+            null,
+            keystoreService.getKeyManagerFactory(unprovisionedKeyAlias),
+            keystoreService.getTrustManagerFactory()
+            )
+
+    and: "the client connects"
+    autoprovisioningClient.connect()
+
+    then: "The client connects with 3 principals"
+    conditions.eventually {
+      Subject subject = mqttBrokerService.getConnectionFromClientID(autoprovisioningClientId).getSubject()
+      assert subject.getPrincipals().size() == 3
+    }
+
+    when: "the provisioning config is created to allow autoprovisioning using mTLS"
+
+    def provisioningConfig = new X509ProvisioningConfig("Valid Test Config",
+            new X509ProvisioningData()
+            .setCACertPEM(MTLSCertificateHelper.getPemString(mtlsHelper.getRootCACertificate()))
+            ).setAssetTemplate(
+            ValueUtil.asJSON(
+                    new ShipAsset("Ship Asset")
+                    .addAttributes(
+                            new Attribute<>("customAttribute", NUMBER).addMeta(
+                                    new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ),
+                                    new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_WRITE)
+                                    ),
+                            new Attribute<>("serialNumber", ValueType.TEXT, UNIQUE_ID_PLACEHOLDER),
+                            new Attribute<>("connected", BOOLEAN).addMeta(
+                                    new MetaItem<>(MetaItemType.USER_CONNECTED, PROVISIONING_USER_PREFIX + "device1")
+                                    )
+                            )
+                    ).orElse("")
+            ).setRealm(Constants.MASTER_REALM)
+            .setRestrictedUser(true)
+            .setUserRoles([
+              ClientRole.WRITE_ASSETS,
+              ClientRole.WRITE_ATTRIBUTES,
+              ClientRole.READ_ASSETS
+            ] as ClientRole[])
+    provisioningConfig = provisioningService.merge(provisioningConfig)
+
+
+    and: "We publish a message to the autoprovisioning message topic"
+
+    def autoProvisioningRequestTopic = "$PROVISIONING_TOKEN/$unprovisionedUsername/$REQUEST_TOKEN".toString()
+    def autoProvisioningResponseTopic = "$PROVISIONING_TOKEN/$unprovisionedUsername/$RESPONSE_TOKEN".toString()
+    List<ProvisioningMessage> autoProvisioningResponses = new CopyOnWriteArrayList<>()
+    Consumer<MQTTMessage<String>> autoProvisioningMessageConsumer = { MQTTMessage<String> msg ->
+      autoProvisioningResponses.add(ValueUtil.parse(msg.payload, ProvisioningMessage.class).orElse(null))
+    }
+    autoprovisioningClient.addMessageConsumer(autoProvisioningResponseTopic, autoProvisioningMessageConsumer)
+    autoprovisioningClient.sendMessage(
+            new MQTTMessage<String>(autoProvisioningRequestTopic, ValueUtil.JSON.writeValueAsString(new MTLSProvisioningMessage()))
+            )
+
+    then: "we should receive a success response provisioning message"
+    conditions.eventually {
+      assert autoProvisioningResponses.size() == 1
+      assert autoProvisioningResponses.get(0) instanceof SuccessResponseMessage
+    }
+
+    then: "the broker should have published to the response topic a success message containing the provisioned asset"
+    ShipAsset provisionedAsset
+    conditions.eventually {
+      assert autoProvisioningResponses.size() == 1
+      assert autoProvisioningResponses.get(0) instanceof SuccessResponseMessage
+      assert ((SuccessResponseMessage)autoProvisioningResponses.get(0)).realm == Constants.MASTER_REALM
+      provisionedAsset = (ShipAsset)((SuccessResponseMessage)autoProvisioningResponses.get(0)).asset
+      assert provisionedAsset != null
+      assert provisionedAsset instanceof ShipAsset
+      assert provisionedAsset.getAttribute("serialNumber").flatMap{
+        it.getValue()
+      }.orElse(null) == unprovisionedUsername
+    }
+
+    when: "the device disconnects"
+    autoprovisioningClient.disconnect()
+
+    then: "the client should reach the disconnected state"
+    // disconnect() is asynchronous and connect() is a no-op unless the client is already
+    // DISCONNECTED, so reconnecting without waiting here silently never reconnects
+    conditions.eventually {
+      assert autoprovisioningClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+    }
+
+    when: "it reconnects again"
+    autoProvisioningResponses.clear()
+    autoprovisioningClient.connect()
+
+    then: "the connection should be created with the provisioned user and roles"
+    conditions.eventually {
+      assert autoprovisioningClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+    }
+
+    and: "the authenticated client should have the correct subject with roles"
+    conditions.eventually {
+      Subject unprovisionedJaasSubject = mqttBrokerService.getConnectionFromClientID(autoprovisioningClientId).getSubject()
+      assert unprovisionedJaasSubject != null
+      // New architecture creates a RemotingConnectionPrincipal, TokenPrincipal and UserPrincipal for the provisioned service user
+      assert unprovisionedJaasSubject.getPrincipals().size() == 3
+      assert unprovisionedJaasSubject.getPrincipals(org.openremote.container.security.TokenPrincipal.class).size() == 1
+      assert unprovisionedJaasSubject.getPrincipals(UserPrincipal.class).size() == 1
+      // ActiveMQORSecurityManager names the UserPrincipal with the keycloak subject id, so the
+      // username is asserted on the TokenPrincipal, which exposes the preferred_username claim.
+      // The provisioning prefix is part of the name: devices created by auto-provisioning are
+      // named the same way whichever flow provisioned them, and certificate authentication
+      // looks for that name before the bare CN
+      assert unprovisionedJaasSubject.getPrincipals(org.openremote.container.security.TokenPrincipal.class)[0].getUsername() == "$User.SERVICE_ACCOUNT_PREFIX$PROVISIONING_USER_PREFIX$unprovisionedUsername"
+    }
+
+    and: "the service user is discoverable under the provisioning naming convention"
+    identityService.getIdentityProvider().getUserByUsername(
+            Constants.MASTER_REALM,
+            User.SERVICE_ACCOUNT_PREFIX + PROVISIONING_USER_PREFIX + unprovisionedUsername) != null
+
+    when: "the client then subscribes to attribute events for the generated asset and asset events for all assets"
+    def assetSubscriptionTopic = "$provisioningConfig.realm/$autoprovisioningClientId/$DefaultMQTTHandler.ASSET_TOPIC/#".toString()
+    def attributeSubscriptionTopic = "$provisioningConfig.realm/$autoprovisioningClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/+/${provisionedAsset.id}".toString()
+    List<AssetEvent> assetEvents = new CopyOnWriteArrayList<>()
+    List<AttributeEvent> attributeEvents = new CopyOnWriteArrayList<>()
+    Consumer<MQTTMessage<String>> eventConsumer = { MQTTMessage<String> msg ->
+      def event = ValueUtil.parse(msg.payload, SharedEvent.class).orElse(null)
+      if (event instanceof AssetEvent) {
+        assetEvents.add(event as AssetEvent)
+      } else {
+        attributeEvents.add(event as AttributeEvent)
+      }
+    }
+    autoprovisioningClient.addMessageConsumer(assetSubscriptionTopic, eventConsumer)
+    autoprovisioningClient.addMessageConsumer(attributeSubscriptionTopic, eventConsumer)
+
+    then: "the subscriptions should be in place"
+    conditions.eventually {
+      assert autoprovisioningClient.topicConsumerMap.get(assetSubscriptionTopic) != null
+      assert autoprovisioningClient.topicConsumerMap.get(attributeSubscriptionTopic) != null
+      assert autoprovisioningClient.topicConsumerMap.get(assetSubscriptionTopic).consumers.size() == 1
+      assert autoprovisioningClient.topicConsumerMap.get(attributeSubscriptionTopic).consumers.size() == 1
+      def connection = mqttBrokerService.getConnectionFromClientID(autoprovisioningClientId)
+      assert connection != null
+    }
+
+    when: "the client updates one of the provisioned asset's attributes"
+    autoprovisioningClient.sendMessage(
+            new MQTTMessage<String>(
+                    "$provisioningConfig.realm/$autoprovisioningClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/customAttribute/${provisionedAsset.id}",
+                    "123"
+                    )
+            )
+
+    then: "the attribute should have been updated"
+    conditions.eventually {
+      def asset = assetStorageService.find(provisionedAsset.id)
+      assert asset.getAttribute("customAttribute").flatMap{it.getValue()}.orElse(0d) == 123d
+    }
+
+    and: "the client should have been notified about the attribute change"
+    conditions.eventually {
+      assert attributeEvents.size() == 1
+      assert attributeEvents.get(0).id == provisionedAsset.id
+      assert attributeEvents.get(0).name == "customAttribute"
+      assert attributeEvents.get(0).value.orElse(0d) == 123d
+    }
+
+
+    and: "an attribute update is sent for the onOff attribute with a value of true"
+
+
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(
+                    testSetup.light1Id,
+                    "onOff",
+                    false,
+                    System.currentTimeMillis()
+                    ))
+
+    when: "the client tries to send an attribute event to that unlinked asset"
+    autoprovisioningClient.sendMessage(
+            new MQTTMessage<String>(
+                    "$provisioningConfig.realm/$autoprovisioningClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/onOff/${testSetup.light1Id}",
+                    "true"
+                    )
+            )
+
+    then: "the attribute should not have been updated"
+    conditions.eventually {
+      LOG.info("Waiting for the system to settle down")
+      def j = 0
+      while (j < 10 && !noEventProcessedIn(assetProcessingService, 100)) {
+        Thread.sleep(100)
+        j++
+      }
+
+      def asset = assetStorageService.find(testSetup.light1Id)
+      assert asset.getAttribute("onOff").flatMap{it.getValue()}.orElse(true) == false
+    }
+
+    cleanup: "disconnect the client and cleanup temporary files"
+    autoprovisioningClient.disconnect()
+
+    and: "delete the created temporary directories"
+    tempDir.deleteDir()
+    tempManagerDir.deleteDir()
   }
 }


### PR DESCRIPTION
## Description

Adds an mTLS variant of the X.509 auto-provisioning flow. A device publishes an `MTLSProvisioningMessage` with no payload — its certificate is already on the connection. The class is purely a type discriminator.

Both flows share everything after the certificate is obtained: matching it against the config's CA, checking the CN against the topic client ID, and creating or reusing the service user and asset. So an mTLS-provisioned device is named exactly like an x509-provisioned one and stays recognisable as provisioning-created.

The mTLS flow adds one check: its subject was verified during the handshake, so an OU there is an authenticated claim about the realm and must not contradict the config's realm.

Unrecognised message types are now logged and answered with `MESSAGE_INVALID` instead of silently dropped.

## How to verify

`UserAndAssetProvisioningTest."mTLS MQTT Autoprovisioning integration test"` runs the flow end to end: an unprovisioned device provisions itself over mTLS, reconnects as the provisioned user, writes an attribute on the generated asset, and is denied a write to an asset it is not linked to.

## Related

Closes #1626, closes #1627

## Checklist

- [x] 1. Acceptance criteria of the linked issue(s) are met
- [x] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
