### PR TITLE
Migrate another set of UI dialogs to or-vaadin-dialog

### DIFF
--- a/ui/app/manager/src/components/configuration/or-conf-map/or-conf-map-card.ts
+++ b/ui/app/manager/src/components/configuration/or-conf-map/or-conf-map-card.ts
@@ -23,7 +23,7 @@ import { when } from "lit/directives/when.js";
 import "@openremote/or-components/or-file-uploader";
 import { i18next } from "@openremote/or-translate";
 import type { MapRealmConfig } from "@openremote/model";
-import { type DialogAction, OrMwcDialog, showDialog } from "@openremote/or-mwc-components/or-mwc-dialog";
+import {getConfirmDialogContent, showConfirmDialog} from "@openremote/or-vaadin-components/or-vaadin-confirm-dialog";
 import type { OrVaadinToggle } from "@openremote/or-vaadin-components/or-vaadin-toggle";
 import type { OrMapLongPressEvent } from "@openremote/or-map";
 import type { LngLat } from "maplibre-gl";
@@ -57,37 +57,13 @@ export class OrConfMapCard extends OrElement {
   }
 
   protected _showRemoveMapDialog() {
-    const dialogActions: DialogAction[] = [
-      {
-        actionName: "cancel",
-        content: "cancel",
-      },
-      {
-        default: true,
-        actionName: "ok",
-        content: "yes",
-        action: () => {
-          this.dispatchEvent(new CustomEvent("remove"));
-        },
-      },
-    ];
-    showDialog(
-      new OrMwcDialog()
-        .setHeading(i18next.t("delete"))
-        .setActions(dialogActions)
-        .setContent(html` ${i18next.t("configuration.deleteMapCustomizationConfirm")} `)
-        .setStyles(html`
-          <style>
-            .mdc-dialog__surface {
-              padding: 4px 8px;
-            }
-
-            #dialog-content {
-              padding: 24px;
-            }
-          </style>
-        `)
-        .setDismissAction(null)
+    showConfirmDialog(
+      this.shadowRoot!,
+      html`
+        <or-vaadin-confirm-dialog @confirm=${() => this.dispatchEvent(new CustomEvent("remove"))}>
+          ${getConfirmDialogContent("error", "delete", "configuration.deleteMapCustomizationConfirm", "delete", "cancel")}
+        </or-vaadin-confirm-dialog>
+      `
     );
   }
 

--- a/ui/app/manager/src/components/configuration/or-conf-map/or-conf-map-card.ts
+++ b/ui/app/manager/src/components/configuration/or-conf-map/or-conf-map-card.ts
@@ -23,7 +23,7 @@ import { when } from "lit/directives/when.js";
 import "@openremote/or-components/or-file-uploader";
 import { i18next } from "@openremote/or-translate";
 import type { MapRealmConfig } from "@openremote/model";
-import {getConfirmDialogContent, showConfirmDialog} from "@openremote/or-vaadin-components/or-vaadin-confirm-dialog";
+import { getConfirmDialogContent, showConfirmDialog } from "@openremote/or-vaadin-components/or-vaadin-confirm-dialog";
 import type { OrVaadinToggle } from "@openremote/or-vaadin-components/or-vaadin-toggle";
 import type { OrMapLongPressEvent } from "@openremote/or-map";
 import type { LngLat } from "maplibre-gl";

--- a/ui/app/manager/src/components/configuration/or-conf-realm/or-conf-realm-card.ts
+++ b/ui/app/manager/src/components/configuration/or-conf-realm/or-conf-realm-card.ts
@@ -38,7 +38,7 @@ import type { FileInfo, ManagerAppRealmConfig } from "@openremote/model";
 import { when } from "lit/directives/when.js";
 import { DefaultHeaderMainMenu, DefaultHeaderSecondaryMenu } from "../../../index";
 import type { OrVaadinMultiSelectComboBox } from "@openremote/or-vaadin-components/or-vaadin-multi-select-combo-box";
-import {getConfirmDialogContent, showConfirmDialog} from "@openremote/or-vaadin-components/or-vaadin-confirm-dialog";
+import { getConfirmDialogContent, showConfirmDialog } from "@openremote/or-vaadin-components/or-vaadin-confirm-dialog";
 
 @customElement("or-conf-realm-card")
 export class OrConfRealmCard extends translate(i18next)(OrElement) {

--- a/ui/app/manager/src/components/configuration/or-conf-realm/or-conf-realm-card.ts
+++ b/ui/app/manager/src/components/configuration/or-conf-realm/or-conf-realm-card.ts
@@ -35,10 +35,10 @@ import {
 } from "@openremote/core";
 import { i18next, translate } from "@openremote/or-translate";
 import type { FileInfo, ManagerAppRealmConfig } from "@openremote/model";
-import { type DialogAction, OrMwcDialog, showDialog } from "@openremote/or-mwc-components/or-mwc-dialog";
 import { when } from "lit/directives/when.js";
 import { DefaultHeaderMainMenu, DefaultHeaderSecondaryMenu } from "../../../index";
 import type { OrVaadinMultiSelectComboBox } from "@openremote/or-vaadin-components/or-vaadin-multi-select-combo-box";
+import {getConfirmDialogContent, showConfirmDialog} from "@openremote/or-vaadin-components/or-vaadin-confirm-dialog";
 
 @customElement("or-conf-realm-card")
 export class OrConfRealmCard extends translate(i18next)(OrElement) {
@@ -229,37 +229,13 @@ export class OrConfRealmCard extends translate(i18next)(OrElement) {
   }
 
   protected _showRemoveRealmDialog() {
-    const dialogActions: DialogAction[] = [
-      {
-        actionName: "cancel",
-        content: "cancel",
-      },
-      {
-        default: true,
-        actionName: "ok",
-        content: "yes",
-        action: () => {
-          this.dispatchEvent(new CustomEvent("remove"));
-        },
-      },
-    ];
-    showDialog(
-      new OrMwcDialog()
-        .setHeading(i18next.t("delete"))
-        .setActions(dialogActions)
-        .setContent(html` ${i18next.t("configuration.deleteRealmCustomizationConfirm")} `)
-        .setStyles(html`
-          <style>
-            .mdc-dialog__surface {
-              padding: 4px 8px;
-            }
-
-            #dialog-content {
-              padding: 24px;
-            }
-          </style>
-        `)
-        .setDismissAction(null)
+    showConfirmDialog(
+      this.shadowRoot!,
+      html`
+        <or-vaadin-confirm-dialog @confirm=${() => this.dispatchEvent(new CustomEvent("remove"))}>
+          ${getConfirmDialogContent("error", "delete", "configuration.deleteRealmCustomizationConfirm", "delete", "cancel")}
+        </or-vaadin-confirm-dialog>
+      `
     );
   }
 

--- a/ui/component/or-asset-viewer/src/index.ts
+++ b/ui/component/or-asset-viewer/src/index.ts
@@ -853,7 +853,7 @@ function getPanelContent(
       };
 
       dialog = showDialog(
-        hostElement,
+        hostElement.shadowRoot!,
         html`
           <or-vaadin-dialog width="384px">
             <h2 slot="header-content">

--- a/ui/component/or-asset-viewer/src/index.ts
+++ b/ui/component/or-asset-viewer/src/index.ts
@@ -853,17 +853,17 @@ function getPanelContent(
       };
 
       dialog = showDialog(
-        document.body,
+        hostElement,
         html`
           <or-vaadin-dialog width="384px">
             <h2 slot="header-content">
               <or-translate value="addRemoveAttributes"></or-translate>
             </h2>
             <or-vaadin-checkbox-group ${ref(groupRef)} theme="vertical" .value="${selectedAttributes}">
-              ${availableAttributes.map(
+              ${availableAttributes.sort().map(
                 (attr) => html`
                   <vaadin-checkbox value=${attr}>
-                    <or-translate slot="label" value=${attr}></or-translate>
+                    <or-translate slot="label" value=${Util.camelCaseToSentenceCase(attr)}></or-translate>
                   </vaadin-checkbox>
                 `
               )}

--- a/ui/component/or-asset-viewer/src/index.ts
+++ b/ui/component/or-asset-viewer/src/index.ts
@@ -28,12 +28,10 @@ import "@openremote/or-attribute-history";
 import "@openremote/or-chart";
 import "@openremote/or-mwc-components/or-mwc-table";
 import "@openremote/or-components/or-panel";
-import "@openremote/or-mwc-components/or-mwc-dialog";
-import { showOkCancelDialog } from "@openremote/or-mwc-components/or-mwc-dialog";
-import "@openremote/or-mwc-components/or-mwc-list";
+import { type OrVaadinDialog, showDialog } from "@openremote/or-vaadin-components/or-vaadin-dialog";
 import { type OrTranslate, translate } from "@openremote/or-translate";
-import { InputType, OrInputChangedEvent, OrMwcInput } from "@openremote/or-mwc-components/or-mwc-input";
-import manager, { OPENREMOTE_CLIENT_ID, RESTRICTED_USER_REALM_ROLE, subscribe, Util } from "@openremote/core";
+import { InputType } from "@openremote/or-mwc-components/or-mwc-input";
+import manager, { RESTRICTED_USER_REALM_ROLE, subscribe, Util } from "@openremote/core";
 import type { OrMwcTable, OrMwcTableRowClickEvent } from "@openremote/or-mwc-components/or-mwc-table";
 import type { OrChartConfig } from "@openremote/or-chart";
 import type { HistoryConfig, OrAttributeHistory } from "@openremote/or-attribute-history";
@@ -67,9 +65,10 @@ import { showSnackbar } from "@openremote/or-mwc-components/or-mwc-snackbar";
 import { progressCircular } from "@openremote/or-mwc-components/style";
 import { when } from "lit/directives/when.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import type { OrVaadinCheckbox } from "@openremote/or-vaadin-components/or-vaadin-checkbox";
 import type { OrVaadinInput } from "@openremote/or-vaadin-components/or-vaadin-input";
 import { getConfirmDialogContent, showConfirmDialog } from "@openremote/or-vaadin-components/or-vaadin-confirm-dialog";
+import type { OrVaadinCheckboxGroup } from "@openremote/or-vaadin-components/or-vaadin-checkbox-group";
+import { createRef, type Ref, ref } from "lit/directives/ref.js";
 
 declare function require(name: string): any;
 
@@ -840,36 +839,46 @@ function getPanelContent(
     };
 
     const attributePickerModalOpen = () => {
-      const newlySelectedAttributes = [...selectedAttributes];
-
-      // TODO: Replace with or-vaadin-dialog, see https://github.com/openremote/openremote/issues/2594
-      showOkCancelDialog(
-        i18next.t("addRemoveAttributes"),
-        html`
-          <div style="display: flex; flex-direction: column;">
-            ${availableAttributes.sort().map(
-              (attribute) => html`
-                <or-vaadin-checkbox
-                  label=${i18next.t(Util.camelCaseToSentenceCase(attribute))}
-                  style="display: inline-flex;"
-                  .checked=${!!selectedAttributes.find((selected) => selected === attribute)}
-                  @change=${(ev: Event) => {
-                    if ((ev.currentTarget as OrVaadinCheckbox).checked) {
-                      newlySelectedAttributes.push(attribute);
-                    } else {
-                      newlySelectedAttributes.splice(newlySelectedAttributes.indexOf(attribute), 1);
-                    }
-                  }}
-                ></or-vaadin-checkbox>
-              `
-            )}
-          </div>
-        `
-      ).then((ok) => {
-        if (ok) {
-          updateSelectedAttributes(newlySelectedAttributes);
+      let dialog: OrVaadinDialog | undefined;
+      const groupRef: Ref<OrVaadinCheckboxGroup> = createRef();
+      const onCancel = () => {
+        dialog?.close();
+      };
+      const onOk = () => {
+        const groupElem = groupRef.value;
+        if (groupElem) {
+          updateSelectedAttributes(groupElem.value);
+          dialog?.close();
         }
-      });
+      };
+
+      dialog = showDialog(
+        document.body,
+        html`
+          <or-vaadin-dialog width="384px">
+            <h2 slot="header-content">
+              <or-translate value="addRemoveAttributes"></or-translate>
+            </h2>
+            <or-vaadin-checkbox-group ${ref(groupRef)} theme="vertical" .value="${selectedAttributes}">
+              ${availableAttributes.map(
+                (attr) => html`
+                  <vaadin-checkbox value=${attr}>
+                    <or-translate slot="label" value=${attr}></or-translate>
+                  </vaadin-checkbox>
+                `
+              )}
+            </or-vaadin-checkbox-group>
+            <div slot="footer" style="width: 100%; display: flex; justify-content: space-between;">
+              <or-vaadin-button theme="tertiary" @click=${onCancel}>
+                <or-translate value="cancel"></or-translate>
+              </or-vaadin-button>
+              <or-vaadin-button theme="primary" @click=${onOk}>
+                <or-translate value="ok"></or-translate>
+              </or-vaadin-button>
+            </div>
+          </or-vaadin-dialog>
+        `
+      );
     };
 
     const headersAndRows = getHeadersAndRows();

--- a/ui/component/or-dashboard-builder/src/settings/barchart-settings.ts
+++ b/ui/component/or-dashboard-builder/src/settings/barchart-settings.ts
@@ -33,9 +33,8 @@ import type { BarChartWidgetConfig } from "../widgets/barchart-widget";
 import type { OrVaadinToggle } from "@openremote/or-vaadin-components/or-vaadin-toggle";
 import { when } from "lit/directives/when.js";
 import type moment from "moment/moment";
-import { type ListItem, ListType, type OrMwcList } from "@openremote/or-mwc-components/or-mwc-list";
 import type { OrVaadinSelect, SelectItem } from "@openremote/or-vaadin-components/or-vaadin-select";
-import { showDialog, OrMwcDialog } from "@openremote/or-mwc-components/or-mwc-dialog";
+import { type OrVaadinDialog, showDialog } from "@openremote/or-vaadin-components/or-vaadin-dialog";
 import {
   type BarChartAttributeConfig,
   type BarChartInterval,
@@ -48,6 +47,7 @@ import { createRef, type Ref, ref } from "lit/directives/ref.js";
 import type { AttributesChartPanel } from "../panels/attributes-chart-panel";
 import debounce from "lodash.debounce";
 import type { OrVaadinNumberField } from "@openremote/or-vaadin-components/or-vaadin-number-field";
+import type { OrVaadinCheckboxGroup } from "@openremote/or-vaadin-components/or-vaadin-checkbox-group";
 
 const styling = css`
   .switch-container {
@@ -640,66 +640,60 @@ export class BarChartSettings extends WidgetSettings {
       "methodModeAttributes",
       "methodSumAttributes",
     ];
-    const methodList: ListItem[] = methodKeys.map((key) => {
-      const attributeRefs = this.widgetConfig.attributeSettings[key];
-      const isActive = attributeRefs?.some(
-        (attrRef) => attrRef.id === attributeRef.id && attrRef.name === attributeRef.name
-      );
-      return {
-        text: key,
-        value: key,
-        data: isActive ? key : undefined,
-        translate: true,
-      };
-    });
+    const activeKeys = methodKeys.filter((key) =>
+      this.widgetConfig?.attributeSettings?.[key]?.find(
+        (ref) => ref.id === attributeRef.id && ref.name === attributeRef.name
+      )
+    );
 
-    const listRef: Ref<OrMwcList> = createRef();
+    const groupRef: Ref<OrVaadinCheckboxGroup> = createRef();
+    let dialog: OrVaadinDialog | undefined;
 
-    showDialog(
-      new OrMwcDialog()
-        .setContent(html`
-          <div id="method-creator">
-            <or-mwc-list
-              ${ref(listRef)}
-              id="method-creator-list"
-              .type="${ListType.MULTI_CHECKBOX}"
-              .listItems="${methodList}"
-              .values="${methodList.map((item) => item.data)}"
-            ></or-mwc-list>
+    const onCancel = () => {
+      dialog?.close();
+    };
+    const onOk = () => {
+      const groupElem = groupRef.value;
+      if (groupElem) {
+        // Find all "active" methods for this AttributeRef, and remove them all. (so they become empty arrays)
+        activeKeys.forEach((key) => {
+          this.toggleAttributeSetting(key, attributeRef, false);
+        });
+        // Add the methods that were checked in the checkbox list
+        groupElem.value.forEach((key) => {
+          this.toggleAttributeSetting(key as keyof BarChartAttributeConfig, attributeRef, false);
+        });
+        this.notifyConfigUpdate();
+        dialog?.close();
+      }
+    };
+
+    dialog = showDialog(
+      this.shadowRoot!,
+      html`
+        <or-vaadin-dialog width="384px">
+          <h2 slot="header-content">
+            <or-translate value="algorithmMethod"></or-translate>
+          </h2>
+          <or-vaadin-checkbox-group ${ref(groupRef)} theme="vertical" .value="${activeKeys}">
+            ${methodKeys.map(
+              (method) => html`
+                <vaadin-checkbox value=${method}>
+                  <or-translate slot="label" value=${method}></or-translate>
+                </vaadin-checkbox>
+              `
+            )}
+          </or-vaadin-checkbox-group>
+          <div slot="footer" style="width: 100%; display: flex; justify-content: space-between;">
+            <or-vaadin-button theme="tertiary" @click=${onCancel}>
+              <or-translate value="cancel"></or-translate>
+            </or-vaadin-button>
+            <or-vaadin-button theme="primary" @click=${onOk}>
+              <or-translate value="ok"></or-translate>
+            </or-vaadin-button>
           </div>
-        `)
-        .setHeading(i18next.t("algorithmMethod"))
-        .setActions([
-          {
-            actionName: "cancel",
-            content: "cancel",
-          },
-          {
-            default: true,
-            actionName: "ok",
-            action: () => {
-              if (listRef.value) {
-                // Find all "active" methods for this AttributeRef, and remove them all. (so they become empty arrays)
-                methodKeys
-                  .filter(
-                    (oldKey) =>
-                      !!this.widgetConfig.attributeSettings[oldKey]?.find(
-                        (attrRef) => attrRef.id === attributeRef.id && attrRef.name === attributeRef.name
-                      )
-                  )
-                  .forEach((oldKey) => this.toggleAttributeSetting(oldKey, attributeRef, false));
-
-                // Add the methods that were checked in the checkbox list
-                (listRef.value.values as (keyof BarChartAttributeConfig)[] | undefined)?.forEach((s) => {
-                  this.toggleAttributeSetting(s, attributeRef, false);
-                });
-                this.notifyConfigUpdate();
-              }
-            },
-            content: "ok",
-          },
-        ])
-        .setDismissAction(null)
+        </or-vaadin-dialog>
+      `
     );
   }
 

--- a/ui/component/or-rules/src/json-viewer/modals/or-rule-radial-modal.ts
+++ b/ui/component/or-rules/src/json-viewer/modals/or-rule-radial-modal.ts
@@ -21,7 +21,6 @@ import { OrElement } from "@openremote/or-element";
 import { customElement, property, query } from "lit/decorators.js";
 import type { AssetDescriptor, AttributePredicate, AssetQuery, RadialGeofencePredicate } from "@openremote/model";
 import type { OrVaadinDialog } from "@openremote/or-vaadin-components/or-vaadin-dialog";
-import "@openremote/or-mwc-components/or-mwc-input";
 import { i18next, translate } from "@openremote/or-translate";
 import { OrRulesJsonRuleChangedEvent } from "../or-rule-json-viewer";
 import { type OrMap, OrMapClickedEvent, type LngLatLike } from "@openremote/or-map";

--- a/ui/component/or-rules/src/json-viewer/modals/or-rule-radial-modal.ts
+++ b/ui/component/or-rules/src/json-viewer/modals/or-rule-radial-modal.ts
@@ -18,21 +18,16 @@
  */
 import { html } from "lit";
 import { OrElement } from "@openremote/or-element";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, query } from "lit/decorators.js";
 import type { AssetDescriptor, AttributePredicate, AssetQuery, RadialGeofencePredicate } from "@openremote/model";
-import { getAssetTypeFromQuery } from "../../index";
+import type { OrVaadinDialog } from "@openremote/or-vaadin-components/or-vaadin-dialog";
 import "@openremote/or-mwc-components/or-mwc-input";
-import { InputType } from "@openremote/or-mwc-components/or-mwc-input";
 import { i18next, translate } from "@openremote/or-translate";
 import { OrRulesJsonRuleChangedEvent } from "../or-rule-json-viewer";
-
-import {
-  type DialogAction,
-  type OrMwcDialog,
-  OrMwcDialogOpenedEvent,
-} from "@openremote/or-mwc-components/or-mwc-dialog";
 import { type OrMap, OrMapClickedEvent, type LngLatLike } from "@openremote/or-map";
 import "@openremote/or-map";
+import type { OrVaadinNumberField } from "@openremote/or-vaadin-components/or-vaadin-number-field";
+import type { OrVaadinButton } from "@openremote/or-vaadin-components/or-vaadin-button";
 
 @customElement("or-rule-radial-modal")
 export class OrRuleRadialModal extends translate(i18next)(OrElement) {
@@ -48,21 +43,24 @@ export class OrRuleRadialModal extends translate(i18next)(OrElement) {
   @property({ type: Object })
   public query?: AssetQuery;
 
-  constructor() {
-    super();
-    this.addEventListener(OrMwcDialogOpenedEvent.NAME, this.initRadialMap);
-  }
+  @query("#radial-modal")
+  protected _mapDialogElem?: OrVaadinDialog;
+
+  @query("#radial-modal-button")
+  protected _mapDialogButton?: OrVaadinButton;
 
   initRadialMap() {
-    const modal = this.shadowRoot!.getElementById("radial-modal");
-    if (!modal) return;
+    if (!this._mapDialogElem) {
+      console.warn("Could not find radial map dialog element!");
+      return;
+    }
 
-    const map = modal.shadowRoot!.querySelector(".or-map") as OrMap;
+    const map = this._mapDialogElem!.querySelector(".or-map") as OrMap;
     if (map) {
       map.addEventListener(OrMapClickedEvent.NAME, (evt: CustomEvent) => {
         const lngLat: any = evt.detail.lngLat;
-        const latElement = modal.shadowRoot!.querySelector(".location-lat") as HTMLInputElement;
-        const lngElement = modal.shadowRoot!.querySelector(".location-lng") as HTMLInputElement;
+        const latElement = this._mapDialogElem!.querySelector(".location-lat") as HTMLInputElement;
+        const lngElement = this._mapDialogElem!.querySelector(".location-lng") as HTMLInputElement;
         latElement.value = lngLat.lat;
         lngElement.value = lngLat.lng;
 
@@ -73,8 +71,8 @@ export class OrRuleRadialModal extends translate(i18next)(OrElement) {
         this.setValuePredicateProperty("lng", lngLat.lng);
       });
 
-      const latElement = modal.shadowRoot!.querySelector(".location-lat") as HTMLInputElement;
-      const lngElement = modal.shadowRoot!.querySelector(".location-lng") as HTMLInputElement;
+      const latElement = this._mapDialogElem!.querySelector(".location-lat") as HTMLInputElement;
+      const lngElement = this._mapDialogElem!.querySelector(".location-lng") as HTMLInputElement;
       if (lngElement.value && latElement.value) {
         const LngLat: LngLatLike = [parseFloat(lngElement.value), parseFloat(latElement.value)];
         map.flyTo(LngLat, 15);
@@ -82,10 +80,6 @@ export class OrRuleRadialModal extends translate(i18next)(OrElement) {
         map.flyTo();
       }
     }
-  }
-
-  protected getAttributeName(attributePredicate: AttributePredicate): string | undefined {
-    return attributePredicate && attributePredicate.name ? attributePredicate.name.value : undefined;
   }
 
   protected setValuePredicateProperty(propertyName: string, value: any) {
@@ -100,57 +94,54 @@ export class OrRuleRadialModal extends translate(i18next)(OrElement) {
     this.requestUpdate();
   }
 
-  renderDialogHTML(value: RadialGeofencePredicate) {
-    const dialog: OrMwcDialog = this.shadowRoot!.getElementById("radial-modal") as OrMwcDialog;
+  getDialogHTML(value: RadialGeofencePredicate) {
+    return html` <div style="display:grid">
+      <or-map class="or-map" type="VECTOR" style="border: 1px solid #d5d5d5; aspect-ratio: 1/1;">
+        <or-map-marker
+          active
+          color="#FF0000"
+          icon="information"
+          lat="${value.lat}"
+          lng="${value.lng}"
+          radius="${value.radius}"
+        ></or-map-marker>
+      </or-map>
 
-    if (dialog) {
-      dialog.content = html` <div style="display:grid">
-        <or-map
-          class="or-map"
-          type="VECTOR"
-          style="border: 1px solid #d5d5d5; height: 400px; min-width: 300px; margin-bottom: 20px;"
-        >
-          <or-map-marker
-            active
-            color="#FF0000"
-            icon="information"
-            lat="${value.lat}"
-            lng="${value.lng}"
-            radius="${value.radius}"
-          ></or-map-marker>
-        </or-map>
-
-        <div class="layout horizontal">
-          <input
-            hidden
-            class="location-lng"
-            required
-            placeholder=" "
-            type="text"
-            .value="${value && value.lng ? value.lng : null}"
-          />
-          <input
-            hidden
-            class="location-lat"
-            required
-            placeholder=" "
-            type="text"
-            .value="${value && value.lat ? value.lat : null}"
-          />
-        </div>
-
-        <label>${i18next.t("radiusMin")}</label>
+      <div class="layout horizontal">
         <input
-          @change="${(e: any) => this.setValuePredicateProperty("radius", parseInt(e.target.value))}"
-          style="max-width: calc(50% - 30px);"
+          hidden
+          class="location-lng"
           required
           placeholder=" "
-          min="100"
-          type="number"
-          .value="${value && value.radius ? value.radius : 100}"
+          type="text"
+          .value="${value && value.lng ? value.lng : null}"
         />
-      </div>`;
-    }
+        <input
+          hidden
+          class="location-lat"
+          required
+          placeholder=" "
+          type="text"
+          .value="${value && value.lat ? value.lat : null}"
+        />
+      </div>
+
+      <or-vaadin-number-field
+        style="max-width: 50%; margin-top: var(--lumo-space-m);"
+        min="100"
+        required
+        value=${value.radius ?? 100}
+        @change=${(ev: Event) => {
+          const elem = ev.currentTarget as OrVaadinNumberField;
+          if (elem.checkValidity()) {
+            this.setValuePredicateProperty("radius", parseInt(elem.value));
+          }
+          this._mapDialogButton!.disabled = !elem.checkValidity();
+        }}
+      >
+        <or-translate slot="label" value="radiusMin"></or-translate>
+      </or-vaadin-number-field>
+    </div>`;
   }
 
   protected render() {
@@ -161,44 +152,29 @@ export class OrRuleRadialModal extends translate(i18next)(OrElement) {
     if (!this.assetDescriptor || !valuePredicate) {
       return html``;
     }
-
-    const attributeName = this.getAttributeName(this.attributePredicate);
-    const assetType = getAssetTypeFromQuery(this.query);
     // @ts-ignore
     const value: RadialGeofencePredicate = valuePredicate || undefined;
 
-    const radiusPickerModalActions: DialogAction[] = [
-      {
-        actionName: "cancel",
-        content: html`<or-mwc-input class="button" .type="${InputType.BUTTON}" label="cancel"></or-mwc-input>`,
-        action: () => {
-          // Nothing to do here
-        },
-      },
-      {
-        actionName: "ok",
-        default: true,
-        content: html`<or-mwc-input class="button" .type="${InputType.BUTTON}" label="ok"></or-mwc-input>`,
-        action: () => {},
-      },
-    ];
-
     const radialPickerModalOpen = () => {
-      const dialog: OrMwcDialog = this.shadowRoot!.getElementById("radial-modal") as OrMwcDialog;
-      if (dialog) {
-        dialog.dismissAction = null;
-        dialog.open();
-        this.renderDialogHTML(value);
-      }
+      this._mapDialogElem?.open();
+      this.initRadialMap();
     };
-
-    this.renderDialogHTML(value);
 
     return html`
       <or-vaadin-button ?disabled=${this.readonly} @click=${() => radialPickerModalOpen()}>
         <or-translate value="area"></or-translate>
       </or-vaadin-button>
-      <or-mwc-dialog id="radial-modal" heading="area" .actions="${radiusPickerModalActions}"></or-mwc-dialog>
+      <or-vaadin-dialog id="radial-modal" width="512px">
+        <h2 slot="header-content">
+          <or-translate value="area"></or-translate>
+        </h2>
+        ${this.getDialogHTML(value)}
+        <div slot="footer" style="width: 100%; display: flex; justify-content: end;">
+          <or-vaadin-button id="radial-modal-button" theme="primary" @click=${() => this._mapDialogElem?.close()}>
+            <or-translate value="ok"></or-translate>
+          </or-vaadin-button>
+        </div>
+      </or-vaadin-dialog>
     `;
   }
 }

--- a/ui/component/or-rules/src/json-viewer/or-rule-trigger-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-trigger-query.ts
@@ -17,26 +17,21 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { type GeoJSONPoint, type RuleCondition, SunPositionTriggerPosition } from "@openremote/model";
-import { InputType, OrInputChangedEvent } from "@openremote/or-mwc-components/or-mwc-input";
-import { css, html, type PropertyValues } from "lit";
+import { css, html, type TemplateResult, type PropertyValues } from "lit";
 import { OrElement } from "@openremote/or-element";
-import { customElement, property, state } from "lit/decorators.js";
+import { customElement, property, query, state } from "lit/decorators.js";
 import moment from "moment";
 import { buttonStyle } from "../style";
 import { OrRulesJsonRuleChangedEvent } from "./or-rule-json-viewer";
 import { TimeTriggerType } from "../index";
 import { Util } from "@openremote/core";
-import {
-  type DialogAction,
-  type OrMwcDialog,
-  OrMwcDialogOpenedEvent,
-} from "@openremote/or-mwc-components/or-mwc-dialog";
 import { type OrMap, OrMapClickedEvent } from "@openremote/or-map";
 import { i18next } from "@openremote/or-translate";
 import type { OrVaadinSelect } from "@openremote/or-vaadin-components/or-vaadin-select";
 import { when } from "lit/directives/when.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import type { OrVaadinTimePicker } from "@openremote/or-vaadin-components/or-vaadin-time-picker";
+import type { OrVaadinDialog } from "@openremote/or-vaadin-components/or-vaadin-dialog";
 
 // language=CSS
 const style = css`
@@ -90,6 +85,9 @@ export class OrRuleTriggerQuery extends OrElement {
   @state()
   protected triggerOptions: TimeTrigger[];
 
+  @query("#map-modal")
+  protected _mapDialogElem?: OrVaadinDialog;
+
   constructor() {
     super();
     this.triggerOptions = [];
@@ -100,8 +98,6 @@ export class OrRuleTriggerQuery extends OrElement {
       this.triggerOptions.push({ key: opt, value: this.triggerToString(opt) });
     });
     this.selectedTrigger = this.triggerOptions[0];
-
-    this.addEventListener(OrMwcDialogOpenedEvent.NAME, this.initMap);
   }
 
   updated(changedProperties: PropertyValues) {
@@ -123,91 +119,73 @@ export class OrRuleTriggerQuery extends OrElement {
   /* ---------------------- */
 
   initMap() {
-    const modal = this.shadowRoot!.getElementById("map-modal");
-    if (!modal) return;
-
-    const map = modal.shadowRoot!.querySelector(".or-map") as OrMap;
-    if (map) {
-      map.addEventListener(OrMapClickedEvent.NAME, (evt: CustomEvent) => {
-        const lngLat: any = evt.detail.lngLat;
-        this.setLocation({ type: "Point", coordinates: [lngLat.lat, lngLat.lng] });
-        const latElement = modal.shadowRoot!.querySelector(".location-lat") as HTMLInputElement;
-        const lngElement = modal.shadowRoot!.querySelector(".location-lng") as HTMLInputElement;
-        latElement.value = lngLat.lat;
-        lngElement.value = lngLat.lng;
-      });
+    if (!this._mapDialogElem) {
+      console.warn("Could not find map dialog element!");
+      return;
     }
+    const map = this._mapDialogElem.querySelector(".or-map") as OrMap;
+    if (!map) {
+      console.warn("Could not find map within dialog element!");
+      return;
+    }
+    map.addEventListener(OrMapClickedEvent.NAME, (evt: CustomEvent) => {
+      const lngLat: any = evt.detail.lngLat;
+      this.setLocation({ type: "Point", coordinates: [lngLat.lat, lngLat.lng] });
+      const latElement = this._mapDialogElem!.querySelector(".location-lat") as HTMLInputElement;
+      const lngElement = this._mapDialogElem!.querySelector(".location-lng") as HTMLInputElement;
+      latElement.value = lngLat.lat;
+      lngElement.value = lngLat.lng;
+    });
   }
 
-  renderDialogHTML(point: GeoJSONPoint | undefined) {
-    const dialog: OrMwcDialog = this.shadowRoot!.getElementById("map-modal") as OrMwcDialog;
-    if (dialog) {
-      dialog.content = html`
-        <div style="display:grid">
-          <or-map
-            class="or-map"
-            type="VECTOR"
-            style="border: 1px solid #d5d5d5; height: 400px; min-width: 300px; margin-bottom: 20px;"
-          >
-            ${
-              point && point.coordinates
-                ? html`
-                    <or-map-marker
-                      class="or-map-marker"
-                      active
-                      color="#FF0000"
-                      icon="white-balance-sunny"
-                      lat="${point.coordinates[0]}"
-                      lng="${point.coordinates[1]}"
-                    ></or-map-marker>
-                  `
-                : undefined
-            }
-          </or-map>
-          <div class="layout horizontal">
-            <input
-              hidden
-              class="location-lng"
-              required
-              placeholder=" "
-              type="text"
-              .value="${point && point.coordinates ? point.coordinates[0] : null}"
-            />
-            <input
-              hidden
-              class="location-lat"
-              required
-              placeholder=" "
-              type="text"
-              .value="${point && point.coordinates ? point.coordinates[1] : null}"
-            />
-          </div>
+  renderDialogHTML(point: GeoJSONPoint | undefined): TemplateResult {
+    return html`
+      <div style="display:grid">
+        <or-map class="or-map" type="VECTOR" style="border: 1px solid #d5d5d5; aspect-ratio: 1/1;">
+          ${
+            point && point.coordinates
+              ? html`
+                  <or-map-marker
+                    class="or-map-marker"
+                    active
+                    color="#FF0000"
+                    icon="white-balance-sunny"
+                    lat="${point.coordinates[0]}"
+                    lng="${point.coordinates[1]}"
+                  ></or-map-marker>
+                `
+              : undefined
+          }
+        </or-map>
+        <div class="layout horizontal">
+          <input
+            hidden
+            class="location-lng"
+            required
+            placeholder=" "
+            type="text"
+            .value="${point && point.coordinates ? point.coordinates[0] : null}"
+          />
+          <input
+            hidden
+            class="location-lat"
+            required
+            placeholder=" "
+            type="text"
+            .value="${point && point.coordinates ? point.coordinates[1] : null}"
+          />
         </div>
-      `;
-    }
+      </div>
+    `;
   }
 
   /* ----------------------------- */
 
   render() {
-    const modalActions: DialogAction[] = [
-      {
-        actionName: "close",
-        default: true,
-        content: html`<or-mwc-input class="button" .type="${InputType.BUTTON}" label="close"></or-mwc-input>`,
-        action: () => {},
-      },
-    ];
-    const onMapModalOpen = () => {
-      const dialog: OrMwcDialog = this.shadowRoot!.getElementById("map-modal") as OrMwcDialog;
-      if (dialog) {
-        dialog.dismissAction = null;
-        dialog.open();
-        this.renderDialogHTML(this.condition.sun?.location);
-      }
+    const openModal = () => {
+      this._mapDialogElem?.open();
+      this.initMap();
     };
-    // Render dialog on every update (for example when changing location in the modal itself)
-    this.renderDialogHTML(this.condition.sun?.location);
 
     return html`
       <div class="trigger-group">
@@ -249,14 +227,20 @@ export class OrRuleTriggerQuery extends OrElement {
                     >
                       <or-translate slot="label" value="offsetInMinutes"></or-translate>
                     </or-vaadin-number-field>
-                    <or-vaadin-button class="min-width" @click=${() => onMapModalOpen()}>
+                    <or-vaadin-button class="min-width" @click=${() => openModal()}>
                       <or-translate value="location"></or-translate>
                     </or-vaadin-button>
-                    <or-mwc-dialog
-                      id="map-modal"
-                      heading="${i18next.t("pickLocation")}"
-                      .actions="${modalActions}"
-                    ></or-mwc-dialog>
+                    <or-vaadin-dialog id="map-modal" width="512px">
+                      <h2 slot="header-content">
+                        <or-translate value="pickLocation"></or-translate>
+                      </h2>
+                      ${this.renderDialogHTML(this.condition.sun?.location)}
+                      <div slot="footer" style="width: 100%; display: flex; justify-content: end;">
+                        <or-vaadin-button theme="primary" @click=${() => this._mapDialogElem?.close()}>
+                          <or-translate value="ok"></or-translate>
+                        </or-vaadin-button>
+                      </div>
+                    </or-vaadin-dialog>
                   `
             }
           `

--- a/ui/component/or-rules/src/json-viewer/or-rule-trigger-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-trigger-query.ts
@@ -25,7 +25,7 @@ import { buttonStyle } from "../style";
 import { OrRulesJsonRuleChangedEvent } from "./or-rule-json-viewer";
 import { TimeTriggerType } from "../index";
 import { Util } from "@openremote/core";
-import {type LngLatLike, type OrMap, OrMapClickedEvent} from "@openremote/or-map";
+import { type LngLatLike, type OrMap, OrMapClickedEvent } from "@openremote/or-map";
 import { i18next } from "@openremote/or-translate";
 import type { OrVaadinSelect } from "@openremote/or-vaadin-components/or-vaadin-select";
 import { when } from "lit/directives/when.js";

--- a/ui/component/or-rules/src/json-viewer/or-rule-trigger-query.ts
+++ b/ui/component/or-rules/src/json-viewer/or-rule-trigger-query.ts
@@ -25,7 +25,7 @@ import { buttonStyle } from "../style";
 import { OrRulesJsonRuleChangedEvent } from "./or-rule-json-viewer";
 import { TimeTriggerType } from "../index";
 import { Util } from "@openremote/core";
-import { type OrMap, OrMapClickedEvent } from "@openremote/or-map";
+import {type LngLatLike, type OrMap, OrMapClickedEvent} from "@openremote/or-map";
 import { i18next } from "@openremote/or-translate";
 import type { OrVaadinSelect } from "@openremote/or-vaadin-components/or-vaadin-select";
 import { when } from "lit/directives/when.js";
@@ -141,7 +141,7 @@ export class OrRuleTriggerQuery extends OrElement {
   renderDialogHTML(point: GeoJSONPoint | undefined): TemplateResult {
     return html`
       <div style="display:grid">
-        <or-map class="or-map" type="VECTOR" style="border: 1px solid #d5d5d5; aspect-ratio: 1/1;">
+        <or-map class="or-map" type="VECTOR" zoom="12" style="border: 1px solid #d5d5d5; aspect-ratio: 1/1;">
           ${
             point && point.coordinates
               ? html`


### PR DESCRIPTION
## Description
This PR migrates another (small) set of `<or-mwc-dialog>` Material dialogs to the new Vaadin `<or-vaadin-dialog>` dialogs.
These are probably less-often used features of the platform, but are worth transferring to the new format.
After this, only the attribute picker dialogs are left to migrate.

The goal of this PR to be **lean** and **simple**, so the tricky attribute picker dialogs can be picked up later.

Work in progress.

## Changelog
- Move barchart settings "algorithm selection" dialog to `<or-vaadin-dialog>`.
- Move group asset "attribute selection" table dialog to `<or-vaadin-dialog>`.
- Move delete prompts in realm/map styling on appearance page to `<or-vaadin-confirm-dialog>`.
- Move map dialogs in Rules UI its when-clause (radius operator and time trigger) to `<or-vaadin-dialog>`

## Checklist
- [x] ~~1. Acceptance criteria of the linked issue(s) are met~~
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [x] ~~4. Documentation is written or updated~~
