### PR TITLE
Use global workers setting in app test config

### DIFF
--- a/ui/test/app.config.cts
+++ b/ui/test/app.config.cts
@@ -52,12 +52,10 @@ function createAppSetupAndTeardown(app: string) {
       name: `setup ${app}`,
       testMatch: "**/*.setup.ts",
       teardown: `cleanup ${app}`,
-      worker: 1,
     },
     {
       name: `cleanup ${app}`,
       testMatch: "**/*.cleanup.ts",
-      worker: 1,
     },
   ];
 }
@@ -89,6 +87,7 @@ export const defineAppConfig = (path: string) => {
       url: "http://localhost:8080",
       reuseExistingServer: !process.env.CI,
     },
+    workers: 1,
     /* Configure projects */
     projects: [
       ...createAppSetupAndTeardown(name),
@@ -97,7 +96,6 @@ export const defineAppConfig = (path: string) => {
         testDir: resolve(path, "test"),
         fullyParallel: false,
         dependencies: [`setup ${name}`],
-        workers: 1,
         ...browser,
       })),
     ],


### PR DESCRIPTION
<!--
  Use a clear and meaningful title for your pull request because the title will be used in the release notes.
  If you have permission to manage labels, add a "Bug", "Enhancement", or "Feature" label if appropriate.
-->

## Description

<!--
  Please describe the changes and add a link to the related issue(s) #
-->

The aim of this PR is to fix the incorrect `worker` setting name (should be `workers`). Though we can combine all `worker` setting references by using a global setting instead: https://playwright.dev/docs/api/class-testconfig#test-config-workers.

See the JSDoc comment of the project level `workers` setting:

> The maximum number of concurrent worker processes to use for parallelizing tests from this project. Can also be set as percentage of logical CPU cores, e.g. '50%'.
This could be useful, for example, when all tests from a project share a single resource like a test account, and therefore cannot be executed in parallel. Limiting workers to one for such a project will prevent simultaneous use of the shared resource.
Note that the global testConfig.workers limit applies to the total number of worker processes. However, Playwright will limit the number of workers used for this project by the value of testProject.workers.
By default, there is no limit per project. See testConfig.workers for the default of the total worker limit.
Usage
> ```ts
> // playwright.config.ts
> import { defineConfig } from '@playwright/test';
> 
> export default defineConfig({
>   workers: 10,  // total workers limit
> 
>   projects: [
>     {
>       name: 'runs in parallel',
>     },
>     {
>       name: 'one at a time',
>       workers: 1,  // workers limit for this project
>     },
>   ],
> });
> ```

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
