### PR TITLE
Migrate JSONSchemaUtil snapshot tests to spock snapshot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ In sandboxed environments, add `--offline` (requires dependencies to already be 
 When running integration tests, part of the stack (PostgreSQL and Keycloak) must be running. Start it with `mkdir -pm 777 tmp && docker compose -f profile/dev-testing.yml -p openremote up -d --no-build`.  
 Running `./gradlew clean` deletes the root `tmp/` directory that is mounted into PostgreSQL (see `profile/dev-testing.yml`), so recreate it and restart the stack before running tests again.
 
+Spock snapshots are stored under `model/src/test/resources/snapshots`. Rewrite them with `./gradlew :model:test -PupdateSnapshots` and review the resulting diff, since a mismatch is only reported as a test failure otherwise.
+
 ## REST resources
 
 ### Endpoint roles

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,6 @@ javaxAnnotationApi = "1.3.2"
 jaywayJsonPath = "2.10.0"
 jdom = "2.0.6.1"
 jserialcomm = "2.11.4"
-jsonassert = "1.5.3"
 junit = "6.1.3"
 keycloak = "25.0.3"
 micrometer = "1.17.0"
@@ -144,7 +143,6 @@ javaxAnnotationApi = { module = "javax.annotation:javax.annotation-api", version
 jaywayJsonPath = { module = "com.jayway.jsonpath:json-path", version.ref = "jaywayJsonPath" }
 jdom2 = { module = "org.jdom:jdom2", version.ref = "jdom" }
 jserialcomm = { module = "com.fazecast:jSerialComm", version.ref = "jserialcomm" }
-jsonassert = { module = "org.skyscreamer:jsonassert", version.ref = "jsonassert" }
 junitJupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junitJupiterEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junitJupiterParams = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -45,7 +45,6 @@ dependencies {
 
   dependencies {
     testImplementation libs.groovy
-    testImplementation libs.jsonassert
     testImplementation platform(libs.spockBom)
     testImplementation libs.spockCore
     testRuntimeOnly libs.jakartaEl
@@ -57,7 +56,11 @@ tasks.withType(Test) {
   environment("OR_LOGGING_CONFIG_FILE", "logging-dev.properties")
 }
 
-test {}
+test {
+  systemProperty("spock.snapshots.rootPath", layout.projectDirectory.dir("src/test/resources/snapshots").asFile.path)
+  // Run with -PupdateSnapshots to rewrite the Spock snapshots
+  systemProperty("spock.snapshots.updateSnapshots", project.hasProperty("updateSnapshots"))
+}
 
 base {
   archivesName = "openremote-${project.name}"

--- a/model/src/test/groovy/org/openremote/model/util/JSONSchemaUtilTest.groovy
+++ b/model/src/test/groovy/org/openremote/model/util/JSONSchemaUtilTest.groovy
@@ -18,12 +18,12 @@
  */
 package org.openremote.model.util
 
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals
-
 import com.fasterxml.jackson.annotation.*
 import org.openremote.model.util.JSONSchemaUtil.*
 import org.openremote.model.value.ValueType
 import org.reflections.Reflections
+import spock.lang.Snapshot
+import spock.lang.Snapshotter
 import spock.lang.Specification
 
 import java.time.*
@@ -32,31 +32,22 @@ class JSONSchemaUtilTest extends Specification {
 
   private static final Reflections reflections = new Reflections("org.openremote")
 
+  @Snapshot(extension = "json")
+  Snapshotter snapshotter
+
   def setupSpec() {
     ValueUtil.doInitialise()
   }
 
-  private static InputStream loadResourceAsStream(String resourcePath) {
-    JSONSchemaUtilTest.getResourceAsStream(
-            "/org/openremote/model/util/" + resourcePath + ".json")
+  private void schemaMatchesSnapshot(Class<?> type) {
+    snapshotter.assertThat(ValueUtil.getSchema(type).toPrettyString()).matchesSnapshot()
   }
 
   static class Title {}
 
   def "schema has a generated title"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "title": "Title",
-                "additionalProperties": true
-            }''')
-
-    def actual = ValueUtil.getSchema(Title)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(Title)
   }
 
   @JsonSchemaTitle(value = "Test Title", i18n = false)
@@ -69,56 +60,19 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema members do not have generated titles"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-                {
-                  "$schema": "http://json-schema.org/draft-07/schema#",
-                  "type": "object",
-                  "properties": {
-                    "test": { "type": "object", "additionalProperties": { "type": "string" } },
-                    "test1": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "title": "Test Title",
-                        "additionalProperties": true
-                      }
-                    }
-                  },
-                  "title": "Members Should Not Have Title",
-                  "additionalProperties": true
-                }
-            ''')
-
-    def actual = ValueUtil.getSchema(MembersShouldNotHaveTitle)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(MembersShouldNotHaveTitle)
   }
 
   def "schema remaps Byte"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(loadResourceAsStream(Byte.name))
-    def actual = ValueUtil.getSchema(Byte)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(Byte)
   }
 
   static class AdditionalProperties {}
 
   def "schema allows additional properties"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "title": "Additional Properties",
-                "additionalProperties": true
-            }''')
-
-    def actual = ValueUtil.getSchema(AdditionalProperties)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(AdditionalProperties)
   }
 
   static class RemapTypes {
@@ -138,33 +92,12 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema remaps annotated types"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema":"http://json-schema.org/draft-07/schema#",
-                "type":"object",
-                "properties": {
-                    "test1":{"type":"string"},
-                    "test2":{"type":"boolean"},
-                    "test3":{"type":"integer","format":"utc-millisec"},
-                    "test4":{"type":"object","patternProperties":{".+":{"type":["null","number","integer","boolean","string","array","object"]}}}}
-                },
-                "required":["test1","test3"],
-                "title":"Remap Types",
-                "additionalProperties":true
-            }''')
-
-    def actual = ValueUtil.getSchema(RemapTypes)
-    assertEquals(expected.toString(), actual.toString(), false)
+    schemaMatchesSnapshot(RemapTypes)
   }
 
   def "schema handles map type #mapType.simpleName"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(loadResourceAsStream(mapType.name))
-    def actual = ValueUtil.getSchema(mapType)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(mapType)
 
     where:
     mapType << [
@@ -190,33 +123,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema handles Jackson annotations"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "properties": {
-                    "renamed": {
-                        "type": "boolean"
-                    },
-                    "renamed1": {
-                        "type": "boolean",
-                        "readOnly": true,
-                        "writeOnly": true
-                    },
-                    "test1": {
-                        "type": "boolean",
-                        "description": "This property should have a description."
-                    }
-                },
-                "required": [ "renamed1" ],
-                "title": "Jackson Annotations",
-                "additionalProperties": true
-            }''')
-
-    def actual = ValueUtil.getSchema(JacksonAnnotations)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(JacksonAnnotations)
   }
 
   static class Primitives {
@@ -231,36 +138,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema requires primitive fields"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "properties": {
-                    "test1": { "type": "boolean", "default": false },
-                    "test2": { "type": "integer" },
-                    "test3": { "type": "integer" },
-                    "test4": { "type": "number" },
-                    "test5": { "type": "number" },
-                    "test6": { "type": "integer" },
-                    "test7": { "type": "string" }
-                },
-                "required": [
-                    "test1",
-                    "test2",
-                    "test3",
-                    "test4",
-                    "test5",
-                    "test6",
-                    "test7"
-                ],
-                "title": "Primitives",
-                "additionalProperties": true
-            }''')
-
-    def actual = ValueUtil.getSchema(Primitives)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(Primitives)
   }
 
   static class AnnotationsForFields {
@@ -274,28 +152,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema applies custom annotations to fields"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "properties": {
-                    "all":{
-                        "type":"boolean",
-                        "title":"test",
-                        "description":"test",
-                        "default": false,
-                        "format":"test",
-                        "examples":["test"]
-                    }
-                },
-                "title": "Annotations For Fields",
-                "additionalProperties": true
-            }''')
-
-    def actual = ValueUtil.getSchema(AnnotationsForFields)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(AnnotationsForFields)
   }
 
   @JsonSchemaTitle(value = "test", i18n = false)
@@ -307,24 +164,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema applies custom annotations to types"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "title": "test",
-                "additionalProperties": true,
-                "description": "test",
-                "format": "test",
-                "default": {},
-                "examples": [
-                    "test"
-                ]
-            }''')
-
-    def actual = ValueUtil.getSchema(AnnotationsForTypes)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(AnnotationsForTypes)
   }
 
   @JsonSchemaTitle("test")
@@ -333,18 +173,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema applies i18n annotations"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "i18n": "org.openremote.model.util.JSONSchemaUtilTest.I18nAnnotations",
-                "additionalProperties": true
-            }''')
-
-    def actual = ValueUtil.getSchema(I18nAnnotations)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(I18nAnnotations)
   }
 
   @JsonSchemaTitle(value = "test", i18n = false)
@@ -353,19 +182,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema applies partially disabled i18n annotations"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "title": "test",
-                "i18n": "org.openremote.model.util.JSONSchemaUtilTest.I18nAnnotationsPartiallyDisabled",
-                "additionalProperties": true
-            }''')
-
-    def actual = ValueUtil.getSchema(I18nAnnotationsPartiallyDisabled)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(I18nAnnotationsPartiallyDisabled)
   }
 
   @JsonTypeInfo(property = "type", use = JsonTypeInfo.Id.NAME)
@@ -383,53 +200,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema includes subtypes with a type property"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "definitions": {
-                    "SubType": {
-                        "title": "Sub Type",
-                        "type": "object",
-                        "additionalProperties": true,
-                        "properties": {
-                            "type": {
-                                "const": "SubType"
-                            }
-                        },
-                        "required": [
-                            "type"
-                        ]
-                    },
-                    "SubTypeSuperclass": {
-                        "title": "Sub Type Superclass",
-                        "type": "object",
-                        "additionalProperties": true,
-                        "properties": {
-                            "type": {
-                                "const": "SubTypeSuperclass"
-                            }
-                        },
-                        "required": [
-                            "type"
-                        ]
-                    }
-                },
-                "discriminator": {
-                    "propertyName": "type"
-                },
-                "oneOf": [
-                    { "$ref": "#/definitions/SubType" },
-                    { "$ref": "#/definitions/SubTypeSuperclass" }
-                ],
-                "type": "object",
-                "additionalProperties": true,
-                "title": "Polymorphic Type"
-            }''')
-
-    def actual = ValueUtil.getSchema(PolymorphicType)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(PolymorphicType)
   }
 
   @JsonTypeInfo(property = "customType", use = JsonTypeInfo.Id.NAME)
@@ -450,53 +221,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema includes subtypes with a custom type property"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "definitions": {
-                    "SubTypeWithCustomProperty": {
-                        "title": "Sub Type With Custom Property",
-                        "type": "object",
-                        "additionalProperties": true,
-                        "properties": {
-                            "customType": {
-                                "const": "SubTypeWithCustomProperty"
-                            }
-                        },
-                        "required": [
-                            "customType"
-                        ]
-                    },
-                    "SubTypeSuperClassWithCustomProperty": {
-                        "title": "Sub Type Super Class With Custom Property",
-                        "type": "object",
-                        "additionalProperties": true,
-                        "properties": {
-                            "customType": {
-                                "const": "SubTypeSuperClassWithCustomProperty"
-                            }
-                        },
-                        "required": [
-                            "customType"
-                        ]
-                    }
-                },
-                "discriminator": {
-                    "propertyName": "customType"
-                },
-                "oneOf": [
-                    { "$ref": "#/definitions/SubTypeWithCustomProperty" },
-                    { "$ref": "#/definitions/SubTypeSuperClassWithCustomProperty" }
-                ],
-                "type": "object",
-                "additionalProperties": true,
-                "title": "Polymorphic Type With Custom Property"
-            }''')
-
-    def actual = ValueUtil.getSchema(PolymorphicTypeWithCustomProperty)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(PolymorphicTypeWithCustomProperty)
   }
 
   // Note: JsonTypeInfo.As.EXISTING_PROPERTY doesn't necessarily change the behavior mainly the
@@ -540,53 +265,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema includes subtypes with an existing custom type property"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "definitions": {
-                    "SubTypeWithCustomExistingProperty": {
-                        "title": "Sub Type With Custom Existing Property",
-                        "type": "object",
-                        "additionalProperties": true,
-                        "properties": {
-                            "customType": {
-                                "const": "sub"
-                            }
-                        },
-                        "required": [
-                            "customType"
-                        ]
-                    },
-                    "SubTypeSuperClassWithCustomExistingProperty": {
-                        "title": "Sub Type Super Class With Custom Existing Property",
-                        "type": "object",
-                        "additionalProperties": true,
-                        "properties": {
-                            "customType": {
-                                "const": "super"
-                            }
-                        },
-                        "required": [
-                            "customType"
-                        ]
-                    }
-                },
-                "discriminator": {
-                    "propertyName": "customType"
-                },
-                "oneOf": [
-                    { "$ref": "#/definitions/SubTypeWithCustomExistingProperty" },
-                    { "$ref": "#/definitions/SubTypeSuperClassWithCustomExistingProperty" }
-                ],
-                "type": "object",
-                "additionalProperties": true,
-                "title": "Polymorphic Type With Custom Existing Property"
-            }''')
-
-    def actual = ValueUtil.getSchema(PolymorphicTypeWithCustomExistingProperty)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(PolymorphicTypeWithCustomExistingProperty)
   }
 
   @JsonTypeInfo(
@@ -606,53 +285,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema sets the enum type for an external property"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "definitions": {
-                    "ExternalSubType": {
-                        "title": "External Sub Type",
-                        "type": "object",
-                        "additionalProperties": true,
-                        "properties": {
-                            "type": {
-                                "const": "ExternalSubType"
-                            }
-                        },
-                        "required": [
-                            "type"
-                        ]
-                    },
-                    "ExternalSubTypeSuperclass": {
-                        "title": "External Sub Type Superclass",
-                        "type": "object",
-                        "additionalProperties": true,
-                        "properties": {
-                            "type": {
-                                "const": "ExternalSubTypeSuperclass"
-                            }
-                        },
-                        "required": [
-                            "type"
-                        ]
-                    }
-                },
-                "discriminator": {
-                    "propertyName": "type"
-                },
-                "oneOf": [
-                    { "$ref": "#/definitions/ExternalSubType" },
-                    { "$ref": "#/definitions/ExternalSubTypeSuperclass" }
-                ],
-                "type": "object",
-                "additionalProperties": true,
-                "title": "External Polymorphic Type"
-            }''')
-
-    def actual = ValueUtil.getSchema(ExternalPolymorphicType)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(ExternalPolymorphicType)
   }
 
   @JsonTypeName("ReflectedPolymorphicType")
@@ -665,47 +298,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema resolves subtypes through reflections"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "definitions": {
-                    "ResolvedSubType": {
-                        "title": "Resolved Sub Type",
-                        "type": "object",
-                        "additionalProperties": true,
-                        "properties": {
-                            "type": {
-                                "const": "ResolvedSubType"
-                            }
-                        },
-                        "required": [
-                            "type"
-                        ]
-                    }
-                },
-                "discriminator": {
-                    "propertyName": "type"
-                },
-                "title": "Reflected Polymorphic Type",
-                "oneOf": [
-                    { "$ref": "#/definitions/ResolvedSubType" }
-                ],
-                "type": "object",
-                "additionalProperties": true,
-                "properties": {
-                    "type": {
-                        "const": "ReflectedPolymorphicType"
-                    }
-                },
-                "required": [
-                    "type"
-                ]
-            }''')
-
-    def actual = ValueUtil.getSchema(ReflectedPolymorphicType)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(ReflectedPolymorphicType)
   }
 
   def "schemas do not use allOf"() {
@@ -735,74 +328,7 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema applies Jackson serializers"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "properties": {
-                    "duration": {
-                        "type": "integer",
-                        "format": "utc-millisec"
-                    },
-                    "instant": {
-                        "type": "integer",
-                        "format": "utc-millisec"
-                    },
-                    "localDate": { "type": "string" },
-                    "localDateTime": { "type": "string" },
-                    "localTime": { "type": "string" },
-                    "monthDay": {
-                        "title": "Month Day",
-                        "type": "object",
-                        "properties": {
-                            "month": {
-                                "type": "integer"
-                            }
-                        },
-                        "required": [
-                            "month"
-                        ],
-                        "additionalProperties": true
-                    },
-                    "offsetDateTime": {
-                        "type": "integer",
-                        "format": "utc-millisec"
-                    },
-                    "offsetTime": { "type": "string" },
-                    "period": { "type": "string" },
-                    "year": { "type": "integer" },
-                    "yearMonth": {
-                        "title": "Year Month",
-                        "type": "object",
-                        "properties": {
-                            "month": {
-                                "type": "integer"
-                            },
-                            "year": {
-                                "type": "integer"
-                            }
-                        },
-                        "required": [
-                            "month",
-                            "year"
-                        ],
-                        "additionalProperties": true
-                    },
-                    "zoneId": { "type": "string" },
-                    "zoneOffset": { "type": "string" },
-                    "zonedDateTime": {
-                        "type": "integer",
-                        "format": "utc-millisec"
-                    }
-                },
-                "title": "Java Time Jackson Module",
-                "additionalProperties": true
-            }''')
-
-    def actual = ValueUtil.getSchema(JavaTimeJacksonModule)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(JavaTimeJacksonModule)
   }
 
   enum TypeOption {
@@ -816,22 +342,6 @@ class JSONSchemaUtilTest extends Specification {
 
   def "schema generates enum values"() {
     expect:
-    def expected =
-            ValueUtil.JSON.readTree(
-            '''
-            {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "string",
-                "enum": [
-                    "INTEGER",
-                    "STRING",
-                    "LONG",
-                    "FLOAT"
-                ],
-                "title": "Type Option"
-            }''')
-
-    def actual = ValueUtil.getSchema(TypeOption)
-    assertEquals(expected.toString(), actual.toString(), true)
+    schemaMatchesSnapshot(TypeOption)
   }
 }

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_allows_additional_properties.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_allows_additional_properties.json
@@ -1,0 +1,6 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "title" : "Additional Properties",
+  "additionalProperties" : true
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_applies_Jackson_serializers.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_applies_Jackson_serializers.json
@@ -1,0 +1,73 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "properties" : {
+    "duration" : {
+      "type" : "integer",
+      "format" : "utc-millisec"
+    },
+    "instant" : {
+      "type" : "integer",
+      "format" : "utc-millisec"
+    },
+    "localDate" : {
+      "type" : "string"
+    },
+    "localDateTime" : {
+      "type" : "string"
+    },
+    "localTime" : {
+      "type" : "string"
+    },
+    "monthDay" : {
+      "type" : "object",
+      "properties" : {
+        "month" : {
+          "type" : "integer"
+        }
+      },
+      "required" : [ "month" ],
+      "title" : "Month Day",
+      "additionalProperties" : true
+    },
+    "offsetDateTime" : {
+      "type" : "integer",
+      "format" : "utc-millisec"
+    },
+    "offsetTime" : {
+      "type" : "string"
+    },
+    "period" : {
+      "type" : "string"
+    },
+    "year" : {
+      "type" : "integer"
+    },
+    "yearMonth" : {
+      "type" : "object",
+      "properties" : {
+        "month" : {
+          "type" : "integer"
+        },
+        "year" : {
+          "type" : "integer"
+        }
+      },
+      "required" : [ "month", "year" ],
+      "title" : "Year Month",
+      "additionalProperties" : true
+    },
+    "zoneId" : {
+      "type" : "string"
+    },
+    "zoneOffset" : {
+      "type" : "string"
+    },
+    "zonedDateTime" : {
+      "type" : "integer",
+      "format" : "utc-millisec"
+    }
+  },
+  "title" : "Java Time Jackson Module",
+  "additionalProperties" : true
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_applies_custom_annotations_to_fields.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_applies_custom_annotations_to_fields.json
@@ -1,0 +1,16 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "properties" : {
+    "all" : {
+      "type" : "boolean",
+      "format" : "test",
+      "default" : false,
+      "examples" : [ "test" ],
+      "title" : "test",
+      "description" : "test"
+    }
+  },
+  "title" : "Annotations For Fields",
+  "additionalProperties" : true
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_applies_custom_annotations_to_types.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_applies_custom_annotations_to_types.json
@@ -1,0 +1,10 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "additionalProperties" : true,
+  "format" : "test",
+  "default" : { },
+  "examples" : [ "test" ],
+  "title" : "test",
+  "description" : "test"
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_applies_i18n_annotations.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_applies_i18n_annotations.json
@@ -1,0 +1,6 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "additionalProperties" : true,
+  "i18n" : "org.openremote.model.util.JSONSchemaUtilTest.I18nAnnotations"
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_applies_partially_disabled_i18n_annotations.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_applies_partially_disabled_i18n_annotations.json
@@ -1,0 +1,7 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "additionalProperties" : true,
+  "title" : "test",
+  "i18n" : "org.openremote.model.util.JSONSchemaUtilTest.I18nAnnotationsPartiallyDisabled"
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_generates_enum_values.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_generates_enum_values.json
@@ -1,0 +1,6 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "string",
+  "enum" : [ "INTEGER", "STRING", "LONG", "FLOAT" ],
+  "title" : "Type Option"
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_Jackson_annotations.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_Jackson_annotations.json
@@ -1,0 +1,21 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "properties" : {
+    "renamed" : {
+      "type" : "boolean"
+    },
+    "renamed1" : {
+      "type" : "boolean",
+      "readOnly" : true,
+      "writeOnly" : true
+    },
+    "test1" : {
+      "type" : "boolean",
+      "description" : "This property should have a description."
+    }
+  },
+  "required" : [ "renamed1" ],
+  "title" : "Jackson Annotations",
+  "additionalProperties" : true
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[0].json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[0].json
@@ -1,0 +1,8 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "additionalProperties" : {
+    "type" : "boolean"
+  },
+  "title" : "Boolean Map"
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[1].json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[1].json
@@ -1,8 +1,8 @@
 {
   "$schema" : "http://json-schema.org/draft-07/schema#",
-  "title" : "Integer Map",
   "type" : "object",
   "additionalProperties" : {
-    "type" : "integer"
-  }
+    "type" : "number"
+  },
+  "title" : "Double Map"
 }

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[2].json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[2].json
@@ -1,11 +1,8 @@
 {
   "$schema" : "http://json-schema.org/draft-07/schema#",
-  "title" : "Multivalued String Map",
   "type" : "object",
   "additionalProperties" : {
-    "type" : "array",
-    "items" : {
-      "type" : "string"
-    }
-  }
+    "type" : "integer"
+  },
+  "title" : "Integer Map"
 }

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[3].json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[3].json
@@ -1,10 +1,10 @@
 {
   "$schema" : "http://json-schema.org/draft-07/schema#",
-  "title" : "Object Map",
   "type" : "object",
   "additionalProperties" : {
     "title" : "Any Type",
     "type" : [ "null", "number", "integer", "boolean", "string", "array", "object" ],
     "additionalProperties" : true
-  }
+  },
+  "title" : "Object Map"
 }

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[4].json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[4].json
@@ -1,8 +1,8 @@
 {
   "$schema" : "http://json-schema.org/draft-07/schema#",
-  "title" : "String Map",
   "type" : "object",
   "additionalProperties" : {
     "type" : "string"
-  }
+  },
+  "title" : "String Map"
 }

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[5].json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_handles_map_type__mapType_simpleName-[5].json
@@ -1,8 +1,11 @@
 {
   "$schema" : "http://json-schema.org/draft-07/schema#",
-  "title" : "Boolean Map",
   "type" : "object",
   "additionalProperties" : {
-    "type" : "boolean"
-  }
+    "type" : "array",
+    "items" : {
+      "type" : "string"
+    }
+  },
+  "title" : "Multivalued String Map"
 }

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_has_a_generated_title.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_has_a_generated_title.json
@@ -1,8 +1,6 @@
 {
   "$schema" : "http://json-schema.org/draft-07/schema#",
-  "title" : "Double Map",
   "type" : "object",
-  "additionalProperties" : {
-    "type" : "number"
-  }
+  "title" : "Title",
+  "additionalProperties" : true
 }

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_includes_subtypes_with_a_custom_type_property.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_includes_subtypes_with_a_custom_type_property.json
@@ -1,0 +1,38 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "definitions" : {
+    "SubTypeSuperClassWithCustomProperty" : {
+      "title" : "Sub Type Super Class With Custom Property",
+      "additionalProperties" : true,
+      "type" : "object",
+      "properties" : {
+        "customType" : {
+          "const" : "SubTypeSuperClassWithCustomProperty"
+        }
+      },
+      "required" : [ "customType" ]
+    },
+    "SubTypeWithCustomProperty" : {
+      "title" : "Sub Type With Custom Property",
+      "additionalProperties" : true,
+      "type" : "object",
+      "properties" : {
+        "customType" : {
+          "const" : "SubTypeWithCustomProperty"
+        }
+      },
+      "required" : [ "customType" ]
+    }
+  },
+  "type" : "object",
+  "discriminator" : {
+    "propertyName" : "customType"
+  },
+  "oneOf" : [ {
+    "$ref" : "#/definitions/SubTypeWithCustomProperty"
+  }, {
+    "$ref" : "#/definitions/SubTypeSuperClassWithCustomProperty"
+  } ],
+  "title" : "Polymorphic Type With Custom Property",
+  "additionalProperties" : true
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_includes_subtypes_with_a_type_property.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_includes_subtypes_with_a_type_property.json
@@ -1,0 +1,38 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "definitions" : {
+    "SubType" : {
+      "title" : "Sub Type",
+      "additionalProperties" : true,
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "const" : "SubType"
+        }
+      },
+      "required" : [ "type" ]
+    },
+    "SubTypeSuperclass" : {
+      "title" : "Sub Type Superclass",
+      "additionalProperties" : true,
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "const" : "SubTypeSuperclass"
+        }
+      },
+      "required" : [ "type" ]
+    }
+  },
+  "type" : "object",
+  "discriminator" : {
+    "propertyName" : "type"
+  },
+  "oneOf" : [ {
+    "$ref" : "#/definitions/SubType"
+  }, {
+    "$ref" : "#/definitions/SubTypeSuperclass"
+  } ],
+  "title" : "Polymorphic Type",
+  "additionalProperties" : true
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_includes_subtypes_with_an_existing_custom_type_property.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_includes_subtypes_with_an_existing_custom_type_property.json
@@ -1,0 +1,38 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "definitions" : {
+    "SubTypeSuperClassWithCustomExistingProperty" : {
+      "properties" : {
+        "customType" : {
+          "const" : "super"
+        }
+      },
+      "title" : "Sub Type Super Class With Custom Existing Property",
+      "additionalProperties" : true,
+      "type" : "object",
+      "required" : [ "customType" ]
+    },
+    "SubTypeWithCustomExistingProperty" : {
+      "properties" : {
+        "customType" : {
+          "const" : "sub"
+        }
+      },
+      "title" : "Sub Type With Custom Existing Property",
+      "additionalProperties" : true,
+      "type" : "object",
+      "required" : [ "customType" ]
+    }
+  },
+  "type" : "object",
+  "discriminator" : {
+    "propertyName" : "customType"
+  },
+  "oneOf" : [ {
+    "$ref" : "#/definitions/SubTypeWithCustomExistingProperty"
+  }, {
+    "$ref" : "#/definitions/SubTypeSuperClassWithCustomExistingProperty"
+  } ],
+  "title" : "Polymorphic Type With Custom Existing Property",
+  "additionalProperties" : true
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_members_do_not_have_generated_titles.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_members_do_not_have_generated_titles.json
@@ -1,0 +1,22 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "properties" : {
+    "test" : {
+      "type" : "object",
+      "additionalProperties" : {
+        "type" : "string"
+      }
+    },
+    "test1" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "additionalProperties" : true,
+        "title" : "Test Title"
+      }
+    }
+  },
+  "title" : "Members Should Not Have Title",
+  "additionalProperties" : true
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_remaps_Byte.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_remaps_Byte.json
@@ -1,5 +1,5 @@
 {
   "$schema" : "http://json-schema.org/draft-07/schema#",
-  "title" : "Byte",
-  "type" : "integer"
+  "type" : "integer",
+  "title" : "Byte"
 }

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_remaps_annotated_types.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_remaps_annotated_types.json
@@ -1,0 +1,28 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "properties" : {
+    "test1" : {
+      "type" : "string"
+    },
+    "test2" : {
+      "type" : "boolean",
+      "default" : false
+    },
+    "test3" : {
+      "type" : "integer",
+      "format" : "utc-millisec"
+    },
+    "test4" : {
+      "type" : "object",
+      "patternProperties" : {
+        ".+" : {
+          "type" : [ "null", "number", "integer", "boolean", "string", "array", "object" ]
+        }
+      }
+    }
+  },
+  "required" : [ "test1", "test3" ],
+  "title" : "Remap Types",
+  "additionalProperties" : true
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_requires_primitive_fields.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_requires_primitive_fields.json
@@ -1,0 +1,31 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "properties" : {
+    "test1" : {
+      "type" : "boolean",
+      "default" : false
+    },
+    "test2" : {
+      "type" : "integer"
+    },
+    "test3" : {
+      "type" : "integer"
+    },
+    "test4" : {
+      "type" : "number"
+    },
+    "test5" : {
+      "type" : "number"
+    },
+    "test6" : {
+      "type" : "integer"
+    },
+    "test7" : {
+      "type" : "string"
+    }
+  },
+  "required" : [ "test1", "test2", "test3", "test4", "test5", "test6", "test7" ],
+  "title" : "Primitives",
+  "additionalProperties" : true
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_resolves_subtypes_through_reflections.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_resolves_subtypes_through_reflections.json
@@ -1,0 +1,31 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "definitions" : {
+    "ResolvedSubType" : {
+      "title" : "Resolved Sub Type",
+      "additionalProperties" : true,
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "const" : "ResolvedSubType"
+        }
+      },
+      "required" : [ "type" ]
+    }
+  },
+  "title" : "Reflected Polymorphic Type",
+  "type" : "object",
+  "oneOf" : [ {
+    "$ref" : "#/definitions/ResolvedSubType"
+  } ],
+  "additionalProperties" : true,
+  "properties" : {
+    "type" : {
+      "const" : "ReflectedPolymorphicType"
+    }
+  },
+  "required" : [ "type" ],
+  "discriminator" : {
+    "propertyName" : "type"
+  }
+}

--- a/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_sets_the_enum_type_for_an_external_property.json
+++ b/model/src/test/resources/snapshots/org/openremote/model/util/JSONSchemaUtilTest/schema_sets_the_enum_type_for_an_external_property.json
@@ -1,0 +1,38 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "definitions" : {
+    "ExternalSubType" : {
+      "type" : "object",
+      "title" : "External Sub Type",
+      "additionalProperties" : true,
+      "required" : [ "type" ],
+      "properties" : {
+        "type" : {
+          "const" : "ExternalSubType"
+        }
+      }
+    },
+    "ExternalSubTypeSuperclass" : {
+      "type" : "object",
+      "title" : "External Sub Type Superclass",
+      "additionalProperties" : true,
+      "required" : [ "type" ],
+      "properties" : {
+        "type" : {
+          "const" : "ExternalSubTypeSuperclass"
+        }
+      }
+    }
+  },
+  "type" : "object",
+  "discriminator" : {
+    "propertyName" : "type"
+  },
+  "oneOf" : [ {
+    "$ref" : "#/definitions/ExternalSubType"
+  }, {
+    "$ref" : "#/definitions/ExternalSubTypeSuperclass"
+  } ],
+  "title" : "External Polymorphic Type",
+  "additionalProperties" : true
+}


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description

<!--
  Please describe the changes and add a link to the related issue(s) #
-->

Migrates `JSONSchemaUtilTest` to the snapshot testing added in [Spock 2.4](https://spockframework.org/spock/docs/2.4/extensions.html#snapshot-testing). The expected schemas moved out of the spec into snapshot files, so each feature is now a single `schemaMatchesSnapshot(SomeType)` call.

This was done in preparation for #2701, to have a unified way of writing snapshot tests in Spock.

## Updating the snapshots

Run `./gradlew :model:test -PupdateSnapshots`, then review the resulting diff before committing. Without the flag a mismatch is reported as a normal test failure.

Snapshots live in `model/src/test/resources/snapshots/`, one file per feature, named after the feature with an iteration index for the data driven map test.

The snapshot root is set through the `spock.snapshots.rootPath` system property in `model/build.gradle` rather than a `SpockConfig.groovy`, because the `snapshots` config block is silently ignored on Spock 2.4-groovy-5.0. Running the spec straight from an IDE therefore requires Gradle delegation.

## Changelog

- Replace the inline expected JSON and the `loadResourceAsStream` expectation resources with Spock snapshots.
- Move the 7 existing expectation resources under `snapshots/` unchanged, so git records them as renames.
- Add `-PupdateSnapshots` to the `:model:test` task for rewriting snapshots.
- Drop the `jsonassert` dependency from `model` and the version catalog, since comparison is now exact rather than lenient.
- Assert 4 fields that the lenient comparison had been hiding in `schema remaps annotated types`, whose expected JSON was malformed (missing space between after `:` like `"key":value`) and got truncated by `readTree`.
- Document snapshot regeneration in `AGENTS.md`.

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
