### PR TITLE
Change AssetDatapointQueryDeserializationTest package

### DIFF
--- a/test/src/test/groovy/org/openremote/test/datapoint/AssetDatapointQueryDeserializationTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/datapoint/AssetDatapointQueryDeserializationTest.groovy
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-package org.openremote.manager.datapoint
+package org.openremote.test.datapoint
 
 import org.openremote.model.datapoint.query.AssetDatapointAllQuery
 import org.openremote.model.datapoint.query.AssetDatapointQuery


### PR DESCRIPTION
## Description

Changes the package from `org.openremote.manager.datapoint` to `org.openremote.test.datapoint` so it follows the same package naming convention as all the other tests.

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
