### PR TITLE
Fix alarm action rollback and unify rules dialog form validation

### DIFF
--- a/ui/app/manager/test/fixtures/pages/rules.ts
+++ b/ui/app/manager/test/fixtures/pages/rules.ts
@@ -61,4 +61,21 @@ export class RulesPage implements BasePage {
     await when.getByRole("option", { name: operator, exact: true }).click();
     await when.getByRole("spinbutton", { name: attribute }).fill(value);
   }
+
+  /**
+   * The overlay of an action settings dialog, which Vaadin renders in its own element rather than
+   * inside `or-rule-json-dialog`.
+   * @param scope - Clause the action belongs to, e.g. the `or-rule-then-otherwise` locator.
+   */
+  actionDialogOverlay(scope: Locator): Locator {
+    return scope.getByRole("dialog").locator("#overlay").first();
+  }
+
+  /**
+   * Moves focus off the field being edited so its `change` event fires and the dialog revalidates.
+   * The overlay padding is the only spot within the dialog that takes no focus of its own.
+   */
+  async blurActiveField(scope: Locator) {
+    await this.actionDialogOverlay(scope).click({ position: { x: 0, y: 0 } });
+  }
 }

--- a/ui/app/manager/test/rules.test.ts
+++ b/ui/app/manager/test/rules.test.ts
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { expect, Locator } from "@openremote/test";
+import { expect } from "@openremote/test";
 import { test, userStatePath } from "./fixtures/manager.js";
 import { preparedAssetsForRules as assets } from "./fixtures/data/assets.js";
 import { energyRule } from "./fixtures/data/rules.js";
@@ -254,16 +254,15 @@ test("Create a When-Then rule for an asset with a email notification action", as
   await then.getByRole("button", { name: "Message", exact: true }).click();
 
   // Set up notification message in dialog
-  const dialog = then.getByRole("dialog");
-  const overlay = dialog.locator("#overlay").first();
+  const overlay = rulesPage.actionDialogOverlay(then);
   await expect(overlay).toBeVisible();
   await then.getByRole("textbox", { name: "Subject", exact: true }).clear();
-  await overlay.click({ position: { x: 0, y: 0 } }); // Click outside the dialog to lose focus
+  await rulesPage.blurActiveField(then);
   await expect(then.getByRole("textbox", { name: "Subject", exact: true })).toHaveAttribute("invalid");
   await expect(then.getByRole("button", { name: "OK", exact: true })).toBeDisabled();
 
   await then.getByRole("textbox", { name: "Subject", exact: true }).fill("Email notification");
-  await overlay.click({ position: { x: 0, y: 0 } }); // Click outside the dialog to lose focus
+  await rulesPage.blurActiveField(then);
   await expect(then.getByRole("textbox", { name: "Subject", exact: true })).not.toHaveAttribute("invalid");
   await expect(then.getByRole("button", { name: "OK", exact: true })).not.toBeDisabled();
 
@@ -320,17 +319,16 @@ test("Create a When-Then rule for an asset with a push notification action", asy
   await then.getByRole("button", { name: "Message", exact: true }).click();
 
   // Set up notification message in dialog
-  const dialog = then.getByRole("dialog");
-  const overlay = dialog.locator("#overlay").first();
+  const overlay = rulesPage.actionDialogOverlay(then);
   await expect(overlay).toBeVisible();
   await then.getByRole("textbox", { name: "Title", exact: true }).fill("Push notification");
   await then.getByRole("textbox", { name: "Body", exact: true }).clear();
-  await overlay.click({ position: { x: 0, y: 0 } }); // Click outside the dialog to lose focus
+  await rulesPage.blurActiveField(then);
   await expect(then.getByRole("textbox", { name: "Body", exact: true })).toHaveAttribute("invalid");
   await expect(then.getByRole("button", { name: "OK", exact: true })).toBeDisabled();
 
   await then.getByRole("textbox", { name: "Body", exact: true }).fill("Impacted assets: %TRIGGER_ASSETS%");
-  await overlay.click({ position: { x: 0, y: 0 } }); // Click outside the dialog to lose focus
+  await rulesPage.blurActiveField(then);
   await expect(then.getByRole("textbox", { name: "Body", exact: true })).not.toHaveAttribute("invalid");
   await expect(then.getByRole("button", { name: "OK", exact: true })).not.toBeDisabled();
 
@@ -391,17 +389,16 @@ test("Create a When-Then rule for an asset with a alarm action", async ({ page, 
   await then.getByRole("button", { name: "Settings", exact: true }).click();
 
   // Set up notification message in dialog
-  const dialog = then.getByRole("dialog");
-  const overlay = dialog.locator("#overlay").first();
+  const overlay = rulesPage.actionDialogOverlay(then);
   await expect(overlay).toBeVisible();
   await then.getByRole("textbox", { name: "Title", exact: true }).fill("High priority alarm");
   await then.getByRole("textbox", { name: "Content", exact: true }).clear();
-  await overlay.click({ position: { x: 0, y: 0 } }); // Click outside the dialog to lose focus
+  await rulesPage.blurActiveField(then);
   await expect(then.getByRole("textbox", { name: "Content", exact: true })).toHaveAttribute("invalid");
   await expect(then.getByRole("button", { name: "OK", exact: true })).toBeDisabled();
 
   await then.getByRole("textbox", { name: "Content", exact: true }).fill("Warning: %TRIGGER_ASSETS%");
-  await overlay.click({ position: { x: 0, y: 0 } }); // Click outside the dialog to lose focus
+  await rulesPage.blurActiveField(then);
   await expect(then.getByRole("textbox", { name: "Content", exact: true })).not.toHaveAttribute("invalid");
   await expect(then.getByRole("button", { name: "OK", exact: true })).not.toBeDisabled();
 
@@ -417,6 +414,72 @@ test("Create a When-Then rule for an asset with a alarm action", async ({ page, 
 
   await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(page.locator(`text=${energyRule.name}`)).toHaveCount(1);
+});
+
+/**
+ * @given A When-Then rule with an alarm action
+ * @when Setting the alarm severity, which sits outside the settings dialog
+ * @and Editing the alarm title inside the dialog and cancelling
+ * @then The severity should be kept, and the saved rule should not contain the cancelled edit
+ */
+test("Cancelling the alarm settings dialog discards only the changes made inside it", async ({
+  page,
+  manager,
+  rulesPage,
+  shared,
+}) => {
+  await manager.setup("smartcity", { assets });
+  await manager.goToRealmStartPage("smartcity");
+  await rulesPage.goto();
+  await rulesPage.createRule("When-Then");
+  await rulesPage.setRuleName(energyRule.name);
+
+  // When clause
+  const when = page.locator("or-rule-when");
+  await rulesPage.configureAttributeWhenClause(when, {
+    assetType: energyRule.asset_type,
+    asset: energyRule.asset,
+    attribute: energyRule.attribute_when,
+    operator: "Less than or equal to",
+    value: energyRule.value.toString(),
+  });
+
+  // Then clause, with an alarm that is filled in and confirmed
+  const then = page.locator("or-rule-then-otherwise");
+  await then.getByRole("menuitem", { name: "Add action" }).click();
+  await then.getByRole("menuitem", { name: "Alarm" }).click();
+  await then.getByRole("button", { name: "Settings", exact: true }).click();
+  await then.getByRole("textbox", { name: "Title", exact: true }).fill("Kept title");
+  await then.getByRole("textbox", { name: "Content", exact: true }).fill("Kept content");
+  await rulesPage.blurActiveField(then);
+  await then.getByRole("button", { name: "OK", exact: true }).click();
+
+  // Severity is edited outside of the dialog
+  await then.getByRole("button", { name: "Severity" }).click();
+  await then.getByRole("option", { name: "High", exact: true }).click();
+
+  // Reopen the dialog, edit the title, and back out again
+  await then.getByRole("button", { name: "Settings", exact: true }).click();
+  await then.getByRole("textbox", { name: "Title", exact: true }).fill("Discarded title");
+  await rulesPage.blurActiveField(then);
+  await then.getByRole("button", { name: "Cancel", exact: true }).click();
+
+  // Cancel used to restore a snapshot of the whole action, undoing the severity picked outside it
+  await expect(then.getByRole("button", { name: "Severity" })).toContainText("High");
+
+  let saved: RealmRuleset | undefined;
+  await shared.interceptResponse<number>("**/rules/realm", (rule, request) => {
+    if (rule) manager.rules.push(rule);
+    saved = request?.postDataJSON();
+  });
+
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.locator(`text=${energyRule.name}`)).toHaveCount(1);
+
+  // Cancel used to swap the element's own action reference, leaving the rule holding the edit
+  const action = JSON.parse(saved!.rules!).rules[0].then[0];
+  expect(action.alarm.title).toBe("Kept title");
+  expect(action.alarm.severity).toBe("HIGH");
 });
 
 /**
@@ -452,15 +515,14 @@ test("Create a When-Then rule for an asset with a webhook action", async ({ page
   await then.getByRole("button", { name: "Message", exact: true }).click();
 
   // Set up notification message in dialog
-  const dialog = then.getByRole("dialog");
-  const overlay = dialog.locator("#overlay").first();
+  const overlay = rulesPage.actionDialogOverlay(then);
   await expect(overlay).toBeVisible();
   await expect(then.getByRole("button", { name: "OK", exact: true })).toBeDisabled();
   await then.getByRole("button", { name: "Method" }).first().click();
   await then.getByRole("option", { name: "PUT", exact: true }).click();
   await expect(then.getByRole("button", { name: "OK", exact: true })).toBeDisabled();
   await then.getByRole("textbox", { name: "Web URL", exact: true }).fill("https://localhost");
-  await overlay.click({ position: { x: 0, y: 0 } }); // Click outside the dialog to lose focus
+  await rulesPage.blurActiveField(then);
   await expect(then.getByRole("button", { name: "OK", exact: true })).not.toBeDisabled();
 
   // Add request header
@@ -478,7 +540,7 @@ test("Create a When-Then rule for an asset with a webhook action", async ({ page
 
   // Remove body
   await then.getByRole("switch", { name: "Include body in Request", exact: true }).click();
-  await expect(then.getByRole("textbox", { name: "", exact: true }).last()).not.toBeVisible();
+  await expect(then.locator("or-vaadin-text-area")).not.toBeVisible(); // The payload is the form's only text area
 
   // Close the dialog
   await expect(page.getByRole("button", { name: "Save", exact: true })).toBeDisabled();

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-alarm.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-alarm.ts
@@ -34,6 +34,9 @@ export class OrRuleFormAlarm extends OrElement implements OrRuleForm {
   @property()
   public users: User[] = [];
 
+  @property({ type: Boolean })
+  public readonly?: boolean;
+
   static get styles() {
     return css`
       #form-container {
@@ -65,6 +68,7 @@ export class OrRuleFormAlarm extends OrElement implements OrRuleForm {
         <or-vaadin-text-field
           value=${alarm?.title}
           required
+          ?readonly=${this.readonly}
           @change=${(ev: Event) => this.setActionAlarmName((ev.currentTarget as HTMLInputElement).value, "title")}
         >
           <or-translate slot="label" value="alarm.title"></or-translate>
@@ -72,6 +76,7 @@ export class OrRuleFormAlarm extends OrElement implements OrRuleForm {
         <or-vaadin-text-area
           value=${alarm?.content}
           required
+          ?readonly=${this.readonly}
           style="min-height: 200px;"
           @change=${(ev: Event) => this.setActionAlarmName((ev.currentTarget as HTMLInputElement).value, "content")}
         >
@@ -80,6 +85,7 @@ export class OrRuleFormAlarm extends OrElement implements OrRuleForm {
         <or-vaadin-combo-box
           .items=${options}
           .selectedItem=${options.find((o) => o.value === this.action.assigneeId)}
+          ?readonly=${this.readonly}
           @change=${(ev: CustomEvent) => {
             // The 'none' option carries no value, which clears the assignee
             this.setActionAssignee((ev.currentTarget as OrVaadinComboBox).selectedItem?.value);

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-alarm.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-alarm.ts
@@ -18,13 +18,13 @@
  */
 import { html, css } from "lit";
 import { OrElement } from "@openremote/or-element";
-import { customElement, property, query } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import type { RuleActionAlarm, Alarm, User } from "@openremote/model";
 import { OrRulesJsonRuleChangedEvent } from "../or-rule-json-viewer";
 import { i18next } from "@openremote/or-translate";
 import "@openremote/or-vaadin-components/or-vaadin-combo-box";
 import type { OrVaadinComboBox } from "@openremote/or-vaadin-components/or-vaadin-combo-box";
-import type { OrRuleForm } from "./or-rule-form";
+import { isFormValid, type OrRuleForm } from "./or-rule-form";
 
 @customElement("or-rule-form-alarm")
 export class OrRuleFormAlarm extends OrElement implements OrRuleForm {
@@ -33,9 +33,6 @@ export class OrRuleFormAlarm extends OrElement implements OrRuleForm {
 
   @property()
   public users: User[] = [];
-
-  @query("#form-container")
-  protected _formContainerElem?: HTMLElement;
 
   static get styles() {
     return css`
@@ -50,12 +47,8 @@ export class OrRuleFormAlarm extends OrElement implements OrRuleForm {
     `;
   }
 
-  checkValidity() {
-    if (this._formContainerElem) {
-      const elems = Array.from(this._formContainerElem!.children) as HTMLInputElement[];
-      return elems.filter((e) => !e.checkValidity()).length === 0;
-    }
-    return false;
+  checkValidity(): boolean {
+    return isFormValid(this.renderRoot);
   }
 
   protected render() {

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-alarm.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-alarm.ts
@@ -22,6 +22,7 @@ import { customElement, property, query } from "lit/decorators.js";
 import type { RuleActionAlarm, Alarm, User } from "@openremote/model";
 import { OrRulesJsonRuleChangedEvent } from "../or-rule-json-viewer";
 import { i18next } from "@openremote/or-translate";
+import "@openremote/or-vaadin-components/or-vaadin-combo-box";
 import type { OrVaadinComboBox } from "@openremote/or-vaadin-components/or-vaadin-combo-box";
 import type { OrRuleForm } from "./or-rule-form";
 

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-alarm.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-alarm.ts
@@ -85,14 +85,11 @@ export class OrRuleFormAlarm extends OrElement implements OrRuleForm {
           <or-translate slot="label" value="alarm.content"></or-translate>
         </or-vaadin-text-area>
         <or-vaadin-combo-box
-          required
           .items=${options}
           .selectedItem=${options.find((o) => o.value === this.action.assigneeId)}
           @change=${(ev: CustomEvent) => {
-            // In the combobox, the 'value' is the User ID, while 'label' holds the username we need for assigneeId
-            const value: string | undefined = (ev.currentTarget as OrVaadinComboBox).selectedItem?.label;
-            this.action.assigneeId = value;
-            this.setActionAlarmName(value, undefined);
+            // The 'none' option carries no value, which clears the assignee
+            this.setActionAssignee((ev.currentTarget as OrVaadinComboBox).selectedItem?.value);
           }}
         >
           <or-translate slot="label" value="alarm.assignee"></or-translate>
@@ -101,19 +98,19 @@ export class OrRuleFormAlarm extends OrElement implements OrRuleForm {
     `;
   }
 
-  protected setActionAlarmName(value: string | undefined, key?: string) {
-    if (key && this.action.alarm) {
+  protected setActionAlarmName(value: string | undefined, key: string) {
+    if (this.action.alarm) {
       const alarm: any = this.action.alarm;
       alarm[key] = value;
       this.action.alarm = { ...alarm };
     }
-    if (!key) {
-      const user = this.users.filter((obj) => obj.username === value).map((obj) => obj.id)[0];
-      if (!user) {
-        console.warn(`Could not select user ${value}, as we can't find the user in cache.`);
-      }
-      this.action.assigneeId = user;
-    }
+
+    this.dispatchEvent(new OrRulesJsonRuleChangedEvent());
+    this.requestUpdate();
+  }
+
+  protected setActionAssignee(assigneeId: string | undefined) {
+    this.action.assigneeId = assigneeId;
 
     this.dispatchEvent(new OrRulesJsonRuleChangedEvent());
     this.requestUpdate();

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-email-message.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-email-message.ts
@@ -29,6 +29,9 @@ export class OrRuleFormEmailMessage extends translate(i18next)(OrElement) implem
   @property({ type: Object })
   public message?: EmailNotificationMessage;
 
+  @property({ type: Boolean })
+  public readonly?: boolean;
+
   static get styles() {
     return css`
       #form-container {
@@ -56,6 +59,7 @@ export class OrRuleFormEmailMessage extends translate(i18next)(OrElement) implem
         <or-vaadin-text-field
           value=${this.message?.subject}
           required
+          ?readonly=${this.readonly}
           @change=${(ev: Event) => this.setActionNotificationName((ev.currentTarget as HTMLInputElement).value, "subject")}
         >
           <or-translate slot="label" value="subject"></or-translate>
@@ -63,6 +67,7 @@ export class OrRuleFormEmailMessage extends translate(i18next)(OrElement) implem
         <or-vaadin-text-area
           value=${this.message?.html}
           required
+          ?readonly=${this.readonly}
           style="min-height: 200px;"
           @change=${(ev: Event) => this.setActionNotificationName((ev.currentTarget as HTMLInputElement).value, "html")}
         >

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-email-message.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-email-message.ts
@@ -18,19 +18,16 @@
  */
 import { html, css } from "lit";
 import { OrElement } from "@openremote/or-element";
-import { customElement, property, query } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import { i18next, translate } from "@openremote/or-translate";
 import type { EmailNotificationMessage } from "@openremote/model";
 import { OrRulesJsonRuleChangedEvent } from "../or-rule-json-viewer";
-import type { OrRuleForm } from "./or-rule-form";
+import { isFormValid, type OrRuleForm } from "./or-rule-form";
 
 @customElement("or-rule-form-email-message")
 export class OrRuleFormEmailMessage extends translate(i18next)(OrElement) implements OrRuleForm {
   @property({ type: Object })
   public message?: EmailNotificationMessage;
-
-  @query("#form-container")
-  protected _formContainerElem?: HTMLDivElement;
 
   static get styles() {
     return css`
@@ -46,11 +43,7 @@ export class OrRuleFormEmailMessage extends translate(i18next)(OrElement) implem
   }
 
   checkValidity(): boolean {
-    if (this._formContainerElem) {
-      const elems = Array.from(this._formContainerElem!.children) as HTMLInputElement[];
-      return elems.filter((e) => !e.checkValidity()).length === 0;
-    }
-    return false;
+    return isFormValid(this.renderRoot);
   }
 
   protected render() {

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-localized.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-localized.ts
@@ -50,6 +50,9 @@ export class OrRuleFormLocalized extends translate(i18next)(OrElement) implement
   @property()
   public wrongLanguage = false;
 
+  @property({ type: Boolean })
+  public readonly?: boolean;
+
   @state()
   protected _selectedLanguage = "en";
 
@@ -88,7 +91,7 @@ export class OrRuleFormLocalized extends translate(i18next)(OrElement) implement
       <div>
         ${when(this.wrongLanguage, () => until(this._getWrongLanguageTemplate()))}
         ${guard(
-          [this.message, this._selectedLanguage, this.languages, this.type],
+          [this.message, this._selectedLanguage, this.languages, this.type, this.readonly],
           () => html`
             ${until(this._getLanguageSelectForm(this._selectedLanguage, this.languages), html`Loading...`)}
             ${until(this._getNotificationForm(this.message, this._selectedLanguage), html`Loading...`)}
@@ -108,7 +111,11 @@ export class OrRuleFormLocalized extends translate(i18next)(OrElement) implement
    */
   protected async _getWrongLanguageTemplate(): Promise<TemplateResult> {
     return html`
-      <or-vaadin-button style="width: 100%; margin: 10px 0;" @click=${() => this._fixDefaultLanguage()}>
+      <or-vaadin-button
+        style="width: 100%; margin: 10px 0;"
+        ?disabled=${this.readonly}
+        @click=${() => this._fixDefaultLanguage()}
+      >
         <or-translate value="defaultLanguageChangedError"></or-translate>
       </or-vaadin-button>
     `;
@@ -179,9 +186,13 @@ export class OrRuleFormLocalized extends translate(i18next)(OrElement) implement
     const msg = message.languages[lang];
 
     if (msg.type === "push") {
-      return html` <or-rule-form-push-notification .message="${msg}"></or-rule-form-push-notification> `;
+      return html`
+        <or-rule-form-push-notification .message="${msg}" ?readonly=${this.readonly}></or-rule-form-push-notification>
+      `;
     } else if (msg.type === "email") {
-      return html` <or-rule-form-email-message .message="${msg}"></or-rule-form-email-message> `;
+      return html`
+        <or-rule-form-email-message .message="${msg}" ?readonly=${this.readonly}></or-rule-form-email-message>
+      `;
     } else {
       return html` <or-translate .value="${"errorOccurred"}"></or-translate> `;
     }

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-localized.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-localized.ts
@@ -19,7 +19,7 @@
 import { i18next, translate } from "@openremote/or-translate";
 import { type TemplateResult, css, html } from "lit";
 import { OrElement } from "@openremote/or-element";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import type { AbstractNotificationMessageUnion, LocalizedNotificationMessage } from "@openremote/model";
 import { showSnackbar } from "@openremote/or-mwc-components/or-mwc-snackbar";
 import { OrRulesJsonRuleChangedEvent } from "../or-rule-json-viewer";
@@ -31,7 +31,7 @@ import "./or-rule-form-push-notification";
 import ISO6391 from "iso-639-1";
 import { DefaultColor6 } from "@openremote/core";
 import type { SelectItem } from "@openremote/or-vaadin-components/or-vaadin-select";
-import type { OrRuleForm } from "./or-rule-form";
+import { isFormValid, type OrRuleForm } from "./or-rule-form";
 
 @customElement("or-rule-form-localized")
 export class OrRuleFormLocalized extends translate(i18next)(OrElement) implements OrRuleForm {
@@ -55,9 +55,6 @@ export class OrRuleFormLocalized extends translate(i18next)(OrElement) implement
 
   @state()
   protected _validLanguages?: string[];
-
-  @query(".form")
-  protected _formElement?: OrRuleForm;
 
   static get styles() {
     return css`
@@ -83,7 +80,7 @@ export class OrRuleFormLocalized extends translate(i18next)(OrElement) implement
   }
 
   checkValidity(): boolean {
-    return (this._formElement?.checkValidity() ?? false) && this.isValid();
+    return isFormValid(this.renderRoot) && this.isValid();
   }
 
   protected render() {
@@ -182,9 +179,9 @@ export class OrRuleFormLocalized extends translate(i18next)(OrElement) implement
     const msg = message.languages[lang];
 
     if (msg.type === "push") {
-      return html` <or-rule-form-push-notification class="form" .message="${msg}"></or-rule-form-push-notification> `;
+      return html` <or-rule-form-push-notification .message="${msg}"></or-rule-form-push-notification> `;
     } else if (msg.type === "email") {
-      return html` <or-rule-form-email-message class="form" .message="${msg}"></or-rule-form-email-message> `;
+      return html` <or-rule-form-email-message .message="${msg}"></or-rule-form-email-message> `;
     } else {
       return html` <or-translate .value="${"errorOccurred"}"></or-translate> `;
     }

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-push-notification.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-push-notification.ts
@@ -24,16 +24,13 @@ import type { PushNotificationMessage, PushNotificationButton } from "@openremot
 import { OrRulesJsonRuleChangedEvent } from "../or-rule-json-viewer";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
-import type { OrRuleForm } from "./or-rule-form";
 import "@openremote/or-vaadin-components/or-vaadin-toggle";
+import { isFormValid, type OrRuleForm } from "./or-rule-form";
 
 @customElement("or-rule-form-push-notification")
 export class OrRuleFormPushNotification extends translate(i18next)(OrElement) implements OrRuleForm {
   @property({ type: Object })
   public message?: PushNotificationMessage;
-
-  @query("#form-container")
-  protected _formContainerElem?: HTMLFormElement;
 
   @query("#push-title")
   protected _pushTitleElem?: HTMLInputElement;
@@ -74,11 +71,8 @@ export class OrRuleFormPushNotification extends translate(i18next)(OrElement) im
     `;
   }
 
-  checkValidity() {
-    if (this._formContainerElem) {
-      return this._formContainerElem.checkValidity();
-    }
-    return false;
+  checkValidity(): boolean {
+    return isFormValid(this.renderRoot);
   }
 
   protected render() {

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-push-notification.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-push-notification.ts
@@ -32,6 +32,9 @@ export class OrRuleFormPushNotification extends translate(i18next)(OrElement) im
   @property({ type: Object })
   public message?: PushNotificationMessage;
 
+  @property({ type: Boolean })
+  public readonly?: boolean;
+
   @query("#push-title")
   protected _pushTitleElem?: HTMLInputElement;
 
@@ -99,6 +102,7 @@ export class OrRuleFormPushNotification extends translate(i18next)(OrElement) im
           id="push-title"
           value=${message.title}
           required
+          ?readonly=${this.readonly}
           @change=${(ev: Event) => onchange(ev, message).then((msg) => this._onTitleChange(this._pushTitleElem!, msg))}
         >
           <or-translate slot="label" value="title"></or-translate>
@@ -107,6 +111,7 @@ export class OrRuleFormPushNotification extends translate(i18next)(OrElement) im
           id="push-body"
           value=${message.body}
           required
+          ?readonly=${this.readonly}
           style="min-height: 200px;"
           @change=${(ev: Event) => onchange(ev, message).then((msg) => this._onBodyChange(this._pushBodyElem!, msg))}
         >
@@ -119,6 +124,7 @@ export class OrRuleFormPushNotification extends translate(i18next)(OrElement) im
           error-message="${i18next.t("invalidUrl")}"
           placeholder="https://example.com"
           value=${message.action?.url}
+          ?readonly=${this.readonly}
           @change=${(ev: Event) => onchange(ev, message).then((msg) => this._onActionUrlChange(this._pushUrlElem!, msg))}
         >
           <or-translate slot="label" value="openWebsiteUrl"></or-translate>
@@ -128,6 +134,7 @@ export class OrRuleFormPushNotification extends translate(i18next)(OrElement) im
         <or-vaadin-toggle
           id="push-browser-toggle"
           ?checked="${message.action?.openInBrowser ?? false}"
+          ?readonly=${this.readonly}
           @change="${(ev: Event) => onchange(ev, message).then((msg) => this._onOpenInBrowserChange(this._pushBrowserToggleElem!, msg))}"
         >
           <or-translate slot="label" value="openInBrowser"></or-translate>
@@ -139,6 +146,7 @@ export class OrRuleFormPushNotification extends translate(i18next)(OrElement) im
             id="push-button1"
             value=${message.buttons?.[0]?.title}
             class="input-small"
+            ?readonly=${this.readonly}
             @change=${(ev: Event) => onchange(ev, message).then((msg) => this._onButtonTitleChange(this._pushButton1Elem!, 0, msg))}
           >
             <or-translate slot="label" value="buttonTextConfirm"></or-translate>
@@ -147,6 +155,7 @@ export class OrRuleFormPushNotification extends translate(i18next)(OrElement) im
             id="push-button2"
             value=${message.buttons?.[1]?.title}
             class="input-small"
+            ?readonly=${this.readonly}
             @change=${(ev: Event) => onchange(ev, message).then((msg) => this._onButtonTitleChange(this._pushButton2Elem!, 1, msg))}
           >
             <or-translate slot="label" value="buttonTextDecline"></or-translate>

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-push-notification.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-push-notification.ts
@@ -25,6 +25,7 @@ import { OrRulesJsonRuleChangedEvent } from "../or-rule-json-viewer";
 import { until } from "lit/directives/until.js";
 import { when } from "lit/directives/when.js";
 import type { OrRuleForm } from "./or-rule-form";
+import "@openremote/or-vaadin-components/or-vaadin-toggle";
 
 @customElement("or-rule-form-push-notification")
 export class OrRuleFormPushNotification extends translate(i18next)(OrElement) implements OrRuleForm {

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-webhook.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-webhook.ts
@@ -26,12 +26,12 @@ import {
 import { i18next } from "@openremote/or-translate";
 import { css, html, type TemplateResult } from "lit";
 import { OrElement } from "@openremote/or-element";
-import { customElement, property, queryAll, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import { when } from "lit/directives/when.js";
 import { OrRulesJsonRuleChangedEvent } from "../or-rule-json-viewer";
 import type { OrVaadinSelect, SelectItem } from "@openremote/or-vaadin-components/or-vaadin-select";
 import type { OrVaadinTextField } from "@openremote/or-vaadin-components/or-vaadin-text-field";
-import type { OrRuleForm } from "./or-rule-form";
+import { isFormValid, type OrRuleForm } from "./or-rule-form";
 import "@openremote/or-vaadin-components/or-vaadin-toggle";
 import type { OrVaadinToggle } from "@openremote/or-vaadin-components/or-vaadin-toggle";
 
@@ -50,9 +50,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
   @state()
   protected loading: boolean = false;
 
-  @queryAll(".input")
-  protected _inputElems?: NodeListOf<HTMLInputElement>;
-
   private httpMethodOptions: HTTPMethod[] = [HTTPMethod.GET, HTTPMethod.POST, HTTPMethod.PUT, HTTPMethod.DELETE];
   private authMethodOptions: Map<string, string> = new Map<string, string>([
     ["username_password", i18next.t("username") + " & " + i18next.t("password")],
@@ -65,7 +62,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
   }
 
   checkValidity(): boolean {
-    return Array.from(this._inputElems ?? []).filter((elem) => !elem.checkValidity()).length === 0;
+    return isFormValid(this.renderRoot);
   }
 
   /* --------------------------- */
@@ -118,7 +115,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
           <!-- HTTP Method & URL -->
           <div style="display: flex; flex-direction: row; align-items: baseline; gap: 5px; margin-bottom: 28px;">
             <or-vaadin-select
-              class="input"
               value=${this.webhook.httpMethod}
               .items=${this.httpMethodOptions.map((o) => ({ value: o, label: o }))}
               required
@@ -131,7 +127,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               <or-translate slot="label" value="method"></or-translate>
             </or-vaadin-select>
             <or-vaadin-text-field
-              class="input"
               type="url"
               value=${this.webhook.url}
               required
@@ -171,7 +166,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
             style="display: flex; flex-direction: column; gap: 10px; margin-bottom: ${this.webhook.oAuthGrant || this.webhook.usernamePassword ? "28px" : "0"};"
           >
             <or-vaadin-toggle
-              class="input"
               ?checked=${!!this.webhook.oAuthGrant || !!this.webhook.usernamePassword}
               @change=${(ev: Event) => {
                 this.webhook.usernamePassword = (ev.currentTarget as OrVaadinToggle).checked
@@ -192,7 +186,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               }));
               return html`
                 <or-vaadin-select
-                  class="input"
                   value=${this.webhook.oAuthGrant?.grant_type ?? values[0].value}
                   .items=${values}
                   @change=${(ev: Event) => {
@@ -212,7 +205,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               this.webhook.httpMethod != HTTPMethod.GET && this.webhook.httpMethod != HTTPMethod.DELETE,
               () => html`
                 <or-vaadin-toggle
-                  class="input"
                   ?checked=${this.webhook.payload != undefined}
                   @change=${(ev: Event) => {
                     this.webhook.payload = (ev.currentTarget as OrVaadinToggle).checked
@@ -233,7 +225,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                 ${when(this.webhook.payload != undefined, () => {
                   return html`
                     <or-vaadin-text-area
-                      class="input"
                       value=${this.webhook.payload}
                       style="min-height: 200px;"
                       @change=${(ev: Event) => {
@@ -261,7 +252,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
           (value, valueIndex) => html`
             <div style="display: flex; align-items: baseline; gap: 5px;">
               <or-vaadin-text-field
-                class="input"
                 value=${key}
                 ?disabled=${loading}
                 style="flex: 1;"
@@ -280,7 +270,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                 <or-translate slot="label" value="header"></or-translate>
               </or-vaadin-text-field>
               <or-vaadin-text-field
-                class="input"
                 value=${value}
                 ?disabled=${loading}
                 style="flex: 1;"
@@ -313,7 +302,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
       return html`
         <div style="display: flex; flex-direction: column; gap: 10px;">
           <or-vaadin-text-field
-            class="input"
             value=${webhook.usernamePassword?.username}
             @change=${(ev: Event) => {
               this.webhook.usernamePassword ??= {};
@@ -324,7 +312,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
             <or-translate slot="label" value="username"></or-translate>
           </or-vaadin-text-field>
           <or-vaadin-password-field
-            class="input"
             value=${webhook.usernamePassword?.password}
             @change=${(ev: Event) => {
               this.webhook.usernamePassword ??= {};
@@ -341,7 +328,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
         <div style="display: flex; flex-direction: column; gap: 10px;">
           <div style="display: flex; flex-direction: row; align-items: center; gap: 5px;">
             <or-vaadin-text-field
-              class="input"
               type="url"
               value=${authGrant.tokenEndpointUri}
               required
@@ -360,7 +346,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                 const grant = authGrant as OAuthClientCredentialsGrant;
                 return html`
                   <or-vaadin-text-field
-                    class="input"
                     value=${grant.client_id}
                     @change=${(ev: Event) => {
                       grant.client_id = (ev.currentTarget as HTMLInputElement).value;
@@ -370,7 +355,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                     <or-translate slot="label" value="clientId"></or-translate>
                   </or-vaadin-text-field>
                   <or-vaadin-password-field
-                    class="input"
                     value=${grant.client_secret}
                     @change=${(ev: Event) => {
                       grant.client_secret = (ev.currentTarget as HTMLInputElement).value;
@@ -385,7 +369,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                 const grant = authGrant as OAuthPasswordGrant;
                 return html`
                   <or-vaadin-text-field
-                    class="input"
                     value=${grant.username}
                     @change=${(ev: Event) => {
                       grant.username = (ev.currentTarget as HTMLInputElement).value;
@@ -395,7 +378,6 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                     <or-translate slot="label" value="username"></or-translate>
                   </or-vaadin-text-field>
                   <or-vaadin-password-field
-                    class="input"
                     value=${grant.password}
                     @change=${(ev: Event) => {
                       grant.password = (ev.currentTarget as HTMLInputElement).value;

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-webhook.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-webhook.ts
@@ -32,6 +32,7 @@ import { OrRulesJsonRuleChangedEvent } from "../or-rule-json-viewer";
 import type { OrVaadinSelect, SelectItem } from "@openremote/or-vaadin-components/or-vaadin-select";
 import type { OrVaadinTextField } from "@openremote/or-vaadin-components/or-vaadin-text-field";
 import type { OrRuleForm } from "./or-rule-form";
+import "@openremote/or-vaadin-components/or-vaadin-toggle";
 import type { OrVaadinToggle } from "@openremote/or-vaadin-components/or-vaadin-toggle";
 
 // language=css

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form-webhook.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form-webhook.ts
@@ -47,6 +47,9 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
   @property({ type: Object })
   protected webhook!: Webhook;
 
+  @property({ type: Boolean })
+  public readonly?: boolean;
+
   @state()
   protected loading: boolean = false;
 
@@ -118,6 +121,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               value=${this.webhook.httpMethod}
               .items=${this.httpMethodOptions.map((o) => ({ value: o, label: o }))}
               required
+              ?readonly=${this.readonly}
               style="flex: 0 0 100px;"
               @change=${(ev: Event) => {
                 this.webhook.httpMethod = (ev.currentTarget as OrVaadinSelect).value as HTTPMethod;
@@ -130,6 +134,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               type="url"
               value=${this.webhook.url}
               required
+              ?readonly=${this.readonly}
               style="flex: 1;"
               @change=${(ev: Event) => {
                 this.webhook.url = (ev.currentTarget as OrVaadinTextField).value;
@@ -148,6 +153,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               () => html` ${this.getHeadersTemplate(this.webhook.headers!, false)} `
             )}
             <or-vaadin-button
+              ?disabled=${this.readonly}
               @click=${() => {
                 if ((this.webhook.headers ? this.webhook.headers[""] : undefined) != undefined) {
                   this.webhook.headers![""].push("");
@@ -167,6 +173,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
           >
             <or-vaadin-toggle
               ?checked=${!!this.webhook.oAuthGrant || !!this.webhook.usernamePassword}
+              ?readonly=${this.readonly}
               @change=${(ev: Event) => {
                 this.webhook.usernamePassword = (ev.currentTarget as OrVaadinToggle).checked
                   ? {
@@ -188,6 +195,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                 <or-vaadin-select
                   value=${this.webhook.oAuthGrant?.grant_type ?? values[0].value}
                   .items=${values}
+                  ?readonly=${this.readonly}
                   @change=${(ev: Event) => {
                     this.webhook.oAuthGrant = this.getOAuthGrant((ev.currentTarget as OrVaadinSelect).value);
                     this.notifyWebhookUpdate();
@@ -206,6 +214,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               () => html`
                 <or-vaadin-toggle
                   ?checked=${this.webhook.payload != undefined}
+                  ?readonly=${this.readonly}
                   @change=${(ev: Event) => {
                     this.webhook.payload = (ev.currentTarget as OrVaadinToggle).checked
                       ? JSON.stringify(
@@ -226,6 +235,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                   return html`
                     <or-vaadin-text-area
                       value=${this.webhook.payload}
+                      ?readonly=${this.readonly}
                       style="min-height: 200px;"
                       @change=${(ev: Event) => {
                         this.webhook.payload = (ev.currentTarget as HTMLInputElement).value;
@@ -254,6 +264,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               <or-vaadin-text-field
                 value=${key}
                 ?disabled=${loading}
+                ?readonly=${this.readonly}
                 style="flex: 1;"
                 @change=${(ev: Event) => {
                   const inputValue = (ev.currentTarget as HTMLInputElement).value;
@@ -272,6 +283,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               <or-vaadin-text-field
                 value=${value}
                 ?disabled=${loading}
+                ?readonly=${this.readonly}
                 style="flex: 1;"
                 @change=${(ev: Event) => {
                   this.webhook.headers![key][valueIndex] = (ev.currentTarget as HTMLInputElement).value;
@@ -282,7 +294,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               </or-vaadin-text-field>
               <or-vaadin-button
                 theme="icon"
-                ?disabled=${loading}
+                ?disabled=${loading || this.readonly}
                 @click=${() => {
                   values.splice(valueIndex, 1);
                   this.reloadHeaders();
@@ -303,6 +315,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
         <div style="display: flex; flex-direction: column; gap: 10px;">
           <or-vaadin-text-field
             value=${webhook.usernamePassword?.username}
+            ?readonly=${this.readonly}
             @change=${(ev: Event) => {
               this.webhook.usernamePassword ??= {};
               this.webhook.usernamePassword.username = (ev.currentTarget as HTMLInputElement).value;
@@ -313,6 +326,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
           </or-vaadin-text-field>
           <or-vaadin-password-field
             value=${webhook.usernamePassword?.password}
+            ?readonly=${this.readonly}
             @change=${(ev: Event) => {
               this.webhook.usernamePassword ??= {};
               this.webhook.usernamePassword.password = (ev.currentTarget as HTMLInputElement).value;
@@ -331,6 +345,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
               type="url"
               value=${authGrant.tokenEndpointUri}
               required
+              ?readonly=${this.readonly}
               style="flex: 1;"
               @change=${(ev: Event) => {
                 authGrant.tokenEndpointUri = (ev.currentTarget as HTMLInputElement).value;
@@ -347,6 +362,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                 return html`
                   <or-vaadin-text-field
                     value=${grant.client_id}
+                    ?readonly=${this.readonly}
                     @change=${(ev: Event) => {
                       grant.client_id = (ev.currentTarget as HTMLInputElement).value;
                       this.notifyWebhookUpdate();
@@ -356,6 +372,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                   </or-vaadin-text-field>
                   <or-vaadin-password-field
                     value=${grant.client_secret}
+                    ?readonly=${this.readonly}
                     @change=${(ev: Event) => {
                       grant.client_secret = (ev.currentTarget as HTMLInputElement).value;
                       this.notifyWebhookUpdate();
@@ -370,6 +387,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                 return html`
                   <or-vaadin-text-field
                     value=${grant.username}
+                    ?readonly=${this.readonly}
                     @change=${(ev: Event) => {
                       grant.username = (ev.currentTarget as HTMLInputElement).value;
                       this.notifyWebhookUpdate();
@@ -379,6 +397,7 @@ export class OrRuleFormWebhook extends OrElement implements OrRuleForm {
                   </or-vaadin-text-field>
                   <or-vaadin-password-field
                     value=${grant.password}
+                    ?readonly=${this.readonly}
                     @change=${(ev: Event) => {
                       grant.password = (ev.currentTarget as HTMLInputElement).value;
                       this.notifyWebhookUpdate();

--- a/ui/component/or-rules/src/json-viewer/forms/or-rule-form.ts
+++ b/ui/component/or-rules/src/json-viewer/forms/or-rule-form.ts
@@ -19,3 +19,16 @@
 export interface OrRuleForm {
   checkValidity(): boolean;
 }
+
+/**
+ * Returns whether every element within {@link root} that can validate itself reports being valid.
+ * Elements without a `checkValidity` function are skipped, so this covers the Vaadin fields as well
+ * as any nested component implementing {@link OrRuleForm}, wherever they sit in the template.
+ */
+export function isFormValid(root: ParentNode | null | undefined): boolean {
+  if (!root) {
+    return false;
+  }
+  const elements = Array.from(root.querySelectorAll("*")) as Partial<HTMLInputElement>[];
+  return elements.every((elem) => typeof elem.checkValidity !== "function" || elem.checkValidity());
+}

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-alarm.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-alarm.ts
@@ -98,6 +98,7 @@ export class OrRuleActionAlarm extends OrElement {
       if (this._initialAction?.alarm && this.action.alarm) {
         // Severity is edited outside of the dialog, so it is kept rather than rolled back
         const initialAlarm = { ...structuredClone(this._initialAction.alarm), severity: this.action.alarm.severity };
+        console.debug("Rolling back the alarm to former state...");
 
         // Check if anything in the alarm has changed
         if (
@@ -109,6 +110,8 @@ export class OrRuleActionAlarm extends OrElement {
           this.action.assigneeId = this._initialAction.assigneeId;
           this._formElem?.requestUpdate();
           this.requestUpdate("action");
+        } else {
+          console.debug("Rolling back was not necessary, as no changes have been done.");
         }
       } else {
         console.warn("Could not rollback alarm form.");

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-alarm.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-alarm.ts
@@ -130,6 +130,7 @@ export class OrRuleActionAlarm extends OrElement {
       <or-vaadin-select
         value=${this.action.alarm?.severity}
         .items=${severityOptions}
+        ?readonly=${this.readonly}
         style="width: 240px;"
         @change=${(ev: Event) => this.setActionAlarmSeverity((ev.currentTarget as OrVaadinSelect).value)}
       >
@@ -138,7 +139,11 @@ export class OrRuleActionAlarm extends OrElement {
       <or-rule-json-dialog ?readonly=${this.readonly} @cancel="${onModalCancel}" @ok="${onModalOk}">
         <or-translate slot="button" value="settings"></or-translate>
         <or-translate slot="title" value="alarm."></or-translate>
-        <or-rule-form-alarm .users="${this._loadedUsers}" .action="${this.action}"></or-rule-form-alarm>
+        <or-rule-form-alarm
+          .users="${this._loadedUsers}"
+          .action="${this.action}"
+          ?readonly=${this.readonly}
+        ></or-rule-form-alarm>
       </or-rule-json-dialog>
     `;
   }

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-alarm.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-alarm.ts
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { html } from "lit";
+import { css, html } from "lit";
 import { OrElement } from "@openremote/or-element";
 import { customElement, property, query } from "lit/decorators.js";
 import type { ActionType, RulesConfig } from "../index";
@@ -31,8 +31,24 @@ import { OrRulesJsonRuleChangedEvent } from "./or-rule-json-viewer";
 import type { OrVaadinSelect, SelectItem } from "@openremote/or-vaadin-components/or-vaadin-select";
 import { i18next } from "@openremote/or-translate";
 
+// language=CSS
+const style = css`
+  :host {
+    display: flex;
+    align-items: baseline;
+  }
+
+  :host > * {
+    margin: 0 3px 6px;
+  }
+`;
+
 @customElement("or-rule-action-alarm")
 export class OrRuleActionAlarm extends OrElement {
+  static get styles() {
+    return style;
+  }
+
   @property({ type: Object, attribute: false })
   public rule!: JsonRule;
 

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-alarm.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-alarm.ts
@@ -21,6 +21,7 @@ import { OrElement } from "@openremote/or-element";
 import { customElement, property } from "lit/decorators.js";
 import type { ActionType, RulesConfig } from "../index";
 import { AlarmSeverity, type JsonRule, type RuleActionAlarm, type User, type UserQuery } from "@openremote/model";
+import "@openremote/or-vaadin-components/or-vaadin-select";
 import "./or-rule-json-dialog";
 import "./forms/or-rule-form-alarm";
 import manager from "@openremote/core";

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-alarm.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-alarm.ts
@@ -16,14 +16,15 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { html, type TemplateResult } from "lit";
+import { html } from "lit";
 import { OrElement } from "@openremote/or-element";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, query } from "lit/decorators.js";
 import type { ActionType, RulesConfig } from "../index";
 import { AlarmSeverity, type JsonRule, type RuleActionAlarm, type User, type UserQuery } from "@openremote/model";
 import "@openremote/or-vaadin-components/or-vaadin-select";
 import "./or-rule-json-dialog";
 import "./forms/or-rule-form-alarm";
+import type { OrRuleFormAlarm } from "./forms/or-rule-form-alarm";
 import manager from "@openremote/core";
 import type { OrRulesActionDialogCancelEvent, OrRulesActionDialogOkEvent } from "./or-rule-json-dialog";
 import { OrRulesJsonRuleChangedEvent } from "./or-rule-json-viewer";
@@ -46,6 +47,9 @@ export class OrRuleActionAlarm extends OrElement {
 
   @property({ type: Object })
   public config?: RulesConfig;
+
+  @query("or-rule-form-alarm")
+  protected _formElem?: OrRuleFormAlarm;
 
   protected _initialAction?: RuleActionAlarm;
   protected _loadedUsers: User[] = [];
@@ -73,22 +77,22 @@ export class OrRuleActionAlarm extends OrElement {
       return html``;
     }
 
-    const alarm = this.action.alarm;
-
-    const modalTemplate: TemplateResult | string = ``;
-
     // When 'cancel' is pressed, reset ACTION to the initial state (all changes get removed)
     const onModalCancel = (_ev: OrRulesActionDialogCancelEvent) => {
-      if (this._initialAction && this.action) {
-        const initialAction = structuredClone(this._initialAction);
+      if (this._initialAction?.alarm && this.action.alarm) {
+        // Severity is edited outside of the dialog, so it is kept rather than rolled back
+        const initialAlarm = { ...structuredClone(this._initialAction.alarm), severity: this.action.alarm.severity };
 
-        // Check if anything in the message has changed
-        if (JSON.stringify(this.action) !== JSON.stringify(initialAction)) {
-          console.debug("Rolling back the alarm to former state...");
-          this.action = initialAction;
+        // Check if anything in the alarm has changed
+        if (
+          JSON.stringify(this.action.alarm) !== JSON.stringify(initialAlarm) ||
+          this.action.assigneeId !== this._initialAction.assigneeId
+        ) {
+          // Assign into the existing action, as the rule holds a reference to it
+          this.action.alarm = initialAlarm;
+          this.action.assigneeId = this._initialAction.assigneeId;
+          this._formElem?.requestUpdate();
           this.requestUpdate("action");
-        } else {
-          console.debug("Rolling back was not necessary, as no changes have been done.");
         }
       } else {
         console.warn("Could not rollback alarm form.");

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-notification.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-notification.ts
@@ -424,11 +424,8 @@ export class OrRuleActionNotification extends OrElement {
 
         // Check if anything in the message has changed
         if (JSON.stringify(this.action.notification.message) !== JSON.stringify(newAction.notification?.message)) {
-          console.debug("Rolling back the notification to former state...");
           this.action.notification.message = newAction.notification?.message;
           this.requestUpdate("action");
-        } else {
-          console.debug("Rolling back was not necessary, as no changes have been done.");
         }
       } else {
         console.warn("Could not rollback notification form.");

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-notification.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-notification.ts
@@ -424,8 +424,11 @@ export class OrRuleActionNotification extends OrElement {
 
         // Check if anything in the message has changed
         if (JSON.stringify(this.action.notification.message) !== JSON.stringify(newAction.notification?.message)) {
+          console.debug("Rolling back the notification to former state...");
           this.action.notification.message = newAction.notification?.message;
           this.requestUpdate("action");
+        } else {
+          console.debug("Rolling back was not necessary, as no changes have been done.");
         }
       } else {
         console.warn("Could not rollback notification form.");

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-notification.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-notification.ts
@@ -445,6 +445,7 @@ export class OrRuleActionNotification extends OrElement {
             <or-translate slot="title" value="push-notification"></or-translate>
             <or-rule-form-push-notification
               .message="${message as PushNotificationMessage}"
+              ?readonly=${this.readonly}
             ></or-rule-form-push-notification>
           </or-rule-json-dialog>
         `;
@@ -453,7 +454,10 @@ export class OrRuleActionNotification extends OrElement {
           <or-rule-json-dialog ?readonly=${this.readonly} @cancel="${onModalCancel}" @ok="${onModalOk}">
             <or-translate slot="button" value="message"></or-translate>
             <or-translate slot="title" value="email"></or-translate>
-            <or-rule-form-email-message .message="${message as EmailNotificationMessage}"></or-rule-form-email-message>
+            <or-rule-form-email-message
+              .message="${message as EmailNotificationMessage}"
+              ?readonly=${this.readonly}
+            ></or-rule-form-email-message>
           </or-rule-json-dialog>
         `;
       } else if (messageType === "localized") {
@@ -482,6 +486,7 @@ export class OrRuleActionNotification extends OrElement {
               .languages="${languages}"
               .defaultLang="${defaultLang}"
               .wrongLanguage="${defaultLangHasChanged}"
+              ?readonly=${this.readonly}
             ></or-rule-form-localized>
           </or-rule-json-dialog>
         `;

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-webhook.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-webhook.ts
@@ -70,11 +70,14 @@ export class OrRuleActionWebhook extends OrElement {
     const onModalCancel = (_ev: OrRulesActionDialogCancelEvent) => {
       if (this._initialWebhook && this.action.webhook) {
         const initialWebhook = structuredClone(this._initialWebhook);
+        console.debug("Rolling back the webhook to former state...");
 
         // Check if anything in the message has changed
         if (JSON.stringify(this.action.webhook) !== JSON.stringify(initialWebhook)) {
           this.action.webhook = initialWebhook;
           this.requestUpdate("action");
+        } else {
+          console.debug("Rolling back was not necessary, as no changes have been done.");
         }
       } else {
         console.warn("Could not rollback webhook form.");

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-webhook.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-webhook.ts
@@ -90,7 +90,7 @@ export class OrRuleActionWebhook extends OrElement {
       <or-rule-json-dialog ?readonly=${this.readonly} @cancel="${onModalCancel}" @ok="${onModalOk}">
         <or-translate slot="button" value="message"></or-translate>
         <or-translate slot="title" value="message"></or-translate>
-        <or-rule-form-webhook .webhook="${this.action.webhook}"></or-rule-form-webhook>
+        <or-rule-form-webhook .webhook="${this.action.webhook}" ?readonly=${this.readonly}></or-rule-form-webhook>
       </or-rule-json-dialog>
     `;
   }

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-webhook.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-webhook.ts
@@ -70,11 +70,8 @@ export class OrRuleActionWebhook extends OrElement {
 
         // Check if anything in the message has changed
         if (JSON.stringify(this.action.webhook) !== JSON.stringify(initialWebhook)) {
-          console.debug("Rolling back the webhook to former state...");
           this.action.webhook = initialWebhook;
           this.requestUpdate("action");
-        } else {
-          console.debug("Rolling back was not necessary, as no changes have been done.");
         }
       } else {
         console.warn("Could not rollback webhook form.");

--- a/ui/component/or-rules/src/json-viewer/or-rule-action-webhook.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-action-webhook.ts
@@ -53,6 +53,9 @@ export class OrRuleActionWebhook extends OrElement {
   @property({ type: Object, attribute: false })
   public action!: RuleActionWebhook;
 
+  @property({ type: Boolean })
+  public readonly?: boolean;
+
   protected _initialWebhook?: Webhook;
 
   override connectedCallback() {
@@ -84,7 +87,7 @@ export class OrRuleActionWebhook extends OrElement {
     };
 
     return html`
-      <or-rule-json-dialog @cancel="${onModalCancel}" @ok="${onModalOk}">
+      <or-rule-json-dialog ?readonly=${this.readonly} @cancel="${onModalCancel}" @ok="${onModalOk}">
         <or-translate slot="button" value="message"></or-translate>
         <or-translate slot="title" value="message"></or-translate>
         <or-rule-form-webhook .webhook="${this.action.webhook}"></or-rule-form-webhook>

--- a/ui/component/or-rules/src/json-viewer/or-rule-condition.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-condition.ts
@@ -67,7 +67,7 @@ export function getWhenTypesMenu(
       component: createMenuBarItem(html`
         <div style="display: flex; align-items: center; gap: 6px;">
           <or-icon
-            style="--or-icon-fill: #${color ?? "4c4c4c"}"
+            style="--or-icon-fill: ${color ? "#" + color : "unset"}"
             icon=${icon || AssetModelUtil.getAssetDescriptorIcon(WellknownAssets.THINGASSET)}
           ></or-icon>
           <span>${Util.getAssetTypeLabel(assetTypeInfo.assetDescriptor!)}</span>

--- a/ui/component/or-rules/src/json-viewer/or-rule-json-dialog.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-json-dialog.ts
@@ -19,6 +19,8 @@
 import { OrElement } from "@openremote/or-element";
 import { customElement, property, query, queryAssignedElements, state } from "lit/decorators.js";
 import { html } from "lit";
+import "@openremote/or-vaadin-components/or-vaadin-button";
+import "@openremote/or-vaadin-components/or-vaadin-dialog";
 import type { OrVaadinDialog } from "@openremote/or-vaadin-components/or-vaadin-dialog";
 import type { OrRuleForm } from "./forms/or-rule-form";
 import { OrRulesJsonRuleChangedEvent } from "./or-rule-json-viewer";

--- a/ui/component/or-rules/src/json-viewer/or-rule-then-otherwise.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-then-otherwise.ts
@@ -99,7 +99,7 @@ function getActionTypesMenu(config?: RulesConfig, assetInfos?: AssetTypeInfo[], 
     createMenuBarItem(html`
       <div style="display: flex; align-items: center; gap: 6px;">
         <or-icon
-          style="--or-icon-fill: #${color ?? "4c4c4c"}"
+          style="--or-icon-fill: ${color ? "#" + color : "unset"}"
           icon=${icon || AssetModelUtil.getAssetDescriptorIcon(WellknownAssets.THINGASSET)}
         ></or-icon>
         ${when(

--- a/ui/component/or-rules/src/json-viewer/or-rule-then-otherwise.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-then-otherwise.ts
@@ -441,6 +441,7 @@ class OrRuleThenOtherwise extends translate(i18next)(OrElement) {
             .rule="${this.rule}"
             .action="${action}"
             .actionType="${ActionType.WEBHOOK}"
+            .readonly="${this.readonly}"
           ></or-rule-action-webhook>`;
           break;
         case ActionType.ALARM:
@@ -448,6 +449,7 @@ class OrRuleThenOtherwise extends translate(i18next)(OrElement) {
             .rule="${this.rule}"
             .action="${action}"
             .actionType="${ActionType.ALARM}"
+            .readonly="${this.readonly}"
           ></or-rule-action-alarm>`;
           break;
         default:


### PR DESCRIPTION
AI summary of the changes:

Follow-up fixes on top of the Vaadin dialog migration, addressing the issues
reported against the rules page. Split into one commit per fix.

### Fixes

- **Alarm settings dialog discarded the wrong changes.** Cancel swapped the
  element's own action reference, so the rule kept the edit that was meant to be
  thrown away, and it restored a snapshot of the whole action, undoing the
  severity picked outside the dialog. It now assigns into the existing action and
  leaves severity alone.
- **Alarm assignee could never be valid.** The combo box was `required` while
  offering a "None" option with no value, which left OK permanently disabled. The
  flag is gone, and the assignee now reads the user id off the selected item
  rather than round-tripping the username through a lookup.
- **Readonly rules were still editable.** `readonly` never reached the alarm and
  webhook actions, the alarm severity select ignored it, and none of the fields
  in the message and settings dialogs honoured it.
- **Asset type icons lost their colour.** The action and condition type menus fell
  back to a hardcoded `#4c4c4c`, overriding the icon fill for every type without
  a colour of its own.
- **Alarm action spacing.** `or-rule-action-alarm` was the only action component
  without host styles, so it missed the margin the others put on their children.
- **Vaadin elements were not registered.** The rules dialogs and forms relied on
  other pages importing `or-vaadin-button`, `-dialog`, `-select`, `-combo-box`
  and `-toggle`. They now import their own.

### Cleanup

- The four divergent form validity checks are replaced by a shared `isFormValid`
  helper in `or-rule-form.ts`, which walks the render root instead of a specific
  container or marker class. Drops the `#form-container` queries, the `.input`
  and `.form` marker classes.
- Removed the rollback `console.debug` noise from the notification and webhook
  actions.

### Tests

- Regression test for the alarm cancel behaviour: it asserts both that the
  severity chosen outside the dialog survives, and that the saved payload carries
  the kept title rather than the discarded one.
- Replaced the repeated "click outside the dialog to lose focus" blocks with a
  `blurActiveField` fixture, and swapped a positional textbox lookup for a
  direct locator.

### Not addressed

- Cancelling a dialog rolls the model back but the fields keep showing the edited
  text, because lit dirty-checks the attribute part against its last committed
  value and user typing bypasses it. Affects all three actions and predates this
  branch.
- The push notification form writes `undefined` on invalid input, and
  `buttons[1] = {}` on an empty array leaves a hole that serialises as
  `[null, {}]`.