### PR TITLE
Show client secret length on the interconnect form #1365

### DIFF
--- a/ui/app/manager/src/pages/page-gateway.ts
+++ b/ui/app/manager/src/pages/page-gateway.ts
@@ -44,6 +44,7 @@ import "@openremote/or-components/or-ace-editor";
 import moment from "moment";
 import type { OrAceEditor } from "@openremote/or-components/or-ace-editor";
 import { showSnackbar } from "@openremote/or-mwc-components/or-mwc-snackbar";
+import { isAxiosError } from "@openremote/rest";
 
 export function pageGatewayProvider(store: Store<AppStateKeyed>): PageProvider<AppStateKeyed> {
   return {
@@ -391,6 +392,9 @@ export class PageGateway extends Page<AppStateKeyed> {
         <or-vaadin-text-field
           id="gateway-clientsecret"
           required
+          minlength="36"
+          maxlength="36"
+          helper-text=${i18next.t("gateway.clientSecretHelper")}
           ?disabled=${disabled}
           value=${connection?.clientSecret}
           @change=${(ev: Event) => this._setConnectionProperty("clientSecret", (ev.currentTarget as HTMLInputElement).value)}
@@ -681,15 +685,38 @@ export class PageGateway extends Page<AppStateKeyed> {
         if (response.status === 204) {
           this._loadData();
         } else {
-          showSnackbar(undefined, i18next.t("errorOccurred"));
+          showSnackbar(undefined, this._saveErrorMessage(response.statusText));
         }
       })
-      .catch(() => {
-        showSnackbar(undefined, i18next.t("errorOccurred"));
+      .catch((e) => {
+        showSnackbar(undefined, this._saveErrorMessage(undefined, e));
       })
       .finally(() => {
         this._loading = false;
       });
+  }
+
+  protected _saveErrorMessage(statusText?: string, error?: unknown): string {
+    if (isAxiosError(error)) {
+      const data = error.response?.data as unknown;
+      if (typeof data === "string" && data.trim()) {
+        return data;
+      }
+      if (data && typeof data === "object") {
+        const body = data as { message?: string; error?: string; exception?: string };
+        const detail = body.message || body.error || body.exception;
+        if (typeof detail === "string" && detail.trim()) {
+          return detail;
+        }
+      }
+      if (error.response?.statusText) {
+        return error.response.statusText;
+      }
+    }
+    if (statusText && statusText.trim()) {
+      return statusText;
+    }
+    return i18next.t("errorOccurred");
   }
 
   protected _setConnection(connection: GatewayConnection) {
@@ -740,6 +767,10 @@ export class PageGateway extends Page<AppStateKeyed> {
     }
     if (!this._connection.clientSecret) {
       console.warn("Interconnect form can't be submitted: Client secret must be set.");
+      return false;
+    }
+    if (this._connection.clientSecret.length !== 36) {
+      console.warn("Interconnect form can't be submitted: Client secret must be 36 characters.");
       return false;
     }
     return true;

--- a/ui/app/shared/locales/en/or.json
+++ b/ui/app/shared/locales/en/or.json
@@ -435,7 +435,8 @@
     "limit_sharing_rate": "Limit the rate of how often attribute value updates are shared",
     "limit_sharing_rate_suffix": "minutes interval",
     "assetSyncRulesEnable": "Customize asset synchronization",
-    "assetSyncRulesInput": "Synchronization config"
+    "assetSyncRulesInput": "Synchronization config",
+    "clientSecretHelper": "Must be exactly 36 characters"
   },
   "gatewayTunnel": "Gateway tunnels",
   "gatewayTunnels": {


### PR DESCRIPTION
## Description

Interconnect client secret must be 36 characters. The field did not say that, save did not check it, and a failed save only showed a generic snackbar.

- Helper text on the client secret field
- Save stays disabled unless the secret is exactly 36 characters
- Snackbar uses the server error when save still fails

Fixes #1365

## Checklist

- [x] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [x] 3. Changes are manually tested by you and the reviewer
- [x] 4. Documentation is written or updated
