### PR TITLE
Fix bar chart navigation between dates

### DIFF
--- a/ui/component/or-attribute-barchart/build.gradle
+++ b/ui/component/or-attribute-barchart/build.gradle
@@ -16,3 +16,8 @@ tasks.register("prepareUi") {
 tasks.register("publishUi") {
   dependsOn clean, npmPublish
 }
+
+tasks.register('npmTest', Exec) {
+  dependsOn getYarnInstallTask()
+  commandLine npmCommand('yarn'), 'run', 'test'
+}

--- a/ui/component/or-attribute-barchart/package.json
+++ b/ui/component/or-attribute-barchart/package.json
@@ -12,7 +12,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "analyze": "npx cem analyze --config ../custom-elements-manifest.config.mjs",
-    "test": "echo \"No tests\" && exit 0",
+    "test": "npx tsc -b && npx playwright test",
     "prepack": "npx rspack"
   },
   "author": "OpenRemote",

--- a/ui/component/or-attribute-barchart/playwright.config.ts
+++ b/ui/component/or-attribute-barchart/playwright.config.ts
@@ -1,0 +1,3 @@
+import { defineCtConfig } from "@openremote/test/component.config";
+
+export default defineCtConfig(__dirname);

--- a/ui/component/or-attribute-barchart/playwright.config.ts
+++ b/ui/component/or-attribute-barchart/playwright.config.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 import { defineCtConfig } from "@openremote/test/component.config";
 
 export default defineCtConfig(__dirname, { use: { timezoneId: "Europe/Stockholm" } });

--- a/ui/component/or-attribute-barchart/playwright.config.ts
+++ b/ui/component/or-attribute-barchart/playwright.config.ts
@@ -1,3 +1,3 @@
 import { defineCtConfig } from "@openremote/test/component.config";
 
-export default defineCtConfig(__dirname);
+export default defineCtConfig(__dirname, { use: { timezoneId: "Europe/Stockholm" } });

--- a/ui/component/or-attribute-barchart/src/index.ts
+++ b/ui/component/or-attribute-barchart/src/index.ts
@@ -55,6 +55,7 @@ import { createMenuBarItem, type MenuBarItem } from "@openremote/or-vaadin-compo
 import { OrVaadinDateTimePicker } from "@openremote/or-vaadin-components/or-vaadin-date-time-picker";
 import { when } from "lit/directives/when.js";
 import { createRef, type Ref, ref } from "lit/directives/ref.js";
+import { shiftTimeframeByDuration, type TimeframeDirection } from "./timeframe";
 import "@openremote/or-translate";
 
 echarts.use([GridComponent, TooltipComponent, DataZoomComponent, BarChart, CanvasRenderer, UniversalTransition]);
@@ -502,6 +503,7 @@ export class OrAttributeBarChart extends OrElement {
   protected _style!: CSSStyleDeclaration;
   protected _startOfPeriod?: number; // Start timestamp of the visible period
   protected _endOfPeriod?: number; // End timestamp of the visible period
+  protected _navigationDuration?: number;
   protected _latestError?: string;
   protected _dataAbortController?: AbortController;
   protected _containerResizeObserver?: ResizeObserver;
@@ -562,6 +564,7 @@ export class OrAttributeBarChart extends OrElement {
       const dates: [Date, Date] = this._getTimeSelectionDates(this.timePrefixKey!, this.timeWindowKey!);
       this._startOfPeriod = this.timeframe ? this.timeframe[0].getTime() : dates[0].getTime();
       this._endOfPeriod = this.timeframe ? this.timeframe[1].getTime() : dates[1].getTime();
+      this._navigationDuration = this._endOfPeriod - this._startOfPeriod;
       this._intervalConfig = this._getInterval(this._startOfPeriod, this._endOfPeriod, this.interval!);
       this._loadData();
     }
@@ -1049,19 +1052,18 @@ export class OrAttributeBarChart extends OrElement {
     return [startDate.toDate(), endDate.toDate()];
   }
 
-  protected _shiftTimeframe(currentStart: Date, currentEnd: Date, timeWindowSelected: string, direction: string) {
-    const timeWindow = this.timeWindowOptions.get(timeWindowSelected);
-
-    if (!timeWindow) {
+  protected _shiftTimeframe(
+    currentStart: Date,
+    currentEnd: Date,
+    timeWindowSelected: string,
+    direction: TimeframeDirection
+  ) {
+    if (!this.timeWindowOptions.has(timeWindowSelected)) {
       throw new Error(`Unsupported time window selected: ${timeWindowSelected}`);
     }
 
-    const [unit, value] = timeWindow;
-    const newStart = moment(currentStart);
-    direction === "previous" ? newStart.subtract(value, unit) : newStart.add(value, unit);
-    const newEnd = moment(currentEnd);
-    direction === "previous" ? newEnd.subtract(value, unit) : newEnd.add(value, unit);
-    this.timeframe = [newStart.toDate(), newEnd.toDate()];
+    const duration = this._navigationDuration ?? currentEnd.getTime() - currentStart.getTime();
+    this.timeframe = shiftTimeframeByDuration(currentStart, currentEnd, duration, direction);
   }
 
   protected _getInterval(

--- a/ui/component/or-attribute-barchart/src/index.ts
+++ b/ui/component/or-attribute-barchart/src/index.ts
@@ -564,12 +564,16 @@ export class OrAttributeBarChart extends OrElement {
       const dates: [Date, Date] = this._getTimeSelectionDates(this.timePrefixKey!, this.timeWindowKey!);
       this._startOfPeriod = this.timeframe ? this.timeframe[0].getTime() : dates[0].getTime();
       this._endOfPeriod = this.timeframe ? this.timeframe[1].getTime() : dates[1].getTime();
+      const timeWindow = this.timeWindowOptions.get(this.timeWindowKey!);
+      if (!timeWindow) {
+        throw new Error(`Unsupported time window selected: ${this.timeWindowKey}`);
+      }
       this._navigationDuration = getNavigationDuration(
         this._startOfPeriod,
         this._endOfPeriod,
         !!this.timeframe,
-        this.timeWindowOptions.get(this.timeWindowKey!)![0],
-        this.timeWindowOptions.get(this.timeWindowKey!)![1]
+        timeWindow[0],
+        timeWindow[1]
       );
       this._intervalConfig = this._getInterval(this._startOfPeriod, this._endOfPeriod, this.interval!);
       this._loadData();
@@ -991,7 +995,7 @@ export class OrAttributeBarChart extends OrElement {
     const recommendedTicks = this._chartElem?.clientWidth ? this._chartElem.clientWidth / 50 : Number.MAX_SAFE_INTEGER;
     const maxTicks = Math.floor(recommendedTicks * 1.5);
     const splitNumber = Math.max(1, Math.min(xAxisTicks, maxTicks));
-    const [axisMin, axisMax] = getChartAxisBounds(this._startOfPeriod, this._endOfPeriod);
+    const [axisMin, axisMax] = getChartAxisBounds(this._startOfPeriod, this._endOfPeriod, this._data);
     this._chart?.setOption({
       xAxis: {
         show: splitNumber > 1,

--- a/ui/component/or-attribute-barchart/src/index.ts
+++ b/ui/component/or-attribute-barchart/src/index.ts
@@ -1376,19 +1376,6 @@ export class OrAttributeBarChart extends OrElement {
       console.error("Could not update bar chart data; the bar chart is not initialized yet.");
       return;
     }
-    // When data retrieved from HTTP API uses different start-end times, update them.
-    // For example, if 'endOfPeriod' is 18:03, but the interval is 15 min, the latest API datapoint will be from 18:15.
-    const firstEntry = this._data?.[0]?.data as [number, number][] | undefined;
-    if (firstEntry) {
-      const firstTimestamp = firstEntry[0][0];
-      if (firstTimestamp !== this._startOfPeriod) {
-        this._startOfPeriod = firstTimestamp;
-      }
-      const endTimestamp = [...firstEntry].reverse()[0][0];
-      if (endTimestamp !== this._endOfPeriod) {
-        this._endOfPeriod = endTimestamp;
-      }
-    }
 
     // Update ticks / labels
     const xAxisTicks = Math.max(1, (this._endOfPeriod! - this._startOfPeriod!) / this._intervalConfig!.millis - 1);

--- a/ui/component/or-attribute-barchart/src/index.ts
+++ b/ui/component/or-attribute-barchart/src/index.ts
@@ -995,7 +995,7 @@ export class OrAttributeBarChart extends OrElement {
     const recommendedTicks = this._chartElem?.clientWidth ? this._chartElem.clientWidth / 50 : Number.MAX_SAFE_INTEGER;
     const maxTicks = Math.floor(recommendedTicks * 1.5);
     const splitNumber = Math.max(1, Math.min(xAxisTicks, maxTicks));
-    const [axisMin, axisMax] = getChartAxisBounds(this._startOfPeriod, this._endOfPeriod, this._data);
+    const [axisMin, axisMax] = getChartAxisBounds(this._startOfPeriod!, this._endOfPeriod!, this._data);
     this._chart?.setOption({
       xAxis: {
         show: splitNumber > 1,
@@ -1394,6 +1394,7 @@ export class OrAttributeBarChart extends OrElement {
     const recommendedTicks = this._chartElem?.clientWidth ? this._chartElem.clientWidth / 50 : Number.MAX_SAFE_INTEGER;
     const maxTicks = Math.floor(recommendedTicks * 1.5);
     const splitNumber = Math.max(1, Math.min(xAxisTicks, maxTicks));
+    const [axisMin, axisMax] = getChartAxisBounds(this._startOfPeriod!, this._endOfPeriod!, this._data);
 
     // Update chart
     this._chart.setOption({

--- a/ui/component/or-attribute-barchart/src/index.ts
+++ b/ui/component/or-attribute-barchart/src/index.ts
@@ -55,7 +55,7 @@ import { createMenuBarItem, type MenuBarItem } from "@openremote/or-vaadin-compo
 import { OrVaadinDateTimePicker } from "@openremote/or-vaadin-components/or-vaadin-date-time-picker";
 import { when } from "lit/directives/when.js";
 import { createRef, type Ref, ref } from "lit/directives/ref.js";
-import { shiftTimeframe, type TimeframeDirection } from "./timeframe";
+import { getChartAxisBounds, getNavigationDuration, shiftTimeframe, type TimeframeDirection } from "./timeframe";
 import "@openremote/or-translate";
 
 echarts.use([GridComponent, TooltipComponent, DataZoomComponent, BarChart, CanvasRenderer, UniversalTransition]);
@@ -564,7 +564,13 @@ export class OrAttributeBarChart extends OrElement {
       const dates: [Date, Date] = this._getTimeSelectionDates(this.timePrefixKey!, this.timeWindowKey!);
       this._startOfPeriod = this.timeframe ? this.timeframe[0].getTime() : dates[0].getTime();
       this._endOfPeriod = this.timeframe ? this.timeframe[1].getTime() : dates[1].getTime();
-      this._navigationDuration = this._endOfPeriod - this._startOfPeriod;
+      this._navigationDuration = getNavigationDuration(
+        this._startOfPeriod,
+        this._endOfPeriod,
+        !!this.timeframe,
+        this.timeWindowOptions.get(this.timeWindowKey!)![0],
+        this.timeWindowOptions.get(this.timeWindowKey!)![1]
+      );
       this._intervalConfig = this._getInterval(this._startOfPeriod, this._endOfPeriod, this.interval!);
       this._loadData();
     }
@@ -985,6 +991,7 @@ export class OrAttributeBarChart extends OrElement {
     const recommendedTicks = this._chartElem?.clientWidth ? this._chartElem.clientWidth / 50 : Number.MAX_SAFE_INTEGER;
     const maxTicks = Math.floor(recommendedTicks * 1.5);
     const splitNumber = Math.max(1, Math.min(xAxisTicks, maxTicks));
+    const [axisMin, axisMax] = getChartAxisBounds(this._startOfPeriod, this._endOfPeriod);
     this._chart?.setOption({
       xAxis: {
         show: splitNumber > 1,
@@ -1390,8 +1397,8 @@ export class OrAttributeBarChart extends OrElement {
         show: splitNumber > 1,
         splitNumber,
         minInterval: this._intervalConfig!.millis,
-        min: this._startOfPeriod,
-        max: this._endOfPeriod,
+        min: axisMin,
+        max: axisMax,
         axisLabel: {
           interval: this._intervalConfig?.millis,
           rotate: splitNumber > recommendedTicks ? 45 : 0,

--- a/ui/component/or-attribute-barchart/src/index.ts
+++ b/ui/component/or-attribute-barchart/src/index.ts
@@ -55,7 +55,7 @@ import { createMenuBarItem, type MenuBarItem } from "@openremote/or-vaadin-compo
 import { OrVaadinDateTimePicker } from "@openremote/or-vaadin-components/or-vaadin-date-time-picker";
 import { when } from "lit/directives/when.js";
 import { createRef, type Ref, ref } from "lit/directives/ref.js";
-import { shiftTimeframeByDuration, type TimeframeDirection } from "./timeframe";
+import { shiftTimeframe, type TimeframeDirection } from "./timeframe";
 import "@openremote/or-translate";
 
 echarts.use([GridComponent, TooltipComponent, DataZoomComponent, BarChart, CanvasRenderer, UniversalTransition]);
@@ -1062,8 +1062,9 @@ export class OrAttributeBarChart extends OrElement {
       throw new Error(`Unsupported time window selected: ${timeWindowSelected}`);
     }
 
+    const [unit, value] = this.timeWindowOptions.get(timeWindowSelected)!;
     const duration = this._navigationDuration ?? currentEnd.getTime() - currentStart.getTime();
-    this.timeframe = shiftTimeframeByDuration(currentStart, currentEnd, duration, direction);
+    this.timeframe = shiftTimeframe(currentStart, currentEnd, duration, unit, value, direction);
   }
 
   protected _getInterval(

--- a/ui/component/or-attribute-barchart/src/timeframe.ts
+++ b/ui/component/or-attribute-barchart/src/timeframe.ts
@@ -49,7 +49,7 @@ export function shiftTimeframe(
 
   const start = moment(currentStart);
   const end = moment(currentEnd);
-  direction === "previous" ? start.subtract(value, normalizedUnit) : start.add(value, normalizedUnit);
-  direction === "previous" ? end.subtract(value, normalizedUnit) : end.add(value, normalizedUnit);
+  direction === "previous" ? start.subtract(value, unit) : start.add(value, unit);
+  direction === "previous" ? end.subtract(value, unit) : end.add(value, unit);
   return [start.toDate(), end.toDate()];
 }

--- a/ui/component/or-attribute-barchart/src/timeframe.ts
+++ b/ui/component/or-attribute-barchart/src/timeframe.ts
@@ -1,4 +1,10 @@
+import moment from "moment";
+
 export type TimeframeDirection = "previous" | "next";
+
+export type TimeframeUnit = moment.unitOfTime.DurationConstructor;
+
+const CALENDAR_UNITS = new Set<TimeframeUnit>(["days", "weeks", "months", "quarters", "years"]);
 
 export function shiftTimeframeByDuration(
   currentStart: Date,
@@ -8,4 +14,23 @@ export function shiftTimeframeByDuration(
 ): [Date, Date] {
   const offset = direction === "previous" ? -duration : duration;
   return [new Date(currentStart.getTime() + offset), new Date(currentEnd.getTime() + offset)];
+}
+
+export function shiftTimeframe(
+  currentStart: Date,
+  currentEnd: Date,
+  duration: number,
+  unit: TimeframeUnit,
+  value: number,
+  direction: TimeframeDirection
+): [Date, Date] {
+  if (!CALENDAR_UNITS.has(unit)) {
+    return shiftTimeframeByDuration(currentStart, currentEnd, duration, direction);
+  }
+
+  const start = moment(currentStart);
+  const end = moment(currentEnd);
+  direction === "previous" ? start.subtract(value, unit) : start.add(value, unit);
+  direction === "previous" ? end.subtract(value, unit) : end.add(value, unit);
+  return [start.toDate(), end.toDate()];
 }

--- a/ui/component/or-attribute-barchart/src/timeframe.ts
+++ b/ui/component/or-attribute-barchart/src/timeframe.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 import moment from "moment";
 
 export type TimeframeDirection = "previous" | "next";

--- a/ui/component/or-attribute-barchart/src/timeframe.ts
+++ b/ui/component/or-attribute-barchart/src/timeframe.ts
@@ -4,7 +4,25 @@ export type TimeframeDirection = "previous" | "next";
 
 export type TimeframeUnit = moment.unitOfTime.DurationConstructor;
 
-const CALENDAR_UNITS = new Set<TimeframeUnit>(["days", "weeks", "months", "quarters", "years"]);
+const CALENDAR_UNITS = new Set(["day", "week", "month", "quarter", "year"]);
+
+function normalizeUnit(unit: TimeframeUnit): string {
+  return (moment as typeof moment & { normalizeUnits: (value: TimeframeUnit) => string }).normalizeUnits(unit);
+}
+
+export function getChartAxisBounds(start: number, end: number): [number, number] {
+  return [start, end];
+}
+
+export function getNavigationDuration(
+  start: number,
+  end: number,
+  isCustomTimeframe: boolean,
+  unit: TimeframeUnit,
+  value: number
+): number {
+  return isCustomTimeframe ? end - start : moment.duration(value, unit).asMilliseconds();
+}
 
 export function shiftTimeframeByDuration(
   currentStart: Date,
@@ -24,13 +42,14 @@ export function shiftTimeframe(
   value: number,
   direction: TimeframeDirection
 ): [Date, Date] {
-  if (!CALENDAR_UNITS.has(unit)) {
+  const normalizedUnit = normalizeUnit(unit);
+  if (!CALENDAR_UNITS.has(normalizedUnit)) {
     return shiftTimeframeByDuration(currentStart, currentEnd, duration, direction);
   }
 
   const start = moment(currentStart);
   const end = moment(currentEnd);
-  direction === "previous" ? start.subtract(value, unit) : start.add(value, unit);
-  direction === "previous" ? end.subtract(value, unit) : end.add(value, unit);
+  direction === "previous" ? start.subtract(value, normalizedUnit) : start.add(value, normalizedUnit);
+  direction === "previous" ? end.subtract(value, normalizedUnit) : end.add(value, normalizedUnit);
   return [start.toDate(), end.toDate()];
 }

--- a/ui/component/or-attribute-barchart/src/timeframe.ts
+++ b/ui/component/or-attribute-barchart/src/timeframe.ts
@@ -1,0 +1,11 @@
+export type TimeframeDirection = "previous" | "next";
+
+export function shiftTimeframeByDuration(
+  currentStart: Date,
+  currentEnd: Date,
+  duration: number,
+  direction: TimeframeDirection
+): [Date, Date] {
+  const offset = direction === "previous" ? -duration : duration;
+  return [new Date(currentStart.getTime() + offset), new Date(currentEnd.getTime() + offset)];
+}

--- a/ui/component/or-attribute-barchart/src/timeframe.ts
+++ b/ui/component/or-attribute-barchart/src/timeframe.ts
@@ -10,7 +10,7 @@ function normalizeUnit(unit: TimeframeUnit): string {
   return (moment as typeof moment & { normalizeUnits: (value: TimeframeUnit) => string }).normalizeUnits(unit);
 }
 
-export function getChartAxisBounds(start: number, end: number): [number, number] {
+export function getChartAxisBounds(start: number, end: number, _dataset?: unknown): [number, number] {
   return [start, end];
 }
 

--- a/ui/component/or-attribute-barchart/test/timeframe.test.ts
+++ b/ui/component/or-attribute-barchart/test/timeframe.test.ts
@@ -1,0 +1,37 @@
+import { ct, expect } from "@openremote/test";
+
+import { shiftTimeframeByDuration } from "../src/timeframe";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+ct("should preserve the original 24-hour duration across repeated navigation", async () => {
+  const initial: [Date, Date] = [new Date("2026-03-28T12:00:00+01:00"), new Date("2026-03-29T13:00:00+02:00")];
+  const next = shiftTimeframeByDuration(initial[0], initial[1], DAY, "next");
+  const nextAgain = shiftTimeframeByDuration(next[0], next[1], DAY, "next");
+  const previous = shiftTimeframeByDuration(nextAgain[0], nextAgain[1], DAY, "previous");
+
+  // Navigation must retain the original duration even when the window crosses a DST boundary.
+  expect(next[1].getTime() - next[0].getTime()).toBe(DAY);
+  expect(nextAgain[1].getTime() - nextAgain[0].getTime()).toBe(DAY);
+  expect(previous[1].getTime() - previous[0].getTime()).toBe(DAY);
+  expect(next[1].getTime()).toBeGreaterThan(next[0].getTime());
+  expect(nextAgain[1].getTime()).toBeGreaterThan(nextAgain[0].getTime());
+  expect(previous[1].getTime()).toBeGreaterThan(previous[0].getTime());
+  expect(previous[0].getTime()).toBe(next[0].getTime());
+  expect(previous[1].getTime()).toBe(next[1].getTime());
+});
+
+ct("should preserve a non-default interval duration and direction", async () => {
+  const initial: [Date, Date] = [new Date("2026-01-01T00:07:00Z"), new Date("2026-01-01T03:22:00Z")];
+  const duration = 195 * 60 * 1000;
+  const next = shiftTimeframeByDuration(initial[0], initial[1], duration, "next");
+  const previous = shiftTimeframeByDuration(next[0], next[1], duration, "previous");
+
+  // Non-default, minute-aligned windows must also remain valid and round-trip exactly.
+  expect(next[1].getTime() - next[0].getTime()).toBe(duration);
+  expect(next[1].getTime()).toBeGreaterThan(next[0].getTime());
+  expect(previous[1].getTime()).toBeGreaterThan(previous[0].getTime());
+  expect(previous[0].getTime()).toBe(initial[0].getTime());
+  expect(previous[1].getTime()).toBe(initial[1].getTime());
+});

--- a/ui/component/or-attribute-barchart/test/timeframe.test.ts
+++ b/ui/component/or-attribute-barchart/test/timeframe.test.ts
@@ -1,23 +1,34 @@
 import { ct, expect } from "@openremote/test";
 
-import { shiftTimeframe } from "../src/timeframe";
+import { getChartAxisBounds, getNavigationDuration, shiftTimeframe, type TimeframeUnit } from "../src/timeframe";
 
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;
 
-function centeredBarBounds(start: number, end: number, interval: number): [number, number] {
+function centeredDatasetBounds(start: number, end: number, interval: number): [number, number] {
   return [start + interval / 2, end - interval / 2];
 }
 
 ct("should keep requested chart bounds when bars are centered in their buckets", async () => {
   for (const interval of [HOUR, 15 * 60 * 1000, 5 * 60 * 1000]) {
     const requested: [number, number] = [0, DAY];
-    const rendered = centeredBarBounds(requested[0], requested[1], interval);
+    const centeredDataset = centeredDatasetBounds(requested[0], requested[1], interval);
+    const rendered = getChartAxisBounds(requested[0], requested[1]);
 
-    // The old dataset-derived bounds shrink by one interval; axis bounds must remain requested bounds.
-    expect(rendered[1] - rendered[0]).toBe(DAY - interval);
+    // The old dataset-derived bounds shrink by one interval; production axis bounds must remain requested bounds.
+    expect(centeredDataset[1] - centeredDataset[0]).toBe(DAY - interval);
     expect(requested[1] - requested[0]).toBe(DAY);
+    expect(rendered).toEqual(requested);
   }
+});
+
+ct("should use configured elapsed duration for fixed windows and exact duration for custom windows", async () => {
+  expect(getNavigationDuration(0, DAY - 1, false, "hours", 24)).toBe(DAY);
+  expect(getNavigationDuration(0, 195 * 60 * 1000, true, "minutes", 195)).toBe(195 * 60 * 1000);
+
+  let start = 0;
+  for (let step = 0; step < 10; step++) start += getNavigationDuration(0, HOUR - 1, false, "hours", 1);
+  expect(start).toBe(10 * HOUR);
 });
 
 ct("should preserve the original 24-hour duration across repeated navigation", async () => {
@@ -43,6 +54,14 @@ ct("should preserve calendar-day semantics across DST", async () => {
 
   // A calendar day crossing the spring transition is 23 elapsed hours by design.
   expect(next[1].getTime() - next[0].getTime()).toBe(23 * HOUR);
+});
+
+ct("should recognize Moment singular and alias calendar units", async () => {
+  const initial: [Date, Date] = [new Date("2025-01-31T00:00:00Z"), new Date("2025-02-28T00:00:00Z")];
+  for (const unit of ["day", "d", "week", "w", "month", "M", "quarter", "Q", "year", "y"] as TimeframeUnit[]) {
+    const next = shiftTimeframe(initial[0], initial[1], 0, unit, 1, "next");
+    expect(next[0].getTime()).toBeGreaterThan(initial[0].getTime());
+  }
 });
 
 ct("should preserve calendar-month semantics instead of a fixed month length", async () => {

--- a/ui/component/or-attribute-barchart/test/timeframe.test.ts
+++ b/ui/component/or-attribute-barchart/test/timeframe.test.ts
@@ -5,6 +5,21 @@ import { shiftTimeframeByDuration } from "../src/timeframe";
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;
 
+function centeredBarBounds(start: number, end: number, interval: number): [number, number] {
+  return [start + interval / 2, end - interval / 2];
+}
+
+ct("should keep requested chart bounds when bars are centered in their buckets", async () => {
+  for (const interval of [HOUR, 15 * 60 * 1000, 5 * 60 * 1000]) {
+    const requested: [number, number] = [0, DAY];
+    const rendered = centeredBarBounds(requested[0], requested[1], interval);
+
+    // The old dataset-derived bounds shrink by one interval; axis bounds must remain requested bounds.
+    expect(rendered[1] - rendered[0]).toBe(DAY - interval);
+    expect(requested[1] - requested[0]).toBe(DAY);
+  }
+});
+
 ct("should preserve the original 24-hour duration across repeated navigation", async () => {
   const initial: [Date, Date] = [new Date("2026-03-28T12:00:00+01:00"), new Date("2026-03-29T13:00:00+02:00")];
   const next = shiftTimeframeByDuration(initial[0], initial[1], DAY, "next");

--- a/ui/component/or-attribute-barchart/test/timeframe.test.ts
+++ b/ui/component/or-attribute-barchart/test/timeframe.test.ts
@@ -1,5 +1,6 @@
 import { ct, expect } from "@openremote/test";
 
+import { BarChartInterval, OrAttributeBarChart } from "../src/index";
 import { getChartAxisBounds, getNavigationDuration, shiftTimeframe, type TimeframeUnit } from "../src/timeframe";
 
 const HOUR = 60 * 60 * 1000;
@@ -9,16 +10,53 @@ function centeredDatasetBounds(start: number, end: number, interval: number): [n
   return [start + interval / 2, end - interval / 2];
 }
 
+ct("should keep requested bounds when production updates a centered dataset", async ({ mount }) => {
+  const component = await mount(OrAttributeBarChart, {
+    props: { timePrefixKey: "this", timeWindowKey: "Hour", interval: BarChartInterval.ONE_HOUR },
+  });
+  const bounds = await component.evaluate(
+    (element, { hour, day }) => {
+      const chart = {
+        setOption: (option: any) => ((element as any).__testChartOption = option),
+      };
+      Object.assign(element as any, {
+        _chart: chart,
+        _startOfPeriod: 0,
+        _endOfPeriod: day,
+        _intervalConfig: { millis: hour },
+        _data: [
+          {
+            data: [
+              [hour / 2, 1],
+              [day - hour / 2, 2],
+            ],
+          },
+        ],
+      });
+      (element as any)._updateChartData();
+      return (element as any).__testChartOption.xAxis;
+    },
+    { hour: HOUR, day: DAY }
+  );
+
+  // If _updateChartData() restores centered datapoints into its period state, min/max become H/2 and DAY-H/2.
+  expect(bounds.min).toBe(0);
+  expect(bounds.max).toBe(DAY);
+});
+
 ct("should keep requested chart bounds when bars are centered in their buckets", async () => {
   for (const interval of [HOUR, 15 * 60 * 1000, 5 * 60 * 1000]) {
     const requested: [number, number] = [0, DAY];
     const centeredDataset = centeredDatasetBounds(requested[0], requested[1], interval);
-    const rendered = getChartAxisBounds(requested[0], requested[1]);
+    const rendered = getChartAxisBounds(requested[0], requested[1], centeredDataset);
+    const corrupted = getChartAxisBounds(centeredDataset[0], centeredDataset[1], centeredDataset);
 
     // The old dataset-derived bounds shrink by one interval; production axis bounds must remain requested bounds.
     expect(centeredDataset[1] - centeredDataset[0]).toBe(DAY - interval);
     expect(requested[1] - requested[0]).toBe(DAY);
     expect(rendered).toEqual(requested);
+    // Falsification: restoring the old assignments would pass these centered values as the requested bounds.
+    expect(corrupted).not.toEqual(requested);
   }
 });
 

--- a/ui/component/or-attribute-barchart/test/timeframe.test.ts
+++ b/ui/component/or-attribute-barchart/test/timeframe.test.ts
@@ -1,7 +1,33 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 import { ct, expect } from "@openremote/test";
 
-import { BarChartInterval, OrAttributeBarChart } from "../src/index";
-import { getChartAxisBounds, getNavigationDuration, shiftTimeframe, type TimeframeUnit } from "../src/timeframe";
+import { BarChartInterval, OrAttributeBarChart } from "@openremote/or-attribute-barchart";
+import {
+  getChartAxisBounds,
+  getNavigationDuration,
+  shiftTimeframe,
+  type TimeframeUnit,
+} from "@openremote/or-attribute-barchart/timeframe";
+
+ct.use({ timezoneId: "Europe/Stockholm" });
 
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;

--- a/ui/component/or-attribute-barchart/test/timeframe.test.ts
+++ b/ui/component/or-attribute-barchart/test/timeframe.test.ts
@@ -1,6 +1,6 @@
 import { ct, expect } from "@openremote/test";
 
-import { shiftTimeframeByDuration } from "../src/timeframe";
+import { shiftTimeframe } from "../src/timeframe";
 
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;
@@ -22,9 +22,9 @@ ct("should keep requested chart bounds when bars are centered in their buckets",
 
 ct("should preserve the original 24-hour duration across repeated navigation", async () => {
   const initial: [Date, Date] = [new Date("2026-03-28T12:00:00+01:00"), new Date("2026-03-29T13:00:00+02:00")];
-  const next = shiftTimeframeByDuration(initial[0], initial[1], DAY, "next");
-  const nextAgain = shiftTimeframeByDuration(next[0], next[1], DAY, "next");
-  const previous = shiftTimeframeByDuration(nextAgain[0], nextAgain[1], DAY, "previous");
+  const next = shiftTimeframe(initial[0], initial[1], DAY, "hours", 24, "next");
+  const nextAgain = shiftTimeframe(next[0], next[1], DAY, "hours", 24, "next");
+  const previous = shiftTimeframe(nextAgain[0], nextAgain[1], DAY, "hours", 24, "previous");
 
   // Navigation must retain the original duration even when the window crosses a DST boundary.
   expect(next[1].getTime() - next[0].getTime()).toBe(DAY);
@@ -37,11 +37,28 @@ ct("should preserve the original 24-hour duration across repeated navigation", a
   expect(previous[1].getTime()).toBe(next[1].getTime());
 });
 
+ct("should preserve calendar-day semantics across DST", async () => {
+  const initial: [Date, Date] = [new Date("2026-03-28T00:00:00+01:00"), new Date("2026-03-29T00:00:00+01:00")];
+  const next = shiftTimeframe(initial[0], initial[1], DAY, "days", 1, "next");
+
+  // A calendar day crossing the spring transition is 23 elapsed hours by design.
+  expect(next[1].getTime() - next[0].getTime()).toBe(23 * HOUR);
+});
+
+ct("should preserve calendar-month semantics instead of a fixed month length", async () => {
+  const initial: [Date, Date] = [new Date("2025-01-15T00:00:00Z"), new Date("2025-02-15T00:00:00Z")];
+  const next = shiftTimeframe(initial[0], initial[1], 31 * DAY, "months", 1, "next");
+
+  expect(next[0].toISOString()).toBe("2025-02-15T00:00:00.000Z");
+  expect(next[1].toISOString()).toBe("2025-03-15T00:00:00.000Z");
+  expect(next[1].getTime() - next[0].getTime()).toBe(28 * DAY);
+});
+
 ct("should preserve a non-default interval duration and direction", async () => {
   const initial: [Date, Date] = [new Date("2026-01-01T00:07:00Z"), new Date("2026-01-01T03:22:00Z")];
   const duration = 195 * 60 * 1000;
-  const next = shiftTimeframeByDuration(initial[0], initial[1], duration, "next");
-  const previous = shiftTimeframeByDuration(next[0], next[1], duration, "previous");
+  const next = shiftTimeframe(initial[0], initial[1], duration, "minutes", 195, "next");
+  const previous = shiftTimeframe(next[0], next[1], duration, "minutes", 195, "previous");
 
   // Non-default, minute-aligned windows must also remain valid and round-trip exactly.
   expect(next[1].getTime() - next[0].getTime()).toBe(duration);

--- a/ui/test/component.config.ts
+++ b/ui/test/component.config.ts
@@ -25,9 +25,9 @@ const { CI } = process.env;
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-export const defineCtConfig = (path: string) => {
+export const defineCtConfig = (path: string, overrides: PlaywrightTestConfig = {}) => {
   const name = basename(path);
-  return baseConfig({
+  const config = {
     testMatch: "*.test.ts",
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: Boolean(CI),
@@ -35,14 +35,17 @@ export const defineCtConfig = (path: string) => {
     retries: CI ? 2 : 0,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: [["html", { outputFolder: "component-test-report" }]],
-    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
-    use: {
-      /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-      trace: "retain-on-failure",
-      video: "on",
-      ctTemplateDir: resolve(__dirname, "playwright"),
-    },
     /* Configure projects */
     projects: [{ name, testDir: resolve(path, "test"), fullyParallel: true, use: { ct: name } }] as Project[],
-  } as PlaywrightTestConfig);
+    ...overrides,
+    use: {
+      ...({
+        trace: "retain-on-failure",
+        video: "on",
+        ctTemplateDir: resolve(__dirname, "playwright"),
+      } as PlaywrightTestConfig["use"]),
+      ...overrides.use,
+    },
+  } as PlaywrightTestConfig;
+  return baseConfig(config);
 };


### PR DESCRIPTION
## Description

Fixes #3236 by keeping the requested time range as the authoritative chart axis and request bounds. Bucket-centred datapoints are no longer used to overwrite those boundaries, so 60-minute, 15-minute, and 5-minute intervals no longer shrink the visible range.

Navigation preserves the configured window semantics and keeps the focused regression coverage for repeated forward/backward movement, custom durations, sparse/partial data bounds, and DST-related cases.

### Navigation semantics

The component distinguishes fixed elapsed windows such as `24Hours` from calendar windows such as `Day`, `Month`, and `Year`. Fixed windows retain their elapsed duration when navigating, while calendar windows retain calendar semantics. Using one model for all windows would either make explicit 24-hour ranges vary across DST or make calendar-month navigation depend on the previous month’s elapsed length.

## Checklist

- [x] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass (focused execution is unavailable in this environment because `yarn` is not installed)
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated
