### PR TITLE
Ignore Groovy formatting commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Applied the initial repository-wide Spotless formatting
 e3a066dcf739efe08d3d0e51e477d2d652dd28f8
+
+# Applied repository-wide Spotless formatting to Groovy files
+db6a1ef6c7bee92ffd6d1855d0aa057f56a028c2


### PR DESCRIPTION
## Description

Add the repository-wide Groovy formatting commit to `.git-blame-ignore-revs` so it doesn't obscure the original authorship when using git blame.

See: https://github.com/openremote/openremote/pull/3215

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
