### PR TITLE
Add gateway API compatibility tests

### DIFF
--- a/test/src/test/groovy/org/openremote/test/gateway/AbstractGatewayCompatibilityTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/gateway/AbstractGatewayCompatibilityTest.groovy
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package org.openremote.test.gateway
+
+import io.netty.channel.ChannelHandler
+import org.apache.http.client.utils.URIBuilder
+import org.openremote.agent.protocol.io.AbstractNettyIOClient
+import org.openremote.agent.protocol.websocket.WebsocketIOClient
+import org.openremote.manager.asset.AssetStorageService
+import org.openremote.manager.gateway.GatewayService
+import org.openremote.manager.security.ManagerIdentityService
+import org.openremote.manager.security.ManagerKeycloakIdentityProvider
+import org.openremote.manager.setup.SetupService
+import org.openremote.manager.system.VersionInfo
+import org.openremote.model.asset.ReadAssetsEvent
+import org.openremote.model.asset.agent.ConnectionStatus
+import org.openremote.model.asset.impl.GatewayAsset
+import org.openremote.model.asset.impl.ThingAsset
+import org.openremote.model.auth.OAuthClientCredentialsGrant
+import org.openremote.model.event.shared.SharedEvent
+import org.openremote.model.gateway.GatewayCapabilitiesRequestEvent
+import org.openremote.model.gateway.GatewayInitDoneEvent
+import org.openremote.model.gateway.GatewayInitStartEvent
+import org.openremote.model.query.AssetQuery
+import org.openremote.model.util.ValueUtil
+import org.openremote.test.ManagerContainerTrait
+import org.openremote.setup.integration.ManagerTestSetup
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import static org.openremote.manager.gateway.GatewayConnector.mapAssetId
+
+abstract class AbstractGatewayCompatibilityTest extends Specification implements ManagerContainerTrait {
+
+  // Frozen AssetsEvent JSON captured from BETA (c706a7fb78542967c68eb97dcf6ef06673475ff7,
+  // be467d6^), 1.0.0 (be467d6dfaa3875c5d48b65146cecb5bc5b8e30b), and 1.1.0
+  // (c7c1c4c962c6954282d1ec38a1361fb3a99177ad). All three serialize these assets identically.
+  // Keep these as wire fixtures: serializing current model objects would hide compatibility regressions.
+  private static final String INITIAL_ASSETS_JSON = '''
+    {"eventType":"assets","assets":[{
+      "id":"0123456789ABCDEFGHIJKL","version":0,"createdOn":1769688000000,
+      "name":"Compatibility asset","accessPublicRead":false,"realm":"master","type":"ThingAsset",
+      "path":["0123456789ABCDEFGHIJKL"]
+    }],"timestamp":0,"messageID":"INITIAL"}
+  '''
+  private static final String BATCH_ASSETS_JSON = '''
+    {"eventType":"assets","assets":[{
+      "id":"0123456789ABCDEFGHIJKL","version":0,"createdOn":1769688000000,
+      "name":"Compatibility asset","accessPublicRead":false,"realm":"master","type":"ThingAsset",
+      "path":["0123456789ABCDEFGHIJKL"],
+      "attributes":{"temperature":{"name":"temperature","type":"number","meta":null,"value":21.5}}
+    }],"timestamp":0,"messageID":"BATCH0"}
+  '''
+
+  def setupSpec() {
+    startContainer(defaultConfig(), defaultServices())
+  }
+
+  protected GatewayAsset provisionCompatibilityGateway(String version) {
+    def storage = container.getService(AssetStorageService)
+    def realm = container.getService(SetupService).getTaskOfType(ManagerTestSetup).realmBuildingName
+    def gateway = storage.merge(new GatewayAsset("Compatibility gateway $version").setRealm(realm))
+    def conditions = new PollingConditions(timeout: 15, delay: 0.1)
+    conditions.eventually {
+      gateway = storage.find(gateway.id, true) as GatewayAsset
+      assert gateway.clientId.present
+      assert gateway.clientSecret.present
+      assert container.getService(GatewayService).gatewayConnectorMap.containsKey(gateway.id.toLowerCase(Locale.ROOT))
+    }
+    return gateway
+  }
+
+  protected WebsocketIOClient createCompatibilityClient(GatewayAsset gateway, List<SharedEvent> receivedEvents) {
+    def identityProvider = container.getService(ManagerIdentityService).identityProvider as ManagerKeycloakIdentityProvider
+    def tokenUri = new URIBuilder(identityProvider.keycloakPublicUrl)
+            .setPath("auth/realms/${gateway.realm}/protocol/openid-connect/token").build().toString()
+    def client = new WebsocketIOClient(
+            new URIBuilder("ws://127.0.0.1:$serverPort/websocket/events?Realm=${gateway.realm}").build(),
+            null,
+            new OAuthClientCredentialsGrant(tokenUri, gateway.clientId.get(), gateway.clientSecret.get(), null)
+            .setBasicAuthHeader(true))
+    client.setEncoderDecoderProvider({
+      [new AbstractNettyIOClient.MessageToMessageDecoder<String>(String.class, client)].toArray(new ChannelHandler[0])
+    })
+    client.addMessageConsumer({ String message ->
+      if (message.startsWith(SharedEvent.MESSAGE_PREFIX)) {
+        receivedEvents.add(ValueUtil.JSON.readValue(message.substring(SharedEvent.MESSAGE_PREFIX.length()), SharedEvent))
+      }
+    })
+    return client
+  }
+
+  protected static <T extends SharedEvent> T awaitGatewayEvent(List<SharedEvent> receivedEvents, Class<T> eventType, String messageId = null) {
+    T event = null
+    def conditions = new PollingConditions(timeout: 15, delay: 0.1)
+    conditions.eventually {
+      event = receivedEvents.find { eventType.isInstance(it) && it.messageID == messageId } as T
+      assert event != null : "Expected ${eventType.simpleName} ($messageId), received: $receivedEvents"
+    }
+    return event
+  }
+
+  protected static void synchronizeCompatibilityAsset(WebsocketIOClient client, List<SharedEvent> receivedEvents) {
+    client.sendMessage(SharedEvent.MESSAGE_PREFIX + INITIAL_ASSETS_JSON)
+    def batchRequest = awaitGatewayEvent(receivedEvents, ReadAssetsEvent, "BATCH0")
+    assert batchRequest.assetQuery.ids.toList() == ["0123456789ABCDEFGHIJKL"]
+    client.sendMessage(SharedEvent.MESSAGE_PREFIX + BATCH_ASSETS_JSON)
+  }
+
+  protected static void initializeVersionedGateway(WebsocketIOClient client, List<SharedEvent> receivedEvents, String capabilitiesJson) {
+    client.connect()
+    def initStart = awaitGatewayEvent(receivedEvents, GatewayInitStartEvent)
+    assert initStart.version == VersionInfo.getGatewayApiVersion()
+    assert initStart.activeTunnels == null
+    synchronizeCompatibilityAsset(client, receivedEvents)
+    awaitGatewayEvent(receivedEvents, GatewayCapabilitiesRequestEvent)
+    assert !receivedEvents.any { it instanceof ReadAssetsEvent && it.messageID == "INITIAL" }
+    client.sendMessage(SharedEvent.MESSAGE_PREFIX + capabilitiesJson)
+  }
+
+  protected void assertCompatibilityConnected(GatewayAsset gateway, List<SharedEvent> receivedEvents, String version, boolean timeoutManagementSupported) {
+    awaitGatewayEvent(receivedEvents, GatewayInitDoneEvent)
+    def storage = container.getService(AssetStorageService)
+    def conditions = new PollingConditions(timeout: 15, delay: 0.1)
+    conditions.eventually {
+      def connector = container.getService(GatewayService).gatewayConnectorMap.get(gateway.id.toLowerCase(Locale.ROOT))
+      assert connector.isConnected()
+      assert !connector.isInitialSyncInProgress()
+      assert connector.isTunnellingSupported()
+      assert connector.gatewayVersion == version
+      assert connector.isTunnelTimeoutManagementSupported() == timeoutManagementSupported
+      def connectedGateway = storage.find(gateway.id) as GatewayAsset
+      assert connectedGateway.gatewayStatus.orElse(null) == ConnectionStatus.CONNECTED
+      assert connectedGateway.tunnelingSupported.orElse(false)
+
+      def syncedAssets = storage.findAll(new AssetQuery().parents(gateway.id).recursive(true))
+      assert syncedAssets.size() == 1
+      def asset = syncedAssets.first()
+      assert asset.id == mapAssetId(gateway.id, "0123456789ABCDEFGHIJKL", false)
+      assert asset.parentId == gateway.id
+      assert asset.realm == gateway.realm
+      assert asset.type == ThingAsset.DESCRIPTOR.name
+      assert asset.name == "Compatibility asset"
+      assert asset.getAttribute("temperature").flatMap { it.value }.orElse(null) == 21.5
+    }
+  }
+
+  protected void cleanupCompatibilityGateway(WebsocketIOClient client, GatewayAsset gateway) {
+    client?.disconnect()
+    client?.removeAllMessageConsumers()
+    if (gateway != null) {
+      container.getService(AssetStorageService).delete([gateway.id])
+      def conditions = new PollingConditions(timeout: 15, delay: 0.1)
+      conditions.eventually {
+        assert !container.getService(GatewayService).gatewayConnectorMap.containsKey(gateway.id.toLowerCase(Locale.ROOT))
+      }
+    }
+  }
+}

--- a/test/src/test/groovy/org/openremote/test/gateway/AbstractGatewayCompatibilityTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/gateway/AbstractGatewayCompatibilityTest.groovy
@@ -116,7 +116,7 @@ abstract class AbstractGatewayCompatibilityTest extends Specification implements
     return event
   }
 
-  protected static void synchronizeCompatibilityAsset(WebsocketIOClient client, List<SharedEvent> receivedEvents) {
+  protected static void synchronizeAssets(WebsocketIOClient client, List<SharedEvent> receivedEvents) {
     client.sendMessage(SharedEvent.MESSAGE_PREFIX + INITIAL_ASSETS_JSON)
     def batchRequest = awaitGatewayEvent(receivedEvents, ReadAssetsEvent, "BATCH0")
     assert batchRequest.assetQuery.ids.toList() == ["0123456789ABCDEFGHIJKL"]
@@ -128,7 +128,7 @@ abstract class AbstractGatewayCompatibilityTest extends Specification implements
     def initStart = awaitGatewayEvent(receivedEvents, GatewayInitStartEvent)
     assert initStart.version == VersionInfo.getGatewayApiVersion()
     assert initStart.activeTunnels == null
-    synchronizeCompatibilityAsset(client, receivedEvents)
+    synchronizeAssets(client, receivedEvents)
     awaitGatewayEvent(receivedEvents, GatewayCapabilitiesRequestEvent)
     assert !receivedEvents.any { it instanceof ReadAssetsEvent && it.messageID == "INITIAL" }
     client.sendMessage(SharedEvent.MESSAGE_PREFIX + capabilitiesJson)

--- a/test/src/test/groovy/org/openremote/test/gateway/GatewayApiBetaTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/gateway/GatewayApiBetaTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package org.openremote.test.gateway
+
+import org.openremote.model.asset.ReadAssetsEvent
+import org.openremote.model.gateway.GatewayCapabilitiesRequestEvent
+import org.openremote.model.gateway.GatewayInitStartEvent
+import org.openremote.model.util.ValueUtil
+import org.openremote.model.event.shared.SharedEvent
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+class GatewayApiBetaTest extends AbstractGatewayCompatibilityTest {
+
+  // BETA: c706a7fb78542967c68eb97dcf6ef06673475ff7 (be467d6^); no gateway API version field.
+  private static final String CAPABILITIES_JSON =
+  '{"eventType":"gateway-capabilities-response","timestamp":0,"tunnelingSupported":true}'
+
+  def "Gateway API BETA legacy initialization compatibility"() {
+    given: "a provisioned gateway using the frozen pre-versioned wire format"
+    def gateway = provisionCompatibilityGateway("BETA")
+    List<SharedEvent> receivedEvents = new CopyOnWriteArrayList<>()
+    def client = createCompatibilityClient(gateway, receivedEvents)
+
+    when: "the BETA gateway connects"
+    client.connect()
+
+    then: "it ignores the unknown init start event and waits for the delayed legacy asset request"
+    awaitGatewayEvent(receivedEvents, GatewayInitStartEvent)
+    def initialRequest = awaitGatewayEvent(receivedEvents, ReadAssetsEvent, "INITIAL")
+    initialRequest.assetQuery != null
+    !receivedEvents.any { it instanceof GatewayCapabilitiesRequestEvent }
+
+    when: "it replies with historical initial and batch asset responses"
+    synchronizeCompatibilityAsset(client, receivedEvents)
+
+    then: "the manager requests capabilities after synchronization"
+    awaitGatewayEvent(receivedEvents, GatewayCapabilitiesRequestEvent)
+    !ValueUtil.JSON.readTree(CAPABILITIES_JSON).has("version")
+
+    when: "the gateway reports tunneling support without an API version"
+    client.sendMessage(SharedEvent.MESSAGE_PREFIX + CAPABILITIES_JSON)
+
+    then: "initialization completes with legacy tunneling support"
+    assertCompatibilityConnected(gateway, receivedEvents, null, false)
+
+    cleanup:
+    cleanupCompatibilityGateway(client, gateway)
+  }
+}

--- a/test/src/test/groovy/org/openremote/test/gateway/GatewayApiBetaTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/gateway/GatewayApiBetaTest.groovy
@@ -47,8 +47,8 @@ class GatewayApiBetaTest extends AbstractGatewayCompatibilityTest {
     initialRequest.assetQuery != null
     !receivedEvents.any { it instanceof GatewayCapabilitiesRequestEvent }
 
-    when: "it replies with historical initial and batch asset responses"
-    synchronizeCompatibilityAsset(client, receivedEvents)
+    when: "assets are synchronized"
+    synchronizeAssets(client, receivedEvents)
 
     then: "the manager requests capabilities after synchronization"
     awaitGatewayEvent(receivedEvents, GatewayCapabilitiesRequestEvent)

--- a/test/src/test/groovy/org/openremote/test/gateway/GatewayApiV100Test.groovy
+++ b/test/src/test/groovy/org/openremote/test/gateway/GatewayApiV100Test.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package org.openremote.test.gateway
+
+import org.openremote.model.event.shared.SharedEvent
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+class GatewayApiV100Test extends AbstractGatewayCompatibilityTest {
+
+  // 1.0.0: be467d6dfaa3875c5d48b65146cecb5bc5b8e30b introduced versioned capabilities.
+  private static final String CAPABILITIES_JSON =
+  '{"eventType":"gateway-capabilities-response","version":"1.0.0","tunnelingSupported":true,"timestamp":0}'
+
+  def "Gateway API 1.0.0 initialization compatibility"() {
+    given: "a provisioned gateway using the frozen 1.0.0 wire format"
+    def gateway = provisionCompatibilityGateway("1.0.0")
+    List<SharedEvent> receivedEvents = new CopyOnWriteArrayList<>()
+    def client = createCompatibilityClient(gateway, receivedEvents)
+
+    when: "the gateway completes versioned initialization"
+    initializeVersionedGateway(client, receivedEvents, CAPABILITIES_JSON)
+
+    then: "the manager detects 1.0.0 and connects without tunnel timeout management"
+    assertCompatibilityConnected(gateway, receivedEvents, "1.0.0", false)
+
+    cleanup:
+    cleanupCompatibilityGateway(client, gateway)
+  }
+}

--- a/test/src/test/groovy/org/openremote/test/gateway/GatewayApiV110Test.groovy
+++ b/test/src/test/groovy/org/openremote/test/gateway/GatewayApiV110Test.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026, OpenRemote Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package org.openremote.test.gateway
+
+import org.openremote.model.event.shared.SharedEvent
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+class GatewayApiV110Test extends AbstractGatewayCompatibilityTest {
+
+  // 1.1.0: c7c1c4c962c6954282d1ec38a1361fb3a99177ad; supports tunnel timeout management.
+  private static final String CAPABILITIES_JSON =
+  '{"eventType":"gateway-capabilities-response","version":"1.1.0","tunnelingSupported":true,"timestamp":0}'
+
+  def "Gateway API 1.1.0 initialization compatibility"() {
+    given: "a provisioned gateway using the frozen 1.1.0 wire format"
+    def gateway = provisionCompatibilityGateway("1.1.0")
+    List<SharedEvent> receivedEvents = new CopyOnWriteArrayList<>()
+    def client = createCompatibilityClient(gateway, receivedEvents)
+
+    when: "the gateway completes versioned initialization"
+    initializeVersionedGateway(client, receivedEvents, CAPABILITIES_JSON)
+
+    then: "the manager detects 1.1.0 and connects with tunnel timeout management"
+    assertCompatibilityConnected(gateway, receivedEvents, "1.1.0", true)
+
+    cleanup:
+    cleanupCompatibilityGateway(client, gateway)
+  }
+}

--- a/test/src/test/groovy/org/openremote/test/gateway/GatewayTest.groovy
+++ b/test/src/test/groovy/org/openremote/test/gateway/GatewayTest.groovy
@@ -51,8 +51,6 @@ import org.openremote.model.auth.OAuthClientCredentialsGrant
 import org.openremote.model.event.shared.SharedEvent
 import org.openremote.model.gateway.*
 import org.openremote.model.geo.GeoJSONPoint
-import org.openremote.model.notification.AbstractNotificationMessage
-import org.openremote.model.notification.Notification
 import org.openremote.model.query.AssetQuery
 import org.openremote.model.query.filter.RealmPredicate
 import org.openremote.model.security.User
@@ -63,7 +61,6 @@ import org.openremote.model.value.ValueFormat
 import org.openremote.setup.integration.ManagerTestSetup
 import org.openremote.test.ManagerContainerTrait
 import spock.lang.Ignore
-import spock.lang.Shared
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -87,7 +84,6 @@ import static org.openremote.model.util.TextUtil.isNullOrEmpty
 import static org.openremote.model.value.MetaItemType.*
 import static org.openremote.model.value.ValueType.*
 
-// TODO: Add tests for each supported version of the gateway API
 class GatewayTest extends Specification implements ManagerContainerTrait {
 
   def setupSpec() {


### PR DESCRIPTION
## Description

Add separate gateway compatibility tests for the supported BETA, 1.0.0 and 1.1.0 API versions.
Use frozen historical JSON payloads to verify backward compatibility with older gateway wire formats.

## Checklist

<!--
  With all these boxes checked this PR conforms to our Definition of Done.
-->

- [ ] 1. Acceptance criteria of the linked issue(s) are met
- [ ] 2. Tests are written and all tests pass
- [ ] 3. Changes are manually tested by you and the reviewer
- [ ] 4. Documentation is written or updated

<!--
  Thank you for your contribution <3
-->
